### PR TITLE
Fix crash on Android after login

### DIFF
--- a/src/components/DisplayTaxonName.js
+++ b/src/components/DisplayTaxonName.js
@@ -44,18 +44,27 @@ const capitalize = s => {
   // just these patterns for use outside of React
   // eslint-disable-next-line max-len
   const lowerCaseChars = "µßàáâãäåæçèéêëìíîïðñòóôõöøØùúûüýþÿāăąćĉċčďēĕėęěĝğġģĥĩīĭįĵķĺļľłńņňōŏőŒœŕŗřśŝşšţťũūŭůűųŵŷźżžơưǎǐǒǔǖǘǚǜǟǡǣǧǩǫǭǯǰǵǹǻǽǿȁȃȅȇȉȋȍȏȑȓȕȗșțȟȧȩȫȭȯȱȳΩḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẛạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ∂∆∑ﬁﬂ";
+  // On the web, we use toUpperCase to generate this at runtime, but that
+  // seems to be causing a bug in the Android JS engine as of 20230110, so
+  // we're hard-coding it here. ~~~kueda 20220110
+  // eslint-disable-next-line max-len
+  const upperCaseChars = "ΜSSÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØØÙÚÛÜÝÞŸĀĂĄĆĈĊČĎĒĔĖĘĚĜĞĠĢĤĨĪĬĮĴĶĹĻĽŁŃŅŇŌŎŐŒŒŔŖŘŚŜŞŠŢŤŨŪŬŮŰŲŴŶŹŻŽƠƯǍǏǑǓǕǗǙǛǞǠǢǦǨǪǬǮJ̌ǴǸǺǼǾȀȂȄȆȈȊȌȎȐȒȔȖȘȚȞȦȨȪȬȮȰȲΩḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔH̱T̈W̊Y̊ṠẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ∂∆∑FIFL";
+  // I don't feel great about disabling this eslint check, but the this
+  // approach does prevent the crash on Android. We should keep in mind that
+  // there may be capitalization issues down the road ~~~kueda 20230110
+  // eslint-disable-next-line no-misleading-character-class
   const allCasePattern = new RegExp(
-    `[A-z${lowerCaseChars}${lowerCaseChars.toUpperCase()}]`
+    `[A-z${lowerCaseChars}${upperCaseChars}]`
   );
   const firstLetterMatch = s.match( allCasePattern );
   let firstLetterIndex = firstLetterMatch ? firstLetterMatch.index : 0;
+  // eslint-disable-next-line no-misleading-character-class
   const leadingContractionPattern = new RegExp(
     `^[a-z${
       lowerCaseChars
     }][’']([A-z${
       lowerCaseChars
-    }${lowerCaseChars.toUpperCase()
-    }]+)`
+    }${upperCaseChars}]+)`
   );
   const leadingContractionMatch = s.match( leadingContractionPattern );
   if ( leadingContractionMatch ) {

--- a/src/components/Observations/ObsCard.js
+++ b/src/components/Observations/ObsCard.js
@@ -19,7 +19,9 @@ type Props = {
 const ObsCard = ( { item, handlePress }: Props ): Node => {
   const onPress = ( ) => handlePress( item );
 
-  const photo = item?.observationPhotos?.[0]?.photo;
+  const photo = item?.observationPhotos && item.observationPhotos[0]
+    ? item.observationPhotos[0].photo
+    : null;
 
   const obsListPhoto = photo ? (
     <Image

--- a/tests/unit/components/ObsEdit/DeleteObservationDialog.test.js
+++ b/tests/unit/components/ObsEdit/DeleteObservationDialog.test.js
@@ -41,7 +41,10 @@ const mockObsEditProviderWithObs = obs => ObsEditProvider.mockImplementation( ( 
     currentObservation: obs[0],
     deleteLocalObservation: ( ) => {
       global.realm.write( ( ) => {
-        global.realm.delete( global.realm.objectForPrimaryKey( "Observation", obs[0].uuid ) );
+        const observation = global.realm.objectForPrimaryKey( "Observation", obs[0].uuid );
+        if ( observation ) {
+          global.realm.delete( observation );
+        }
       } );
     }
   }}

--- a/tests/unit/components/Projects/ProjectObservations.test.js
+++ b/tests/unit/components/Projects/ProjectObservations.test.js
@@ -7,7 +7,7 @@ import { renderComponent } from "../../../helpers/render";
 const mockProject = factory( "RemoteProject" );
 const mockObservation = factory( "RemoteObservation", {
   taxon: { preferred_common_name: "Foo", name: "bar" }
-} );;
+} );
 
 jest.mock( "@react-navigation/native", ( ) => {
   const actualNav = jest.requireActual( "@react-navigation/native" );


### PR DESCRIPTION
The problem has something to do with the unicode capitalization code that got [ported from the web.](https://github.com/inaturalist/iNaturalistReactNative/pull/334) It seems like the JS engine in Android has a problem with calling `toUpperCase()` on some unicode characters, and this gets around that particular bug, plus one problem with a null check on a Realm collection.

This isn't the best solution and probably isn't the final one. We need to keep an eye out for problems with common name capitalization.