### PR TITLE
Fix for android build in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,16 @@ buildscript {
     }
 }
 
+// android build was failing as of Nov 4, 2022
+// and this fixes it: https://github.com/facebook/react-native/issues/35204
+def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
+
 allprojects {
+    configurations.all {
+        resolutionStrategy {
+            force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
+        }
+    }
     repositories {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
Couldn't get Android to build, and this fixes it. Seems to be a known issue [since 0.71.0-rc.0 tag added](https://github.com/facebook/react-native/issues/35204#top). 