### PR TITLE
Add double tap to zoom in Camera; update Gesture API

### DIFF
--- a/ios/iNaturalistReactNative.xcodeproj/xcshareddata/xcschemes/iNaturalistReactNative.xcscheme
+++ b/ios/iNaturalistReactNative.xcodeproj/xcshareddata/xcschemes/iNaturalistReactNative.xcscheme
@@ -41,7 +41,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/src/components/Camera/CameraView.js
+++ b/src/components/Camera/CameraView.js
@@ -52,6 +52,7 @@ const CameraView = ( { camera, device }: Props ): Node => {
     if ( scale.value < SCALE_MAX_ZOOM ) {
       scale.value = Math.min( SCALE_MAX_ZOOM, scale.value += 1 );
     }
+    savedScale.value = scale.value;
   };
 
   const singleTap = Gesture.Tap( )
@@ -75,11 +76,11 @@ const CameraView = ( { camera, device }: Props ): Node => {
     .withTestId( "PinchGestureHandler" )
     .requireExternalGestureToFail( singleTap, doubleTap )
     .onUpdate( e => {
-      const minScaleValue = Math.max( SCALE_MIN_ZOOM, savedScale.value * e.scale );
-      const maxScaleValue = Math.min( SCALE_MAX_ZOOM, savedScale.value * e.scale );
-      const isZoomingIn = Math.sign( e.velocity ) >= 0;
+      const newValue = savedScale.value * e.scale;
+      const minScaleValue = Math.max( SCALE_MIN_ZOOM, newValue );
+      const maxScaleValue = Math.min( SCALE_MAX_ZOOM, newValue );
 
-      if ( isZoomingIn ) {
+      if ( newValue > savedScale.value ) {
         scale.value = maxScaleValue;
       } else {
         scale.value = minScaleValue;

--- a/src/components/Camera/CameraView.js
+++ b/src/components/Camera/CameraView.js
@@ -72,6 +72,7 @@ const CameraView = ( { camera, device }: Props ): Node => {
 
   const pinch = Gesture.Pinch( )
     .runOnJS( true )
+    .withTestId( "PinchGestureHandler" )
     .requireExternalGestureToFail( singleTap, doubleTap )
     .onUpdate( e => {
       const minScaleValue = Math.max( SCALE_MIN_ZOOM, savedScale.value * e.scale );
@@ -90,17 +91,15 @@ const CameraView = ( { camera, device }: Props ): Node => {
 
   return (
     <>
-      <Reanimated.View style={StyleSheet.absoluteFill}>
-        <GestureDetector gesture={Gesture.Exclusive( doubleTap, singleTap, pinch )}>
-          <ReanimatedCamera
-            ref={camera}
-            style={[StyleSheet.absoluteFill, animatedStyle]}
-            device={device}
-            isActive={isActive}
-            photo
-          />
-        </GestureDetector>
-      </Reanimated.View>
+      <GestureDetector gesture={Gesture.Exclusive( doubleTap, singleTap, pinch )}>
+        <ReanimatedCamera
+          ref={camera}
+          style={[StyleSheet.absoluteFill, animatedStyle]}
+          device={device}
+          isActive={isActive}
+          photo
+        />
+      </GestureDetector>
       <FocusSquare
         singleTapToFocusAnimation={singleTapToFocusAnimation}
         tappedCoordinates={tappedCoordinates}

--- a/src/components/Camera/CameraView.js
+++ b/src/components/Camera/CameraView.js
@@ -1,27 +1,21 @@
 // @flow
 import { useIsFocused } from "@react-navigation/native";
 import type { Node } from "react";
-import React, {
-  useEffect, useRef, useState
-} from "react";
+import React, { useRef, useState } from "react";
 import { Animated, StyleSheet } from "react-native";
-import {
-  Gesture, GestureDetector, PinchGestureHandler
-} from "react-native-gesture-handler";
-import Reanimated, {
-  Extrapolate, interpolate,
-  useAnimatedGestureHandler, useAnimatedProps,
-  useSharedValue
-} from "react-native-reanimated";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Reanimated, { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
 import { Camera } from "react-native-vision-camera";
 import useIsForeground from "sharedHooks/useIsForeground";
 
 import FocusSquare from "./FocusSquare";
 
-// a lot of the camera functionality (pinch to zoom, etc.) is lifted from the example library:
+// there are examples of zoom/tap gestures in the react-native-vision-camera library
+// but they use an older version of react-native-gesture-handler
 // https://github.com/mrousavy/react-native-vision-camera/blob/7335883969c9102b8a6d14ca7ed871f3de7e1389/example/src/CameraPage.tsx
 
-const SCALE_FULL_ZOOM = 3;
+const SCALE_MAX_ZOOM = 8;
+const SCALE_MIN_ZOOM = 1;
 
 const ReanimatedCamera = Reanimated.createAnimatedComponent( Camera );
 Reanimated.addWhitelistedNativeProps( {
@@ -34,7 +28,6 @@ type Props = {
 }
 
 const CameraView = ( { camera, device }: Props ): Node => {
-  const zoom = useSharedValue( 0 );
   const [tappedCoordinates, setTappedCoordinates] = useState( null );
   const singleTapToFocusAnimation = useRef( new Animated.Value( 0 ) ).current;
   // check if camera page is active
@@ -42,51 +35,12 @@ const CameraView = ( { camera, device }: Props ): Node => {
   const isForeground = useIsForeground( );
   const isActive = isFocused && isForeground;
 
-  const minZoom = device?.minZoom ?? 1;
-  const maxZoom = Math.min( device?.maxZoom ?? 1, 5 );
-
-  const cameraAnimatedProps = useAnimatedProps( ( ) => {
-    const z = Math.max( Math.min( zoom.value, maxZoom ), minZoom );
-    return {
-      zoom: z
-    };
-  }, [maxZoom, minZoom, zoom] );
-  // #endregion
-
-  // #region Pinch to Zoom Gesture
-  // The gesture handler maps the linear pinch gesture (0 - 1) to an
-  // exponential curve since a camera's zoom function does not appear linear
-  // to the user. (aka zoom 0.1 -> 0.2 does not look equal in difference as
-  // 0.8 -> 0.9)
-  const onPinchGesture = useAnimatedGestureHandler( {
-    onStart: ( _, context ) => {
-      context.startZoom = zoom.value;
-    },
-    onActive: ( event, context ) => {
-      // we're trying to map the scale gesture to a linear zoom here
-      const startZoom = context.startZoom ?? 0;
-      const scale = interpolate(
-        event.scale,
-        [1 - 1 / SCALE_FULL_ZOOM, 1, SCALE_FULL_ZOOM],
-        [-1, 0, 1],
-        Extrapolate.CLAMP
-      );
-      zoom.value = interpolate(
-        scale,
-        [-1, 0, 1],
-        [minZoom, startZoom, maxZoom],
-        Extrapolate.CLAMP
-      );
-    }
-  } );
-  // #endregion
-
-  // #region Effects
-  const neutralZoom = device?.neutralZoom ?? 1;
-  useEffect( ( ) => {
-    // Run everytime the neutralZoomScaled value changes. (reset zoom when device changes)
-    zoom.value = neutralZoom;
-  }, [neutralZoom, zoom] );
+  // used for pinch and double tap to zoom
+  const scale = useSharedValue( SCALE_MIN_ZOOM );
+  const savedScale = useSharedValue( SCALE_MIN_ZOOM );
+  const animatedStyle = useAnimatedStyle( ( ) => ( {
+    transform: [{ scale: scale.value }]
+  } ) );
 
   const singleTapToFocus = async event => {
     await camera.current.focus( { x: event.x, y: event.y } );
@@ -95,8 +49,8 @@ const CameraView = ( { camera, device }: Props ): Node => {
   };
 
   const doubleTapToZoom = ( ) => {
-    if ( zoom.value < SCALE_FULL_ZOOM ) {
-      zoom.value += 1;
+    if ( scale.value < SCALE_MAX_ZOOM ) {
+      scale.value = Math.min( SCALE_MAX_ZOOM, scale.value += 1 );
     }
   };
 
@@ -116,22 +70,37 @@ const CameraView = ( { camera, device }: Props ): Node => {
       doubleTapToZoom( );
     } );
 
+  const pinch = Gesture.Pinch( )
+    .runOnJS( true )
+    .requireExternalGestureToFail( singleTap, doubleTap )
+    .onUpdate( e => {
+      const minScaleValue = Math.max( SCALE_MIN_ZOOM, savedScale.value * e.scale );
+      const maxScaleValue = Math.min( SCALE_MAX_ZOOM, savedScale.value * e.scale );
+      const isZoomingIn = Math.sign( e.velocity ) >= 0;
+
+      if ( isZoomingIn ) {
+        scale.value = maxScaleValue;
+      } else {
+        scale.value = minScaleValue;
+      }
+    } )
+    .onEnd( ( ) => {
+      savedScale.value = scale.value;
+    } );
+
   return (
     <>
-      <PinchGestureHandler onGestureEvent={onPinchGesture} enabled={isActive}>
-        <Reanimated.View style={StyleSheet.absoluteFill}>
-          <GestureDetector gesture={Gesture.Exclusive( doubleTap, singleTap )}>
-            <ReanimatedCamera
-              ref={camera}
-              style={StyleSheet.absoluteFill}
-              device={device}
-              isActive={isActive}
-              photo
-              animatedProps={cameraAnimatedProps}
-            />
-          </GestureDetector>
-        </Reanimated.View>
-      </PinchGestureHandler>
+      <Reanimated.View style={StyleSheet.absoluteFill}>
+        <GestureDetector gesture={Gesture.Exclusive( doubleTap, singleTap, pinch )}>
+          <ReanimatedCamera
+            ref={camera}
+            style={[StyleSheet.absoluteFill, animatedStyle]}
+            device={device}
+            isActive={isActive}
+            photo
+          />
+        </GestureDetector>
+      </Reanimated.View>
       <FocusSquare
         singleTapToFocusAnimation={singleTapToFocusAnimation}
         tappedCoordinates={tappedCoordinates}

--- a/src/components/Camera/FocusSquare.js
+++ b/src/components/Camera/FocusSquare.js
@@ -6,14 +6,14 @@ import { Animated } from "react-native";
 
 type Props = {
   tappedCoordinates: Object,
-  tapToFocusAnimation: any
+  singleTapToFocusAnimation: any
 }
 
-const FocusSquare = ( { tappedCoordinates, tapToFocusAnimation }: Props ): Node => {
+const FocusSquare = ( { tappedCoordinates, singleTapToFocusAnimation }: Props ): Node => {
   useEffect( ( ) => {
     if ( tappedCoordinates ) {
       Animated.timing(
-        tapToFocusAnimation,
+        singleTapToFocusAnimation,
         {
           toValue: 0,
           duration: 2000,
@@ -21,7 +21,7 @@ const FocusSquare = ( { tappedCoordinates, tapToFocusAnimation }: Props ): Node 
         }
       ).start( );
     }
-  }, [tapToFocusAnimation, tappedCoordinates] );
+  }, [singleTapToFocusAnimation, tappedCoordinates] );
 
   if ( !tappedCoordinates ) { return null; }
 
@@ -32,7 +32,7 @@ const FocusSquare = ( { tappedCoordinates, tapToFocusAnimation }: Props ): Node 
       style={[{
         left: tappedCoordinates.x,
         top: tappedCoordinates.y,
-        opacity: tapToFocusAnimation
+        opacity: singleTapToFocusAnimation
       }
       ]}
     />


### PR DESCRIPTION
Closes #355 by adding double tap to zoom.

Also updates code to use the newest `react-native-gesture-handler` API with Gesture & GestureDetector. This makes code cleaner to read & makes it easier to support multiple gestures without needing multiple components.