### PR TITLE
353 retry with jwt

### DIFF
--- a/src/api/error.js
+++ b/src/api/error.js
@@ -1,4 +1,7 @@
 // @flow
+import { log } from "../../react-native-logs.config";
+
+const logger = log.extend( "INatApiError" );
 
 class INatApiError extends Error {
   // Object literal of the JSON body returned by the server
@@ -22,7 +25,7 @@ const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( !e.response ) { throw e; }
   const errorText = await e.response.text( );
   const error = new INatApiError( errorText );
-  console.error(
+  logger.error(
     `Error requesting ${e.response.url} (status: ${e.response.status}): ${errorText}`
   );
   if ( options.throw ) {

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -25,6 +25,8 @@ const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( !e.response ) { throw e; }
   const errorText = await e.response.text( );
   const error = new INatApiError( errorText );
+  // TODO: this will log all errors handled here to the log file, in a production build
+  // we probably don't want to do that, so change this back to console.error at one point
   logger.error(
     `Error requesting ${e.response.url} (status: ${e.response.status}): ${errorText}`
   );

--- a/src/components/LoginSignUp/AuthenticationService.js
+++ b/src/components/LoginSignUp/AuthenticationService.js
@@ -131,7 +131,7 @@ const getAnonymousJWT = () => {
  *  logged-in, use anonymous JWT
  * @returns {Promise<string|*>}
  */
-const getJWTToken = async ( allowAnonymousJWT: boolean = false ): Promise<?string> => {
+const getJWT = async ( allowAnonymousJWT: boolean = false ): Promise<?string> => {
   let jwtToken = await RNSInfo.getItem( "jwtToken", {} );
   let jwtGeneratedAt = await RNSInfo.getItem( "jwtGeneratedAt", {} );
   if ( jwtGeneratedAt ) {
@@ -213,7 +213,7 @@ const getAPIToken = async (
   }
 
   if ( useJWT ) {
-    return getJWTToken( allowAnonymousJWT );
+    return getJWT( allowAnonymousJWT );
   }
   const accessToken = await RNSInfo.getItem( "accessToken", {} );
   return `Bearer ${accessToken}`;
@@ -399,7 +399,7 @@ export {
   API_HOST,
   authenticateUser,
   getAPIToken,
-  getJWTToken,
+  getJWT,
   getUsername,
   isCurrentUser,
   isLoggedIn,

--- a/src/components/LoginSignUp/AuthenticationService.js
+++ b/src/components/LoginSignUp/AuthenticationService.js
@@ -28,8 +28,7 @@ const API_HOST: string = Config.OAUTH_API_URL || process.env.OAUTH_API_URL || "h
 const USER_AGENT = `iNaturalistRN/${getVersion()} ${getDeviceType()} (Build ${getBuildNumber()}) ${getSystemName()}/${getSystemVersion()}`;
 
 // JWT Tokens expire after 30 mins - consider 25 mins as the max time (safe margin)
-// const JWT_EXPIRATION_MINS = 25;
-const JWT_EXPIRATION_MINS = 2;
+const JWT_EXPIRATION_MINS = 25;
 
 /**
  * Creates base API client for all requests

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -6,9 +6,10 @@ import useCurrentUser from "sharedHooks/useCurrentUser";
 
 const useApiToken = ( ): string | null => {
   const [apiToken, setApiToken] = useState( null );
-  const [shouldFetchToken, setShouldFetchToken] = useState( true );
   const currentUser = useCurrentUser( );
 
+  // Without the dependency array, this hook will run on every render, then every time
+  // a new token is fetched, and if expired fetched from API (in getJWT).
   useEffect( ( ) => {
     const fetchApiToken = async ( ) => {
       if ( !currentUser ) {
@@ -21,13 +22,12 @@ const useApiToken = ( ): string | null => {
         if ( token !== apiToken ) {
           setApiToken( token );
         }
-        setShouldFetchToken( false );
       } else {
         console.error( "Failed to get API token even though user is logged in: ", currentUser );
       }
     };
-    if ( shouldFetchToken ) fetchApiToken( );
-  }, [shouldFetchToken, currentUser, apiToken] );
+    fetchApiToken( );
+  } );
 
   return apiToken;
 };

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getJWTToken } from "components/LoginSignUp/AuthenticationService";
+import { getJWT } from "components/LoginSignUp/AuthenticationService";
 import { useEffect, useState } from "react";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 
@@ -16,7 +16,7 @@ const useApiToken = ( ): string | null => {
         // setShouldFetchToken( false );
         return;
       }
-      const token = await getJWTToken( );
+      const token = await getJWT( );
       if ( token ) {
         if ( token !== apiToken ) {
           setApiToken( token );

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -14,7 +14,6 @@ const useApiToken = ( ): string | null => {
     const fetchApiToken = async ( ) => {
       if ( !currentUser ) {
         setApiToken( null );
-        // setShouldFetchToken( false );
         return;
       }
       const token = await getJWT( );

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -1,32 +1,32 @@
 // @flow
 
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 
 const useApiToken = ( ): string | null => {
   const [apiToken, setApiToken] = useState( null );
   const currentUser = useCurrentUser( );
 
-  const fetchApiToken = async () => {
-    if ( !currentUser ) {
-      setApiToken( null );
-      return;
-    }
-    const token = await getJWT();
-    if ( token ) {
-      if ( token !== apiToken ) {
-        setApiToken( token );
+  // Without the dependency array, this hook will run on every render, then every time
+  // a new token is fetched, and if expired fetched from API (in getJWT).
+  useEffect( ( ) => {
+    const fetchApiToken = async ( ) => {
+      if ( !currentUser ) {
+        setApiToken( null );
+        return;
       }
-    } else {
-      console.error(
-        "Failed to get API token even though user is logged in: ",
-        currentUser
-      );
-    }
-  };
-
-  fetchApiToken();
+      const token = await getJWT( );
+      if ( token ) {
+        if ( token !== apiToken ) {
+          setApiToken( token );
+        }
+      } else {
+        console.error( "Failed to get API token even though user is logged in: ", currentUser );
+      }
+    };
+    fetchApiToken( );
+  } );
 
   return apiToken;
 };

--- a/src/sharedHooks/useApiToken.js
+++ b/src/sharedHooks/useApiToken.js
@@ -1,32 +1,32 @@
 // @flow
 
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 
 const useApiToken = ( ): string | null => {
   const [apiToken, setApiToken] = useState( null );
   const currentUser = useCurrentUser( );
 
-  // Without the dependency array, this hook will run on every render, then every time
-  // a new token is fetched, and if expired fetched from API (in getJWT).
-  useEffect( ( ) => {
-    const fetchApiToken = async ( ) => {
-      if ( !currentUser ) {
-        setApiToken( null );
-        return;
+  const fetchApiToken = async () => {
+    if ( !currentUser ) {
+      setApiToken( null );
+      return;
+    }
+    const token = await getJWT();
+    if ( token ) {
+      if ( token !== apiToken ) {
+        setApiToken( token );
       }
-      const token = await getJWT( );
-      if ( token ) {
-        if ( token !== apiToken ) {
-          setApiToken( token );
-        }
-      } else {
-        console.error( "Failed to get API token even though user is logged in: ", currentUser );
-      }
-    };
-    fetchApiToken( );
-  } );
+    } else {
+      console.error(
+        "Failed to get API token even though user is logged in: ",
+        currentUser
+      );
+    }
+  };
+
+  fetchApiToken();
 
   return apiToken;
 };

--- a/src/sharedHooks/useAuthenticatedMutation.js
+++ b/src/sharedHooks/useAuthenticatedMutation.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { useMutation } from "@tanstack/react-query";
-import { getJWTToken } from "components/LoginSignUp/AuthenticationService";
+import { getJWT } from "components/LoginSignUp/AuthenticationService";
 
 // Should work like React Query's useMutation except it calls the queryFunction
 // with an object that includes the JWT
@@ -13,7 +13,7 @@ const useAuthenticatedMutation = (
     // Note, getJWTToken() takes care of fetching a new token if the existing
     // one is expired. We *could* store the token in state with useState if
     // fetching from RNSInfo becomes a performance issue
-    const apiToken = await getJWTToken( );
+    const apiToken = await getJWT( );
     const options = {
       api_token: apiToken
     };

--- a/src/sharedHooks/useAuthenticatedQuery.js
+++ b/src/sharedHooks/useAuthenticatedQuery.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { useQuery } from "@tanstack/react-query";
-import { getJWTToken } from "components/LoginSignUp/AuthenticationService";
+import { getJWT } from "components/LoginSignUp/AuthenticationService";
 
 // Should work like React Query's useQuery except it calls the queryFunction
 // with an object that includes the JWT
@@ -12,10 +12,10 @@ const useAuthenticatedQuery = (
 ): any => useQuery( {
   queryKey,
   queryFn: async ( ) => {
-    // Note, getJWTToken() takes care of fetching a new token if the existing
+    // Note, getJWT() takes care of fetching a new token if the existing
     // one is expired. We *could* store the token in state with useState if
     // fetching from RNSInfo becomes a performance issue
-    const apiToken = await getJWTToken( );
+    const apiToken = await getJWT( );
     const options = {
       api_token: apiToken
     };

--- a/tests/helpers/user.js
+++ b/tests/helpers/user.js
@@ -12,14 +12,14 @@ async function signOut( ) {
   } );
   await RNSInfo.deleteItem( "username" );
   await RNSInfo.deleteItem( "jwtToken" );
-  await RNSInfo.deleteItem( "jwtTokenExpiration" );
+  await RNSInfo.deleteItem( "jwtGeneratedAt" );
   await RNSInfo.deleteItem( "accessToken" );
 }
 
 async function signIn( user ) {
   await RNSInfo.setItem( "username", user.login );
   await RNSInfo.setItem( "jwtToken", "yaddayadda" );
-  await RNSInfo.setItem( "jwtTokenExpiration", Date.now( ).toString( ), {} );
+  await RNSInfo.setItem( "jwtGeneratedAt", Date.now( ).toString( ), {} );
   await RNSInfo.setItem( "accessToken", "yaddayadda" );
   inatjs.users.me.mockResolvedValue( makeResponse( [user] ) );
   user.signedIn = true;


### PR DESCRIPTION
I was never able to reliably reproduce errors with an invalid or expired JWT. So I am not sure if anything is fixed with this now. However, this PR addresses two TODOs in this issue #353 :
1) Adds a retry for react-query calls when 401 or 403 is hit, after fetching the JWT token again (if expired).
2) Now the token is not kept in state in the useApiToken hook.