### PR TITLE
Make sync icon active for unuploaded obs

### DIFF
--- a/src/components/SharedComponents/ObservationViews/ObsListHeader.js
+++ b/src/components/SharedComponents/ObservationViews/ObsListHeader.js
@@ -38,6 +38,7 @@ const ObsListHeader = ( {
         isLoggedIn={isLoggedIn}
         syncObservations={syncObservations}
         setView={setView}
+        numOfUnuploadedObs={numOfUnuploadedObs}
       />
     </View>
   );

--- a/src/components/SharedComponents/ObservationViews/Toolbar.js
+++ b/src/components/SharedComponents/ObservationViews/Toolbar.js
@@ -5,27 +5,34 @@ import React from "react";
 import { Pressable, View } from "react-native";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 
+import colors from "../../../styles/colors";
 import { viewStyles } from "../../../styles/observations/obsList";
 
 type Props = {
   isExplore: boolean,
   isLoggedIn: ?boolean,
   syncObservations: Function,
-  setView: Function
-}
+  setView: Function,
+  numOfUnuploadedObs: number,
+  }
 
 const Toolbar = ( {
   isExplore,
   isLoggedIn,
   syncObservations,
-  setView
+  setView,
+  numOfUnuploadedObs
 }: Props ): Node => (
   <>
     {!isExplore && (
       <View style={viewStyles.toggleButtons}>
-        {isLoggedIn && (
+        {!isLoggedIn && (
         <Pressable onPress={syncObservations}>
-          <Icon name="sync" size={30} />
+          <Icon
+            name="sync"
+            size={30}
+            color={numOfUnuploadedObs > 0 ? colors.inatGreen : colors.gray}
+          />
         </Pressable>
         )}
       </View>

--- a/src/components/SharedComponents/ObservationViews/Toolbar.js
+++ b/src/components/SharedComponents/ObservationViews/Toolbar.js
@@ -26,7 +26,7 @@ const Toolbar = ( {
   <>
     {!isExplore && (
       <View style={viewStyles.toggleButtons}>
-        {!isLoggedIn && (
+        {isLoggedIn && (
         <Pressable onPress={syncObservations}>
           <Icon
             name="sync"


### PR DESCRIPTION
This PR resolves issue #176

- passes a prop to check if there is any unuploaded obs
- If so it would turn the sync icon to green.