### PR TITLE
Only mark obs as viewed when an existing mutation is not in flight

### DIFF
--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -169,7 +169,7 @@ const ObsDetails = ( ): Node => {
   };
 
   useEffect( ( ) => {
-    if ( localObservation && !localObservation?.viewed ) {
+    if ( localObservation && !localObservation.viewed && !markViewedMutation.isLoading ) {
       markViewedMutation.mutate( { id: uuid } );
     }
   }, [localObservation, markViewedMutation, uuid] );
@@ -275,7 +275,7 @@ const ObsDetails = ( ): Node => {
         </View>
       );
     }
-    if ( photos.length > 0 || observation.observationSounds.length > 0 ) {
+    if ( photos.length > 0 || observation?.observationSounds?.length > 0 ) {
       return (
         <View className="bg-black">
           <PhotoScroll photos={photos} />

--- a/src/sharedHooks/useAuthenticatedMutation.js
+++ b/src/sharedHooks/useAuthenticatedMutation.js
@@ -8,18 +8,18 @@ import { getJWTToken } from "components/LoginSignUp/AuthenticationService";
 const useAuthenticatedMutation = (
   mutationFunction: Function,
   mutationOptions: Object = {}
-): any => useMutation( {
-  mutationFn: async id => {
-  // Note, getJWTToken() takes care of fetching a new token if the existing
-  // one is expired. We *could* store the token in state with useState if
-  // fetching from RNSInfo becomes a performance issue
+): any => useMutation(
+  async id => {
+    // Note, getJWTToken() takes care of fetching a new token if the existing
+    // one is expired. We *could* store the token in state with useState if
+    // fetching from RNSInfo becomes a performance issue
     const apiToken = await getJWTToken( );
     const options = {
       api_token: apiToken
     };
     return mutationFunction( id, options );
   },
-  ...mutationOptions
-} );
+  mutationOptions
+);
 
 export default useAuthenticatedMutation;


### PR DESCRIPTION
@jtklein, this might address the repeated requests resulting in the 429 blocks you were experiencing in your JWT work. If you've already fixed that we can just close this PR without merging.