### PR TITLE
Enforce globalized text with eslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,10 +6,7 @@ module.exports = {
     "comma-dangle": [2, "never"],
     "space-in-parens": [2, "always"],
     "prettier/prettier": 0,
-    "no-var": 1,
-    // TODO: remove this line once we have image assets and no longer need
-    // placeholder text; better to enforce globalized text with errors, not warnings
-    "i18next/no-literal-string": 1
+    "no-var": 1
   },
   // need this so jest doesn't show as undefined in jest.setup.js
   env: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,15 @@
 module.exports = {
   root: true,
-  extends: "@react-native-community",
+  extends: ["@react-native-community", "plugin:i18next/recommended"],
   rules: {
     quotes: [2, "double"],
     "comma-dangle": [2, "never"],
     "space-in-parens": [2, "always"],
     "prettier/prettier": 0,
-    "no-var": 1
+    "no-var": 1,
+    // TODO: remove this line once we have image assets and no longer need
+    // placeholder text; better to enforce globalized text with errors, not warnings
+    "i18next/no-literal-string": 1
   },
   // need this so jest doesn't show as undefined in jest.setup.js
   env: {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -541,9 +541,9 @@ SPEC CHECKSUMS:
   FBLazyVector: f7b0632c6437e312acf6349288d9aa4cb6d59030
   FBReactNativeSpec: 0f4e1f4cfeace095694436e7c7fcc5bf4b03a0ff
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   Permission-LocationWhenInUse: 006c85c8de0c05b5d8be8e8029e4f6b813270293
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 0aa6c1c27e1d65920df35ceea5341a5fe76bdb79
   RCTTypeSafety: d76a59d00632891e11ed7522dba3fd1a995e573a
   React: ab8c09da2e7704f4b3ebad4baa6cfdfcc852dcb5

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-flowtype": "^7.0.0",
+        "eslint-plugin-i18next": "^6.0.0-2",
         "eslint-plugin-jest": "^26.1.3",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.29.4",
@@ -6085,6 +6086,18 @@
       },
       "peerDependencies": {
         "eslint": "^7.32.0"
+      }
+    },
+    "node_modules/eslint-plugin-i18next": {
+      "version": "6.0.0-2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.0.0-2.tgz",
+      "integrity": "sha512-3jm5ufmACjecaE/q6R3ZHhc3uzgx5ZMXoJhArZyg2tmBlk6AP/q1dfY12JWLFb4loNJdJPJncGCBOhG+cJsv9Q==",
+      "dev": true,
+      "dependencies": {
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint-plugin-jest": {
@@ -13577,6 +13590,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -17559,7 +17581,8 @@
     "@jsamr/react-native-li": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@jsamr/react-native-li/-/react-native-li-2.3.1.tgz",
-      "integrity": "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="
+      "integrity": "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==",
+      "requires": {}
     },
     "@native-html/css-processor": {
       "version": "1.11.0",
@@ -17614,12 +17637,14 @@
     "@react-native-community/cameraroll": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@react-native-community/cameraroll/-/cameraroll-4.1.2.tgz",
-      "integrity": "sha512-jkdhMByMKD2CZ/5MPeBieYn8vkCfC4MOTouPpBpps3I8N6HUYJk+1JnDdktVYl2WINnqXpQptDA2YptVyifYAg=="
+      "integrity": "sha512-jkdhMByMKD2CZ/5MPeBieYn8vkCfC4MOTouPpBpps3I8N6HUYJk+1JnDdktVYl2WINnqXpQptDA2YptVyifYAg==",
+      "requires": {}
     },
     "@react-native-community/checkbox": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@react-native-community/checkbox/-/checkbox-0.5.12.tgz",
-      "integrity": "sha512-Dd3eiAW7AkpRgndwKGdgQ6nNgEmZlVD8+KAOBqwjuZQ/M67BThXJ9Ni+ydpPjNm4e28KXmIILfkvhcDt0ZoFTQ=="
+      "integrity": "sha512-Dd3eiAW7AkpRgndwKGdgQ6nNgEmZlVD8+KAOBqwjuZQ/M67BThXJ9Ni+ydpPjNm4e28KXmIILfkvhcDt0ZoFTQ==",
+      "requires": {}
     },
     "@react-native-community/cli-debugger-ui": {
       "version": "6.0.0",
@@ -17798,7 +17823,8 @@
           "version": "22.4.1",
           "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz",
           "integrity": "sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "eslint-plugin-prettier": {
           "version": "3.1.2",
@@ -17830,12 +17856,14 @@
     "@react-native-community/netinfo": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-8.3.0.tgz",
-      "integrity": "sha512-VlmjD7Vg1BacbNhwuJCel1eeD8N2Ps6BEcZe9qoSoeIptpCbC86o4ZqD0meSjJzioKSvgalrkmPgMaVYsVipKw=="
+      "integrity": "sha512-VlmjD7Vg1BacbNhwuJCel1eeD8N2Ps6BEcZe9qoSoeIptpCbC86o4ZqD0meSjJzioKSvgalrkmPgMaVYsVipKw==",
+      "requires": {}
     },
     "@react-native-picker/picker": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.1.tgz",
-      "integrity": "sha512-1XWy3IQgwr7MWd30KdY1iUh2gQZD+JiotN1ifj/ptFUYKon/0UFwngKQaWCO/CP/FdLl20/huSSLwKedYrdMMA=="
+      "integrity": "sha512-1XWy3IQgwr7MWd30KdY1iUh2gQZD+JiotN1ifj/ptFUYKon/0UFwngKQaWCO/CP/FdLl20/huSSLwKedYrdMMA==",
+      "requires": {}
     },
     "@react-native/assets": {
       "version": "1.0.0",
@@ -17865,7 +17893,8 @@
     "@react-navigation/elements": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.3.tgz",
-      "integrity": "sha512-Lv2lR7si5gNME8dRsqz57d54m4FJtrwHRjNQLOyQO546ZxO+g864cSvoLC6hQedQU0+IJnPTsZiEI2hHqfpEpw=="
+      "integrity": "sha512-Lv2lR7si5gNME8dRsqz57d54m4FJtrwHRjNQLOyQO546ZxO+g864cSvoLC6hQedQU0+IJnPTsZiEI2hHqfpEpw==",
+      "requires": {}
     },
     "@react-navigation/native": {
       "version": "6.0.10",
@@ -18578,7 +18607,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -18876,7 +18906,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "requires": {}
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -19804,7 +19835,8 @@
     "date-fns-tz": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.3.tgz",
-      "integrity": "sha512-Gks46gwbSauBQnV3Oofluj1wTm8J0tM7sbSJ9P+cJq/ZnTCpMohTKmmO5Tn+jQ7dyn0+b8G7cY4O2DZ5P/LXcA=="
+      "integrity": "sha512-Gks46gwbSauBQnV3Oofluj1wTm8J0tM7sbSJ9P+cJq/ZnTCpMohTKmmO5Tn+jQ7dyn0+b8G7cY4O2DZ5P/LXcA==",
+      "requires": {}
     },
     "dayjs": {
       "version": "1.11.1",
@@ -20485,7 +20517,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-eslint-comments": {
       "version": "3.2.0",
@@ -20513,6 +20546,15 @@
       "requires": {
         "lodash": "^4.17.21",
         "string-natural-compare": "^3.0.1"
+      }
+    },
+    "eslint-plugin-i18next": {
+      "version": "6.0.0-2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.0.0-2.tgz",
+      "integrity": "sha512-3jm5ufmACjecaE/q6R3ZHhc3uzgx5ZMXoJhArZyg2tmBlk6AP/q1dfY12JWLFb4loNJdJPJncGCBOhG+cJsv9Q==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
       }
     },
     "eslint-plugin-jest": {
@@ -20577,7 +20619,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
       "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react-native": {
       "version": "4.0.0",
@@ -22812,7 +22855,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -23548,7 +23592,8 @@
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
           "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -25371,14 +25416,16 @@
         "ws": {
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+          "requires": {}
         }
       }
     },
     "react-freeze": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.0.tgz",
-      "integrity": "sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw=="
+      "integrity": "sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==",
+      "requires": {}
     },
     "react-i18next": {
       "version": "11.16.8",
@@ -25528,17 +25575,20 @@
     "react-native-config": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.4.5.tgz",
-      "integrity": "sha512-5oiAsoW88SOYDg/0cleJ2vJDqv98FJUbFQYEnH4sdMtEn3AAT3lb7BkTGW8HO/t3Vk9VOruwxUUnO4tzuxzCsw=="
+      "integrity": "sha512-5oiAsoW88SOYDg/0cleJ2vJDqv98FJUbFQYEnH4sdMtEn3AAT3lb7BkTGW8HO/t3Vk9VOruwxUUnO4tzuxzCsw==",
+      "requires": {}
     },
     "react-native-device-info": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-8.7.1.tgz",
-      "integrity": "sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg=="
+      "integrity": "sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg==",
+      "requires": {}
     },
     "react-native-dropdown-picker": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/react-native-dropdown-picker/-/react-native-dropdown-picker-5.4.0.tgz",
-      "integrity": "sha512-O5jlHb9+MRurVXNL3IrNK4f2HGODxYRoE1n+7MMA0NvrO0Mz7ICwrWZWC3qfbopTBy0ERjIWf+BRQiS2vFnaRQ=="
+      "integrity": "sha512-O5jlHb9+MRurVXNL3IrNK4f2HGODxYRoE1n+7MMA0NvrO0Mz7ICwrWZWC3qfbopTBy0ERjIWf+BRQiS2vFnaRQ==",
+      "requires": {}
     },
     "react-native-fs": {
       "version": "2.19.0",
@@ -25574,17 +25624,20 @@
     "react-native-image-pan-zoom": {
       "version": "2.1.12",
       "resolved": "https://registry.npmjs.org/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz",
-      "integrity": "sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q=="
+      "integrity": "sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==",
+      "requires": {}
     },
     "react-native-image-picker": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/react-native-image-picker/-/react-native-image-picker-4.8.4.tgz",
-      "integrity": "sha512-Mjh2j/sddyolb16EpmprWzbtyeFvW8Xgzr/8WNi9d6bR2FC/kL78cY/a+7Yzujg5ZDtT1MWys+eWw/qtfwgGiw=="
+      "integrity": "sha512-Mjh2j/sddyolb16EpmprWzbtyeFvW8Xgzr/8WNi9d6bR2FC/kL78cY/a+7Yzujg5ZDtT1MWys+eWw/qtfwgGiw==",
+      "requires": {}
     },
     "react-native-image-resizer": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/react-native-image-resizer/-/react-native-image-resizer-1.4.5.tgz",
-      "integrity": "sha512-33EgL3C9pyvjKpullAB6fWyD5QhoYEpNNB9rxNvUsrpAnL2mHBW7PTrUCCZudJeB6Weg7nbweKrSw1nnto5aqg=="
+      "integrity": "sha512-33EgL3C9pyvjKpullAB6fWyD5QhoYEpNNB9rxNvUsrpAnL2mHBW7PTrUCCZudJeB6Weg7nbweKrSw1nnto5aqg==",
+      "requires": {}
     },
     "react-native-jwt-io": {
       "version": "1.0.3",
@@ -25597,7 +25650,8 @@
     "react-native-localize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-native-localize/-/react-native-localize-2.2.1.tgz",
-      "integrity": "sha512-BuPaQWvxLZG1NrCDGqgAnecDrNQu3LED9/Pyl4H2LwTMHcEngXpE5PfVntW2GiLumdr6nUOkWmMnh8PynZqrsw=="
+      "integrity": "sha512-BuPaQWvxLZG1NrCDGqgAnecDrNQu3LED9/Pyl4H2LwTMHcEngXpE5PfVntW2GiLumdr6nUOkWmMnh8PynZqrsw==",
+      "requires": {}
     },
     "react-native-maps": {
       "version": "0.30.1",
@@ -25627,7 +25681,8 @@
     "react-native-network-logger": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/react-native-network-logger/-/react-native-network-logger-1.12.0.tgz",
-      "integrity": "sha512-3Esss/+caz0d53vuKOYS5i9YtNn76O2AvnKMwQovtXbpJs0Fc4oyJhNJ50YWNQBCKJ5aHqWUEYNE4Ryp5GLmeQ=="
+      "integrity": "sha512-3Esss/+caz0d53vuKOYS5i9YtNn76O2AvnKMwQovtXbpJs0Fc4oyJhNJ50YWNQBCKJ5aHqWUEYNE4Ryp5GLmeQ==",
+      "requires": {}
     },
     "react-native-paper": {
       "version": "4.12.1",
@@ -25656,14 +25711,16 @@
         "react-native-iphone-x-helper": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
-          "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
+          "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+          "requires": {}
         }
       }
     },
     "react-native-permissions": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.3.1.tgz",
-      "integrity": "sha512-Ap9nVWBWJ7lyU6Ye3Qltm2V+Ut6XjDcs+6ZBmK1UUxcCoSSGx/mQg2GbMJLjlnoVtUgVHR3IhyZ0mN9DlMPRFQ=="
+      "integrity": "sha512-Ap9nVWBWJ7lyU6Ye3Qltm2V+Ut6XjDcs+6ZBmK1UUxcCoSSGx/mQg2GbMJLjlnoVtUgVHR3IhyZ0mN9DlMPRFQ==",
+      "requires": {}
     },
     "react-native-picker-select": {
       "version": "8.0.4",
@@ -25677,7 +25734,8 @@
         "@react-native-picker/picker": {
           "version": "1.16.8",
           "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-1.16.8.tgz",
-          "integrity": "sha512-pacdQDX6V6EmjF+HoiIh6u++qx4mTK0WnhgUHRc01B+Qt5eoeUwseBqmqfTSXTx/aHDEd6PiIw7UGvKgFoqgFQ=="
+          "integrity": "sha512-pacdQDX6V6EmjF+HoiIh6u++qx4mTK0WnhgUHRc01B+Qt5eoeUwseBqmqfTSXTx/aHDEd6PiIw7UGvKgFoqgFQ==",
+          "requires": {}
         }
       }
     },
@@ -25714,7 +25772,8 @@
     "react-native-safe-area-context": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.2.4.tgz",
-      "integrity": "sha512-OOX+W2G4YYufvryonn6Kw6YnyT8ZThkxPHZBD04NLHaZmicUaaDVII/PZ3M5fD1o5N62+T+8K4bCS5Un2ggvkA=="
+      "integrity": "sha512-OOX+W2G4YYufvryonn6Kw6YnyT8ZThkxPHZBD04NLHaZmicUaaDVII/PZ3M5fD1o5N62+T+8K4bCS5Un2ggvkA==",
+      "requires": {}
     },
     "react-native-screens": {
       "version": "3.13.1",
@@ -25728,7 +25787,8 @@
     "react-native-sensitive-info": {
       "version": "6.0.0-alpha.9",
       "resolved": "https://registry.npmjs.org/react-native-sensitive-info/-/react-native-sensitive-info-6.0.0-alpha.9.tgz",
-      "integrity": "sha512-W2R1gUHgBAmy+wVl0BvA7s01SqqTitnG4Sdj2zmck0OS5a54kq+pTnXRqDljMa2NQs4Mue2IHyvd+Tf0X1ZL6Q=="
+      "integrity": "sha512-W2R1gUHgBAmy+wVl0BvA7s01SqqTitnG4Sdj2zmck0OS5a54kq+pTnXRqDljMa2NQs4Mue2IHyvd+Tf0X1ZL6Q==",
+      "requires": {}
     },
     "react-native-uuid": {
       "version": "2.0.1",
@@ -25768,7 +25828,8 @@
     "react-native-vision-camera": {
       "version": "2.13.3",
       "resolved": "https://registry.npmjs.org/react-native-vision-camera/-/react-native-vision-camera-2.13.3.tgz",
-      "integrity": "sha512-aikp6kNmb9b8lsVFKEKCBgch5h93Cs8Qqw/bSZsn/dO+Qa4uktpe89WIO1VTs88d40vJiLeYFlbyWe589E/UuA=="
+      "integrity": "sha512-aikp6kNmb9b8lsVFKEKCBgch5h93Cs8Qqw/bSZsn/dO+Qa4uktpe89WIO1VTs88d40vJiLeYFlbyWe589E/UuA==",
+      "requires": {}
     },
     "react-refresh": {
       "version": "0.4.3",
@@ -26118,6 +26179,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -27562,7 +27629,8 @@
     "use-debounce": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
-      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q=="
+      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==",
+      "requires": {}
     },
     "use-subscription": {
       "version": "1.7.0",
@@ -27575,7 +27643,8 @@
     "use-sync-external-store": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
-      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ=="
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "requires": {}
     },
     "utf8": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-flowtype": "^7.0.0",
+    "eslint-plugin-i18next": "^6.0.0-2",
     "eslint-plugin-jest": "^26.1.3",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.4",

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,13 +1,11 @@
 // @flow
 
 import React from "react";
-import {
-  Text
-} from "react-native";
 import { getVersion, getBuildNumber } from "react-native-device-info";
 
 import type { Node } from "react";
 import ViewWithFooter from "./SharedComponents/ViewWithFooter";
+import PlaceholderText from "./PlaceholderText";
 
 const AboutScreen = ( ): Node => {
   const appVersion = getVersion( );
@@ -15,10 +13,7 @@ const AboutScreen = ( ): Node => {
 
   return (
     <ViewWithFooter>
-      <Text>
-        app version:
-        {` ${appVersion} (${buildVersion})`}
-      </Text>
+      <PlaceholderText text={`app version: ${appVersion} (${buildVersion})`} />
     </ViewWithFooter>
   );
 };

--- a/src/components/Camera/CameraOptionsModal.js
+++ b/src/components/Camera/CameraOptionsModal.js
@@ -1,8 +1,9 @@
 // @flow
 
 import * as React from "react";
-import { Text, View, Pressable } from "react-native";
+import { View, Pressable } from "react-native";
 import { useNavigation } from "@react-navigation/native";
+import { Avatar } from "react-native-paper";
 
 import { textStyles, viewStyles } from "../../styles/sharedComponents/modal";
 import { ObsEditContext } from "../../providers/contexts";
@@ -52,27 +53,27 @@ const CameraOptionsModal = ( { closeModal }: Props ): React.Node => {
        <Pressable
         onPress={navToStandardCamera}
       >
-        <Text style={textStyles.whiteText}>take photo with camera</Text>
+        <Avatar.Icon size={40} icon="camera" />
       </Pressable>
       {!currentObs && (
         <Pressable
           onPress={navToPhotoGallery}
         >
-          <Text style={textStyles.whiteText}>upload photo from gallery</Text>
+          <Avatar.Icon size={40} icon="folder-multiple-image" />
         </Pressable>
       )}
       {!hasSound && (
         <Pressable
           onPress={navToSoundRecorder}
         >
-          <Text style={textStyles.whiteText}>record a sound</Text>
+          <Avatar.Icon size={40} icon="microphone" />
         </Pressable>
       )}
       {!currentObs && (
         <Pressable
           onPress={navToObsEdit}
         >
-          <Text style={textStyles.whiteText}>submit without evidence</Text>
+          <Avatar.Icon size={40} icon="square-edit-outline" />
         </Pressable>
       )}
     </View>

--- a/src/components/Camera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera.js
@@ -7,6 +7,7 @@ import type { Node } from "react";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { Avatar } from "react-native-paper";
 import Realm from "realm";
+import { t } from "i18next";
 
 import { viewStyles } from "../../styles/camera/standardCamera";
 import { ObsEditContext } from "../../providers/contexts";
@@ -101,7 +102,7 @@ const StandardCamera = ( ): Node => {
           style={viewStyles.nextButton}
           onPress={navToObsEdit}
         >
-          <Text style={textStyles.whiteText}>next</Text>
+          <Text style={textStyles.whiteText}>{t( "Next" )}</Text>
         </Pressable>
       </View>
     </View>

--- a/src/components/Explore/FiltersIcon.js
+++ b/src/components/Explore/FiltersIcon.js
@@ -1,8 +1,9 @@
 // @flow
 
 import * as React from "react";
-import { Text, Pressable } from "react-native";
+import { Pressable } from "react-native";
 import { useNavigation } from "@react-navigation/native";
+import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 
 import { viewStyles } from "../../styles/observations/messagesIcon";
 
@@ -15,7 +16,7 @@ const FiltersIcon = ( ): React.Node => {
       onPress={navToExploreFilters}
       style={viewStyles.messages}
     >
-      <Text>filters</Text>
+      <Icon name="filter-variant" size={35} />
     </Pressable>
   );
 };

--- a/src/components/Identify/CardSwipeView.js
+++ b/src/components/Identify/CardSwipeView.js
@@ -9,6 +9,7 @@ import { viewStyles, imageStyles, textStyles } from "../../styles/identify/ident
 import Observation from "../../models/Observation";
 import markAsReviewed from "./helpers/markAsReviewed";
 import createIdentification from "./helpers/createIdentification";
+import PlaceholderText from "../PlaceholderText";
 
 type Props = {
   loading: boolean,
@@ -39,8 +40,8 @@ const CardSwipeView = ( { loading, observationList, testID }: Props ): Node => {
 
   return (
     <View style={viewStyles.cardContainer}>
-      <Text>Swipe left to mark as reviewed.</Text>
-      <Text>Swipe right to agree.</Text>
+      <PlaceholderText text="Swipe left to mark as reviewed." />
+      <PlaceholderText text="Swipe right to agree." />
       {observationList.map( obs => {
         const commonName = obs.taxon && obs.taxon.preferred_common_name;
         const name = obs.taxon ? obs.taxon.name : "unknown";

--- a/src/components/LoginSignUp/SignUp.js
+++ b/src/components/LoginSignUp/SignUp.js
@@ -1,8 +1,9 @@
-// @flow strict-local
+// @flow
 
 import React, { useState } from "react";
 import { Button, Text, TextInput, View } from "react-native";
 import type { Node } from "react";
+import { t } from "i18next";
 
 import { viewStyles, textStyles } from "../../styles/login/login";
 import { registerUser } from "./AuthenticationService";
@@ -24,9 +25,9 @@ const SignUp = (): Node => {
 
   return (
     <View>
-      <Text style={textStyles.text}>Sign Up</Text>
+      <Text style={textStyles.text}>{t( "Sign-Up" )}</Text>
 
-      <Text style={textStyles.text}>Email</Text>
+      <Text style={textStyles.text}>{t( "Email" )}</Text>
       <TextInput
         style={viewStyles.input}
         onChangeText={setEmail}
@@ -34,14 +35,14 @@ const SignUp = (): Node => {
         autoComplete="email"
       />
 
-      <Text style={textStyles.text}>Username</Text>
+      <Text style={textStyles.text}>{t( "Username" )}</Text>
       <TextInput
         style={viewStyles.input}
         onChangeText={setUsername}
         value={username}
       />
 
-      <Text style={textStyles.text}>Password</Text>
+      <Text style={textStyles.text}>{t( "Password" )}</Text>
       <TextInput
         style={viewStyles.input}
         onChangeText={setPassword}

--- a/src/components/ObsDetails/ActivityItem.js
+++ b/src/components/ObsDetails/ActivityItem.js
@@ -11,6 +11,7 @@ import Taxon from "../../models/Taxon";
 import User from "../../models/User";
 import KebabMenu from "./KebabMenu";
 import { timeAgo } from "../../sharedHelpers/dateAndTime";
+import PlaceholderText from "../PlaceholderText";
 
 type Props = {
   item: Object,
@@ -47,12 +48,12 @@ const ActivityItem = ( { item, navToTaxonDetails, handlePress, toggleRefetch }: 
           </Pressable>
         )}
         <View style={viewStyles.labels}>
-          {item.vision && <Text style={textStyles.labels}>vision</Text>}
+          {item.vision && <PlaceholderText style={[textStyles.labels]} text="vision" />}
           <Text style={textStyles.labels}>{item.category}</Text>
           {item.created_at && <Text style={textStyles.labels}>{timeAgo( item.created_at )}</Text>}
           {item.body && currentUser
             ? <KebabMenu uuid={item.uuid} toggleRefetch={toggleRefetch} />
-            : <Text>menu</Text>}
+            : <PlaceholderText text="menu" />}
         </View>
       </View>
       {taxon && (

--- a/src/components/ObsDetails/ActivityTab.js
+++ b/src/components/ObsDetails/ActivityTab.js
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { View, Text } from "react-native";
+import { t } from "i18next";
 
 import ActivityItem from "./ActivityItem";
 
@@ -15,7 +16,7 @@ type Props = {
 
 const ActivityTab = ( { comments, ids, navToTaxonDetails, navToUserProfile, toggleRefetch }: Props ): React.Node => {
   if ( comments.length === 0 && ids.length === 0 ) {
-    return <Text>no comments or ids to display</Text>;
+    return <Text>{t( "No-comments-or-ids-to-display" )}</Text>;
   }
 
   const activityItems = ids.concat( comments )

--- a/src/components/ObsDetails/DataTab.js
+++ b/src/components/ObsDetails/DataTab.js
@@ -51,8 +51,8 @@ const DataTab = ( { observation }: Props ): Node => {
         {checkCamelAndSnakeCase( observation, "placeGuess" )}
       </Text>
       <Text style={textStyles.dataTabText}>{t( "Date" )}</Text>
-      <Text style={textStyles.dataTabText}>{`${t( "Date-observed" )} ${displayTimeObserved( )}`}</Text>
-      <Text style={textStyles.dataTabText}>{`${t( "Date-uploaded" )} ${observation._synced_at}`}</Text>
+      <Text style={textStyles.dataTabText}>{`${t( "Date-observed-colon" )} ${displayTimeObserved( )}`}</Text>
+      <Text style={textStyles.dataTabText}>{`${t( "Date-uploaded-colon" )} ${observation._synced_at}`}</Text>
       <Text style={textStyles.dataTabText}>{t( "Projects" )}</Text>
       {/* TODO: create a custom dropdown that doesn't use FlatList */}
       <DropdownPicker

--- a/src/components/ObsDetails/DataTab.js
+++ b/src/components/ObsDetails/DataTab.js
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { View, Text } from "react-native";
 import type { Node } from "react";
+import { t } from "i18next";
 
 import { textStyles } from "../../styles/obsDetails/obsDetails";
 import Map from "../SharedComponents/Map";
@@ -39,7 +40,7 @@ const DataTab = ( { observation }: Props ): Node => {
 
   return (
     <View>
-      <Text style={textStyles.dataTabText}>Notes</Text>
+      <Text style={textStyles.dataTabText}>{t( "Notes" )}</Text>
       <Text style={textStyles.dataTabText}>{observation.description || "no description"}</Text>
       <Map
         obsLatitude={observation.latitude}
@@ -49,10 +50,10 @@ const DataTab = ( { observation }: Props ): Node => {
       <Text style={textStyles.dataTabText}>
         {checkCamelAndSnakeCase( observation, "placeGuess" )}
       </Text>
-      <Text style={textStyles.dataTabText}>Date</Text>
-      <Text style={textStyles.dataTabText}>{`date observed ${displayTimeObserved( )}`}</Text>
-      <Text style={textStyles.dataTabText}>{`date created ${observation._created_at}`}</Text>
-      <Text style={textStyles.dataTabText}>Projects</Text>
+      <Text style={textStyles.dataTabText}>{t( "Date" )}</Text>
+      <Text style={textStyles.dataTabText}>{`${t( "Date-observed" )} ${displayTimeObserved( )}`}</Text>
+      <Text style={textStyles.dataTabText}>{`${t( "Date-uploaded" )} ${observation._synced_at}`}</Text>
+      <Text style={textStyles.dataTabText}>{t( "Projects" )}</Text>
       {/* TODO: create a custom dropdown that doesn't use FlatList */}
       <DropdownPicker
         searchQuery={project}
@@ -61,12 +62,11 @@ const DataTab = ( { observation }: Props ): Node => {
         sources="projects"
         value={projectId}
       />
-      <Text style={textStyles.dataTabText}>Observation Fields & Annotations</Text>
-      <Text style={textStyles.dataTabText}>Other Data</Text>
+      <Text style={textStyles.dataTabText}>{t( "Other-Data" )}</Text>
       {attribution && <Text style={textStyles.dataTabText}>{attribution}</Text>}
       {application && (
         <>
-          <Text style={textStyles.dataTabText}>This observation was created using:</Text>
+          <Text style={textStyles.dataTabText}>{t( "This-observation-was-created-using" )}</Text>
           <Text style={textStyles.dataTabText}>{application}</Text>
         </>
       )}

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -6,6 +6,7 @@ import { Text, View, Image, Pressable, ScrollView, LogBox } from "react-native";
 import type { Node } from "react";
 import ViewWithFooter from "../SharedComponents/ViewWithFooter";
 import { useNavigation, useRoute } from "@react-navigation/native";
+import { t } from "i18next";
 
 import { viewStyles, textStyles } from "../../styles/obsDetails/obsDetails";
 import ActivityTab from "./ActivityTab";
@@ -79,7 +80,7 @@ const ObsDetails = ( ): Node => {
   };
 
   const showTaxon = ( ) => {
-    if ( !taxon ) { return <Text>unknown organism</Text>; }
+    if ( !taxon ) { return <Text>{t( "Unknown-organism" )}</Text>; }
     return (
       <>
        <Image source={Taxon.uri( taxon )} style={viewStyles.imageBackground} />

--- a/src/components/ObsEdit/BottomModal.js
+++ b/src/components/ObsEdit/BottomModal.js
@@ -1,13 +1,14 @@
 // @flow
 
 import React, { useContext } from "react";
-import { Text, View } from "react-native";
+import { View } from "react-native";
 import type { Node } from "react";
 import { useNavigation } from "@react-navigation/native";
 
 import { viewStyles } from "../../styles/obsEdit/obsEdit";
 import RoundGreenButton from "../SharedComponents/Buttons/RoundGreenButton";
 import { ObsEditContext } from "../../providers/contexts";
+import PlaceholderText from "../PlaceholderText";
 
 const BottomModal = ( ): Node => {
   const navigation = useNavigation( );
@@ -29,8 +30,7 @@ const BottomModal = ( ): Node => {
 
   return (
     <View style={viewStyles.bottomModal}>
-      <Text>cancel creating observations?</Text>
-      <Text>by exiting...</Text>
+      <PlaceholderText text="cancel creating observations?" />
       <View style={viewStyles.row}>
         <View style={viewStyles.saveButton}>
           <RoundGreenButton

--- a/src/components/ObsEdit/CVSuggestions.js
+++ b/src/components/ObsEdit/CVSuggestions.js
@@ -15,6 +15,7 @@ import RoundGreenButton from "../SharedComponents/Buttons/RoundGreenButton";
 import useRemoteObsEditSearchResults from "../../sharedHooks/useRemoteSearchResults";
 import { useLoggedIn } from "../../sharedHooks/useLoggedIn";
 import PhotoCarousel from "../SharedComponents/PhotoCarousel";
+import PlaceholderText from "../PlaceholderText";
 
 const CVSuggestions = ( ): Node => {
   const {
@@ -38,11 +39,11 @@ const CVSuggestions = ( ): Node => {
     return (
       <View>
         <Pressable onPress={navToTaxonDetails}>
-          <Text>info</Text>
+          <PlaceholderText text="info" />
         </Pressable>
-        <Text>compare tool</Text>
+        <PlaceholderText text="compare tool" />
         <Pressable onPress={updateIdentification}>
-          <Text>confirm id</Text>
+          <PlaceholderText text="confirm id" />
         </Pressable>
       </View>
     );
@@ -65,7 +66,8 @@ const CVSuggestions = ( ): Node => {
         <View style={viewStyles.obsDetailsColumn}>
           <Text style={textStyles.text}>{taxon.preferred_common_name}</Text>
           <Text style={textStyles.text}>{taxon.name}</Text>
-          {showSeenNearby && <Text style={textStyles.greenText}>seen nearby</Text>}
+          {showSeenNearby
+            && <PlaceholderText style={[textStyles.greenText]} text="seen nearby" />}
         </View>
         {renderNavButtons( updateIdentification, taxon.id )}
       </View>
@@ -102,9 +104,9 @@ const CVSuggestions = ( ): Node => {
 
   const emptySuggestionsList = ( ) => {
     if ( !isLoggedIn ) {
-      return <Text style={textStyles.explainerText}>you must be logged in to see computer vision suggestions</Text>;
+      return <PlaceholderText style={[textStyles.explainerText]} text="you must be logged in to see computer vision suggestions" />;
     } else if ( status === "no_results" ) {
-      return <Text style={textStyles.explainerText}>no computervision suggestions found</Text>;
+      return <PlaceholderText style={[textStyles.explainerText]} text="no computervision suggestions found" />;
     } else {
       return <ActivityIndicator />;
     }

--- a/src/components/ObsEdit/IdentificationSection.js
+++ b/src/components/ObsEdit/IdentificationSection.js
@@ -11,6 +11,7 @@ import RoundGreenButton from "../SharedComponents/Buttons/RoundGreenButton";
 import { textStyles, viewStyles } from "../../styles/obsEdit/obsEdit";
 import { iconicTaxaIds, iconicTaxaNames } from "../../dictionaries/iconicTaxaIds";
 import { ObsEditContext } from "../../providers/contexts";
+import PlaceholderText from "../PlaceholderText";
 
 const IdentificationSection = ( ): Node => {
   const {
@@ -61,7 +62,7 @@ const IdentificationSection = ( ): Node => {
           <Pressable
             onPress={navToSuggestionsPage}
           >
-            <Text style={textStyles.text}>edit</Text>
+            <PlaceholderText text="edit" style={[textStyles.text]} />
           </Pressable>
         </View>
       );

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -7,6 +7,7 @@ import type { Node } from "react";
 import { useTranslation } from "react-i18next";
 import { HeaderBackButton } from "@react-navigation/elements";
 import { Headline, Portal, Modal } from "react-native-paper";
+import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 
 import ScrollNoFooter from "../SharedComponents/ScrollNoFooter";
 import RoundGreenButton from "../SharedComponents/Buttons/RoundGreenButton";
@@ -70,7 +71,7 @@ const ObsEdit = ( ): Node => {
                 <Pressable
                   onPress={showPrevObservation}
                 >
-                  <Text>previous obs</Text>
+                  <Icon name="arrow-left" size={35} />
                 </Pressable>
               )}
               <Text>{`${currentObsIndex + 1} of ${observations.length}`}</Text>
@@ -78,7 +79,7 @@ const ObsEdit = ( ): Node => {
                 <Pressable
                   onPress={showNextObservation}
                 >
-                  <Text>next obs</Text>
+                  <Icon name="arrow-right" size={35} />
                 </Pressable>
               )}
             </View>
@@ -141,7 +142,6 @@ const ObsEdit = ( ): Node => {
         <IdentificationSection />
         <Headline style={textStyles.headerText}>{t( "Other-Data" )}</Headline>
         <OtherDataSection />
-        {!isLoggedIn && <Text style={textStyles.text}>you must be logged in to upload observations</Text>}
         <View style={viewStyles.row}>
           <View style={viewStyles.saveButton}>
             <RoundGreenButton

--- a/src/components/ObsEdit/OtherDataSection.js
+++ b/src/components/ObsEdit/OtherDataSection.js
@@ -76,7 +76,7 @@ const OtherDataSection = ( ): Node => {
         />
       </View>
       <View style={viewStyles.row}>
-        <Text style={textStyles.text}>is the organism wild?</Text>
+        <Text style={textStyles.text}>{t( "Organism-is-wild" )}</Text>
         <RNPickerSelect
           onValueChange={updateCaptiveStatus}
           items={captiveOptions}

--- a/src/components/Observations/ObsList.js
+++ b/src/components/Observations/ObsList.js
@@ -14,6 +14,7 @@ import RoundGreenButton from "../SharedComponents/Buttons/RoundGreenButton";
 import uploadObservation from "../../providers/uploadHelpers/uploadObservation";
 import Observation from "../../models/Observation";
 import useObservations from "./hooks/useObservations";
+import { t } from "i18next";
 
 const ObsList = ( ): Node => {
   const { params } = useRoute( );
@@ -41,7 +42,7 @@ const ObsList = ( ): Node => {
 
     return (
       <>
-        <Text>Whenever you get internet connection, you can sync your observations to iNaturalist.</Text>
+        <Text>{t( "Whenever-you-get-internet-connection-you-can-upload" )}</Text>
         <RoundGreenButton
           buttonText="Upload-X-Observations"
           count={obsToUpload.length}

--- a/src/components/PhotoLibrary/PhotoGallery.js
+++ b/src/components/PhotoLibrary/PhotoGallery.js
@@ -4,6 +4,7 @@ import React, { useContext, useEffect } from "react";
 import { Pressable, Image, FlatList, ActivityIndicator, View, Text } from "react-native";
 import type { Node } from "react";
 import { useNavigation } from "@react-navigation/native";
+import { t } from "i18next";
 
 import { imageStyles, viewStyles } from "../../styles/photoLibrary/photoGallery";
 import PhotoGalleryHeader from "./PhotoGalleryHeader";
@@ -126,7 +127,7 @@ const PhotoGallery = ( ): Node => {
     if ( fetchingPhotos ) {
       return <ActivityIndicator />;
     } else {
-      return <Text>no photos found. if this is your first time opening the app and giving permissions, try restarting the app.</Text>;
+      return <Text>{t( "No-photos-found" )}</Text>;
     }
   };
 

--- a/src/components/PlaceholderComponent.js
+++ b/src/components/PlaceholderComponent.js
@@ -1,13 +1,13 @@
 // @flow
 
 import React from "react";
-import { Text } from "react-native";
 import ViewWithFooter from "./SharedComponents/ViewWithFooter";
 import type { Node } from "react";
+import PlaceholderText from "./PlaceholderText";
 
 const PlaceholderComponent = ( ): Node => (
   <ViewWithFooter>
-    <Text>placeholder, accessible from left side menu</Text>
+    <PlaceholderText text="placeholder, accessible from left side menu" />
   </ViewWithFooter>
 );
 

--- a/src/components/PlaceholderText.js
+++ b/src/components/PlaceholderText.js
@@ -1,0 +1,20 @@
+// @flow
+
+import React from "react";
+import { Text } from "react-native";
+import type { Node } from "react";
+
+type Props = {
+  text: string,
+  style?: Array<Object>
+}
+
+const PlaceholderText = ( { text, style }: Props ): Node => (
+  // eslint-disable-next-line react-native/no-inline-styles
+  <Text style={[{ color: "red", textTransform: "uppercase", fontSize: 30 }].concat( style )}>
+    { text }
+  </Text>
+);
+
+
+export default PlaceholderText;

--- a/src/components/Projects/ProjectSearch.js
+++ b/src/components/Projects/ProjectSearch.js
@@ -1,9 +1,10 @@
 // @flow
 
 import * as React from "react";
-import { Pressable, Text } from "react-native";
+import { Pressable } from "react-native";
 
 import useRemoteSearchResults from "../../sharedHooks/useRemoteSearchResults";
+import PlaceholderText from "../PlaceholderText";
 import ProjectList from "./ProjectList";
 
 type Props = {
@@ -23,7 +24,7 @@ const ProjectSearch = ( { q, clearSearch }: Props ): React.Node => {
       <Pressable
         onPress={clearSearch}
       >
-        <Text>cancel search</Text>
+        <PlaceholderText text="cancel search" />
       </Pressable>
       <ProjectList data={projectSearchResults} />
     </>

--- a/src/components/Projects/ProjectTabs.js
+++ b/src/components/Projects/ProjectTabs.js
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { Pressable, Text, View } from "react-native";
+import { t } from "i18next";
 
 import { viewStyles } from "../../styles/projects/projects";
 import useProjects from "./hooks/useProjects";
@@ -33,18 +34,18 @@ const ProjectTabs = ( ): React.Node => {
         <Pressable
           onPress={fetchUserJoinedProjects}
         >
-          <Text>joined projects</Text>
+          <Text>{t( "Joined" )}</Text>
+        </Pressable>
+        <Pressable
+          onPress={fetchFeaturedProjects}
+        >
+          <Text>{t( "Featured" )}</Text>
         </Pressable>
         <Pressable
           onPress={fetchProjectsByLatLng}
           testID="ProjectTabs.featured"
         >
-          <Text>nearby projects</Text>
-        </Pressable>
-        <Pressable
-          onPress={fetchFeaturedProjects}
-        >
-          <Text>featured projects</Text>
+          <Text>{t( "Nearby" )}</Text>
         </Pressable>
       </View>
       <ProjectList data={projects} />

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -8,6 +8,7 @@ import ViewWithFooter from "../SharedComponents/ViewWithFooter";
 import useRemoteSearchResults from "../../sharedHooks/useRemoteSearchResults";
 import InputField from "../SharedComponents/InputField";
 import { viewStyles, imageStyles } from "../../styles/search/search";
+import PlaceholderText from "../PlaceholderText";
 
 const Search = ( ): React.Node => {
   const navigation = useNavigation( );
@@ -59,14 +60,14 @@ const Search = ( ): React.Node => {
           testID="Search.taxa"
           accessibilityRole="button"
         >
-          <Text>search taxa</Text>
+          <PlaceholderText text="search taxa" />
         </Pressable>
         <Pressable
           onPress={setUserSearch}
           testID="Search.users"
           accessibilityRole="button"
         >
-          <Text>search users</Text>
+          <PlaceholderText text="search users" />
         </Pressable>
       </View>
       <InputField

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -25,6 +25,7 @@ import SettingsApplications from "./SettingsApplications";
 import SettingsRelationships from "./SettingsRelationships";
 import ViewWithFooter from "../SharedComponents/ViewWithFooter";
 import useUserMe from "./hooks/useUserMe";
+import { t } from "i18next";
 
 const TAB_TYPE_PROFILE = "profile";
 const TAB_TYPE_ACCOUNT = "account";
@@ -79,7 +80,7 @@ const SettingsTabs = ( { activeTab, onTabPress } ): React.Node => {
           <Text
             style={activeTab === TAB_TYPE_PROFILE ? textStyles.activeTab : null}
           >
-            profile
+            {t( "Profile" )}
           </Text>
         </Pressable>
         <Pressable
@@ -89,7 +90,7 @@ const SettingsTabs = ( { activeTab, onTabPress } ): React.Node => {
           <Text
             style={activeTab === TAB_TYPE_ACCOUNT ? textStyles.activeTab : null}
           >
-            account
+            {t( "Account" )}
           </Text>
         </Pressable>
         <Pressable
@@ -101,7 +102,7 @@ const SettingsTabs = ( { activeTab, onTabPress } ): React.Node => {
               activeTab === TAB_TYPE_NOTIFICATIONS ? textStyles.activeTab : null
             }
           >
-            notifications
+            {t( "Notifications" )}
           </Text>
         </Pressable>
         <Pressable
@@ -113,7 +114,7 @@ const SettingsTabs = ( { activeTab, onTabPress } ): React.Node => {
               activeTab === TAB_TYPE_RELATIONSHIPS ? textStyles.activeTab : null
             }
           >
-            relationships
+            {t( "Relationships" )}
           </Text>
         </Pressable>
         <Pressable
@@ -127,7 +128,7 @@ const SettingsTabs = ( { activeTab, onTabPress } ): React.Node => {
                 : null
             }
           >
-            content&display
+            {t( "Content-Display" )}
           </Text>
         </Pressable>
         <Pressable
@@ -139,7 +140,7 @@ const SettingsTabs = ( { activeTab, onTabPress } ): React.Node => {
               activeTab === TAB_TYPE_APPLICATIONS ? textStyles.activeTab : null
             }
           >
-            applications
+            {t( "Applications" )}
           </Text>
         </Pressable>
       </View>
@@ -222,8 +223,8 @@ const Settings = ( { children }: Props ): Node => {
   useFocusEffect(
     React.useCallback( () => {
       // Reload the settings
-      getAPIToken( true ).then( ( t ) => {
-        setAccessToken( t );
+      getAPIToken( true ).then( ( token ) => {
+        setAccessToken( token );
       } );
 
       return () => {
@@ -238,7 +239,7 @@ const Settings = ( { children }: Props ): Node => {
       <SafeAreaView style={viewStyles.container}>
         <StatusBar barStyle="dark-content" />
         <View style={viewStyles.headerRow}>
-          <Text style={textStyles.header}>Settings</Text>
+          <Text style={textStyles.header}>{t( "Settings" )}</Text>
           <Button
             title="Save"
             onPress={saveSettings}

--- a/src/components/Settings/SettingsAccount.js
+++ b/src/components/Settings/SettingsAccount.js
@@ -12,15 +12,16 @@ import {inatNetworks} from "../../dictionaries/networks";
 import PlaceSearchInput from "./PlaceSearchInput";
 import type { Node } from "react";
 import type { SettingsProps } from "./types";
+import { t } from "i18next";
 
 const SettingsAccount = ( { settings, onSettingsModified }: SettingsProps ): Node => {
 
   return (
     <>
-      <Text style={textStyles.title}>Account</Text>
+      <Text style={textStyles.title}>{t( "Account" )}</Text>
 
-      <Text style={[textStyles.subTitle]}>Language/Locale</Text>
-      <Text>This sets your language and date formatting preferences across iNaturalist based on your locale.</Text>
+      <Text style={[textStyles.subTitle]}>{t( "Language-Locale" )}</Text>
+      <Text>{t( "This-sets-your-language-and-date-formatting-preferences-across-iNaturalist" )}</Text>
       <View style={viewStyles.selectorContainer}>
         <Picker
           style={viewStyles.selector}
@@ -38,12 +39,11 @@ const SettingsAccount = ( { settings, onSettingsModified }: SettingsProps ): Nod
         </Picker>
       </View>
 
-      <Text style={[textStyles.subTitle]}>Default Search Place</Text>
-      <Text>This will be your default place for all searches in Explore and Identify.</Text>
+      <Text style={[textStyles.subTitle]}>{t( "Default-Search-Place" )}</Text>
+      <Text>{t( "This-will-be-your-default-place-for-all-searches-in-Explore-and-Identify" )}</Text>
       <PlaceSearchInput placeId={settings.search_place_id} onPlaceChanged={( p ) => onSettingsModified( { ...settings, search_place_id: p} )} />
 
-      <Text style={[textStyles.subTitle]}>Privacy</Text>
-      <Text>This will be your default place for all searches in Explore and Identify.</Text>
+      <Text style={[textStyles.subTitle]}>{t( "Privacy" )}</Text>
       <Pressable style={[viewStyles.row, viewStyles.notificationCheckbox]}
                  onPress={() => onSettingsModified( { ...settings, prefers_no_tracking: !settings.prefers_no_tracking} )}>
         <CheckBox
@@ -51,11 +51,11 @@ const SettingsAccount = ( { settings, onSettingsModified }: SettingsProps ): Nod
           onValueChange={( v ) => onSettingsModified( { ...settings, prefers_no_tracking: v} )}
           tintColors={{false: colors.inatGreen, true: colors.inatGreen}}
         />
-        <Text style={[textStyles.checkbox, viewStyles.column]}>Do not collect stability and usage data using third-party services</Text>
+        <Text style={[textStyles.checkbox, viewStyles.column]}>{t( "Do-not-collect-stability-and-usage-data-using-third-party-services" )}</Text>
       </Pressable>
 
 
-      <Text style={[textStyles.subTitle]}>iNaturalist Network Affiliation</Text>
+      <Text style={[textStyles.subTitle]}>{t( "iNaturalist-Network-Affiliation" )}</Text>
       <View style={viewStyles.selectorContainer}>
         <Picker
           style={viewStyles.selector}
@@ -72,9 +72,7 @@ const SettingsAccount = ( { settings, onSettingsModified }: SettingsProps ): Nod
           ) )}
         </Picker>
       </View>
-      <Text>The iNaturalist Network is a collection of localized websites that are fully connected to the global iNaturalist community. Network sites are supported by local institutions that have signed an agreement with iNaturalist to promote local use and benefit local biodiversity. They have access to true coordinates from their countries that are automatically obscured from public view in order to protect threatened species.
-        Your username and password works on all sites that are part of the iNaturalist Network. If you choose to affiliate with a Network site, the local institutions that operate each site will also have access to your email address (only to communicate with you about site activities) and access to the true coordinates for observations that are publicly obscured or private.
-        Note: Please do not experimentally change your affiliation if you have more than 1000 observations.</Text>
+      <Text>{t( "The-iNaturalist-Network-is-a-collection-of-localized-websites" )}</Text>
 
 
     </>

--- a/src/components/Settings/SettingsApplications.js
+++ b/src/components/Settings/SettingsApplications.js
@@ -9,6 +9,7 @@ import {inatProviders} from "../../dictionaries/providers";
 import inatjs from "inaturalistjs";
 import useAuthorizedApplications from "./hooks/useAuthorizedApplications";
 import useProviderAuthorizations from "./hooks/useProviderAuthorizations";
+import { t } from "i18next";
 
 type Props = {
   accessToken: string
@@ -48,12 +49,12 @@ const SettingsApplications = ( { accessToken }: Props ): Node => {
 
   return (
     <View style={viewStyles.column}>
-      <Text style={textStyles.title}>iNaturalist Applications</Text>
+      <Text style={textStyles.title}>{t( "iNaturalist-Applications" )}</Text>
       {authorizedApps.filter( ( app ) => app.application.official ).map( ( app ) => (
-        <Text key={app.application.id}>{app.application.name} (authorized on: {app.created_at})</Text>
+        <Text key={app.application.id}>{t( "authorized-on-date", { appName: app.application.name, date: app.created_at } )}</Text>
       ) )}
 
-      <Text style={[textStyles.title, textStyles.marginTop]}>Connected Accounts</Text>
+      <Text style={[textStyles.title, textStyles.marginTop]}>{t( "Connected-Accounts" )}</Text>
       {Object.keys( inatProviders ).map( ( providerKey ) => {
         const connectedProvider = providerAuthorizations.find( x => x.provider_name === providerKey );
         return ( <Text
@@ -61,11 +62,11 @@ const SettingsApplications = ( { accessToken }: Props ): Node => {
       } )}
 
 
-      <Text style={[textStyles.title, textStyles.marginTop]}>External Applications</Text>
+      <Text style={[textStyles.title, textStyles.marginTop]}>{t( "External-Applications" )}</Text>
       {authorizedApps.filter( ( app ) => !app.application.official ).map( ( app ) => (
         <View key={app.application.id} style={[viewStyles.row, viewStyles.applicationRow]}>
-          <Text style={textStyles.applicationName}>{app.application.name} (authorized on: {app.created_at})</Text>
-          <Pressable style={viewStyles.revokeAccess} onPress={() => askToRevokeApp( app )}><Text>Revoke</Text></Pressable>
+          <Text style={textStyles.applicationName}>{t( "authorized-on-date", { appName: app.application.name, date: app.created_at } )}</Text>
+          <Pressable style={viewStyles.revokeAccess} onPress={() => askToRevokeApp( app )}><Text>{t( "Revoke" )}</Text></Pressable>
         </View>
       ) )}
     </View>

--- a/src/components/Settings/SettingsContentDisplay.js
+++ b/src/components/Settings/SettingsContentDisplay.js
@@ -10,6 +10,7 @@ import PlaceSearchInput from "./PlaceSearchInput";
 import {inatLicenses} from "../../dictionaries/licenses";
 import type { Node } from "react";
 import type { SettingsProps } from "./types";
+import { t } from "i18next";
 
 const PROJECT_SETTINGS = {
   any: "Any",
@@ -73,8 +74,8 @@ const SettingsContentDisplay = ( { settings, onSettingsModified }: SettingsProps
 
   return (
     <>
-      <Text style={textStyles.title}>Project Settings</Text>
-      <Text style={textStyles.subTitle}>Which traditional projects can add your observations?</Text>
+      <Text style={textStyles.title}>{t( "Project-Settings" )}</Text>
+      <Text style={textStyles.subTitle}>{t( "Which-traditional-projects-can-add-your-observations" )}</Text>
       <View style={viewStyles.selectorContainer}>
         <Picker
           style={viewStyles.selector}
@@ -92,7 +93,7 @@ const SettingsContentDisplay = ( { settings, onSettingsModified }: SettingsProps
         </Picker>
       </View>
 
-      <Text style={[textStyles.title, textStyles.marginTop]}>Taxonomy Settings</Text>
+      <Text style={[textStyles.title, textStyles.marginTop]}>{t( "Taxonomy-Settings" )}</Text>
       <Pressable style={[viewStyles.row, viewStyles.notificationCheckbox]}  onPress={() => {
         onSettingsModified( { ...settings, prefers_automatic_taxonomic_changes: !settings.prefers_automatic_taxonomic_changes } );
       }}>
@@ -103,12 +104,12 @@ const SettingsContentDisplay = ( { settings, onSettingsModified }: SettingsProps
           }}
           tintColors={{false: colors.inatGreen, true: colors.inatGreen}}
         />
-        <Text style={textStyles.notificationTitle}>Automatically update my content for taxon changes</Text>
+        <Text style={textStyles.notificationTitle}>{t( "Automatically-update-my-content-for-taxon-changes" )}</Text>
       </Pressable>
 
-      <Text style={[textStyles.title, textStyles.marginTop]}>Names</Text>
-      <Text style={textStyles.subTitle}>Display</Text>
-      <Text>This is how all taxon names will be displayed to you across iNaturalist</Text>
+      <Text style={[textStyles.title, textStyles.marginTop]}>{t( "Names" )}</Text>
+      <Text style={textStyles.subTitle}>{t( "Display" )}</Text>
+      <Text>{t( "This-is-how-all-taxon-names-will-be-displayed-to-you-across-iNaturalist" )}</Text>
       <View style={viewStyles.selectorContainer}>
         <Picker
           style={viewStyles.selector}
@@ -145,10 +146,10 @@ const SettingsContentDisplay = ( { settings, onSettingsModified }: SettingsProps
           ) )}
         </Picker>
       </View>
-      <Text style={textStyles.subTitle}>Prioritize common names used in this place.</Text>
+      <Text style={textStyles.subTitle}>{t( "Prioritize-common-names-used-in-this-place" )}</Text>
       <PlaceSearchInput placeId={settings.place_id} onPlaceChanged={( p ) => onSettingsModified( { ...settings, place_id: p} )} />
 
-      <Text style={[textStyles.title, textStyles.marginTop]}>Community Moderation Settings</Text>
+      <Text style={[textStyles.title, textStyles.marginTop]}>{t( "Community-Moderation-Settings" )}</Text>
       <Pressable style={[viewStyles.row, viewStyles.notificationCheckbox]}  onPress={() => {
         onSettingsModified( { ...settings, prefers_community_taxa: !settings.prefers_community_taxa } );
       }}>
@@ -159,9 +160,9 @@ const SettingsContentDisplay = ( { settings, onSettingsModified }: SettingsProps
           }}
           tintColors={{false: colors.inatGreen, true: colors.inatGreen}}
         />
-        <Text style={textStyles.notificationTitle}>Accept community identifications</Text>
+        <Text style={textStyles.notificationTitle}>{t( "Accept-community-identifications" )}</Text>
       </Pressable>
-      <Text style={textStyles.subTitle}>Who can add observation fields to my observations?</Text>
+      <Text style={textStyles.subTitle}>{t( "Who-can-add-observation-fields-to-my-observations" )}</Text>
       <View style={viewStyles.selectorContainer}>
         <Picker
           style={viewStyles.selector}
@@ -179,7 +180,7 @@ const SettingsContentDisplay = ( { settings, onSettingsModified }: SettingsProps
         </Picker>
       </View>
 
-      <Text style={[textStyles.title, textStyles.marginTop]}>Licensing</Text>
+      <Text style={[textStyles.title, textStyles.marginTop]}>{t( "Licensing" )}</Text>
       <LicenseSelector
         title="Default observation license"
         value={settings.preferred_observation_license}

--- a/src/components/Settings/SettingsNotifications.js
+++ b/src/components/Settings/SettingsNotifications.js
@@ -8,6 +8,7 @@ import Switch from "react-native/Libraries/Components/Switch/Switch";
 import CheckBox from "@react-native-community/checkbox";
 import { colors } from "../../styles/global";
 import type { SettingsProps } from "./types";
+import { t } from "i18next";
 
 
 const EMAIL_NOTIFICATIONS = {
@@ -50,7 +51,7 @@ const Notification = ( { title, description, value, onValueChange } ): Node => (
 
 const SettingsNotifications = ( { settings, onSettingsModified }: SettingsProps ): Node => (
     <>
-      <Text style={textStyles.title}>iNaturalist Activity Notifications</Text>
+      <Text style={textStyles.title}>{t( "iNaturalist-Activity-Notifications" )}</Text>
       <Notification
         title="Notify me of mentions (e.g. @username)"
         description="If you turn this off, you will not get any notifications when someone mentions you on iNaturalist."
@@ -63,7 +64,7 @@ const SettingsNotifications = ( { settings, onSettingsModified }: SettingsProps 
         value={settings.prefers_redundant_identification_notifications}
         onValueChange={( v ) => onSettingsModified( { ...settings, prefers_redundant_identification_notifications: v} )}
       />
-      <Text style={textStyles.title}>Email Notifications</Text>
+      <Text style={textStyles.title}>{t( "Email-Notifications" )}</Text>
       <Notification
         title="Receive Email Notifications"
         description="If you turn this off, you will no longer receive any emails from iNaturalist regarding notifications."

--- a/src/components/Settings/SettingsProfile.js
+++ b/src/components/Settings/SettingsProfile.js
@@ -2,6 +2,7 @@
 
 import {Button, Image, Text, TextInput, View} from "react-native";
 import {viewStyles} from "../../styles/settings/settings";
+import { t } from "i18next";
 // $FlowIgnore
 import {launchImageLibrary} from "react-native-image-picker";
 import React from "react";
@@ -26,7 +27,7 @@ const SettingsProfile = ( { settings, onSettingsModified }: SettingsProps ): Nod
 
   return (
     <>
-      <Text>Profile Picture</Text>
+      <Text>{t( "Profile-Picture" )}</Text>
       <View style={viewStyles.row}>
         <Image
           style={viewStyles.profileImage}
@@ -38,7 +39,7 @@ const SettingsProfile = ( { settings, onSettingsModified }: SettingsProps ): Nod
         </View>
       </View>
       <View style={viewStyles.column}>
-        <Text>Username</Text>
+        <Text>{t( "Username" )}</Text>
         <TextInput
           style={viewStyles.textInput}
           onChangeText={( x ) => onSettingsModified( { ...settings, login: x} )}
@@ -46,7 +47,7 @@ const SettingsProfile = ( { settings, onSettingsModified }: SettingsProps ): Nod
         />
       </View>
       <View style={viewStyles.column}>
-        <Text>Email</Text>
+        <Text>{t( "Email" )}</Text>
         <TextInput
           style={viewStyles.textInput}
           onChangeText={( x ) => onSettingsModified( { ...settings, email: x} )}
@@ -54,7 +55,7 @@ const SettingsProfile = ( { settings, onSettingsModified }: SettingsProps ): Nod
         />
       </View>
       <View style={viewStyles.column}>
-        <Text>Display Name</Text>
+        <Text>{t( "Display-Name" )}</Text>
         <TextInput
           style={viewStyles.textInput}
           onChangeText={( x ) => onSettingsModified( { ...settings, name: x} )}
@@ -62,7 +63,7 @@ const SettingsProfile = ( { settings, onSettingsModified }: SettingsProps ): Nod
         />
       </View>
       <View style={viewStyles.column}>
-        <Text>Bio</Text>
+        <Text>{t( "Bio" )}</Text>
         <TextInput
           style={viewStyles.textInput}
           multiline

--- a/src/components/Settings/SettingsRelationships.js
+++ b/src/components/Settings/SettingsRelationships.js
@@ -4,6 +4,7 @@ import {Alert, Image, Text, TextInput, View} from "react-native";
 import {viewStyles, textStyles} from "../../styles/settings/settings";
 import React, {useEffect} from "react";
 import type { Node } from "react";
+import { t } from "i18next";
 import Pressable from "react-native/Libraries/Components/Pressable/Pressable";
 import {useDebounce} from "use-debounce";
 import inatjs from "inaturalistjs";
@@ -235,7 +236,7 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
         <Text>{user.login}</Text>
         <Text>{user.name}</Text>
       </View>
-      <Pressable style={viewStyles.removeRelationship} onPress={() => unblockUser( user )}><Text>Unblock</Text></Pressable>
+      <Pressable style={viewStyles.removeRelationship} onPress={() => unblockUser( user )}><Text>{t( "Unblock" )}</Text></Pressable>
     </View>;
   };
 
@@ -299,7 +300,7 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
         <Text>{user.login}</Text>
         <Text>{user.name}</Text>
       </View>
-      <Pressable style={viewStyles.removeRelationship} onPress={() => unmuteUser( user )}><Text>Unmute</Text></Pressable>
+      <Pressable style={viewStyles.removeRelationship} onPress={() => unmuteUser( user )}><Text>{t( "Unmute" )}</Text></Pressable>
     </View>;
   };
 
@@ -322,7 +323,7 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
               onValueChange={( x ) => { updateRelationship( relationship, { following: !relationship.following } ); }}
               tintColors={{false: colors.inatGreen, true: colors.inatGreen}}
             />
-            <Text>Following</Text>
+            <Text>{t( "Following" )}</Text>
           </View>
           <View style={[viewStyles.row, viewStyles.notificationCheckbox]}>
             <CheckBox
@@ -330,19 +331,19 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
               onValueChange={( x ) => { updateRelationship( relationship, { trust: !relationship.trust } ); }}
               tintColors={{false: colors.inatGreen, true: colors.inatGreen}}
             />
-            <Text>Trust with hidden coordinates</Text>
+            <Text>{t( "Trust-with-hidden-coordinates" )}</Text>
           </View>
         </View>
       </View>
-      <Text>Added on {relationship.created_at}</Text>
-      <Pressable style={viewStyles.removeRelationship} onPress={() => askToRemoveRelationship( relationship )}><Text>Remove Relationship</Text></Pressable>
+      <Text>{t( "Added-on-date", { date: relationship.created_at } )}</Text>
+      <Pressable style={viewStyles.removeRelationship} onPress={() => askToRemoveRelationship( relationship )}><Text>{t( "Remove-Relationship" )}</Text></Pressable>
     </View>;
   };
 
 
   return (
     <View style={viewStyles.column}>
-      <Text style={textStyles.title}>Relationships</Text>
+      <Text style={textStyles.title}>{t( "Relationships" )}</Text>
       <View style={viewStyles.row}>
         <TextInput
           style={viewStyles.textInput}
@@ -361,7 +362,7 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
           />
         </Pressable>
       </View>
-      <Text>Following</Text>
+      <Text>{t( "Following" )}</Text>
       <View style={viewStyles.row}>
         <View style={viewStyles.selectorContainer}>
           <Picker
@@ -381,7 +382,7 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
         </View>
       </View>
 
-      <Text>Trusted</Text>
+      <Text>{t( "Trusted" )}</Text>
       <View style={viewStyles.row}>
         <View style={viewStyles.selectorContainer}>
           <Picker
@@ -401,7 +402,7 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
         </View>
       </View>
 
-      <Text>Sort By</Text>
+      <Text>{t( "Sort-By" )}</Text>
       <View style={viewStyles.row}>
         <View style={viewStyles.selectorContainer}>
           <Picker
@@ -432,13 +433,13 @@ const SettingsRelationships = ( { accessToken, settings, onRefreshUser }: Props 
         <Pressable disabled={page === totalPages} style={viewStyles.pageButton} onPress={() => setPage( page + 1 )}><Text>&gt;</Text></Pressable>
       </View>}
 
-      <Text style={textStyles.title}>Blocked Users</Text>
+      <Text style={textStyles.title}>{t( "Blocked-Users" )}</Text>
       <UserSearchInput userId={0} onUserChanged={( u ) => blockUser( u )} />
       {blockedUsers.map( ( user ) => (
         <BlockedUser key={user.id} user={user} />
       ) )}
 
-      <Text style={textStyles.title}>Muted Users</Text>
+      <Text style={textStyles.title}>{t( "Muted-Users" )}</Text>
       <UserSearchInput userId={0} onUserChanged={( u ) => muteUser( u )} />
       {mutedUsers.map( ( user ) => (
         <MutedUser key={user.id} user={user} />

--- a/src/components/SharedComponents/ObservationViews/EmptyList.js
+++ b/src/components/SharedComponents/ObservationViews/EmptyList.js
@@ -12,7 +12,7 @@ const EmptyList = ( ): Node => {
 
   return (
     <View style={viewStyles.center}>
-      <Text style={textStyles.text} testID="ObsList.emptyList">{t( "iNaturalist-is-a-community-of-naturalists." )}</Text>
+      <Text style={textStyles.text} testID="ObsList.emptyList">{t( "iNaturalist-is-a-community-of-naturalists" )}</Text>
     </View>
   );
 };

--- a/src/components/SharedComponents/ObservationViews/EmptyList.js
+++ b/src/components/SharedComponents/ObservationViews/EmptyList.js
@@ -1,8 +1,9 @@
-// @flow strict-local
+// @flow
 
 import React from "react";
 import { Text, View } from "react-native";
 import type { Node } from "react";
+import { t } from "i18next";
 
 import { viewStyles, textStyles } from "../../../styles/sharedComponents/observationViews/obsCard";
 
@@ -11,8 +12,7 @@ const EmptyList = ( ): Node => {
 
   return (
     <View style={viewStyles.center}>
-      <Text style={textStyles.text} testID="ObsList.emptyList">welcome to inaturalist!</Text>
-      <Text style={textStyles.text}>make sure you're logged in to fetch observations</Text>
+      <Text style={textStyles.text} testID="ObsList.emptyList">{t( "iNaturalist-is-a-community-of-naturalists." )}</Text>
     </View>
   );
 };

--- a/src/components/SharedComponents/ObservationViews/ObsCard.js
+++ b/src/components/SharedComponents/ObservationViews/ObsCard.js
@@ -1,10 +1,11 @@
 // @flow
 
 import React from "react";
-import { Pressable, View, Image, Text } from "react-native";
+import { Pressable, View, Image } from "react-native";
 import type { Node } from "react";
+import { Avatar } from "react-native-paper";
 
-import { viewStyles, textStyles } from "../../../styles/sharedComponents/observationViews/obsCard";
+import { viewStyles } from "../../../styles/sharedComponents/observationViews/obsCard";
 import ObsCardDetails from "./ObsCardDetails";
 import ObsCardStats from "./ObsCardStats";
 import Photo from "../../../models/Photo";
@@ -37,7 +38,9 @@ const ObsCard = ( { item, handlePress }: Props ): Node => {
         {/* TODO: fill in with actual empty states */}
         <ObsCardDetails item={item} needsUpload={needsUpload} />
       </View>
-      {needsUpload ? <Text style={textStyles.wrap}>needs upload</Text> : <ObsCardStats item={item} type="list" />}
+      {needsUpload
+        ? <Avatar.Icon size={40} icon="arrow-up-circle-outline" />
+        : <ObsCardStats item={item} type="list" />}
     </Pressable>
   );
 };

--- a/src/components/SoundRecorder/SoundRecorder.js
+++ b/src/components/SoundRecorder/SoundRecorder.js
@@ -113,7 +113,7 @@ const SoundRecorder = ( ): Node => {
         <Pressable
           onPress={startRecording}
         >
-          <Text style={[textStyles.alignCenter, textStyles.duration]}>start</Text>
+          <Text style={[textStyles.alignCenter, textStyles.duration]}>{t( "Press-Record-to-Start" )}</Text>
         </Pressable>
       );
     } else if ( status === "paused" ) {
@@ -121,11 +121,11 @@ const SoundRecorder = ( ): Node => {
         <Pressable
           onPress={resumeRecording}
         >
-          <Text style={[textStyles.alignCenter, textStyles.duration]}>resume</Text>
+          <Text style={[textStyles.alignCenter, textStyles.duration]}>{t( "Paused" )}</Text>
         </Pressable>
       );
     } else if ( status === "playing" ) {
-      return <Text style={[textStyles.alignCenter, textStyles.duration]}>playing</Text>;
+      return <Text style={[textStyles.alignCenter, textStyles.duration]}>{t( "Playing-Sound" )}</Text>;
     } else {
       return (
         <Pressable
@@ -144,7 +144,7 @@ const SoundRecorder = ( ): Node => {
           onPress={playRecording}
           style={viewStyles.playbackButton}
         >
-          <Text>play</Text>
+          <Text>{t( "Play" )}</Text>
         </Pressable>
       );
     } else if ( status === "playing" ) {

--- a/src/components/SoundRecorder/SoundRecorder.js
+++ b/src/components/SoundRecorder/SoundRecorder.js
@@ -11,6 +11,7 @@ import { useNavigation } from "@react-navigation/native";
 import ViewWithFooter from "../SharedComponents/ViewWithFooter";
 import { viewStyles, textStyles } from "../../styles/soundRecorder/soundRecorder";
 import { ObsEditContext } from "../../providers/contexts";
+import PlaceholderText from "../PlaceholderText";
 
 // needs to be outside of the component for stopRecorder to work correctly
 const audioRecorderPlayer = new AudioRecorderPlayer( );
@@ -131,7 +132,7 @@ const SoundRecorder = ( ): Node => {
         <Pressable
           onPress={stopRecording}
         >
-          <Text style={[textStyles.alignCenter, textStyles.duration]}>stop</Text>
+          <PlaceholderText text="stop" style={[textStyles.alignCenter, textStyles.duration]} />
         </Pressable>
       );
     }
@@ -153,7 +154,7 @@ const SoundRecorder = ( ): Node => {
           onPress={stopPlayback}
           style={viewStyles.playbackButton}
         >
-          <Text>stop</Text>
+          <PlaceholderText text="stop" />
         </Pressable>
       );
     }
@@ -173,7 +174,6 @@ const SoundRecorder = ( ): Node => {
         </View>
         <View>
           {/* TODO: add visualization for sound recording */}
-          <Text>insert visualization here</Text>
         </View>
         <View>
           <View style={viewStyles.recordButtonRow}>

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -71,7 +71,7 @@ const TaxonDetails = ( ): React.Node => {
             accessibilityRole="link"
             testID="TaxonDetails.wikipedia"
           >
-            <Text style={textStyles.header}>Read more on Wikipedia</Text>
+            <Text style={textStyles.header}>{ t( "Read-more-on-Wikipedia" )}</Text>
           </Pressable>
           <Text style={textStyles.header}>{ t( "TAXONOMY-header" ) }</Text>
           {displayTaxonomyList}

--- a/src/components/UserProfile/UserProfile.js
+++ b/src/components/UserProfile/UserProfile.js
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Text, View, useWindowDimensions } from "react-native";
 import { useRoute } from "@react-navigation/native";
 import HTML from "react-native-render-html";
+import { t } from "i18next";
 
 import { textStyles, viewStyles } from "../../styles/userProfile/userProfile";
 import UserIcon from "../SharedComponents/UserIcon";
@@ -45,9 +46,9 @@ const UserProfile = ( ): React.Node => {
         <View>
           <Text>{user.name}</Text>
           {showUserRole}
-          <Text>{`Joined: ${user.created_at}`}</Text>
-          <Text>{`Last Active: ${user.updated_at}`}</Text>
-          <Text>{`Affiliation: ${user.site_id}`}</Text>
+          <Text>{`${t( "Joined-colon" )} ${user.created_at}`}</Text>
+          <Text>{`${t( "Last-Active-colon" )} ${user.updated_at}`}</Text>
+          <Text>{`${t( "Affiliation-colon" )} ${user.site_id}`}</Text>
         </View>
       </View>
       {!currentUser && (
@@ -61,22 +62,20 @@ const UserProfile = ( ): React.Node => {
         </View>
       )}
       <View style={viewStyles.countRow}>
-        {showCount( user.observations_count, "Observations" )}
-        {showCount( user.species_count, "Species" )}
-        {showCount( user.identifications_count, "ID's" )}
-        {showCount( user.journal_posts_count, "Journal Posts" )}
+        {showCount( user.observations_count, t( "Observations" ) )}
+        {showCount( user.species_count, t( "Species" ) )}
+        {showCount( user.identifications_count, t( "IDs" ) )}
+        {showCount( user.journal_posts_count, t( "Journal-Posts" ) )}
       </View>
-      <Text>Bio:</Text>
+      <Text>{t( "BIO" )}</Text>
       { user && user.description && user.description.length > 0  && (
         <HTML
           contentWidth={width}
           source={{ html: user.description }}
         />
       ) }
-      <Text>Projects</Text>
+      <Text>{t( "PROJECTS" )}</Text>
       <UserProjects userId={userId} />
-      <Text>Following</Text>
-      <Text>Followers</Text>
     </ViewWithFooter>
   );
 };

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1,5 +1,11 @@
+
+
 # Header for a block of text describing a taxon
 ABOUT-taxon-header = ABOUT
+
+Accept-community-identifications = Accept community identifications
+
+Account = Account
 
 Add-Date-Time = Add Date/Time
 
@@ -8,6 +14,9 @@ Add-Location = Add Location
 Add-optional-notes = Add optional notes
 
 Add-to-projects = Add to projects
+
+# Date relationship created, shown on settings relationships screen
+Added-on-date = Added on { $date }
 
 # Shows user network affiliation on user profile
 Affiliation-colon = Affiliation:
@@ -24,10 +33,21 @@ Are-you-sure = Are you sure?
 
 Are-you-sure-you-want-to-sign-out = Are you sure you want to sign out? This will delete all your observations on this device. It will not affect any observations you've uploaded to iNaturalist.
 
+app-authorized-on-date = { $appName } (authorized on: { $date })
+
+Applications = Applications
+
+Automatically-update-my-content-for-taxon-changes = Automatically update my content for taxon changes
+
 # Header above user biography / user description on user profile
 BIO = BIO
 
+# Header for inserting user description in settings profile tab
+Bio = Bio
+
 Birds = Birds
+
+Blocked-Users = Blocked Users
 
 Cancel = Cancel
 
@@ -36,10 +56,19 @@ Captive-Cultivated = Captive/Cultivated
 # Quality grade option
 Casual = Casual
 
+# After pressing the reset password button
+Check-your-email = Check your email! We've sent password reset instructions.
+
 Combine-Photos = Combine Photos
 
 # Onboarding for users learning to group photos in the camera roll
 Combine-photos-onboarding = Combine photos into observations – make sure there is only one species per observation
+
+Community-Moderation-Settings = Community Moderation Settings
+
+Connected-Accounts = Connected Accounts
+
+Content-Display = Content & Display
 
 CREATE-AN-OBSERVATION = CREATE AN OBSERVATION
 
@@ -53,6 +82,8 @@ Date-observed-colon = Date observed:
 
 Date-uploaded-colon = Date uploaded:
 
+Default-Search-Place = Default Search Place
+
 Delete-comment = Delete comment
 
 DELETE-X-OBSERVATIONS = DELETE {$count ->
@@ -62,9 +93,22 @@ DELETE-X-OBSERVATIONS = DELETE {$count ->
 
 Description-Tags = Description/Tags
 
+Display = Display
+
+Display-Name = Display Name
+
+Do-not-collect-stability-and-usage-data-using-third-party-services = Do not collect stability and usage data using third-party services
+
+# Appears above the email text field
+Email = email
+
+Email-Notifications = Email Notifications
+
 Evidence = Evidence
 
 Explore = Explore
+
+External-Applications = External Applications
 
 # Header for featured projects
 Featured = Featured
@@ -74,6 +118,11 @@ Filters = Filters
 Finish = Finish
 
 Fish = Fish
+
+Following = Following
+
+# Forgot password link
+Forgot-Password = Forgot Password?
 
 Fungi = Fungi
 
@@ -103,11 +152,20 @@ IDENTIFICATION = IDENTIFICATION
 
 Identification = Identification
 
+iNaturalist-Activity-Notifications = iNaturalist Activity Notifications
+
+iNaturalist-Applications = iNaturalist Applications
+
+iNaturalist-Network-Affiliation = iNaturalist Network Affiliation
+
 iNaturalist-is-a-community-of-naturalists = iNaturalist is a community of naturalists.
 
 Insects = Insects
 
 Introduced = Introduced
+
+# Appears when the user enters invalid username/password
+Invalid-login = The username or password is incorrect
 
 # Header for joined projects
 Joined = Joined
@@ -117,12 +175,24 @@ Joined-colon = Joined:
 
 Journal-Posts = Journal Posts
 
+Language-Locale = Language/Locale
+
 # Shows date user last active on iNaturalist on user profile
 Last-Active-colon = Last Active:
+
+Licensing = Licensing
 
 Location = Location
 
 Log-in = Log in
+
+Logged-in-as = Logged in as: { $username }
+
+# Appears in the login screen
+Login-header = Log in to use iNaturalist
+
+# Appears in the login screen
+Login-sub-title = Document living things, identify organisms & contribute to science
 
 Low = Low
 
@@ -161,6 +231,10 @@ Months = Months
 
 Most-faved = Most faved
 
+Muted-Users = Muted Users
+
+Names = Names
+
 Native = Native
 
 # Header for nearby projects
@@ -173,10 +247,19 @@ New-Observation = New Observation
 
 Next = Next
 
+# When the user tries to reset password but enters a non-existent email
+No-account-found = No account found with that email
+
+No-comments-or-ids-to-display = No comments or ids to display
+
 No-Location = No Location
+
+No-photos-found = No photos found. If this is your first time opening the app and giving permissions, try restarting the app.
 
 # Header for observation description on observation detail
 Notes = Notes
+
+Notifications = Notifications
 
 Obscured = Obscured
 
@@ -190,6 +273,8 @@ Open = Open
 Organism-is-wild = Organism is wild
 
 Other-Data = Other Data
+
+Password = Password
 
 Paused = Paused
 
@@ -205,7 +290,17 @@ Playing-Sound = Playing Sound
 # Help text for beginning a sound recording
 Press-Record-to-Start = Press Record to Start
 
+Prioritize-common-names-used-in-this-place = Prioritize common names used in this place.
+
+Privacy = Privacy
+
 Private = Private
+
+Profile = Profile
+
+Profile-Picture = Profile Picture
+
+Project-Settings = Project Settings
 
 PROJECTS = PROJECTS
 
@@ -298,9 +393,13 @@ Record-new-sound = Record new sound
 
 Recording-Sound = Recording Sound
 
+Relationships = Relationships
+
 Remove-Photo = Remove Photo
 
 Remove-Photos = Remove Photos
+
+Remove-Relationship = Remove Relationship
 
 Reptiles = Reptiles
 
@@ -309,9 +408,19 @@ Research-Grade = Research Grade
 
 Reset = Reset
 
+# Appears in the reset password screen
+Reset-password-header = Let's reset your password
+
+# Reset password button
+Reset-Password = Reset Password
+
+Return-to-login = Return to login
+
 Reviewed = Reviewed
 
 Reviewed-only = Reviewed only
+
+Revoke = Revoke
 
 Search-for-a-location = Search for a location
 
@@ -327,12 +436,16 @@ Select = Select
 
 Separate-Photos = Separate Photos
 
+Settings = Settings
+
 Sign-out = Sign out
 
 Sign-Up = Sign Up
 
 # Header for a section showing taxa similar to a single taxon
 SIMILAR-SPECIES-header = SIMILAR SPECIES
+
+Sort-By = Sort By
 
 Sort-by = Sort by
 
@@ -357,13 +470,33 @@ Taxon = Taxon
 # Header for a block of text describing a taxon's taxonomy
 TAXONOMY-header = TAXONOMY
 
+Taxonomy-Settings = Taxonomy Settings
+
 # Onboarding for users adding their first evidence of an organism
 The-first-thing-you-need-is-evidence = The first thing you need is evidence of an organism. This helps others identify what you saw.
+
+The-iNaturalist-Network-is-a-collection-of-localized-websites = The iNaturalist Network is a collection of localized websites that are fully connected to the global iNaturalist community. Network sites are supported by local institutions that have signed an agreement with iNaturalist to promote local use and benefit local biodiversity. They have access to true coordinates from their countries that are automatically obscured from public view in order to protect threatened species. Your username and password works on all sites that are part of the iNaturalist Network. If you choose to affiliate with a Network site, the local institutions that operate each site will also have access to your email address (only to communicate with you about site activities) and access to the true coordinates for observations that are publicly obscured or private. Note: Please do not experimentally change your affiliation if you have more than 1000 observations.
+
+This-is-how-all-taxon-names-will-be-displayed-to-you-across-iNaturalist = This is how all taxon names will be displayed to you across iNaturalist
 
 # Describes whether a user made this observation from web, iOS, or Android
 This-observation-was-created-using = This observation was created using:
 
+This-sets-your-language-and-date-formatting-preferences-across-iNaturalist = This sets your language and date formatting preferences across iNaturalist based on your locale.
+
+This-will-be-your-default-place-for-all-searches-in-Explore-and-Identify = This will be your default place for all searches in Explore and Identify.
+
 Threatened = Threatened
+
+Trust-with-hidden-coordinates = Trust with hidden coordinates
+
+Trusted = Trusted
+
+Unblock = Unblock
+
+Unknown-organism = Unknown organism
+
+Unmute = Unmute
 
 Unreviewed-only = Unreviewed only
 
@@ -393,9 +526,16 @@ User = User
 
 Username = Username
 
+# Appears above the text fields
+Username-or-Email = Username or Email
+
 Visually-search-iNaturalist-data = Visually search iNaturalist’s wealth of data. Search by a taxon in a location
 
 Whenever-you-get-internet-connection-you-can-upload = Whenever you get internet connection, you can upload your observations to iNaturalist.
+
+Which-traditional-projects-can-add-your-observations = Which traditional projects can add your observations?
+
+Who-can-add-observation-fields-to-my-observations = Who can add observation fields to my observations?
 
 # Banner above Explore Map showing total number of results
 X-Observations = {$observationCount ->
@@ -423,33 +563,3 @@ Yes-delete-photo = Yes, delete photo
 # Message shown when a permission is required to use a part of the app
 # (e.g. permission to access the camera) but the user denied the permission.
 You-denied-iNaturalist-permission-to-do-that = You denied iNaturalist permission to do that
-
-# Appears in the login screen
-Login-header = Log in to use iNaturalist
-Login-sub-title = Document living things, identify organisms & contribute to science
-
-# Appears above the text fields
-Username-or-Email = Username or Email
-Password = Password
-
-# Forgot password link
-Forgot-Password = Forgot Password?
-
-# Appears when the user enters invalid username/password
-Invalid-login = The username or password is incorrect
-
-# Appears in the reset password screen
-Reset-password-header = Let's reset your password
-# Appears above the email text field
-Email = email
-# Reset password button
-Reset-Password = Reset Password
-
-# When the user tries to reset password but enters a non-existent email
-No-account-found = No account found with that email
-
-# After pressing the reset password button
-Check-your-email = Check your email! We've sent password reset instructions.
-Return-to-login = Return to login
-
-Logged-in-as = Logged in as: { $username }

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -9,6 +9,9 @@ Add-optional-notes = Add optional notes
 
 Add-to-projects = Add to projects
 
+# Shows user network affiliation on user profile
+Affiliation-colon = Affiliation:
+
 All = All
 
 All-observations = All observations
@@ -20,6 +23,9 @@ Arachnids = Arachnids
 Are-you-sure = Are you sure?
 
 Are-you-sure-you-want-to-sign-out = Are you sure you want to sign out? This will delete all your observations on this device. It will not affect any observations you've uploaded to iNaturalist.
+
+# Header above user biography / user description on user profile
+BIO = BIO
 
 Birds = Birds
 
@@ -43,6 +49,10 @@ Date-added-newest-to-oldest = Date added - newest to oldest
 
 Date-added-oldest-to-newest = Date added - oldest to newest
 
+Date-observed-colon = Date observed:
+
+Date-uploaded-colon = Date uploaded:
+
 Delete-comment = Delete comment
 
 DELETE-X-OBSERVATIONS = DELETE {$count ->
@@ -55,6 +65,9 @@ Description-Tags = Description/Tags
 Evidence = Evidence
 
 Explore = Explore
+
+# Header for featured projects
+Featured = Featured
 
 Filters = Filters
 
@@ -84,13 +97,28 @@ Has-Sounds = Has Sounds
 
 High = High
 
+IDs = ID's
+
 IDENTIFICATION = IDENTIFICATION
 
 Identification = Identification
 
+iNaturalist-is-a-community-of-naturalists = iNaturalist is a community of naturalists.
+
 Insects = Insects
 
 Introduced = Introduced
+
+# Header for joined projects
+Joined = Joined
+
+# Shows date user joined iNaturalist on user profile
+Joined-colon = Joined:
+
+Journal-Posts = Journal Posts
+
+# Shows date user last active on iNaturalist on user profile
+Last-Active-colon = Last Active:
 
 Location = Location
 
@@ -135,6 +163,9 @@ Most-faved = Most faved
 
 Native = Native
 
+# Header for nearby projects
+Nearby = Nearby
+
 # Quality grade option
 Needs-ID = Needs ID
 
@@ -144,11 +175,19 @@ Next = Next
 
 No-Location = No Location
 
+# Header for observation description on observation detail
+Notes = Notes
+
 Obscured = Obscured
 
 Observation = Observation
 
+Observations = Observations
+
 Open = Open
+
+# Picker prompt on observation edit
+Organism-is-wild = Organism is wild
 
 Other-Data = Other Data
 
@@ -167,6 +206,8 @@ Playing-Sound = Playing Sound
 Press-Record-to-Start = Press Record to Start
 
 Private = Private
+
+PROJECTS = PROJECTS
 
 Projects = Projects
 
@@ -247,6 +288,8 @@ Ranks-form = form
 
 Ranks-infrahybrid = infrahybrid
 
+Read-more-on-Wikipedia = Read more on Wikipedia
+
 Recently-observed = Recently observed
 
 Record-a-sound = Record a sound
@@ -286,10 +329,14 @@ Separate-Photos = Separate Photos
 
 Sign-out = Sign out
 
+Sign-Up = Sign Up
+
 # Header for a section showing taxa similar to a single taxon
 SIMILAR-SPECIES-header = SIMILAR SPECIES
 
 Sort-by = Sort by
+
+Species = Species
 
 Status = Status
 
@@ -312,6 +359,9 @@ TAXONOMY-header = TAXONOMY
 
 # Onboarding for users adding their first evidence of an organism
 The-first-thing-you-need-is-evidence = The first thing you need is evidence of an organism. This helps others identify what you saw.
+
+# Describes whether a user made this observation from web, iOS, or Android
+This-observation-was-created-using = This observation was created using:
 
 Threatened = Threatened
 
@@ -341,7 +391,11 @@ Uploading-X-Observations = Uploading {$count ->
 
 User = User
 
+Username = Username
+
 Visually-search-iNaturalist-data = Visually search iNaturalist’s wealth of data. Search by a taxon in a location
+
+Whenever-you-get-internet-connection-you-can-upload = Whenever you get internet connection, you can upload your observations to iNaturalist.
 
 # Banner above Explore Map showing total number of results
 X-Observations = {$observationCount ->
@@ -398,5 +452,4 @@ No-account-found = No account found with that email
 Check-your-email = Check your email! We've sent password reset instructions.
 Return-to-login = Return to login
 
-Sign-out = Sign out
 Logged-in-as = Logged in as: { $username }

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -3,10 +3,16 @@
     "comment": "Header for a block of text describing a taxon",
     "val": "ABOUT"
   },
+  "Accept-community-identifications": "Accept community identifications",
+  "Account": "Account",
   "Add-Date-Time": "Add Date/Time",
   "Add-Location": "Add Location",
   "Add-optional-notes": "Add optional notes",
   "Add-to-projects": "Add to projects",
+  "Added-on-date": {
+    "comment": "Date relationship created, shown on settings relationships screen",
+    "val": "Added on { $date }"
+  },
   "Affiliation-colon": {
     "comment": "Shows user network affiliation on user profile",
     "val": "Affiliation:"
@@ -17,33 +23,58 @@
   "Arachnids": "Arachnids",
   "Are-you-sure": "Are you sure?",
   "Are-you-sure-you-want-to-sign-out": "Are you sure you want to sign out? This will delete all your observations on this device. It will not affect any observations you've uploaded to iNaturalist.",
+  "app-authorized-on-date": "{ $appName } (authorized on: { $date })",
+  "Applications": "Applications",
+  "Automatically-update-my-content-for-taxon-changes": "Automatically update my content for taxon changes",
   "BIO": {
     "comment": "Header above user biography / user description on user profile",
     "val": "BIO"
   },
+  "Bio": {
+    "comment": "Header for inserting user description in settings profile tab",
+    "val": "Bio"
+  },
   "Birds": "Birds",
+  "Blocked-Users": "Blocked Users",
   "Cancel": "Cancel",
   "Captive-Cultivated": "Captive/Cultivated",
   "Casual": {
     "comment": "Quality grade option",
     "val": "Casual"
   },
+  "Check-your-email": {
+    "comment": "After pressing the reset password button",
+    "val": "Check your email! We've sent password reset instructions."
+  },
   "Combine-Photos": "Combine Photos",
   "Combine-photos-onboarding": {
     "comment": "Onboarding for users learning to group photos in the camera roll",
     "val": "Combine photos into observations – make sure there is only one species per observation"
   },
+  "Community-Moderation-Settings": "Community Moderation Settings",
+  "Connected-Accounts": "Connected Accounts",
+  "Content-Display": "Content & Display",
   "CREATE-AN-OBSERVATION": "CREATE AN OBSERVATION",
   "Date": "Date",
   "Date-added-newest-to-oldest": "Date added - newest to oldest",
   "Date-added-oldest-to-newest": "Date added - oldest to newest",
   "Date-observed-colon": "Date observed:",
   "Date-uploaded-colon": "Date uploaded:",
+  "Default-Search-Place": "Default Search Place",
   "Delete-comment": "Delete comment",
   "DELETE-X-OBSERVATIONS": "DELETE { $count ->\n  [one] 1 OBSERVATION\n *[other] { $count } OBSERVATIONS\n}",
   "Description-Tags": "Description/Tags",
+  "Display": "Display",
+  "Display-Name": "Display Name",
+  "Do-not-collect-stability-and-usage-data-using-third-party-services": "Do not collect stability and usage data using third-party services",
+  "Email": {
+    "comment": "Appears above the email text field",
+    "val": "email"
+  },
+  "Email-Notifications": "Email Notifications",
   "Evidence": "Evidence",
   "Explore": "Explore",
+  "External-Applications": "External Applications",
   "Featured": {
     "comment": "Header for featured projects",
     "val": "Featured"
@@ -51,6 +82,11 @@
   "Filters": "Filters",
   "Finish": "Finish",
   "Fish": "Fish",
+  "Following": "Following",
+  "Forgot-Password": {
+    "comment": "Forgot password link",
+    "val": "Forgot Password?"
+  },
   "Fungi": "Fungi",
   "Geoprivacy": "Geoprivacy:",
   "Go-to-the-Settings-app-to-grant-permissions": {
@@ -68,9 +104,16 @@
   "IDs": "ID's",
   "IDENTIFICATION": "IDENTIFICATION",
   "Identification": "Identification",
+  "iNaturalist-Activity-Notifications": "iNaturalist Activity Notifications",
+  "iNaturalist-Applications": "iNaturalist Applications",
+  "iNaturalist-Network-Affiliation": "iNaturalist Network Affiliation",
   "iNaturalist-is-a-community-of-naturalists": "iNaturalist is a community of naturalists.",
   "Insects": "Insects",
   "Introduced": "Introduced",
+  "Invalid-login": {
+    "comment": "Appears when the user enters invalid username/password",
+    "val": "The username or password is incorrect"
+  },
   "Joined": {
     "comment": "Header for joined projects",
     "val": "Joined"
@@ -80,12 +123,23 @@
     "val": "Joined:"
   },
   "Journal-Posts": "Journal Posts",
+  "Language-Locale": "Language/Locale",
   "Last-Active-colon": {
     "comment": "Shows date user last active on iNaturalist on user profile",
     "val": "Last Active:"
   },
+  "Licensing": "Licensing",
   "Location": "Location",
   "Log-in": "Log in",
+  "Logged-in-as": "Logged in as: { $username }",
+  "Login-header": {
+    "comment": "Appears in the login screen",
+    "val": "Log in to use iNaturalist"
+  },
+  "Login-sub-title": {
+    "comment": "Appears in the login screen",
+    "val": "Document living things, identify organisms & contribute to science"
+  },
   "Low": "Low",
   "Mammals": "Mammals",
   "Media": "Media",
@@ -107,6 +161,8 @@
   "Month-December": "December",
   "Months": "Months",
   "Most-faved": "Most faved",
+  "Muted-Users": "Muted Users",
+  "Names": "Names",
   "Native": "Native",
   "Nearby": {
     "comment": "Header for nearby projects",
@@ -118,11 +174,18 @@
   },
   "New-Observation": "New Observation",
   "Next": "Next",
+  "No-account-found": {
+    "comment": "When the user tries to reset password but enters a non-existent email",
+    "val": "No account found with that email"
+  },
+  "No-comments-or-ids-to-display": "No comments or ids to display",
   "No-Location": "No Location",
+  "No-photos-found": "No photos found. If this is your first time opening the app and giving permissions, try restarting the app.",
   "Notes": {
     "comment": "Header for observation description on observation detail",
     "val": "Notes"
   },
+  "Notifications": "Notifications",
   "Obscured": "Obscured",
   "Observation": "Observation",
   "Observations": "Observations",
@@ -132,6 +195,7 @@
     "val": "Organism is wild"
   },
   "Other-Data": "Other Data",
+  "Password": "Password",
   "Paused": "Paused",
   "Photo-Licensing": "Photo Licensing",
   "Photos-you-take-will-appear-here": "Photos you take will appear here",
@@ -144,7 +208,12 @@
     "comment": "Help text for beginning a sound recording",
     "val": "Press Record to Start"
   },
+  "Prioritize-common-names-used-in-this-place": "Prioritize common names used in this place.",
+  "Privacy": "Privacy",
   "Private": "Private",
+  "Profile": "Profile",
+  "Profile-Picture": "Profile Picture",
+  "Project-Settings": "Project Settings",
   "PROJECTS": "PROJECTS",
   "Projects": "Projects",
   "Quality-Grade": "Quality Grade",
@@ -193,16 +262,28 @@
   "Record-a-sound": "Record a sound",
   "Record-new-sound": "Record new sound",
   "Recording-Sound": "Recording Sound",
+  "Relationships": "Relationships",
   "Remove-Photo": "Remove Photo",
   "Remove-Photos": "Remove Photos",
+  "Remove-Relationship": "Remove Relationship",
   "Reptiles": "Reptiles",
   "Research-Grade": {
     "comment": "Quality grade option",
     "val": "Research Grade"
   },
   "Reset": "Reset",
+  "Reset-password-header": {
+    "comment": "Appears in the reset password screen",
+    "val": "Let's reset your password"
+  },
+  "Reset-Password": {
+    "comment": "Reset password button",
+    "val": "Reset Password"
+  },
+  "Return-to-login": "Return to login",
   "Reviewed": "Reviewed",
   "Reviewed-only": "Reviewed only",
+  "Revoke": "Revoke",
   "Search-for-a-location": "Search for a location",
   "Search-for-a-project": "Search for a project",
   "Search-for-a-taxon": "Search for a taxon",
@@ -210,12 +291,14 @@
   "Search-for-description-tags-text": "Search for description/tags text",
   "Select": "Select",
   "Separate-Photos": "Separate Photos",
+  "Settings": "Settings",
   "Sign-out": "Sign out",
   "Sign-Up": "Sign Up",
   "SIMILAR-SPECIES-header": {
     "comment": "Header for a section showing taxa similar to a single taxon",
     "val": "SIMILAR SPECIES"
   },
+  "Sort-By": "Sort By",
   "Sort-by": "Sort by",
   "Species": "Species",
   "Status": "Status",
@@ -235,15 +318,25 @@
     "comment": "Header for a block of text describing a taxon's taxonomy",
     "val": "TAXONOMY"
   },
+  "Taxonomy-Settings": "Taxonomy Settings",
   "The-first-thing-you-need-is-evidence": {
     "comment": "Onboarding for users adding their first evidence of an organism",
     "val": "The first thing you need is evidence of an organism. This helps others identify what you saw."
   },
+  "The-iNaturalist-Network-is-a-collection-of-localized-websites": "The iNaturalist Network is a collection of localized websites that are fully connected to the global iNaturalist community. Network sites are supported by local institutions that have signed an agreement with iNaturalist to promote local use and benefit local biodiversity. They have access to true coordinates from their countries that are automatically obscured from public view in order to protect threatened species. Your username and password works on all sites that are part of the iNaturalist Network. If you choose to affiliate with a Network site, the local institutions that operate each site will also have access to your email address (only to communicate with you about site activities) and access to the true coordinates for observations that are publicly obscured or private. Note: Please do not experimentally change your affiliation if you have more than 1000 observations.",
+  "This-is-how-all-taxon-names-will-be-displayed-to-you-across-iNaturalist": "This is how all taxon names will be displayed to you across iNaturalist",
   "This-observation-was-created-using": {
     "comment": "Describes whether a user made this observation from web, iOS, or Android",
     "val": "This observation was created using:"
   },
+  "This-sets-your-language-and-date-formatting-preferences-across-iNaturalist": "This sets your language and date formatting preferences across iNaturalist based on your locale.",
+  "This-will-be-your-default-place-for-all-searches-in-Explore-and-Identify": "This will be your default place for all searches in Explore and Identify.",
   "Threatened": "Threatened",
+  "Trust-with-hidden-coordinates": "Trust with hidden coordinates",
+  "Trusted": "Trusted",
+  "Unblock": "Unblock",
+  "Unknown-organism": "Unknown organism",
+  "Unmute": "Unmute",
   "Unreviewed-only": "Unreviewed only",
   "Upload-a-photo-from-your-gallery": "Upload a photo from your gallery",
   "UPLOAD-OBSERVATION": "UPLOAD OBSERVATION",
@@ -261,8 +354,14 @@
   },
   "User": "User",
   "Username": "Username",
+  "Username-or-Email": {
+    "comment": "Appears above the text fields",
+    "val": "Username or Email"
+  },
   "Visually-search-iNaturalist-data": "Visually search iNaturalist’s wealth of data. Search by a taxon in a location",
   "Whenever-you-get-internet-connection-you-can-upload": "Whenever you get internet connection, you can upload your observations to iNaturalist.",
+  "Which-traditional-projects-can-add-your-observations": "Which traditional projects can add your observations?",
+  "Who-can-add-observation-fields-to-my-observations": "Who can add observation fields to my observations?",
   "X-Observations": {
     "comment": "Banner above Explore Map showing total number of results",
     "val": "{ $observationCount ->\n  [one] 1 Observation\n *[other] { $observationCount } Observations\n}"
@@ -279,45 +378,5 @@
   "You-denied-iNaturalist-permission-to-do-that": {
     "comment": "Message shown when a permission is required to use a part of the app\n(e.g. permission to access the camera) but the user denied the permission.",
     "val": "You denied iNaturalist permission to do that"
-  },
-  "Login-header": {
-    "comment": "Appears in the login screen",
-    "val": "Log in to use iNaturalist"
-  },
-  "Login-sub-title": "Document living things, identify organisms & contribute to science",
-  "Username-or-Email": {
-    "comment": "Appears above the text fields",
-    "val": "Username or Email"
-  },
-  "Password": "Password",
-  "Forgot-Password": {
-    "comment": "Forgot password link",
-    "val": "Forgot Password?"
-  },
-  "Invalid-login": {
-    "comment": "Appears when the user enters invalid username/password",
-    "val": "The username or password is incorrect"
-  },
-  "Reset-password-header": {
-    "comment": "Appears in the reset password screen",
-    "val": "Let's reset your password"
-  },
-  "Email": {
-    "comment": "Appears above the email text field",
-    "val": "email"
-  },
-  "Reset-Password": {
-    "comment": "Reset password button",
-    "val": "Reset Password"
-  },
-  "No-account-found": {
-    "comment": "When the user tries to reset password but enters a non-existent email",
-    "val": "No account found with that email"
-  },
-  "Check-your-email": {
-    "comment": "After pressing the reset password button",
-    "val": "Check your email! We've sent password reset instructions."
-  },
-  "Return-to-login": "Return to login",
-  "Logged-in-as": "Logged in as: { $username }"
+  }
 }

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -7,12 +7,20 @@
   "Add-Location": "Add Location",
   "Add-optional-notes": "Add optional notes",
   "Add-to-projects": "Add to projects",
+  "Affiliation-colon": {
+    "comment": "Shows user network affiliation on user profile",
+    "val": "Affiliation:"
+  },
   "All": "All",
   "All-observations": "All observations",
   "Amphibians": "Amphibians",
   "Arachnids": "Arachnids",
   "Are-you-sure": "Are you sure?",
   "Are-you-sure-you-want-to-sign-out": "Are you sure you want to sign out? This will delete all your observations on this device. It will not affect any observations you've uploaded to iNaturalist.",
+  "BIO": {
+    "comment": "Header above user biography / user description on user profile",
+    "val": "BIO"
+  },
   "Birds": "Birds",
   "Cancel": "Cancel",
   "Captive-Cultivated": "Captive/Cultivated",
@@ -29,11 +37,17 @@
   "Date": "Date",
   "Date-added-newest-to-oldest": "Date added - newest to oldest",
   "Date-added-oldest-to-newest": "Date added - oldest to newest",
+  "Date-observed-colon": "Date observed:",
+  "Date-uploaded-colon": "Date uploaded:",
   "Delete-comment": "Delete comment",
   "DELETE-X-OBSERVATIONS": "DELETE { $count ->\n  [one] 1 OBSERVATION\n *[other] { $count } OBSERVATIONS\n}",
   "Description-Tags": "Description/Tags",
   "Evidence": "Evidence",
   "Explore": "Explore",
+  "Featured": {
+    "comment": "Header for featured projects",
+    "val": "Featured"
+  },
   "Filters": "Filters",
   "Finish": "Finish",
   "Fish": "Fish",
@@ -51,10 +65,25 @@
   "Has-Photos": "Has Photos",
   "Has-Sounds": "Has Sounds",
   "High": "High",
+  "IDs": "ID's",
   "IDENTIFICATION": "IDENTIFICATION",
   "Identification": "Identification",
+  "iNaturalist-is-a-community-of-naturalists": "iNaturalist is a community of naturalists.",
   "Insects": "Insects",
   "Introduced": "Introduced",
+  "Joined": {
+    "comment": "Header for joined projects",
+    "val": "Joined"
+  },
+  "Joined-colon": {
+    "comment": "Shows date user joined iNaturalist on user profile",
+    "val": "Joined:"
+  },
+  "Journal-Posts": "Journal Posts",
+  "Last-Active-colon": {
+    "comment": "Shows date user last active on iNaturalist on user profile",
+    "val": "Last Active:"
+  },
   "Location": "Location",
   "Log-in": "Log in",
   "Low": "Low",
@@ -79,6 +108,10 @@
   "Months": "Months",
   "Most-faved": "Most faved",
   "Native": "Native",
+  "Nearby": {
+    "comment": "Header for nearby projects",
+    "val": "Nearby"
+  },
   "Needs-ID": {
     "comment": "Quality grade option",
     "val": "Needs ID"
@@ -86,9 +119,18 @@
   "New-Observation": "New Observation",
   "Next": "Next",
   "No-Location": "No Location",
+  "Notes": {
+    "comment": "Header for observation description on observation detail",
+    "val": "Notes"
+  },
   "Obscured": "Obscured",
   "Observation": "Observation",
+  "Observations": "Observations",
   "Open": "Open",
+  "Organism-is-wild": {
+    "comment": "Picker prompt on observation edit",
+    "val": "Organism is wild"
+  },
   "Other-Data": "Other Data",
   "Paused": "Paused",
   "Photo-Licensing": "Photo Licensing",
@@ -103,6 +145,7 @@
     "val": "Press Record to Start"
   },
   "Private": "Private",
+  "PROJECTS": "PROJECTS",
   "Projects": "Projects",
   "Quality-Grade": "Quality Grade",
   "Rank": "Rank",
@@ -145,6 +188,7 @@
   "Ranks-variety": "variety",
   "Ranks-form": "form",
   "Ranks-infrahybrid": "infrahybrid",
+  "Read-more-on-Wikipedia": "Read more on Wikipedia",
   "Recently-observed": "Recently observed",
   "Record-a-sound": "Record a sound",
   "Record-new-sound": "Record new sound",
@@ -167,11 +211,13 @@
   "Select": "Select",
   "Separate-Photos": "Separate Photos",
   "Sign-out": "Sign out",
+  "Sign-Up": "Sign Up",
   "SIMILAR-SPECIES-header": {
     "comment": "Header for a section showing taxa similar to a single taxon",
     "val": "SIMILAR SPECIES"
   },
   "Sort-by": "Sort by",
+  "Species": "Species",
   "Status": "Status",
   "STATUS-header": {
     "comment": "Header for a block of text describing a taxon's conservation status",
@@ -193,6 +239,10 @@
     "comment": "Onboarding for users adding their first evidence of an organism",
     "val": "The first thing you need is evidence of an organism. This helps others identify what you saw."
   },
+  "This-observation-was-created-using": {
+    "comment": "Describes whether a user made this observation from web, iOS, or Android",
+    "val": "This observation was created using:"
+  },
   "Threatened": "Threatened",
   "Unreviewed-only": "Unreviewed only",
   "Upload-a-photo-from-your-gallery": "Upload a photo from your gallery",
@@ -210,7 +260,9 @@
     "val": "Uploading { $count ->\n  [one] 1 Observation\n *[other] { $count } Observations\n}"
   },
   "User": "User",
+  "Username": "Username",
   "Visually-search-iNaturalist-data": "Visually search iNaturalist’s wealth of data. Search by a taxon in a location",
+  "Whenever-you-get-internet-connection-you-can-upload": "Whenever you get internet connection, you can upload your observations to iNaturalist.",
   "X-Observations": {
     "comment": "Banner above Explore Map showing total number of results",
     "val": "{ $observationCount ->\n  [one] 1 Observation\n *[other] { $observationCount } Observations\n}"

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1,5 +1,11 @@
+
+
 # Header for a block of text describing a taxon
 ABOUT-taxon-header = ABOUT
+
+Accept-community-identifications = Accept community identifications
+
+Account = Account
 
 Add-Date-Time = Add Date/Time
 
@@ -8,6 +14,9 @@ Add-Location = Add Location
 Add-optional-notes = Add optional notes
 
 Add-to-projects = Add to projects
+
+# Date relationship created, shown on settings relationships screen
+Added-on-date = Added on { $date }
 
 # Shows user network affiliation on user profile
 Affiliation-colon = Affiliation:
@@ -24,10 +33,21 @@ Are-you-sure = Are you sure?
 
 Are-you-sure-you-want-to-sign-out = Are you sure you want to sign out? This will delete all your observations on this device. It will not affect any observations you've uploaded to iNaturalist.
 
+app-authorized-on-date = { $appName } (authorized on: { $date })
+
+Applications = Applications
+
+Automatically-update-my-content-for-taxon-changes = Automatically update my content for taxon changes
+
 # Header above user biography / user description on user profile
 BIO = BIO
 
+# Header for inserting user description in settings profile tab
+Bio = Bio
+
 Birds = Birds
+
+Blocked-Users = Blocked Users
 
 Cancel = Cancel
 
@@ -36,10 +56,19 @@ Captive-Cultivated = Captive/Cultivated
 # Quality grade option
 Casual = Casual
 
+# After pressing the reset password button
+Check-your-email = Check your email! We've sent password reset instructions.
+
 Combine-Photos = Combine Photos
 
 # Onboarding for users learning to group photos in the camera roll
 Combine-photos-onboarding = Combine photos into observations – make sure there is only one species per observation
+
+Community-Moderation-Settings = Community Moderation Settings
+
+Connected-Accounts = Connected Accounts
+
+Content-Display = Content & Display
 
 CREATE-AN-OBSERVATION = CREATE AN OBSERVATION
 
@@ -53,6 +82,8 @@ Date-observed-colon = Date observed:
 
 Date-uploaded-colon = Date uploaded:
 
+Default-Search-Place = Default Search Place
+
 Delete-comment = Delete comment
 
 DELETE-X-OBSERVATIONS = DELETE {$count ->
@@ -62,9 +93,22 @@ DELETE-X-OBSERVATIONS = DELETE {$count ->
 
 Description-Tags = Description/Tags
 
+Display = Display
+
+Display-Name = Display Name
+
+Do-not-collect-stability-and-usage-data-using-third-party-services = Do not collect stability and usage data using third-party services
+
+# Appears above the email text field
+Email = email
+
+Email-Notifications = Email Notifications
+
 Evidence = Evidence
 
 Explore = Explore
+
+External-Applications = External Applications
 
 # Header for featured projects
 Featured = Featured
@@ -74,6 +118,11 @@ Filters = Filters
 Finish = Finish
 
 Fish = Fish
+
+Following = Following
+
+# Forgot password link
+Forgot-Password = Forgot Password?
 
 Fungi = Fungi
 
@@ -103,11 +152,20 @@ IDENTIFICATION = IDENTIFICATION
 
 Identification = Identification
 
+iNaturalist-Activity-Notifications = iNaturalist Activity Notifications
+
+iNaturalist-Applications = iNaturalist Applications
+
+iNaturalist-Network-Affiliation = iNaturalist Network Affiliation
+
 iNaturalist-is-a-community-of-naturalists = iNaturalist is a community of naturalists.
 
 Insects = Insects
 
 Introduced = Introduced
+
+# Appears when the user enters invalid username/password
+Invalid-login = The username or password is incorrect
 
 # Header for joined projects
 Joined = Joined
@@ -117,12 +175,24 @@ Joined-colon = Joined:
 
 Journal-Posts = Journal Posts
 
+Language-Locale = Language/Locale
+
 # Shows date user last active on iNaturalist on user profile
 Last-Active-colon = Last Active:
+
+Licensing = Licensing
 
 Location = Location
 
 Log-in = Log in
+
+Logged-in-as = Logged in as: { $username }
+
+# Appears in the login screen
+Login-header = Log in to use iNaturalist
+
+# Appears in the login screen
+Login-sub-title = Document living things, identify organisms & contribute to science
 
 Low = Low
 
@@ -161,6 +231,10 @@ Months = Months
 
 Most-faved = Most faved
 
+Muted-Users = Muted Users
+
+Names = Names
+
 Native = Native
 
 # Header for nearby projects
@@ -173,10 +247,19 @@ New-Observation = New Observation
 
 Next = Next
 
+# When the user tries to reset password but enters a non-existent email
+No-account-found = No account found with that email
+
+No-comments-or-ids-to-display = No comments or ids to display
+
 No-Location = No Location
+
+No-photos-found = No photos found. If this is your first time opening the app and giving permissions, try restarting the app.
 
 # Header for observation description on observation detail
 Notes = Notes
+
+Notifications = Notifications
 
 Obscured = Obscured
 
@@ -190,6 +273,8 @@ Open = Open
 Organism-is-wild = Organism is wild
 
 Other-Data = Other Data
+
+Password = Password
 
 Paused = Paused
 
@@ -205,7 +290,17 @@ Playing-Sound = Playing Sound
 # Help text for beginning a sound recording
 Press-Record-to-Start = Press Record to Start
 
+Prioritize-common-names-used-in-this-place = Prioritize common names used in this place.
+
+Privacy = Privacy
+
 Private = Private
+
+Profile = Profile
+
+Profile-Picture = Profile Picture
+
+Project-Settings = Project Settings
 
 PROJECTS = PROJECTS
 
@@ -298,9 +393,13 @@ Record-new-sound = Record new sound
 
 Recording-Sound = Recording Sound
 
+Relationships = Relationships
+
 Remove-Photo = Remove Photo
 
 Remove-Photos = Remove Photos
+
+Remove-Relationship = Remove Relationship
 
 Reptiles = Reptiles
 
@@ -309,9 +408,19 @@ Research-Grade = Research Grade
 
 Reset = Reset
 
+# Appears in the reset password screen
+Reset-password-header = Let's reset your password
+
+# Reset password button
+Reset-Password = Reset Password
+
+Return-to-login = Return to login
+
 Reviewed = Reviewed
 
 Reviewed-only = Reviewed only
+
+Revoke = Revoke
 
 Search-for-a-location = Search for a location
 
@@ -327,12 +436,16 @@ Select = Select
 
 Separate-Photos = Separate Photos
 
+Settings = Settings
+
 Sign-out = Sign out
 
 Sign-Up = Sign Up
 
 # Header for a section showing taxa similar to a single taxon
 SIMILAR-SPECIES-header = SIMILAR SPECIES
+
+Sort-By = Sort By
 
 Sort-by = Sort by
 
@@ -357,13 +470,33 @@ Taxon = Taxon
 # Header for a block of text describing a taxon's taxonomy
 TAXONOMY-header = TAXONOMY
 
+Taxonomy-Settings = Taxonomy Settings
+
 # Onboarding for users adding their first evidence of an organism
 The-first-thing-you-need-is-evidence = The first thing you need is evidence of an organism. This helps others identify what you saw.
+
+The-iNaturalist-Network-is-a-collection-of-localized-websites = The iNaturalist Network is a collection of localized websites that are fully connected to the global iNaturalist community. Network sites are supported by local institutions that have signed an agreement with iNaturalist to promote local use and benefit local biodiversity. They have access to true coordinates from their countries that are automatically obscured from public view in order to protect threatened species. Your username and password works on all sites that are part of the iNaturalist Network. If you choose to affiliate with a Network site, the local institutions that operate each site will also have access to your email address (only to communicate with you about site activities) and access to the true coordinates for observations that are publicly obscured or private. Note: Please do not experimentally change your affiliation if you have more than 1000 observations.
+
+This-is-how-all-taxon-names-will-be-displayed-to-you-across-iNaturalist = This is how all taxon names will be displayed to you across iNaturalist
 
 # Describes whether a user made this observation from web, iOS, or Android
 This-observation-was-created-using = This observation was created using:
 
+This-sets-your-language-and-date-formatting-preferences-across-iNaturalist = This sets your language and date formatting preferences across iNaturalist based on your locale.
+
+This-will-be-your-default-place-for-all-searches-in-Explore-and-Identify = This will be your default place for all searches in Explore and Identify.
+
 Threatened = Threatened
+
+Trust-with-hidden-coordinates = Trust with hidden coordinates
+
+Trusted = Trusted
+
+Unblock = Unblock
+
+Unknown-organism = Unknown organism
+
+Unmute = Unmute
 
 Unreviewed-only = Unreviewed only
 
@@ -393,9 +526,16 @@ User = User
 
 Username = Username
 
+# Appears above the text fields
+Username-or-Email = Username or Email
+
 Visually-search-iNaturalist-data = Visually search iNaturalist’s wealth of data. Search by a taxon in a location
 
 Whenever-you-get-internet-connection-you-can-upload = Whenever you get internet connection, you can upload your observations to iNaturalist.
+
+Which-traditional-projects-can-add-your-observations = Which traditional projects can add your observations?
+
+Who-can-add-observation-fields-to-my-observations = Who can add observation fields to my observations?
 
 # Banner above Explore Map showing total number of results
 X-Observations = {$observationCount ->
@@ -423,33 +563,3 @@ Yes-delete-photo = Yes, delete photo
 # Message shown when a permission is required to use a part of the app
 # (e.g. permission to access the camera) but the user denied the permission.
 You-denied-iNaturalist-permission-to-do-that = You denied iNaturalist permission to do that
-
-# Appears in the login screen
-Login-header = Log in to use iNaturalist
-Login-sub-title = Document living things, identify organisms & contribute to science
-
-# Appears above the text fields
-Username-or-Email = Username or Email
-Password = Password
-
-# Forgot password link
-Forgot-Password = Forgot Password?
-
-# Appears when the user enters invalid username/password
-Invalid-login = The username or password is incorrect
-
-# Appears in the reset password screen
-Reset-password-header = Let's reset your password
-# Appears above the email text field
-Email = email
-# Reset password button
-Reset-Password = Reset Password
-
-# When the user tries to reset password but enters a non-existent email
-No-account-found = No account found with that email
-
-# After pressing the reset password button
-Check-your-email = Check your email! We've sent password reset instructions.
-Return-to-login = Return to login
-
-Logged-in-as = Logged in as: { $username }

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -49,9 +49,9 @@ Date-added-newest-to-oldest = Date added - newest to oldest
 
 Date-added-oldest-to-newest = Date added - oldest to newest
 
-Date-observed = Date observed:
+Date-observed-colon = Date observed:
 
-Date-uploaded = Date uploaded:
+Date-uploaded-colon = Date uploaded:
 
 Delete-comment = Delete comment
 

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -9,6 +9,9 @@ Add-optional-notes = Add optional notes
 
 Add-to-projects = Add to projects
 
+# Shows user network affiliation on user profile
+Affiliation-colon = Affiliation:
+
 All = All
 
 All-observations = All observations
@@ -20,6 +23,9 @@ Arachnids = Arachnids
 Are-you-sure = Are you sure?
 
 Are-you-sure-you-want-to-sign-out = Are you sure you want to sign out? This will delete all your observations on this device. It will not affect any observations you've uploaded to iNaturalist.
+
+# Header above user biography / user description on user profile
+BIO = BIO
 
 Birds = Birds
 
@@ -43,6 +49,10 @@ Date-added-newest-to-oldest = Date added - newest to oldest
 
 Date-added-oldest-to-newest = Date added - oldest to newest
 
+Date-observed = Date observed:
+
+Date-uploaded = Date uploaded:
+
 Delete-comment = Delete comment
 
 DELETE-X-OBSERVATIONS = DELETE {$count ->
@@ -55,6 +65,9 @@ Description-Tags = Description/Tags
 Evidence = Evidence
 
 Explore = Explore
+
+# Header for featured projects
+Featured = Featured
 
 Filters = Filters
 
@@ -84,13 +97,28 @@ Has-Sounds = Has Sounds
 
 High = High
 
+IDs = ID's
+
 IDENTIFICATION = IDENTIFICATION
 
 Identification = Identification
 
+iNaturalist-is-a-community-of-naturalists = iNaturalist is a community of naturalists.
+
 Insects = Insects
 
 Introduced = Introduced
+
+# Header for joined projects
+Joined = Joined
+
+# Shows date user joined iNaturalist on user profile
+Joined-colon = Joined:
+
+Journal-Posts = Journal Posts
+
+# Shows date user last active on iNaturalist on user profile
+Last-Active-colon = Last Active:
 
 Location = Location
 
@@ -135,6 +163,9 @@ Most-faved = Most faved
 
 Native = Native
 
+# Header for nearby projects
+Nearby = Nearby
+
 # Quality grade option
 Needs-ID = Needs ID
 
@@ -144,11 +175,19 @@ Next = Next
 
 No-Location = No Location
 
+# Header for observation description on observation detail
+Notes = Notes
+
 Obscured = Obscured
 
 Observation = Observation
 
+Observations = Observations
+
 Open = Open
+
+# Picker prompt on observation edit
+Organism-is-wild = Organism is wild
 
 Other-Data = Other Data
 
@@ -167,6 +206,8 @@ Playing-Sound = Playing Sound
 Press-Record-to-Start = Press Record to Start
 
 Private = Private
+
+PROJECTS = PROJECTS
 
 Projects = Projects
 
@@ -247,6 +288,8 @@ Ranks-form = form
 
 Ranks-infrahybrid = infrahybrid
 
+Read-more-on-Wikipedia = Read more on Wikipedia
+
 Recently-observed = Recently observed
 
 Record-a-sound = Record a sound
@@ -286,10 +329,14 @@ Separate-Photos = Separate Photos
 
 Sign-out = Sign out
 
+Sign-Up = Sign Up
+
 # Header for a section showing taxa similar to a single taxon
 SIMILAR-SPECIES-header = SIMILAR SPECIES
 
 Sort-by = Sort by
+
+Species = Species
 
 Status = Status
 
@@ -312,6 +359,9 @@ TAXONOMY-header = TAXONOMY
 
 # Onboarding for users adding their first evidence of an organism
 The-first-thing-you-need-is-evidence = The first thing you need is evidence of an organism. This helps others identify what you saw.
+
+# Describes whether a user made this observation from web, iOS, or Android
+This-observation-was-created-using = This observation was created using:
 
 Threatened = Threatened
 
@@ -341,7 +391,11 @@ Uploading-X-Observations = Uploading {$count ->
 
 User = User
 
+Username = Username
+
 Visually-search-iNaturalist-data = Visually search iNaturalist’s wealth of data. Search by a taxon in a location
+
+Whenever-you-get-internet-connection-you-can-upload = Whenever you get internet connection, you can upload your observations to iNaturalist.
 
 # Banner above Explore Map showing total number of results
 X-Observations = {$observationCount ->

--- a/src/styles/sharedComponents/observationViews/obsCard.js
+++ b/src/styles/sharedComponents/observationViews/obsCard.js
@@ -49,9 +49,6 @@ const viewStyles: { [string]: ViewStyleProp } = StyleSheet.create( {
 } );
 
 const textStyles: { [string]: TextStyleProp } = StyleSheet.create( {
-  wrap: {
-    maxWidth: 45
-  }
 } );
 
 export {


### PR DESCRIPTION
This uses the `eslint-plugin-i18next` plugin to enforce globalized text (i.e. no string literals in a `<Text>` component).

I set the eslint plugin to warning mode instead of error mode for the time being, mostly because we have a lot of text as placeholders for image assets that won't need to be translated, and we also have a lot of text in screens like CVSuggestions which have had complete design overhauls since we first built these components. I'm thinking we can slowly pick away at these over time, but maybe there's a better approach.

All the Settings components also have text that needs to be translated, and I'm assuming we can tackle that sooner since the text will likely be similar to what's on the web.