### PR TITLE
Cache ci node modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,17 @@ jobs:
       with:
         node-version: 16
 
-    - name: Install deps
+    - name: Cache node modules
+      uses: actions/cache@v3
+      id: cache
+      with:
+        path: node_modules
+        key: node-modules-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       run: npm install --legacy-peer-deps
+
     - run: npm run lint
     - run: npm test
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 * Xcode 13 or above
 * [Android and iOS environment setup](https://reactnative.dev/docs/environment-setup) described in the RN docs
-* Be nice to each other
 
 ## Install packages and pods
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * Xcode 13 or above
 * [Android and iOS environment setup](https://reactnative.dev/docs/environment-setup) described in the RN docs
+* Be nice to each other
 
 ## Install packages and pods
 


### PR DESCRIPTION
I have enabled caching of node_modules in the GitHub Actions test workflow. This saves us about 1min of time running the workflow on every push that does not require a new install of the dependencies. Adding a dependency or using a newer version would still require the install step. A hash of the package-lock.json file is used as a check for this.