### PR TITLE
Edit existing observations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inaturalistreactnative",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inaturalistreactnative",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@react-native-community/cameraroll": "^4.1.2",
         "@react-native-community/checkbox": "^0.5.12",
@@ -17,6 +17,7 @@
         "@react-navigation/elements": "^1.3.1",
         "@react-navigation/native": "^6.0.8",
         "@react-navigation/native-stack": "^6.5.2",
+        "@realm/react": "^0.2.1",
         "apisauce": "^2.1.2",
         "axios": "^0.25.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.3",
@@ -3459,6 +3460,221 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@realm.io/common/-/common-0.1.1.tgz",
       "integrity": "sha512-sXc7Ndhh39O9bm7/e0eeAx8keDBO83yoG7WfH04o6PqwVaIwm4T1uT0bhTO6OizP6ojhugZlVSu9HzgUVRE1Ag=="
+    },
+    "node_modules/@realm/react": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@realm/react/-/react-0.2.1.tgz",
+      "integrity": "sha512-X1UdST8GoTWG6/JVPBSdVgi6UQ2J/9ixXzJ6AFXV6+TomtMtE82/Tb2xI/sU+wTi01y8A96zTnU+IXii9N9Itw==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "realm": ">=10"
+      },
+      "optionalDependencies": {
+        "@babel/runtime": ">=7",
+        "react-native": ">=0.59"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "realm": ">=10"
+      }
+    },
+    "node_modules/@realm/react/node_modules/agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@realm/react/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@realm/react/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@realm/react/node_modules/deepmerge": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+      "integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@realm/react/node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@realm/react/node_modules/fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/@realm/react/node_modules/https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "dependencies": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/@realm/react/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@realm/react/node_modules/node-abi": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
+      "integrity": "sha512-Ic6z/j6I9RLm4ov7npo1I48UQr2BEyFCqh6p7S1dhEx9jPO0GPGq/e2Rb7x7DroQrmiVMz/Bw1vJm9sPAl2nxA==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@realm/react/node_modules/prebuild-install": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
+      "integrity": "sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@realm/react/node_modules/realm": {
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-10.17.0.tgz",
+      "integrity": "sha512-8G5xJXoe+HHKdgtSoXvGv1yGLfS9IzXBsRnamAQJCjfI64uiYxPa/wSHkzGnqrcpmIq4VkV07AgPmzG5YmtZQw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@realm.io/common": "^0.1.1",
+        "bindings": "^1.5.0",
+        "bson": "4.4.1",
+        "clang-format": "^1.6.0",
+        "command-line-args": "^5.1.1",
+        "deepmerge": "2.1.0",
+        "fs-extra": "^4.0.3",
+        "https-proxy-agent": "^2.2.4",
+        "ini": "^1.3.7",
+        "node-addon-api": "4.2.0",
+        "node-fetch": "^2.6.1",
+        "node-machine-id": "^1.1.10",
+        "prebuild-install": "^7.0.1",
+        "progress": "^2.0.3",
+        "prop-types": "^15.6.2",
+        "realm-network-transport": "^0.7.2",
+        "request": "^2.88.0",
+        "stream-counter": "^1.0.0",
+        "sync-request": "^3.0.1",
+        "tar": "^6.0.1",
+        "url-parse": "^1.4.4"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=7"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@realm/react/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@realm/react/node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.2",
@@ -10950,7 +11166,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13644,9 +13859,9 @@
       }
     },
     "node_modules/realm-network-transport": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.1.tgz",
-      "integrity": "sha512-ZKGJVk6hzVeLE/cme9H4MyVnfpPlCTMheQdnMHWkLMhvNUqgyPFkgSCB+B5IsnGns2l5g2rmKeTNPoUFHi+Khw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.2.tgz",
+      "integrity": "sha512-/5/YtZ5+ZIHIPgVFL6fRyx0/FRhmMaaF7L/h+iU8VKWGzesiBusSaeInosrM6v8MQvsW3W9ApBCeUwNW6m+8sg==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"
@@ -18901,6 +19116,151 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@realm.io/common/-/common-0.1.1.tgz",
       "integrity": "sha512-sXc7Ndhh39O9bm7/e0eeAx8keDBO83yoG7WfH04o6PqwVaIwm4T1uT0bhTO6OizP6ojhugZlVSu9HzgUVRE1Ag=="
+    },
+    "@realm/react": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@realm/react/-/react-0.2.1.tgz",
+      "integrity": "sha512-X1UdST8GoTWG6/JVPBSdVgi6UQ2J/9ixXzJ6AFXV6+TomtMtE82/Tb2xI/sU+wTi01y8A96zTnU+IXii9N9Itw==",
+      "requires": {
+        "@babel/runtime": ">=7",
+        "lodash": "^4.17.21",
+        "react-native": ">=0.59",
+        "realm": ">=10"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "deepmerge": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+          "integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
+        },
+        "detect-libc": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        },
+        "node-abi": {
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
+          "integrity": "sha512-Ic6z/j6I9RLm4ov7npo1I48UQr2BEyFCqh6p7S1dhEx9jPO0GPGq/e2Rb7x7DroQrmiVMz/Bw1vJm9sPAl2nxA==",
+          "requires": {
+            "semver": "^7.3.5"
+          }
+        },
+        "prebuild-install": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
+          "integrity": "sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==",
+          "requires": {
+            "detect-libc": "^2.0.0",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^3.3.0",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^4.0.0",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "realm": {
+          "version": "10.17.0",
+          "resolved": "https://registry.npmjs.org/realm/-/realm-10.17.0.tgz",
+          "integrity": "sha512-8G5xJXoe+HHKdgtSoXvGv1yGLfS9IzXBsRnamAQJCjfI64uiYxPa/wSHkzGnqrcpmIq4VkV07AgPmzG5YmtZQw==",
+          "requires": {
+            "@realm.io/common": "^0.1.1",
+            "bindings": "^1.5.0",
+            "bson": "4.4.1",
+            "clang-format": "^1.6.0",
+            "command-line-args": "^5.1.1",
+            "deepmerge": "2.1.0",
+            "fs-extra": "^4.0.3",
+            "https-proxy-agent": "^2.2.4",
+            "ini": "^1.3.7",
+            "node-addon-api": "4.2.0",
+            "node-fetch": "^2.6.1",
+            "node-machine-id": "^1.1.10",
+            "prebuild-install": "^7.0.1",
+            "progress": "^2.0.3",
+            "prop-types": "^15.6.2",
+            "realm-network-transport": "^0.7.2",
+            "request": "^2.88.0",
+            "stream-counter": "^1.0.0",
+            "sync-request": "^3.0.1",
+            "tar": "^6.0.1",
+            "url-parse": "^1.4.4"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "simple-get": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+          "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+          "requires": {
+            "decompress-response": "^6.0.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        }
+      }
     },
     "@sideway/address": {
       "version": "4.1.2",
@@ -24636,7 +24996,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -26756,9 +27115,9 @@
       }
     },
     "realm-network-transport": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.1.tgz",
-      "integrity": "sha512-ZKGJVk6hzVeLE/cme9H4MyVnfpPlCTMheQdnMHWkLMhvNUqgyPFkgSCB+B5IsnGns2l5g2rmKeTNPoUFHi+Khw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/realm-network-transport/-/realm-network-transport-0.7.2.tgz",
+      "integrity": "sha512-/5/YtZ5+ZIHIPgVFL6fRyx0/FRhmMaaF7L/h+iU8VKWGzesiBusSaeInosrM6v8MQvsW3W9ApBCeUwNW6m+8sg==",
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-navigation/elements": "^1.3.1",
     "@react-navigation/native": "^6.0.8",
     "@react-navigation/native-stack": "^6.5.2",
+    "@realm/react": "^0.2.1",
     "apisauce": "^2.1.2",
     "axios": "^0.25.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",

--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -20,7 +20,6 @@ const EvidenceList = ( { currentObs, showCameraOptions, setSelectedPhoto, select
   const renderEvidence = ( { item, index } ) => {
     const isSound = item?.file_url;
     let photoUrl = item.photo?.url || item?.photo?.localFilePath;
-    console.log( photoUrl, item.photo, "photo url in render evidence" );
     const imageUri = { uri: photoUrl };
 
     const handlePress = ( ) => {

--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -1,0 +1,104 @@
+// @flow
+
+import React, { useState, useContext } from "react";
+import { Text, Pressable, Modal } from "react-native";
+import type { Node } from "react";
+import { useTranslation } from "react-i18next";
+
+import { textStyles } from "../../styles/obsEdit/obsEdit";
+import LocationPicker from "./LocationPicker";
+import { ObsEditContext } from "../../providers/contexts";
+import EvidenceList from "./EvidenceList";
+import DatePicker from "./DatePicker";
+import { createObservedOnStringForUpload } from "../../sharedHelpers/dateAndTime";
+
+const EvidenceSection = ( ): Node => {
+  const {
+    currentObsIndex,
+    observations,
+    setObservations,
+    updateObservationKey
+  } = useContext( ObsEditContext );
+  const { t } = useTranslation( );
+
+  const [showLocationPicker, setShowLocationPicker] = useState( false );
+
+  const formatDecimal = coordinate => coordinate && coordinate.toFixed( 6 );
+
+  const updateObservedOn = value => updateObservationKey( "observed_on_string", value );
+
+  const currentObs = observations[currentObsIndex];
+  const latitude = currentObs && currentObs.latitude;
+  const longitude = currentObs && currentObs.longitude;
+
+  const openLocationPicker = ( ) => setShowLocationPicker( true );
+  const closeLocationPicker = ( ) => setShowLocationPicker( false );
+
+  const updateLocation = newLocation => {
+    const updatedObs = observations.map( ( obs, index ) => {
+      if ( index === currentObsIndex ) {
+        return {
+          ...obs,
+          // $FlowFixMe
+          latitude: newLocation.latitude,
+          longitude: newLocation.longitude,
+          place_guess: newLocation.placeGuess
+        };
+      } else {
+        return obs;
+      }
+    } );
+    setObservations( updatedObs );
+  };
+
+  const handleDatePicked = ( selectedDate ) => {
+    if ( selectedDate ) {
+      const dateString = createObservedOnStringForUpload( selectedDate );
+      updateObservedOn( dateString );
+    }
+  };
+
+  const renderLocationPickerModal = ( ) => (
+    <Modal visible={showLocationPicker}>
+      <LocationPicker
+        closeLocationPicker={closeLocationPicker}
+        updateLocation={updateLocation}
+      />
+    </Modal>
+  );
+
+  const displayLocation = ( ) => {
+    let location = "";
+    if ( latitude ) {
+      location += `Lat: ${formatDecimal( latitude )}`;
+    }
+    if ( longitude ) {
+      location += `, Lon: ${formatDecimal( longitude )}`;
+    }
+    if ( currentObs.positional_accuracy ) {
+      location += `, Acc: ${formatDecimal( currentObs.positional_accuracy )}`;
+    }
+    return location;
+  };
+
+  return (
+    <>
+      {renderLocationPickerModal( )}
+      {/* TODO: allow user to tap into bigger version of photo (crop screen) */}
+      <EvidenceList currentObs={currentObs} showCameraOptions />
+      <Pressable
+        onPress={openLocationPicker}
+      >
+        <Text style={textStyles.text}>
+          {currentObs.place_guess || t( "Add-Location" )}
+        </Text>
+        <Text style={textStyles.text}>
+          {displayLocation( ) || t( "No-Location" )}
+        </Text>
+      </Pressable>
+      <DatePicker currentObs={currentObs} handleDatePicked={handleDatePicked} />
+    </>
+  );
+};
+
+export default EvidenceSection;

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -1,7 +1,7 @@
 // @flow
 
-import React, { useState, useContext } from "react";
-import { Text, Pressable, View, Modal } from "react-native";
+import React, { useContext } from "react";
+import { Text, Pressable, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { Node } from "react";
 import { useTranslation } from "react-i18next";
@@ -11,14 +11,11 @@ import { Headline } from "react-native-paper";
 import ScrollNoFooter from "../SharedComponents/ScrollNoFooter";
 import RoundGreenButton from "../SharedComponents/Buttons/RoundGreenButton";
 import { textStyles, viewStyles } from "../../styles/obsEdit/obsEdit";
-import LocationPicker from "./LocationPicker";
 import { ObsEditContext } from "../../providers/contexts";
-import EvidenceList from "./EvidenceList";
 import { useLoggedIn } from "../../sharedHooks/useLoggedIn";
-import DatePicker from "./DatePicker";
-import { createObservedOnStringForUpload } from "../../sharedHelpers/dateAndTime";
 import IdentificationSection from "./IdentificationSection";
 import OtherDataSection from "./OtherDataSection";
+import EvidenceSection from "./EvidenceSection";
 // import BottomModal from "./BottomModal";
 // import uploadObservation from "./helpers/uploadObservation";
 
@@ -27,8 +24,6 @@ const ObsEdit = ( ): Node => {
     currentObsIndex,
     setCurrentObsIndex,
     observations,
-    setObservations,
-    updateObservationKey,
     saveObservation,
     saveAndUploadObservation
   } = useContext( ObsEditContext );
@@ -39,12 +34,6 @@ const ObsEdit = ( ): Node => {
 
   // const openBottomModal = useCallback( ( ) => setBottomModal( true ), [] );
   // const closeBottomModal = useCallback( ( ) => setBottomModal( false ), [] );
-
-  const [showLocationPicker, setShowLocationPicker] = useState( false );
-
-  const formatDecimal = coordinate => coordinate && coordinate.toFixed( 6 );
-
-  const updateObservedOn = value => updateObservationKey( "observed_on_string", value );
 
   const showNextObservation = ( ) => setCurrentObsIndex( currentObsIndex + 1 );
   const showPrevObservation = ( ) => setCurrentObsIndex( currentObsIndex - 1 );
@@ -87,60 +76,8 @@ const ObsEdit = ( ): Node => {
   };
 
   const currentObs = observations[currentObsIndex];
-  const latitude = currentObs && currentObs.latitude;
-  const longitude = currentObs && currentObs.longitude;
-
-  const openLocationPicker = ( ) => setShowLocationPicker( true );
-  const closeLocationPicker = ( ) => setShowLocationPicker( false );
-
-  const updateLocation = newLocation => {
-    const updatedObs = observations.map( ( obs, index ) => {
-      if ( index === currentObsIndex ) {
-        return {
-          ...obs,
-          // $FlowFixMe
-          latitude: newLocation.latitude,
-          longitude: newLocation.longitude,
-          place_guess: newLocation.placeGuess
-        };
-      } else {
-        return obs;
-      }
-    } );
-    setObservations( updatedObs );
-  };
-
-  const handleDatePicked = ( selectedDate ) => {
-    if ( selectedDate ) {
-      const dateString = createObservedOnStringForUpload( selectedDate );
-      updateObservedOn( dateString );
-    }
-  };
-
-  const renderLocationPickerModal = ( ) => (
-    <Modal visible={showLocationPicker}>
-      <LocationPicker
-        closeLocationPicker={closeLocationPicker}
-        updateLocation={updateLocation}
-      />
-    </Modal>
-  );
 
   if ( !currentObs ) { return null; }
-
-  const displayLocation = ( ) => {
-    let location = "";
-    if ( latitude ) {
-      location += `Lat: ${formatDecimal( latitude )}`;
-    }
-    if ( longitude ) {
-      location += `, Lon: ${formatDecimal( longitude )}`;
-    }
-    if ( currentObs.positional_accuracy ) {
-      location += `, Acc: ${formatDecimal( currentObs.positional_accuracy )}`;
-    }
-    return location;
-  };
 
   return (
     <ScrollNoFooter>
@@ -152,22 +89,9 @@ const ObsEdit = ( ): Node => {
         )}
         style={viewStyles.noMargin}
       /> */}
-      {renderLocationPickerModal( )}
       {renderArrowNavigation( )}
       <Headline style={textStyles.headerText}>{t( "Evidence" )}</Headline>
-      {/* TODO: allow user to tap into bigger version of photo (crop screen) */}
-      <EvidenceList currentObs={currentObs} showCameraOptions />
-      <Pressable
-        onPress={openLocationPicker}
-      >
-        <Text style={textStyles.text}>
-          {currentObs.place_guess || t( "Add-Location" )}
-        </Text>
-        <Text style={textStyles.text}>
-          {displayLocation( ) || t( "No-Location" )}
-        </Text>
-      </Pressable>
-      <DatePicker currentObs={currentObs} handleDatePicked={handleDatePicked} />
+      <EvidenceSection />
       <Headline style={textStyles.headerText}>{t( "Identification" )}</Headline>
       <IdentificationSection />
       <Headline style={textStyles.headerText}>{t( "Other-Data" )}</Headline>

--- a/src/components/ObsEdit/OtherDataSection.js
+++ b/src/components/ObsEdit/OtherDataSection.js
@@ -15,6 +15,7 @@ import Notes from "./Notes";
 
 
 const OtherDataSection = ( ): Node => {
+  const showForMilestoneOne = false;
   const {
     currentObsIndex,
     observations,
@@ -55,7 +56,7 @@ const OtherDataSection = ( ): Node => {
 
   const addNotes = text => updateObservationKey( "description", text );
   const updateGeoprivacyStatus = value => updateObservationKey( "geoprivacy", value );
-  const updateCaptiveStatus = value => updateObservationKey( "captive", value );
+  const updateCaptiveStatus = value => updateObservationKey( "captive_flag", value );
 
   const searchForProjects = ( ) => {
     setSource( "projects" );
@@ -112,12 +113,14 @@ const OtherDataSection = ( ): Node => {
           items={captiveOptions}
           useNativeAndroidPickerStyle={false}
           style={pickerSelectStyles}
-          value={currentObs.captive}
+          value={currentObs.captive_flag}
         />
       </View>
-      <Pressable onPress={searchForProjects}>
-        <TranslatedText style={textStyles.text} text="Add-to-projects" />
-      </Pressable>
+      {showForMilestoneOne && (
+        <Pressable onPress={searchForProjects}>
+          <TranslatedText style={textStyles.text} text="Add-to-projects" />
+        </Pressable>
+      )}
       <Notes addNotes={addNotes} description={currentObs.description} />
     </>
   );

--- a/src/components/ObsEdit/OtherDataSection.js
+++ b/src/components/ObsEdit/OtherDataSection.js
@@ -1,33 +1,24 @@
 // @flow
 
-import React, { useState, useCallback, useContext } from "react";
-import { Text, Pressable, View } from "react-native";
+import React, { useContext } from "react";
+import { Text, View } from "react-native";
 import RNPickerSelect from "react-native-picker-select";
 import type { Node } from "react";
 import { useTranslation } from "react-i18next";
 
 import { pickerSelectStyles, textStyles, viewStyles } from "../../styles/obsEdit/obsEdit";
-import CustomModal from "../SharedComponents/Modal";
-import ObsEditSearch from "./ObsEditSearch";
 import { ObsEditContext } from "../../providers/contexts";
 import TranslatedText from "../SharedComponents/TranslatedText";
 import Notes from "./Notes";
 
 
 const OtherDataSection = ( ): Node => {
-  const showForMilestoneOne = false;
   const {
     currentObsIndex,
     observations,
-    updateObservationKey,
-    setObservations
+    updateObservationKey
   } = useContext( ObsEditContext );
   const { t } = useTranslation( );
-  const [showModal, setModal] = useState( false );
-  const [source, setSource] = useState( null );
-
-  const openModal = useCallback( ( ) => setModal( true ), [] );
-  const closeModal = useCallback( ( ) => setModal( false ), [] );
 
   const geoprivacyOptions = [{
     label: t( "Open" ),
@@ -58,44 +49,22 @@ const OtherDataSection = ( ): Node => {
   const updateGeoprivacyStatus = value => updateObservationKey( "geoprivacy", value );
   const updateCaptiveStatus = value => updateObservationKey( "captive_flag", value );
 
-  const searchForProjects = ( ) => {
-    setSource( "projects" );
-    openModal( );
-  };
-
-  const updateProjectIds = projectId => {
-    const updatedObs = observations.map( ( obs, index ) => {
-      if ( index === currentObsIndex ) {
-        return {
-          ...obs,
-          project_ids: obs.project_ids.concat( [projectId] )
-        };
-      } else {
-        return obs;
-      }
-    } );
-    setObservations( updatedObs );
-  };
-
-  const updateObsAndCloseModal = id => {
-    // TODO: need somewhere to display which projects a user has joined
-    updateProjectIds( id );
-    closeModal( );
-  };
+  // const updateProjectIds = projectId => {
+  //   const updatedObs = observations.map( ( obs, index ) => {
+  //     if ( index === currentObsIndex ) {
+  //       return {
+  //         ...obs,
+  //         project_ids: obs.project_ids.concat( [projectId] )
+  //       };
+  //     } else {
+  //       return obs;
+  //     }
+  //   } );
+  //   setObservations( updatedObs );
+  // };
 
   return (
     <>
-      <CustomModal
-        showModal={showModal}
-        closeModal={closeModal}
-        modal={(
-          <ObsEditSearch
-            // $FlowFixMe
-            source={source}
-            handlePress={updateObsAndCloseModal}
-          />
-        )}
-      />
       <View style={viewStyles.row}>
         <TranslatedText style={textStyles.text} text="Geoprivacy" />
         <RNPickerSelect
@@ -116,11 +85,6 @@ const OtherDataSection = ( ): Node => {
           value={currentObs.captive_flag}
         />
       </View>
-      {showForMilestoneOne && (
-        <Pressable onPress={searchForProjects}>
-          <TranslatedText style={textStyles.text} text="Add-to-projects" />
-        </Pressable>
-      )}
       <Notes addNotes={addNotes} description={currentObs.description} />
     </>
   );

--- a/src/components/Observations/hooks/useObservations.js
+++ b/src/components/Observations/hooks/useObservations.js
@@ -88,6 +88,15 @@ const useObservations = ( ): Object => {
     if ( results.length === 0 ) { return; }
     const realm = realmRef.current;
     results.forEach( obs => {
+      const existingObs = realm?.objectForPrimaryKey( "Observation", obs.uuid );
+
+      if ( existingObs ) {
+        // if observation has been updated locally since the last sync, do not overwrite
+        // with observation attributes from server
+        if ( existingObs._updated_at >= existingObs._synced_at ) {
+          return;
+        }
+      }
       const newObs = Observation.createObservationForRealm( obs, realm );
       realm?.write( ( ) => {
         // To upsert an object, call Realm.create() with the update mode set

--- a/src/components/Observations/hooks/useObservations.js
+++ b/src/components/Observations/hooks/useObservations.js
@@ -41,9 +41,11 @@ const useObservations = ( ): Object => {
 
     // When querying a realm to find objects (e.g. realm.objects('Observation')) the result we get back
     // and the objects in it are "live" and will always reflect the latest state.
+    const obs = realm.objects( "Observation" );
+    const localObservations = obs.sorted( "_created_at", true );
 
-    const localObservations = realm.objects( "Observation" ).sorted( "_created_at", true );
-    const notUploadedObs = realm.objects( "Observation" ).filtered( "_synced_at == null" );
+    // includes obs which have never been synced or which have been updated locally since the last sync
+    const notUploadedObs = obs.filtered( "_synced_at == null || _synced_at <= _updated_at" );
 
     if ( localObservations?.length ) {
       setObservationList( localObservations );

--- a/src/models/Comment.js
+++ b/src/models/Comment.js
@@ -1,5 +1,7 @@
+import Realm from "realm";
+
 import User from "./User";
-class Comment {
+class Comment extends Realm.Object {
   static COMMENT_FIELDS = {
     body: true,
     created_at: true,

--- a/src/models/Identification.js
+++ b/src/models/Identification.js
@@ -1,6 +1,8 @@
+import Realm from "realm";
+
 import User from "./User";
 import Taxon from "./Taxon";
-class Identification {
+class Identification extends Realm.Object {
   static ID_FIELDS = {
     body: true,
     category: true,

--- a/src/models/Observation.js
+++ b/src/models/Observation.js
@@ -165,9 +165,9 @@ class Observation extends Realm.Object {
       _updated_at: new Date( )
     };
 
-    const isSavedObservation = realm.objectForPrimaryKey( "Observation", obs.uuid );
+    const existingObservation = realm.objectForPrimaryKey( "Observation", obs.uuid );
 
-    if ( !isSavedObservation ) {
+    if ( !existingObservation ) {
       timestamps._created_at = new Date( );
       timestamps._synced_at = null;
     }
@@ -175,7 +175,7 @@ class Observation extends Realm.Object {
     const addTimestampsToEvidence = ( evidence ) => {
       // right now there isn't a way to edit photos or sounds via ObsEdit
       // so we only need to add timestamps on the first time a local observation is saved
-      if ( !isSavedObservation ) {
+      if ( !existingObservation ) {
         evidence && evidence.map( record => {
           return {
             ...timestamps,
@@ -204,8 +204,7 @@ class Observation extends Realm.Object {
       // also using modified for updating observations which were already saved locally
       realm?.create( "Observation", obsToSave, "modified" );
     } );
-    const observation = realm.objectForPrimaryKey( "Observation", obs.uuid );
-    return observation;
+    return realm.objectForPrimaryKey( "Observation", obs.uuid );
   }
 
   static mapObservationForUpload( obs ) {

--- a/src/models/Observation.js
+++ b/src/models/Observation.js
@@ -1,4 +1,5 @@
 import uuid from "react-native-uuid";
+import Realm from "realm";
 
 import Comment from "./Comment";
 import Identification from "./Identification";
@@ -11,7 +12,9 @@ import fetchUserLocation from "../sharedHelpers/fetchUserLocation";
 import { formatCameraDate } from "../sharedHelpers/dateAndTime";
 import { getUserId } from "../components/LoginSignUp/AuthenticationService";
 
-class Observation {
+// noting that methods like .toJSON( ) are only accessible when the model class is extended with Realm.Object
+// per this issue: https://github.com/realm/realm-js/issues/3600#issuecomment-785828614
+class Observation extends Realm.Object {
   static FIELDS = {
     captive: true,
     comments: Comment.COMMENT_FIELDS,
@@ -219,27 +222,6 @@ class Observation {
       uuid: obs.uuid,
       captive_flag: obs.captive_flag,
       owners_identification_from_vision: obs.owners_identification_from_vision
-    };
-  }
-
-  static mapPlainObjectForObsEdit( obs ) {
-    // need to convert everything into plain JS objects
-    // so user can edit fields in ObsEdit before saving a modified object in realm
-    return {
-      species_guess: obs.species_guess,
-      description: obs.description,
-      observed_on_string: obs.observed_on_string,
-      place_guess: obs.place_guess,
-      latitude: obs.latitude,
-      longitude: obs.longitude,
-      positional_accuracy: obs.positional_accuracy,
-      taxon: Taxon.mapPlainObjectForObsEdit( obs.taxon ),
-      geoprivacy: obs.geoprivacy,
-      uuid: obs.uuid,
-      captive_flag: obs.captive_flag,
-      owners_identification_from_vision: obs.owners_identification_from_vision,
-      observationPhotos: obs.observationPhotos.map( photo => ObservationPhoto.mapPlainObjectForObsEdit( photo ) )
-      // observationSounds: obs.observationSounds
     };
   }
 

--- a/src/models/ObservationPhoto.js
+++ b/src/models/ObservationPhoto.js
@@ -1,10 +1,11 @@
 import { FileUpload } from "inaturalistjs";
 import uuid from "react-native-uuid";
+import Realm from "realm";
 
 import Photo from "./Photo";
 import resizeImageForUpload from "../providers/uploadHelpers/resizeImage";
 
-class ObservationPhoto {
+class ObservationPhoto extends Realm.Object {
   static OBSERVATION_PHOTOS_FIELDS = {
     id: true,
     photo: Photo.PHOTO_FIELDS,
@@ -39,15 +40,6 @@ class ObservationPhoto {
       photo: {
         localFilePath
       }
-    };
-  }
-
-  static mapPlainObjectForObsEdit( obsPhoto ) {
-    return {
-      uuid: obsPhoto.uuid,
-      id: obsPhoto.id,
-      photo: Photo.mapPlainObjectForObsEdit( obsPhoto.photo ),
-      position: obsPhoto.position
     };
   }
 

--- a/src/models/ObservationPhoto.js
+++ b/src/models/ObservationPhoto.js
@@ -42,6 +42,15 @@ class ObservationPhoto {
     };
   }
 
+  static mapPlainObjectForObsEdit( obsPhoto ) {
+    return {
+      uuid: obsPhoto.uuid,
+      id: obsPhoto.id,
+      photo: Photo.mapPlainObjectForObsEdit( obsPhoto.photo ),
+      position: obsPhoto.position
+    };
+  }
+
   static schema = {
     name: "ObservationPhoto",
     primaryKey: "uuid",

--- a/src/models/ObservationSound.js
+++ b/src/models/ObservationSound.js
@@ -2,7 +2,8 @@ import { Platform } from "react-native";
 import { FileUpload } from "inaturalistjs";
 import RNFS from "react-native-fs";
 import uuid from "react-native-uuid";
-class ObservationSound {
+import Realm from "realm";
+class ObservationSound extends Realm.Object {
   static async moveFromCacheToDocumentDirectory( soundUUID ) {
     const fileExt = Platform.OS === "android" ? "mp4" : "m4a";
     const soundPath = `${soundUUID}.${fileExt}`;

--- a/src/models/Photo.js
+++ b/src/models/Photo.js
@@ -1,4 +1,3 @@
-import { photos } from "inaturalistjs";
 import { Platform } from "react-native";
 
 class Photo {

--- a/src/models/Photo.js
+++ b/src/models/Photo.js
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
+import Realm from "realm";
 
-class Photo {
+class Photo extends Realm.Object {
   static PHOTO_FIELDS = {
     id: true,
     attribution: true,
@@ -14,16 +15,6 @@ class Photo {
 
   static setPlatformSpecificFilePath( uri ) {
     return Platform.OS === "android" ? "file://" + uri : uri;
-  }
-
-  static mapPlainObjectForObsEdit( photo ) {
-    return {
-      id: photo.id,
-      attribution: photo.attribution,
-      license_code: photo.license_code,
-      url: photo.url,
-      localFilePath: photo.localFilePath
-    };
   }
 
   static schema = {

--- a/src/models/Photo.js
+++ b/src/models/Photo.js
@@ -1,3 +1,4 @@
+import { photos } from "inaturalistjs";
 import { Platform } from "react-native";
 
 class Photo {
@@ -14,6 +15,16 @@ class Photo {
 
   static setPlatformSpecificFilePath( uri ) {
     return Platform.OS === "android" ? "file://" + uri : uri;
+  }
+
+  static mapPlainObjectForObsEdit( photo ) {
+    return {
+      id: photo.id,
+      attribution: photo.attribution,
+      license_code: photo.license_code,
+      url: photo.url,
+      localFilePath: photo.localFilePath
+    };
   }
 
   static schema = {

--- a/src/models/Taxon.js
+++ b/src/models/Taxon.js
@@ -28,6 +28,16 @@ class Taxon {
     };
   }
 
+  static mapPlainObjectForObsEdit( taxon ) {
+    return {
+      id: taxon.id,
+      default_photo: taxon.default_photo,
+      name: taxon.name,
+      preferred_common_name: taxon.preferred_common_name,
+      rank: taxon.rank
+    };
+  }
+
   static uri = ( item ) => ( item && item.default_photo ) && { uri: item.default_photo.url };
 
   static schema = {

--- a/src/models/Taxon.js
+++ b/src/models/Taxon.js
@@ -1,5 +1,7 @@
+import Realm from "realm";
+
 import Photo from "./Photo";
-class Taxon {
+class Taxon extends Realm.Object {
   static TAXON_FIELDS = {
     default_photo: {
       url: true,
@@ -25,16 +27,6 @@ class Taxon {
     return {
       ...taxon,
       default_photo: Photo.mapApiToRealm( taxon.default_photo )
-    };
-  }
-
-  static mapPlainObjectForObsEdit( taxon ) {
-    return {
-      id: taxon.id,
-      default_photo: taxon.default_photo,
-      name: taxon.name,
-      preferred_common_name: taxon.preferred_common_name,
-      rank: taxon.rank
     };
   }
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,4 +1,6 @@
-class User {
+import Realm from "realm";
+
+class User extends Realm.Object {
   static USER_FIELDS = {
     icon_url: true,
     id: true,

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -20,9 +20,19 @@ export default {
     Taxon,
     User
   ],
-  schemaVersion: 20,
+  schemaVersion: 21,
   path: "db.realm",
   migration: ( oldRealm: any, newRealm: any ) => {
+    if ( oldRealm.schemaVersion < 21 ) {
+      const oldObservations = oldRealm.objects( "Observation" );
+      const newObservations = newRealm.objects( "Observation" );
+
+      for ( const objectIndex in oldObservations ) {
+        const oldObservation = oldObservations[objectIndex];
+        const newObservation = newObservations[objectIndex];
+        newObservation.captive_flag = oldObservation.captive;
+      }
+    }
     if ( oldRealm.schemaVersion < 16 ) {
       const oldObservations = oldRealm.objects( "Observation" );
       const newObservations = newRealm.objects( "Observation" );

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -102,16 +102,11 @@ const ObsEditProvider = ( { children }: Props ): Node => {
   };
 
   const openSavedObservation = async ( savedUUID ) => {
-    try {
-      const realm = await Realm.open( realmConfig );
-      const obs = realm.objectForPrimaryKey( "Observation", savedUUID );
-      const plainObject = obs.toJSON( );
-      setObservations( [plainObject] );
-      return obs;
-    } catch ( e ) {
-      console.log( e, "couldn't open saved observation in realm" );
-      return null;
-    }
+    const realm = await Realm.open( realmConfig );
+    const obs = realm.objectForPrimaryKey( "Observation", savedUUID );
+    const plainObject = obs.toJSON( );
+    setObservations( [plainObject] );
+    return obs;
   };
 
   const obsEditValue = {

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -105,7 +105,8 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     try {
       const realm = await Realm.open( realmConfig );
       const obs = realm.objectForPrimaryKey( "Observation", savedUUID );
-      setObservations( [obs] );
+      const plainObject = Observation.mapPlainObjectForObsEdit( obs );
+      setObservations( [plainObject] );
       return obs;
     } catch ( e ) {
       console.log( e, "couldn't open saved observation in realm" );

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -105,7 +105,7 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     try {
       const realm = await Realm.open( realmConfig );
       const obs = realm.objectForPrimaryKey( "Observation", savedUUID );
-      const plainObject = Observation.mapPlainObjectForObsEdit( obs );
+      const plainObject = obs.toJSON( );
       setObservations( [plainObject] );
       return obs;
     } catch ( e ) {

--- a/src/providers/uploadHelpers/resizeImage.js
+++ b/src/providers/uploadHelpers/resizeImage.js
@@ -4,7 +4,6 @@ import RNFS from "react-native-fs";
 const photoUploadPath = `${RNFS.DocumentDirectoryPath}/photoUploads`;
 
 const resizeImage = async ( path, width, height? ) => {
-  console.log( path, "path for resizing image, android" );
   await RNFS.mkdir( photoUploadPath );
   try {
     const { uri } = await ImageResizer.createResizedImage(

--- a/src/providers/uploadHelpers/saveLocalObservation.js
+++ b/src/providers/uploadHelpers/saveLocalObservation.js
@@ -8,6 +8,7 @@ import Observation from "../../models/Observation";
 const saveLocalObservation = async ( currentObs: Object ): Promise<any> => {
   try {
     const realm = await Realm.open( realmConfig );
+
     return await Observation.saveLocalObservationForUpload( currentObs, realm );
   } catch ( e ) {
     console.log( e, "couldn't save observation locally" );

--- a/src/providers/uploadHelpers/saveLocalObservation.js
+++ b/src/providers/uploadHelpers/saveLocalObservation.js
@@ -6,14 +6,8 @@ import realmConfig from "../../models/index";
 import Observation from "../../models/Observation";
 
 const saveLocalObservation = async ( currentObs: Object ): Promise<any> => {
-  try {
-    const realm = await Realm.open( realmConfig );
-
-    return await Observation.saveLocalObservationForUpload( currentObs, realm );
-  } catch ( e ) {
-    console.log( e, "couldn't save observation locally" );
-    return null;
-  }
+  const realm = await Realm.open( realmConfig );
+  return await Observation.saveLocalObservationForUpload( currentObs, realm );
 };
 
 export default saveLocalObservation;


### PR DESCRIPTION
When a saved Realm observation is opened for ObsEdit, this PR converts that observation into a plain JS object for editing. The plain JS object can be saved as a modified object with an updated `_updated_at` timestamp.

ObsList checks to see if there are any observations which have been modified since the last `_synced_at` date and shows the correct number of observations to upload in the bottom upload modal.

This also makes ObsEdit more readable by breaking out the top section into a separate `EvidenceSection` component.