### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@react-native-async-storage/async-storage": "^1.17.10",
     "@react-native-camera-roll/camera-roll": ">=5.0.4",
     "@react-native-community/checkbox": "^0.5.12",
+    "@react-native-community/cli-platform-ios": "10.0.0",
     "@react-native-community/datetimepicker": "^6.5.3",
     "@react-native-community/netinfo": "^9.3.6",
     "@react-native-picker/picker": "^2.4.8",


### PR DESCRIPTION
Looks like `@react-native-community/cli-platform-ios` doesn't get installed automatically, though `@react-native-community/cli-platform-android` does.

On a related note, this is my first PR and had some issues w/ node/npm versions. I just moved to latest: node v13.9.0 and npm v9.2.0

But for new devs is there a recommended version for both we can add to the readme or potentially w/ and nvmrc?