### PR TITLE
Delete user JWT on 401 error

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -536,9 +536,9 @@ SPEC CHECKSUMS:
   FBLazyVector: f7b0632c6437e312acf6349288d9aa4cb6d59030
   FBReactNativeSpec: 0f4e1f4cfeace095694436e7c7fcc5bf4b03a0ff
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
   Permission-LocationWhenInUse: 006c85c8de0c05b5d8be8e8029e4f6b813270293
-  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
+  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
   RCTRequired: 0aa6c1c27e1d65920df35ceea5341a5fe76bdb79
   RCTTypeSafety: d76a59d00632891e11ed7522dba3fd1a995e573a
   React: ab8c09da2e7704f4b3ebad4baa6cfdfcc852dcb5

--- a/src/components/LoginSignUp/AuthenticationService.js
+++ b/src/components/LoginSignUp/AuthenticationService.js
@@ -97,6 +97,11 @@ const getJWTToken = async ( allowAnonymousJWTToken: boolean = false ): Promise<?
     const response = await api.get( "/users/api_token.json" );
 
     if ( !response.ok ) {
+      // this deletes the user JWT and saved login details when a user is not actually signed in anymore
+      // for example, if they installed, deleted, and reinstalled the app without logging out
+      if ( response.status === 401 ) {
+        signOut( );
+      }
       console.error(
         `Error while renewing JWT: ${response.problem} - ${response.status}`
       );


### PR DESCRIPTION
This treats the user like they are signed out when encountering a 401 unauthorized error while fetching the JWT.