### PR TITLE
Fixes bug preventing photo uploads

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,7 @@ module.exports = {
     "space-in-parens": [2, "always"],
     "module-resolver/use-alias": 2,
     // At least before we start making production builds
-    "no-console": ["error", { allow: ["warn", "error"] }],
+    "no-console": 0,
     "no-restricted-globals": 0,
     "no-param-reassign": 0,
     "no-var": 1,

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -20,9 +20,11 @@ Object.defineProperty( INatApiError.prototype, "name", {
 
 const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( !e.response ) { throw e; }
-  const errorJson = await e.response.json( );
-  const error = new INatApiError( errorJson );
-  console.error( `Error requesting ${e.response.url}` );
+  const errorText = await e.response.text( );
+  const error = new INatApiError( errorText );
+  console.error(
+    `Error requesting ${e.response.url} (status: ${e.response.status}): ${errorText}`
+  );
   if ( options.throw ) {
     throw error;
   }

--- a/src/components/Observations/ObsListBottomSheet.js
+++ b/src/components/Observations/ObsListBottomSheet.js
@@ -17,8 +17,7 @@ type Props = {
 
 const ObsListBottomSheet = ( { hasScrolled }: Props ): Node => {
   const currentUser = useCurrentUser( );
-  const localObservations = useLocalObservations( );
-  const { unuploadedObsList, allObsToUpload } = localObservations;
+  const { unuploadedObsList, allObsToUpload } = useLocalObservations( );
   const numOfUnuploadedObs = unuploadedObsList?.length;
   const { uploadInProgress, updateUploadStatus } = useUploadStatus( );
 
@@ -33,6 +32,9 @@ const ObsListBottomSheet = ( { hasScrolled }: Props ): Node => {
       </BottomSheet>
     );
   }
+  // FYI, this actually controls uploading, because the UploadProgressBar
+  // calls useUploadObservations which immediately tries to upload, so just
+  // rendering UploadProgressBar kicks off the upload
   if ( uploadInProgress ) {
     return (
       <UploadProgressBar

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -226,16 +226,6 @@ class Observation extends Realm.Object {
     return unsyncedObs.length > 0;
   }
 
-  needsSync( ) {
-    const obsPhotosNeedSync = this.observationPhotos
-      .filter( obsPhoto => obsPhoto.needsSync( ) ).length > 0;
-    return !this._synced_at || this._synced_at <= this._updated_at || obsPhotosNeedSync;
-  }
-
-  wasSynced( ) {
-    return this._synced_at !== null;
-  }
-
   static markRecordUploaded = async ( recordUUID, type, response, realm ) => {
     const { id } = response.results[0];
 
@@ -269,13 +259,11 @@ class Observation extends Realm.Object {
     realm: any,
     options: Object
   ): Promise<any> => {
-    let response;
-
     // only try to upload evidence which is not yet on the server
     const unsyncedEvidence = evidence.filter( item => !item.wasSynced( ) );
 
-    for ( let i = 0; i < unsyncedEvidence.length; i += 1 ) {
-      const currentEvidence = unsyncedEvidence[i].toJSON( );
+    const responses = await Promise.all( unsyncedEvidence.map( item => {
+      const currentEvidence = item.toJSON( );
       const evidenceUUID = currentEvidence.uuid;
 
       // Remove all null values, b/c the API doesn't seem to like them
@@ -290,7 +278,7 @@ class Observation extends Realm.Object {
       currentEvidence.photo = newPhoto;
 
       const params = apiSchemaMapper( observationId, currentEvidence );
-      response = Observation.uploadToServer(
+      return Observation.uploadToServer(
         evidenceUUID,
         type,
         params,
@@ -298,9 +286,9 @@ class Observation extends Realm.Object {
         realm,
         options
       );
-    }
+    } ) );
     // eslint-disable-next-line consistent-return
-    return response;
+    return responses[0];
   };
 
   static uploadObservation = async ( obs, apiToken, realm ) => {
@@ -337,14 +325,14 @@ class Observation extends Realm.Object {
     }
 
     await Observation.markRecordUploaded( obs.uuid, "Observation", response, realm );
-    const { id } = response.results[0];
+    const { uuid: obsUUID } = response.results[0];
 
     if ( obs?.observationPhotos?.length > 0 ) {
       await Observation.uploadEvidence(
         obs.observationPhotos,
         "ObservationPhoto",
         ObservationPhoto.mapPhotoForUpload,
-        id,
+        obsUUID,
         inatjs.observation_photos.create,
         realm,
         options
@@ -355,7 +343,7 @@ class Observation extends Realm.Object {
         obs.observationSounds,
         "ObservationSound",
         ObservationSound.mapSoundForUpload,
-        id,
+        obsUUID,
         inatjs.observation_sounds.create,
         realm,
         options
@@ -403,6 +391,16 @@ class Observation extends Realm.Object {
       user: "User?",
       viewed: "bool?"
     }
+  }
+
+  needsSync( ) {
+    const obsPhotosNeedSync = this.observationPhotos
+      .filter( obsPhoto => obsPhoto.needsSync( ) ).length > 0;
+    return !this._synced_at || this._synced_at <= this._updated_at || obsPhotosNeedSync;
+  }
+
+  wasSynced( ) {
+    return this._synced_at !== null;
   }
 }
 

--- a/src/realmModels/ObservationPhoto.js
+++ b/src/realmModels/ObservationPhoto.js
@@ -35,9 +35,9 @@ class ObservationPhoto extends Realm.Object {
     return localObsPhoto;
   }
 
-  static mapPhotoForUpload( id, observationPhoto ) {
+  static mapPhotoForUpload( observtionID, observationPhoto ) {
     return {
-      "observation_photo[observation_id]": id,
+      "observation_photo[observation_id]": observtionID,
       "observation_photo[uuid]": observationPhoto.uuid,
       file: new FileUpload( {
         uri: observationPhoto.photo.localFilePath,

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -35,7 +35,7 @@ const useLocalObservations = ( ): Object => {
       const unsyncedObs = Observation.filterUnsyncedObservations( realm );
       setUnuploadedObsList( Array.from( unsyncedObs ) );
 
-      if ( allObsToUpload.length === 0 ) {
+      if ( allObsToUpload.length < unsyncedObs.length ) {
         setAllObsToUpload( Array.from( unsyncedObs ) );
       }
     } );

--- a/src/sharedHooks/useUploadObservations.js
+++ b/src/sharedHooks/useUploadObservations.js
@@ -21,12 +21,10 @@ const useUploadObservations = ( allObsToUpload: Array<Object> ): Object => {
     const upload = async obs => {
       if ( !apiToken ) return;
       await Observation.uploadObservation( obs, apiToken, realm );
-    };
-    if ( currentUploadIndex < allObsToUpload.length - 1 ) {
       setCurrentUploadIndex( currentUploadIndex + 1 );
-    }
+    };
 
-    if ( !cancelUpload ) {
+    if ( !cancelUpload && allObsToUpload[currentUploadIndex] ) {
       upload( allObsToUpload[currentUploadIndex] );
     }
   }, [


### PR DESCRIPTION
Primary bug was that requests to POST /v2/observation_photos were using the obs serial ID instead of the obs UUID.

Another major problem was that uploads always quit before the last observation when there were multiple observations to upload, which I address by changing the way we set `allObsToUpload` in `useLocalObservations`.