### PR TITLE
123 permission fetch location

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
       android:name=".MainApplication"

--- a/src/components/ObsEdit/Notes.js
+++ b/src/components/ObsEdit/Notes.js
@@ -19,6 +19,7 @@ const Notes = ( { addNotes, description }: Props ): Node => {
   const [keyboardOffset, setKeyboardOffset] = useState( 0 );
   const { width } = useWindowDimensions( );
   const insets = useSafeAreaInsets( );
+  const [localDescription, setLocalDescription] = useState( description );
 
   useEffect( ( ) => {
     const showSubscription = Keyboard.addListener( "keyboardDidShow", e => {
@@ -44,8 +45,9 @@ const Notes = ( { addNotes, description }: Props ): Node => {
     <TextInput
       keyboardType="default"
       multiline
-      onChangeText={addNotes}
-      value={description}
+      onChangeText={text => setLocalDescription( text )}
+      onBlur={( ) => addNotes( localDescription )}
+      value={localDescription}
       placeholder={t( "Add-optional-notes" )}
       style={[textStyles.notes, keyboardOffset > 0 && offset]}
       testID="ObsEdit.notes"

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -58,6 +58,7 @@ const ObsEdit = ( ): Node => {
   const [deleteDialogVisible, setDeleteDialogVisible] = useState( false );
   const [fetchedLocation, setFetchedLocation] = useState( false );
   const [positionalAccuracy, setPositionalAccuracy] = useState( 1000000 );
+  const [mounted, setMounted] = useState( true );
 
   const disableAddingMoreEvidence = photoUris.length >= MAX_PHOTOS_ALLOWED;
 
@@ -133,7 +134,7 @@ const ObsEdit = ( ): Node => {
         }
       };
 
-      if ( !fetchedLocation && !currentObs._created_at ) {
+      if ( !fetchedLocation && !currentObs._created_at && mounted ) {
         if ( positionalAccuracy >= 15 ) {
           fetchLocation();
         } else {
@@ -141,7 +142,9 @@ const ObsEdit = ( ): Node => {
         }
       }
     }
-  }, [updateObservationKeys, fetchedLocation, positionalAccuracy, currentObs] );
+
+    return setMounted( false );
+  }, [updateObservationKeys, fetchedLocation, positionalAccuracy, currentObs, mounted] );
 
   const setPhotos = uris => {
     const updatedObservations = observations;

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -129,21 +129,21 @@ const ObsEdit = ( ): Node => {
           longitude: location?.longitude,
           positional_accuracy: location?.positional_accuracy
         } );
-        if ( location ) {
+        if ( location && mounted ) {
           setPositionalAccuracy( location.positional_accuracy );
         }
       };
 
-      if ( !fetchedLocation && !currentObs._created_at && mounted ) {
+      if ( !fetchedLocation && !currentObs._created_at ) {
         if ( positionalAccuracy >= 15 ) {
           fetchLocation();
-        } else {
-          setFetchedLocation( true );
         }
+        setFetchedLocation( true );
       }
     }
-
-    return setMounted( false );
+    return () => {
+      setMounted( false );
+    };
   }, [updateObservationKeys, fetchedLocation, positionalAccuracy, currentObs, mounted] );
 
   const setPhotos = uris => {

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -141,9 +141,7 @@ const ObsEdit = ( ): Node => {
         setFetchedLocation( true );
       }
     }
-    return () => {
-      setMounted( false );
-    };
+    return setMounted( false );
   }, [updateObservationKeys, fetchedLocation, positionalAccuracy, currentObs, mounted] );
 
   const setPhotos = uris => {

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -129,16 +129,17 @@ const ObsEdit = ( ): Node => {
           longitude: location?.longitude,
           positional_accuracy: location?.positional_accuracy
         } );
-        if ( location && mounted ) {
+        if ( location ) {
           setPositionalAccuracy( location.positional_accuracy );
         }
       };
 
-      if ( !fetchedLocation && !currentObs._created_at ) {
+      if ( !fetchedLocation && !currentObs._created_at && !mounted ) {
         if ( positionalAccuracy >= 15 ) {
           fetchLocation();
+        } else {
+          setFetchedLocation( true );
         }
-        setFetchedLocation( true );
       }
     }
     return setMounted( false );

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -133,7 +133,7 @@ const ObsEdit = ( ): Node => {
         }
       };
 
-      if ( !fetchedLocation ) {
+      if ( !fetchedLocation && !currentObs._created_at ) {
         if ( positionalAccuracy >= 15 ) {
           fetchLocation();
         } else {

--- a/src/models/Observation.js
+++ b/src/models/Observation.js
@@ -55,7 +55,7 @@ class Observation extends Realm.Object {
   }
 
   static async createObsWithPhotos( observationPhotos ) {
-    const observation = await Observation.new();
+    const observation = await Observation.new( );
     observation.observationPhotos = observationPhotos;
     return observation;
   }

--- a/src/models/Observation.js
+++ b/src/models/Observation.js
@@ -45,6 +45,7 @@ class Observation extends Realm.Object {
   static async new( obs ) {
     // TODO remove this from the model. IMO this kind of system interaction
     // should happen in the component
+
     const latLng = await fetchUserLocation( );
 
     return {
@@ -60,8 +61,20 @@ class Observation extends Realm.Object {
     };
   }
 
+  static async import( obs ) {
+    return {
+      ...obs,
+      captive_flag: false,
+      geoprivacy: "open",
+      owners_identification_from_vision: false,
+      observed_on_string: createObservedOnStringForUpload( ),
+      quality_grade: "needs_id",
+      uuid: uuid.v4( )
+    };
+  }
+
   static async createObsWithPhotos( observationPhotos ) {
-    const observation = await Observation.new( );
+    const observation = await Observation.new();
     observation.observationPhotos = observationPhotos;
     return observation;
   }

--- a/src/models/Observation.js
+++ b/src/models/Observation.js
@@ -7,7 +7,6 @@ import {
   getJWTToken, getUserId, getUsername
 } from "../components/LoginSignUp/AuthenticationService";
 import { createObservedOnStringForUpload, formatDateAndTime } from "../sharedHelpers/dateAndTime";
-import fetchUserLocation from "../sharedHelpers/fetchUserLocation";
 // eslint-disable-next-line import/no-cycle
 import Comment from "./Comment";
 // eslint-disable-next-line import/no-cycle
@@ -43,32 +42,14 @@ class Observation extends Realm.Object {
   }
 
   static async new( obs ) {
-    // TODO remove this from the model. IMO this kind of system interaction
-    // should happen in the component
-
-    const latLng = await fetchUserLocation( );
-
     return {
       ...obs,
-      ...latLng,
       captive_flag: false,
       geoprivacy: "open",
       owners_identification_from_vision: false,
       observed_on_string: createObservedOnStringForUpload( ),
       quality_grade: "needs_id",
       // project_ids: [],
-      uuid: uuid.v4( )
-    };
-  }
-
-  static async import( obs ) {
-    return {
-      ...obs,
-      captive_flag: false,
-      geoprivacy: "open",
-      owners_identification_from_vision: false,
-      observed_on_string: createObservedOnStringForUpload( ),
-      quality_grade: "needs_id",
       uuid: uuid.v4( )
     };
   }

--- a/src/navigation/mainStackNavigation.js
+++ b/src/navigation/mainStackNavigation.js
@@ -70,6 +70,15 @@ const SoundRecorderWithPermission = ( ) => (
   </PermissionGate>
 );
 
+const ObsEditWithPermission = () => (
+  <Mortal>
+    <PermissionGate permission={PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION}>
+      <ObsEdit />
+    </PermissionGate>
+  </Mortal>
+
+);
+
 const MainStackNavigation = ( ): React.Node => (
   <Mortal>
     <ExploreProvider>
@@ -102,7 +111,7 @@ const MainStackNavigation = ( ): React.Node => (
         />
         <Stack.Screen
           name="ObsEdit"
-          component={ObsEdit}
+          component={ObsEditWithPermission}
         />
         <Stack.Screen
           name="SoundRecorder"

--- a/src/navigation/mainStackNavigation.js
+++ b/src/navigation/mainStackNavigation.js
@@ -70,6 +70,12 @@ const SoundRecorderWithPermission = ( ) => (
   </PermissionGate>
 );
 
+const RequestLocationWithPermission = ( ) => (
+  <PermissionGate permission={PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION}>
+    <ObsEdit />
+  </PermissionGate>
+);
+
 const MainStackNavigation = ( ): React.Node => (
   <Mortal>
     <ExploreProvider>
@@ -102,7 +108,7 @@ const MainStackNavigation = ( ): React.Node => (
         />
         <Stack.Screen
           name="ObsEdit"
-          component={ObsEdit}
+          component={RequestLocationWithPermission}
         />
         <Stack.Screen
           name="SoundRecorder"

--- a/src/navigation/mainStackNavigation.js
+++ b/src/navigation/mainStackNavigation.js
@@ -70,12 +70,6 @@ const SoundRecorderWithPermission = ( ) => (
   </PermissionGate>
 );
 
-const RequestLocationWithPermission = ( ) => (
-  <PermissionGate permission={PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION}>
-    <ObsEdit />
-  </PermissionGate>
-);
-
 const MainStackNavigation = ( ): React.Node => (
   <Mortal>
     <ExploreProvider>
@@ -108,7 +102,7 @@ const MainStackNavigation = ( ): React.Node => (
         />
         <Stack.Screen
           name="ObsEdit"
-          component={RequestLocationWithPermission}
+          component={ObsEdit}
         />
         <Stack.Screen
           name="SoundRecorder"

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -39,7 +39,7 @@ const ObsEditProvider = ( { children }: Props ): Node => {
   const addObservations = async obs => setObservations( obs );
 
   const addObservationNoEvidence = async ( ) => {
-    const newObs = await Observation.import( );
+    const newObs = await Observation.new( );
     setObservations( [newObs] );
   };
 
@@ -51,6 +51,19 @@ const ObsEditProvider = ( { children }: Props ): Node => {
             ...obs,
             // $FlowFixMe
             [key]: value
+          };
+        }
+        return obs;
+      } );
+      setObservations( updatedObs );
+    };
+
+    const updateObservationKeys = keysAndValues => {
+      const updatedObs = observations.map( ( obs, index ) => {
+        if ( index === currentObsIndex ) {
+          return {
+            ...obs,
+            ...keysAndValues
           };
         }
         return obs;
@@ -131,6 +144,7 @@ const ObsEditProvider = ( { children }: Props ): Node => {
       setCurrentObsIndex,
       setObservations,
       updateObservationKey,
+      updateObservationKeys,
       updateTaxon
     };
   }, [

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -39,7 +39,7 @@ const ObsEditProvider = ( { children }: Props ): Node => {
   const addObservations = async obs => setObservations( obs );
 
   const addObservationNoEvidence = async ( ) => {
-    const newObs = await Observation.new( );
+    const newObs = await Observation.import( );
     setObservations( [newObs] );
   };
 

--- a/src/sharedHelpers/fetchUserLocation.js
+++ b/src/sharedHelpers/fetchUserLocation.js
@@ -6,7 +6,7 @@ import { PERMISSIONS, request } from "react-native-permissions";
 
 import fetchPlaceName from "./fetchPlaceName";
 
-const requestiOSPermissions = async ( ): Promise<?string> => {
+const requestLocationPermissions = async ( ): Promise<?string> => {
   // TODO: test this on a real device
   if ( Platform.OS === "ios" ) {
     try {
@@ -16,16 +16,12 @@ const requestiOSPermissions = async ( ): Promise<?string> => {
       console.log( e, ": error requesting iOS permissions" );
     }
   }
-  return null;
-};
-
-const requestAndroidPermissions = async ( ): Promise<?string> => {
   if ( Platform.OS === "android" ) {
     try {
       const permission = await request( PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION );
       return permission;
     } catch ( e ) {
-      console.log( e, ": error requesting iOS permissions" );
+      console.log( e, ": error requesting android permissions" );
     }
   }
   return null;
@@ -38,18 +34,17 @@ const getCurrentPosition = ( ) => new Promise(
 );
 
 const fetchUserLocation = async ( ): ?Object => {
-  const permissions = await requestiOSPermissions( );
-  const androidPermissions = await requestAndroidPermissions( );
+  const permissions = await requestLocationPermissions( );
 
   // TODO: handle case where iOS permissions are not granted
-  if ( Platform.OS !== "android" && permissions !== "granted" ) { return null; }
-  if ( Platform.OS !== "ios" && androidPermissions !== "granted" ) {
+  if ( Platform.OS !== "android" && permissions !== "granted" ) {
     return null;
   }
 
   try {
     const { coords } = await getCurrentPosition( );
     const placeGuess = await fetchPlaceName( coords.latitude, coords.longitude );
+
     return {
       place_guess: placeGuess,
       latitude: coords.latitude,

--- a/src/sharedHelpers/fetchUserLocation.js
+++ b/src/sharedHelpers/fetchUserLocation.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Platform } from "react-native";
+import { PermissionsAndroid, Platform } from "react-native";
 import Geolocation from "react-native-geolocation-service";
 import { PERMISSIONS, request } from "react-native-permissions";
 
@@ -19,6 +19,18 @@ const requestiOSPermissions = async ( ): Promise<?string> => {
   return null;
 };
 
+const requestAndroidPermissions = async ( ): Promise<?string> => {
+  if ( Platform.OS === "android" ) {
+    try {
+      const permission = await request( PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION );
+      return permission;
+    } catch ( e ) {
+      console.log( e, ": error requesting iOS permissions" );
+    }
+  }
+  return null;
+};
+
 const options = { enableHighAccuracy: true, timeout: 15000, maximumAge: 10000 };
 
 const getCurrentPosition = ( ) => new Promise(
@@ -27,8 +39,13 @@ const getCurrentPosition = ( ) => new Promise(
 
 const fetchUserLocation = async ( ): ?Object => {
   const permissions = await requestiOSPermissions( );
+  const androidPermissions = await requestAndroidPermissions( );
+
   // TODO: handle case where iOS permissions are not granted
-  if ( permissions !== "granted" ) { return null; }
+  if ( Platform.OS !== "android" && permissions !== "granted" ) { return null; }
+  if ( Platform.OS !== "ios" && androidPermissions !== "granted" ) {
+    return null;
+  }
 
   try {
     const { coords } = await getCurrentPosition( );

--- a/src/sharedHelpers/fetchUserLocation.js
+++ b/src/sharedHelpers/fetchUserLocation.js
@@ -33,7 +33,14 @@ const getCurrentPosition = ( ) => new Promise(
   ( resolve, error ) => { Geolocation.getCurrentPosition( resolve, error, options ); }
 );
 
-const fetchUserLocation = async ( ): ?Object => {
+type UserLocation = {
+  latitude: number,
+  longitude: number,
+  positional_accuracy: number,
+  place_guess: ?string
+
+}
+const fetchUserLocation = async ( ): Promise<?UserLocation> => {
   const permissions = await requestLocationPermissions( );
 
   // TODO: handle case where iOS permissions are not granted


### PR DESCRIPTION
This PR resolves issue #123 

- [x] Request permission to access the user's location (probably good to use <PermissionGate>
- [x] Fetch the user's current location if the observation's location is not already set, and continue fetching it until accuracy drops below 15 m
- [x]  Pull any existing location retrieval out of the models
- [x] When the location updates, set the observation latitude, longitude, and positional_accuracy to match
- [x]  Update the displayed location every time the observation gets updated
- [x] Not fetch location for existing observation
 


 


