### PR TITLE
216 remove excess space below the tab bar

### DIFF
--- a/src/components/SharedComponents/Footer.js
+++ b/src/components/SharedComponents/Footer.js
@@ -1,8 +1,8 @@
 // @flow
-
 import { useNavigation } from "@react-navigation/native";
 import { Pressable, View } from "components/styledComponents";
 import * as React from "react";
+import { Platform } from "react-native";
 import IconMaterial from "react-native-vector-icons/MaterialIcons";
 import { viewStyles } from "styles/sharedComponents/footer";
 
@@ -15,9 +15,13 @@ const Footer = ( ): React.Node => {
   const navToExplore = ( ) => navigation.navigate( "MainStack", { screen: "ExploreLanding" } );
   const navToNotifications = ( ) => navigation.navigate( "MainStack", { screen: "Messages" } );
 
+  const footerClassName = ( Platform.OS === "ios" )
+    ? "flex-row h-20 absolute bottom-0 bg-white w-full justify-evenly pt-2"
+    : "flex-row h-14 absolute bottom-0 bg-white w-full justify-evenly pt-2";
+
   return (
     <View
-      className="flex-row h-16 absolute bottom-0 bg-white w-full justify-evenly pt-2"
+      className={footerClassName}
       style={viewStyles.shadow}
     >
       <Pressable onPress={toggleSideMenu} accessibilityRole="link">

--- a/src/components/SharedComponents/Footer.js
+++ b/src/components/SharedComponents/Footer.js
@@ -17,7 +17,7 @@ const Footer = ( ): React.Node => {
 
   return (
     <View
-      className="flex-row h-24 absolute bottom-0 bg-white w-full justify-evenly pt-2"
+      className="flex-row h-16 absolute bottom-0 bg-white w-full justify-evenly pt-2"
       style={viewStyles.shadow}
     >
       <Pressable onPress={toggleSideMenu} accessibilityRole="link">


### PR DESCRIPTION
Android still has a small space at the bottom of the tab bar but if it is reduced to less the iOS tab bar buttons will be too close to the bar at the bottom swipe up. 