### PR TITLE
Fix infinite loop in ObsDetail for local observations

### DIFF
--- a/src/api/error.js
+++ b/src/api/error.js
@@ -18,13 +18,14 @@ Object.defineProperty( INatApiError.prototype, "name", {
   value: "INatApiError"
 } );
 
-const handleError = async ( e: Object, options: Object = {} ) => {
+const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( !e.response ) { throw e; }
   const errorJson = await e.response.json( );
   const error = new INatApiError( errorJson );
   if ( options.throw ) {
     throw error;
   }
+  return error;
 };
 
 export default handleError;

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -25,7 +25,6 @@ const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( options.throw ) {
     throw error;
   }
-  return error;
 };
 
 export default handleError;

--- a/src/api/observations.js
+++ b/src/api/observations.js
@@ -114,7 +114,7 @@ const fetchRemoteObservation = async (
     }
     return null;
   } catch ( e ) {
-    return handleError( e );
+    return handleError( e, { throw: true } );
   }
 };
 

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -138,8 +138,11 @@ const ObsDetails = ( ): Node => {
 
   useEffect( ( ) => {
     // set initial ids for activity tab
-    if ( observation && ids.length === 0 ) {
-      setIds( observation.identifications );
+    const currentIds = observation?.identifications;
+    if ( currentIds
+        && ids.length === 0
+        && currentIds.length !== ids.length ) {
+      setIds( currentIds );
     }
   }, [observation, ids] );
 


### PR DESCRIPTION
Closes #223

- Set initial state of `setIds` once instead of infinite times
- Add option to throw error from `handleError` when uuid doesn't exist on server / local observation hasn't been synced; otherwise `useQuery` throws an error that says data should not be undefined