### PR TITLE
Consolidate API URL config into .env

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,5 +1,8 @@
 # Base URL for the iNat API
-API_URL=https://www.inaturalist.org
+API_URL=https://api.inaturalist.org/v2
+
+# Base URL for the iNat API used for OAUTH
+OAUTH_API_URL=https://www.inaturalist.org
 
 # Javascript Web Token for anonymous access to protected iNat API endpoints
 JWT_ANONYMOUS_API_SECRET=some-secret

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import "react-native-gesture-handler";
 
 import { AppRegistry } from "react-native";
 import inatjs from "inaturalistjs";
+import Config from "react-native-config";
 import App from "./src/navigation/rootNavigation";
 import {name as appName} from "./app.json";
 import "./src/i18n";
@@ -11,24 +12,10 @@ import { startNetworkLogging } from "react-native-network-logger";
 
 startNetworkLogging();
 
-// inatjs.setConfig( {
-//   apiURL: "https://stagingapi.inaturalist.org/v1",
-//   writeApiURL: "https://stagingapi.inaturalist.org/v1"
-// } );
-
+// Configure inatjs to use the chosen URLs
 inatjs.setConfig( {
-  apiURL: "https://stagingapi.inaturalist.org/v2",
-  writeApiURL: "https://stagingapi.inaturalist.org/v2"
+  apiURL: Config.API_URL,
+  writeApiURL: Config.API_URL
 } );
-
-// inatjs.setConfig( {
-//   apiURL: "https://api.inaturalist.org/v2",
-//   writeApiURL: "https://api.inaturalist.org/v2"
-// } );
-
-// inatjs.setConfig( {
-//   apiURL: "https://api.inaturalist.org/v1",
-//   writeApiURL: "https://api.inaturalist.org/v1"
-// } );
 
 AppRegistry.registerComponent( appName, ( ) => App );

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -536,9 +536,9 @@ SPEC CHECKSUMS:
   FBLazyVector: f7b0632c6437e312acf6349288d9aa4cb6d59030
   FBReactNativeSpec: 0f4e1f4cfeace095694436e7c7fcc5bf4b03a0ff
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   Permission-LocationWhenInUse: 006c85c8de0c05b5d8be8e8029e4f6b813270293
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 0aa6c1c27e1d65920df35ceea5341a5fe76bdb79
   RCTTypeSafety: d76a59d00632891e11ed7522dba3fd1a995e573a
   React: ab8c09da2e7704f4b3ebad4baa6cfdfcc852dcb5

--- a/src/components/LoginSignUp/AuthenticationService.js
+++ b/src/components/LoginSignUp/AuthenticationService.js
@@ -10,7 +10,7 @@ import {getBuildNumber, getDeviceType, getSystemName, getSystemVersion, getVersi
 
 // Base API domain can be overridden (in case we want to use staging URL) - either by placing it in .env file, or
 // in an environment variable.
-const HOST = Config.API_URL || process.env.API_URL || "https://www.inaturalist.org";
+const HOST = Config.OAUTH_API_URL || process.env.OAUTH_API_URL || "https://www.inaturalist.org";
 
 // User agent being used, when calling the iNat APIs
 const USER_AGENT = `iNaturalistRN/${getVersion()} ${getDeviceType()} (Build ${getBuildNumber()}) ${getSystemName()}/${getSystemVersion()}`;


### PR DESCRIPTION
It was bugging me that we specified API URLs in multiple places. This will make it easier to find where those values are. Note that you have to update your `.env` file to get this branch to work correctly. See `env.example`.