### PR TITLE
Abort fastlane if release notes exceed 500 char limit

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,6 +114,7 @@ lane :tag do
 
 
       # Enter notes about what's new in #{tag}. Lines beginning with # will be ignored.
+      # Keep notes within the 500 character limit required by Google Play.
       #
       # Here's what changed since the last tag:
       #{changes}
@@ -129,6 +130,10 @@ lane :tag do
   if release_notes.strip.size == 0
     reset_git_repo skip_clean: true
     UI.abort_with_message! "You gotta enter release notes!"
+  end
+  if release_notes.strip.length > 500
+    reset_git_repo skip_clean: true
+    UI.abort_with_message! "Release notes must be 500 characters or less"
   end
 
   # Write release notes to a place where they can be translated and add that file to git
@@ -364,3 +369,4 @@ lane :prod do
   # been able to test that yet
   upload_to_play_store( version_code: build_number, track: "beta", track_promote_to: "production" )
 end
+


### PR DESCRIPTION
Closes #146 