### PR TITLE
Fixes for API calls, useCurrentUser hook, api token not being fetched

### DIFF
--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -17,10 +17,9 @@ const PARAMS = {
 };
 
 const searchMessages = async ( params: Object = {}, opts: Object = {} ): Promise<any> => {
-  console.log( opts, "options in search messages" );
   try {
     const { results } = await inatjs.messages.search( { ...PARAMS, ...params }, opts );
-    return results || [];
+    return results;
   } catch ( e ) {
     return handleError( e, { throw: true } );
   }

--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -17,11 +17,12 @@ const PARAMS = {
 };
 
 const searchMessages = async ( params: Object = {}, opts: Object = {} ): Promise<any> => {
+  console.log( opts, "options in search messages" );
   try {
     const { results } = await inatjs.messages.search( { ...PARAMS, ...params }, opts );
-    return results;
+    return results || [];
   } catch ( e ) {
-    return handleError( e );
+    return handleError( e, { throw: true } );
   }
 };
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,15 +1,14 @@
 // @flow
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { fetchUserMe } from "api/users";
 import { getUserId, signOut } from "components/LoginSignUp/AuthenticationService";
 import i18next from "i18next";
 import RootDrawerNavigator from "navigation/rootDrawerNavigation";
 import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
 import React, { useEffect } from "react";
-import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 import useCurrentUser from "sharedHooks/useCurrentUser";
+import useUserMe from "sharedHooks/useUserMe";
 
 const { useRealm } = RealmContext;
 
@@ -25,16 +24,7 @@ const App = ( { children }: Props ): Node => {
 
   // fetch current user from server and save to realm in useEffect
   // this is used for changing locale and also for showing UserCard
-  const {
-    data: remoteUser
-  } = useAuthenticatedQuery(
-    ["fetchUserMe"],
-    optsWithAuth => fetchUserMe( { }, optsWithAuth ),
-    {},
-    {
-      enabled: !!currentUser
-    }
-  );
+  const { remoteUser } = useUserMe( );
 
   useEffect( ( ) => {
     const checkForSignedInUser = async ( ) => {

--- a/src/components/Messages/Messages.js
+++ b/src/components/Messages/Messages.js
@@ -2,29 +2,42 @@
 
 import searchMessages from "api/messages";
 import ViewWithFooter from "components/SharedComponents/ViewWithFooter";
+import { Text } from "components/styledComponents";
+import { t } from "i18next";
 import type { Node } from "react";
 import React from "react";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useCurrentUser from "sharedHooks/useCurrentUser";
 
 import MessageList from "./MessageList";
 
 const Messages = ( ): Node => {
+  const currentUser = useCurrentUser( );
   const {
     data,
     isLoading
   } = useAuthenticatedQuery(
     ["searchMessages"],
-    optsWithAuth => searchMessages( { page: 1 }, optsWithAuth )
+    optsWithAuth => searchMessages( { page: 1 }, optsWithAuth ),
+    { },
+    {
+      enabled: !!currentUser
+    }
   );
-  // TODO: Reload when accessing again
 
   return (
     <ViewWithFooter>
-      <MessageList
-        loading={isLoading}
-        messageList={data}
-        testID="Messages.messages"
-      />
+      {currentUser ? (
+        <MessageList
+          loading={isLoading}
+          messageList={data}
+          testID="Messages.messages"
+        />
+      ) : (
+        <Text className="self-center">
+          {t( "You-must-be-logged-in-to-view-messages" )}
+        </Text>
+      )}
     </ViewWithFooter>
   );
 };

--- a/src/components/Observations/LoginPrompt.js
+++ b/src/components/Observations/LoginPrompt.js
@@ -16,7 +16,7 @@ const LoginPrompt = ( ): Node => {
       <Button
         level="neutral"
         text={t( "LOG-IN-TO-INATURALIST" )}
-        className="mt-5"
+        className="py-1 mt-5"
         onPress={( ) => navigation.navigate( "login" )}
       />
     </>

--- a/src/components/Observations/hooks/useInfiniteScroll.js
+++ b/src/components/Observations/hooks/useInfiniteScroll.js
@@ -5,6 +5,7 @@ import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
 import Observation from "realmModels/Observation";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useCurrentUser from "sharedHooks/useCurrentUser";
 import useLoggedIn from "sharedHooks/useLoggedIn";
 
 const { useRealm } = RealmContext;
@@ -12,7 +13,7 @@ const { useRealm } = RealmContext;
 const useInfiniteScroll = ( idBelow: ?number ): boolean => {
   const isLoggedIn = useLoggedIn( );
   const realm = useRealm( );
-  const currentUser = realm.objects( "User" ).filtered( "signedIn == true" )[0];
+  const currentUser = useCurrentUser( );
 
   const params = {
     user_id: currentUser?.id,

--- a/src/components/Projects/ProjectTabs.js
+++ b/src/components/Projects/ProjectTabs.js
@@ -2,21 +2,20 @@
 
 import { searchProjects } from "api/projects";
 import { t } from "i18next";
-import * as React from "react";
+import type { Node } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Pressable, Text, View } from "react-native";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useCurrentUser from "sharedHooks/useCurrentUser";
 import useUserLocation from "sharedHooks/useUserLocation";
 import { viewStyles } from "styles/projects/projects";
 
 import ProjectList from "./ProjectList";
 
-type Props = {
-  memberId: number
-}
-
-const ProjectTabs = ( { memberId }: Props ): React.Node => {
-  const userJoined = { member_id: memberId };
-  const [apiParams, setApiParams] = React.useState( userJoined );
+const ProjectTabs = ( ): Node => {
+  const currentUser = useCurrentUser( );
+  const memberId = currentUser?.id;
+  const [apiParams, setApiParams] = React.useState( { } );
 
   const latLng = useUserLocation( );
 
@@ -35,7 +34,15 @@ const ProjectTabs = ( { memberId }: Props ): React.Node => {
   };
 
   const fetchFeaturedProjects = ( ) => setApiParams( { features: true } );
-  const fetchUserJoinedProjects = ( ) => setApiParams( userJoined );
+  const fetchUserJoinedProjects = useCallback( ( ) => setApiParams(
+    { member_id: memberId }
+  ), [memberId] );
+
+  useEffect( ( ) => {
+    if ( memberId ) {
+      fetchUserJoinedProjects( );
+    }
+  }, [memberId, fetchUserJoinedProjects] );
 
   return (
     <>

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -1,10 +1,8 @@
 // @flow
 
-import { fetchUserMe } from "api/users";
 import InputField from "components/SharedComponents/InputField";
 import ViewWithFooter from "components/SharedComponents/ViewWithFooter";
 import * as React from "react";
-import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 
 import ProjectSearch from "./ProjectSearch";
 import ProjectTabs from "./ProjectTabs";
@@ -13,15 +11,6 @@ const Projects = ( ): React.Node => {
   const [q, setQ] = React.useState( "" );
 
   const clearSearch = ( ) => setQ( "" );
-
-  const {
-    data: user
-  } = useAuthenticatedQuery(
-    ["fetchUserMe"],
-    optsWithAuth => fetchUserMe( { }, optsWithAuth )
-  );
-
-  const memberId = user?.id;
 
   return (
     <ViewWithFooter testID="Projects">
@@ -35,7 +24,7 @@ const Projects = ( ): React.Node => {
       {/* TODO: make project search a separate screen or a modal?
       not sure what the final designs will look like but unlikely
       tabs and search will both be on the same screen */}
-      {memberId && <ProjectTabs memberId={memberId} />}
+      <ProjectTabs />
       <ProjectSearch q={q} clearSearch={clearSearch} />
     </ViewWithFooter>
   );

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -2,15 +2,25 @@
 
 import InputField from "components/SharedComponents/InputField";
 import ViewWithFooter from "components/SharedComponents/ViewWithFooter";
-import * as React from "react";
+import type { Node } from "react";
+import React, { useEffect, useState } from "react";
 
 import ProjectSearch from "./ProjectSearch";
 import ProjectTabs from "./ProjectTabs";
 
-const Projects = ( ): React.Node => {
-  const [q, setQ] = React.useState( "" );
+const Projects = ( ): Node => {
+  const [q, setQ] = useState( "" );
+  const [view, setView] = useState( "tabs" );
 
   const clearSearch = ( ) => setQ( "" );
+
+  useEffect( ( ) => {
+    if ( q.length > 0 ) {
+      setView( "search" );
+    } else {
+      setView( "tabs" );
+    }
+  }, [q] );
 
   return (
     <ViewWithFooter testID="Projects">
@@ -21,11 +31,9 @@ const Projects = ( ): React.Node => {
         type="none"
         testID="ProjectSearch.input"
       />
-      {/* TODO: make project search a separate screen or a modal?
-      not sure what the final designs will look like but unlikely
-      tabs and search will both be on the same screen */}
-      <ProjectTabs />
-      <ProjectSearch q={q} clearSearch={clearSearch} />
+      {view === "tabs"
+        ? <ProjectTabs />
+        : <ProjectSearch q={q} clearSearch={clearSearch} />}
     </ViewWithFooter>
   );
 };

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { fetchUserMe, updateUsers } from "api/users";
+import { updateUsers } from "api/users";
 import ViewWithFooter from "components/SharedComponents/ViewWithFooter";
 import { t } from "i18next";
 import type { Node } from "react";
@@ -15,7 +15,7 @@ import {
   View
 } from "react-native";
 import useAuthenticatedMutation from "sharedHooks/useAuthenticatedMutation";
-import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useUserMe from "sharedHooks/useUserMe";
 import { textStyles, viewStyles } from "styles/settings/settings";
 
 import SettingsAccount from "./SettingsAccount";
@@ -150,14 +150,7 @@ const Settings = ( { children: _children }: Props ): Node => {
   const [settings, setSettings] = useState( {} );
   const [isSaving, setIsSaving] = useState( false );
 
-  const {
-    data: user,
-    isLoading,
-    refetch: refetchUserMe
-  } = useAuthenticatedQuery(
-    ["fetchUserMe"],
-    optsWithAuth => fetchUserMe( { }, optsWithAuth )
-  );
+  const { remoteUser: user, isLoading, refetchUserMe } = useUserMe( );
 
   const queryClient = useQueryClient( );
 

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -643,6 +643,8 @@ You-denied-iNaturalist-permission-to-do-that = You denied iNaturalist permission
 
 You-have-unsaved-changes = You have unsaved changes. Would you like to save this observation?
 
+You-must-be-logged-in-to-view-messages = You must be logged in to view messages
+
 You-will-lose-all-existing-observations = {$count ->
     [one] You will lose all existing observations. Would you like to discard 1 observation?
     *[other] You will lose all existing observations. Would you like to discard {$count} observations?

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -434,6 +434,7 @@
     "val": "You denied iNaturalist permission to do that"
   },
   "You-have-unsaved-changes": "You have unsaved changes. Would you like to save this observation?",
+  "You-must-be-logged-in-to-view-messages": "You must be logged in to view messages",
   "You-will-lose-all-existing-observations": "{ $count ->\n  [one] You will lose all existing observations. Would you like to discard 1 observation?\n *[other] You will lose all existing observations. Would you like to discard { $count } observations?\n}",
   "You will lose all existing observations. Would you like to discard # observations?": "",
   "Category-leading": {

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -643,6 +643,8 @@ You-denied-iNaturalist-permission-to-do-that = You denied iNaturalist permission
 
 You-have-unsaved-changes = You have unsaved changes. Would you like to save this observation?
 
+You-must-be-logged-in-to-view-messages = You must be logged in to view messages
+
 You-will-lose-all-existing-observations = {$count ->
     [one] You will lose all existing observations. Would you like to discard 1 observation?
     *[other] You will lose all existing observations. Would you like to discard {$count} observations?

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -10,6 +10,7 @@ import { formatDateAndTime } from "sharedHelpers/dateAndTime";
 import fetchPlaceName from "sharedHelpers/fetchPlaceName";
 import { parseExif, parseExifDateToLocalTimezone } from "sharedHelpers/parseExif";
 import useApiToken from "sharedHooks/useApiToken";
+import useCurrentUser from "sharedHooks/useCurrentUser";
 
 import { ObsEditContext, RealmContext } from "./contexts";
 
@@ -23,6 +24,7 @@ const ObsEditProvider = ( { children }: Props ): Node => {
   const navigation = useNavigation( );
   const realm = useRealm( );
   const apiToken = useApiToken( );
+  const currentUser = useCurrentUser( );
   const [currentObservationIndex, setCurrentObservationIndex] = useState( 0 );
   const [observations, setObservations] = useState( [] );
   const [cameraPreviewUris, setCameraPreviewUris] = useState( [] );
@@ -243,8 +245,6 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     };
 
     const downloadRemoteObservationsFromServer = async ( ) => {
-      const currentUser = realm.objects( "User" ).filtered( "signedIn == true" )[0];
-
       const params = {
         user_id: currentUser?.id,
         per_page: 50,
@@ -322,7 +322,8 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     setAlbum,
     loading,
     setLoading,
-    unsavedChanges
+    unsavedChanges,
+    currentUser?.id
   ] );
 
   return (

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -9,8 +9,6 @@ const useApiToken = ( ): string | null => {
   const [shouldFetchToken, setShouldFetchToken] = useState( true );
   const currentUser = useCurrentUser( );
 
-  console.log( shouldFetchToken, currentUser, "should fetch current user" );
-
   useEffect( ( ) => {
     const fetchApiToken = async ( ) => {
       if ( !currentUser ) {

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -2,13 +2,14 @@
 
 import { getJWTToken } from "components/LoginSignUp/AuthenticationService";
 import { useEffect, useState } from "react";
-
-import useCurrentUser from "./useCurrentUser";
+import useCurrentUser from "sharedHooks/useCurrentUser";
 
 const useApiToken = ( ): string | null => {
   const [apiToken, setApiToken] = useState( null );
   const [shouldFetchToken, setShouldFetchToken] = useState( true );
   const currentUser = useCurrentUser( );
+
+  console.log( shouldFetchToken, currentUser, "should fetch current user" );
 
   useEffect( ( ) => {
     const fetchApiToken = async ( ) => {

--- a/src/sharedHooks/useCurrentUser.js
+++ b/src/sharedHooks/useCurrentUser.js
@@ -1,22 +1,12 @@
+// @flow
+
 import { RealmContext } from "providers/contexts";
-import { useEffect, useState } from "react";
 
 const { useRealm } = RealmContext;
 
-const useCurrentUser = ( ) => {
-  const [currentUser, setCurrentUser] = useState( null );
+const useCurrentUser = ( ): ?Object => {
   const realm = useRealm( );
-
-  useEffect( ( ) => {
-    const signedInUsers = realm.objects( "User" ).filtered( "signedIn == true" );
-    if ( signedInUsers.length > 0 ) {
-      setCurrentUser( signedInUsers[0] );
-    } else {
-      setCurrentUser( null );
-    }
-  }, [realm] );
-
-  return currentUser;
+  return realm.objects( "User" ).filtered( "signedIn == true" )[0];
 };
 
 export default useCurrentUser;

--- a/src/sharedHooks/useUserMe.js
+++ b/src/sharedHooks/useUserMe.js
@@ -1,0 +1,29 @@
+// @flow
+import { fetchUserMe } from "api/users";
+import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useCurrentUser from "sharedHooks/useCurrentUser";
+
+const useUserMe = ( ): Object => {
+  const currentUser = useCurrentUser( );
+
+  const {
+    data: remoteUser,
+    isLoading,
+    refetch: refetchUserMe
+  } = useAuthenticatedQuery(
+    ["fetchUserMe"],
+    optsWithAuth => fetchUserMe( { }, optsWithAuth ),
+    {},
+    {
+      enabled: !!currentUser
+    }
+  );
+
+  return {
+    remoteUser,
+    isLoading,
+    refetchUserMe
+  };
+};
+
+export default useUserMe;

--- a/tests/unit/components/Messages/Messages.test.js
+++ b/tests/unit/components/Messages/Messages.test.js
@@ -7,6 +7,12 @@ import factory from "../../../factory";
 
 const mockedNavigate = jest.fn( );
 const mockMessage = factory( "RemoteMessage" );
+const mockUser = factory( "LocalUser" );
+
+jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
+  __esModule: true,
+  default: ( ) => mockUser
+} ) );
 
 jest.mock( "@react-navigation/native", ( ) => {
   const actualNav = jest.requireActual( "@react-navigation/native" );

--- a/tests/unit/components/Projects/Projects.test.js
+++ b/tests/unit/components/Projects/Projects.test.js
@@ -8,27 +8,11 @@ import { renderComponent } from "../../../helpers/render";
 const mockedNavigate = jest.fn( );
 const mockProject = factory( "RemoteProject" );
 
-const mockLatLng = {
-  latitude: 37.77,
-  longitude: -122.42
-};
-
 jest.mock( "sharedHooks/useAuthenticatedQuery", ( ) => ( {
   __esModule: true,
   default: ( ) => ( {
     data: [mockProject]
   } )
-} ) );
-
-jest.mock( "../../../../src/sharedHooks/useLoggedIn", ( ) => ( {
-  __esModule: true,
-  default: ( ) => true
-} ) );
-
-// Mock the hooks we use on Map since we're not trying to test them here
-jest.mock( "../../../../src/sharedHooks/useUserLocation", ( ) => ( {
-  default: ( ) => mockLatLng,
-  __esModule: true
 } ) );
 
 jest.mock( "@react-navigation/native", ( ) => {


### PR DESCRIPTION
This simplifies the `useCurrentUser` hook so that this data will be available before `useAuthenticatedQuery` tries to fetch an API token. Also fixes padding around the buttons in upload/login prompts.