### PR TITLE
Fix nearby projects query for android

### DIFF
--- a/src/components/DisplayTaxonName.js
+++ b/src/components/DisplayTaxonName.js
@@ -106,6 +106,7 @@ const DisplayTaxonName = ( { item: { user, taxon } }: Props ): Node => {
     const text = "unknown";
     return <Text numberOfLines={1}>{text}</Text>;
   }
+
   const taxonData = {};
 
   taxonData.rank = taxon.rank;

--- a/src/components/Projects/ProjectTabs.js
+++ b/src/components/Projects/ProjectTabs.js
@@ -37,10 +37,10 @@ const ProjectTabs = ( ): Node => {
     } else if ( currentTabId === FEATURED_TAB_ID ) {
       setApiParams( { features: true } );
     } else if ( currentTabId === NEARBY_TAB_ID && latLng ) {
-        setApiParams( {
-          lat: latLng.latitude,
-          lng: latLng.longitude
-        } );
+      setApiParams( {
+        lat: latLng.latitude,
+        lng: latLng.longitude
+      } );
     }
   }, [
     memberId,

--- a/src/components/Projects/ProjectTabs.js
+++ b/src/components/Projects/ProjectTabs.js
@@ -36,13 +36,11 @@ const ProjectTabs = ( ): Node => {
       setApiParams( { member_id: memberId } );
     } else if ( currentTabId === FEATURED_TAB_ID ) {
       setApiParams( { features: true } );
-    } else if ( currentTabId === NEARBY_TAB_ID ) {
-      if ( latLng ) {
+    } else if ( currentTabId === NEARBY_TAB_ID && latLng ) {
         setApiParams( {
           lat: latLng.latitude,
           lng: latLng.longitude
         } );
-      }
     }
   }, [
     memberId,

--- a/src/components/Projects/ProjectTabs.js
+++ b/src/components/Projects/ProjectTabs.js
@@ -4,7 +4,7 @@ import { searchProjects } from "api/projects";
 import Tabs from "components/SharedComponents/Tabs";
 import { t } from "i18next";
 import type { Node } from "react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 import useUserLocation from "sharedHooks/useUserLocation";
@@ -29,23 +29,22 @@ const ProjectTabs = ( ): Node => {
     optsWithAuth => searchProjects( apiParams, optsWithAuth )
   );
 
-  const fetchProjectsByLatLng = ( ) => {
-    setApiParams( {
-      lat: latLng.latitude,
-      lng: latLng.longitude
-    } );
-  };
-
-  const fetchFeaturedProjects = ( ) => setApiParams( { features: true } );
-  const fetchUserJoinedProjects = useCallback( ( ) => setApiParams(
-    { member_id: memberId }
-  ), [memberId] );
-
   useEffect( ( ) => {
-    if ( memberId ) {
-      fetchUserJoinedProjects( );
+    if ( memberId && currentTabId === JOINED_TAB_ID ) {
+      setApiParams( { member_id: memberId } );
+    } else if ( currentTabId === FEATURED_TAB_ID ) {
+      setApiParams( { features: true } );
+    } else if ( currentTabId === NEARBY_TAB_ID ) {
+      setApiParams( {
+        lat: latLng.latitude,
+        lng: latLng.longitude
+      } );
     }
-  }, [memberId, fetchUserJoinedProjects] );
+  }, [
+    memberId,
+    currentTabId,
+    latLng
+  ] );
 
   const tabs = [
     {
@@ -53,7 +52,6 @@ const ProjectTabs = ( ): Node => {
       text: t( "Joined" ),
       onPress: () => {
         setCurrentTabId( JOINED_TAB_ID );
-        fetchUserJoinedProjects();
       }
     },
     {
@@ -61,15 +59,15 @@ const ProjectTabs = ( ): Node => {
       text: t( "Featured" ),
       onPress: () => {
         setCurrentTabId( FEATURED_TAB_ID );
-        fetchFeaturedProjects();
       }
     },
     {
       id: NEARBY_TAB_ID,
       text: t( "Nearby" ),
       onPress: () => {
-        setCurrentTabId( NEARBY_TAB_ID );
-        fetchProjectsByLatLng();
+        if ( latLng ) {
+          setCurrentTabId( NEARBY_TAB_ID );
+        }
       }
     }
   ];

--- a/src/components/Projects/ProjectTabs.js
+++ b/src/components/Projects/ProjectTabs.js
@@ -5,6 +5,7 @@ import Tabs from "components/SharedComponents/Tabs";
 import { t } from "i18next";
 import type { Node } from "react";
 import React, { useEffect, useState } from "react";
+import { Text } from "react-native";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 import useUserLocation from "sharedHooks/useUserLocation";
@@ -20,10 +21,11 @@ const ProjectTabs = ( ): Node => {
   const memberId = currentUser?.id;
   const [apiParams, setApiParams] = useState( { } );
   const [currentTabId, setCurrentTabId] = useState( JOINED_TAB_ID );
-  const latLng = useUserLocation( );
+  const { latLng, isLoading: isLoadingLocation } = useUserLocation( { skipPlaceGuess: true } );
 
   const {
-    data: projects
+    data: projects,
+    isLoading
   } = useAuthenticatedQuery(
     ["searchProjects", apiParams],
     optsWithAuth => searchProjects( apiParams, optsWithAuth )
@@ -35,10 +37,12 @@ const ProjectTabs = ( ): Node => {
     } else if ( currentTabId === FEATURED_TAB_ID ) {
       setApiParams( { features: true } );
     } else if ( currentTabId === NEARBY_TAB_ID ) {
-      setApiParams( {
-        lat: latLng.latitude,
-        lng: latLng.longitude
-      } );
+      if ( latLng ) {
+        setApiParams( {
+          lat: latLng.latitude,
+          lng: latLng.longitude
+        } );
+      }
     }
   }, [
     memberId,
@@ -65,17 +69,17 @@ const ProjectTabs = ( ): Node => {
       id: NEARBY_TAB_ID,
       text: t( "Nearby" ),
       onPress: () => {
-        if ( latLng ) {
-          setCurrentTabId( NEARBY_TAB_ID );
-        }
+        setCurrentTabId( NEARBY_TAB_ID );
       }
     }
   ];
 
+  const loading = isLoading || ( currentTabId === NEARBY_TAB_ID && isLoadingLocation );
+  /* eslint-disable i18next/no-literal-string */
   return (
     <>
       <Tabs tabs={tabs} activeId={currentTabId} />
-      <ProjectList data={projects} />
+      { loading ? <Text>Loading</Text> : <ProjectList data={projects} />}
     </>
   );
 };

--- a/src/components/SharedComponents/Map.js
+++ b/src/components/SharedComponents/Map.js
@@ -20,7 +20,7 @@ type Props = {
 const Map = ( {
   obsLatitude, obsLongitude, mapHeight, taxonId, updateCoords, region
 }: Props ): React.Node => {
-  const latLng = useUserLocation( );
+  const { latLng } = useUserLocation( { skipPlaceGuess: true } );
 
   const initialLatitude = obsLatitude || ( latLng && latLng.latitude );
   const initialLongitude = obsLongitude || ( latLng && latLng.longitude );

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -192,7 +192,7 @@ class Observation extends Realm.Object {
   }
 
   static projectUri = obs => {
-    const photo = obs.observation_photos[0];
+    const photo = obs?.observation_photos?.[0];
     if ( !photo ) { return null; }
     if ( !photo.photo ) { return null; }
     if ( !photo.photo.url ) { return null; }

--- a/src/sharedHooks/useUserLocation.js
+++ b/src/sharedHooks/useUserLocation.js
@@ -1,6 +1,7 @@
 // @flow
+
 import Geolocation from "@react-native-community/geolocation";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Platform } from "react-native";
 import { PERMISSIONS, request } from "react-native-permissions";
 import fetchPlaceName from "sharedHelpers/fetchPlaceName";
@@ -9,75 +10,64 @@ type Props = {
   skipPlaceGuess?: bool
 }
 
-type LatLng = {
-  place_guess: string | null | typeof undefined,
-  latitude: number,
-  longitude: number,
-  positional_accuracy: any
-}
-
 const useUserLocation = ( { skipPlaceGuess = false }: Props ): Object => {
-  const [latLng, setLatLng] = useState<LatLng | null>( null );
+  const [latLng, setLatLng] = useState( null );
   const [isLoading, setIsLoading] = useState( true );
 
   // TODO: wrap this in PermissionsGate so permissions aren't requested at odd times
-  const requestiOSPermissions = ( ): string | null => {
+  const requestiOSPermissions = async ( ): Promise<?string> => {
     // TODO: test this on a real device
     try {
-      return request( PERMISSIONS.IOS.LOCATION_WHEN_IN_USE );
+      const permission = await request( PERMISSIONS.IOS.LOCATION_WHEN_IN_USE );
+      return permission;
     } catch ( e ) {
       console.warn( e, ": error requesting iOS permissions" );
     }
     return null;
   };
 
-  // TODO: set geolocation fetch error
-  const failure = error => {
-    console.warn( error.code, error.message );
-    setIsLoading( false );
-  };
-
-  const success = ( { coords } ) => {
-    setLatLng( {
-      place_guess: null,
-      latitude: coords.latitude,
-      longitude: coords.longitude,
-      positional_accuracy: coords.accuracy
-    } );
-  };
-
-  const fetchLocation = useCallback( async ( ) => {
-    if ( Platform.OS === "ios" ) {
-      const permissions = await requestiOSPermissions( );
-      // TODO: handle case where iOS permissions are not granted
-      if ( permissions !== "granted" ) { return; }
-    }
-
-    const options = { enableHighAccuracy: true, maximumAge: 0 };
-
-    Geolocation.getCurrentPosition( success, failure, options );
-  }, [] );
-
-  const fetchPlaceGuess = useCallback( async ( ) => {
-    if ( latLng ) {
-      const placeGuess = await fetchPlaceName( latLng.latitude, latLng.longitude );
-      setLatLng( currentLatLng => currentLatLng && {
-        ...currentLatLng, place_guess: placeGuess
-      } );
-    }
-  }, [latLng] );
-
-  useEffect( () => {
-    fetchLocation();
-  }, [fetchLocation] );
-
   useEffect( ( ) => {
-    setIsLoading( true );
-    if ( !skipPlaceGuess ) {
-      fetchPlaceGuess();
-    }
-    setIsLoading( false );
-  }, [fetchPlaceGuess, skipPlaceGuess] );
+    let isCurrent = true;
+
+    const fetchLocation = async ( ) => {
+      setIsLoading( true );
+      if ( Platform.OS === "ios" ) {
+        const permissions = await requestiOSPermissions( );
+        // TODO: handle case where iOS permissions are not granted
+        if ( permissions !== "granted" ) { return; }
+      }
+
+      const success = async ( { coords } ) => {
+        if ( !isCurrent ) { return; }
+        let placeGuess = null;
+        if ( !skipPlaceGuess ) {
+          placeGuess = await fetchPlaceName( coords.latitude, coords.longitude );
+        }
+        setLatLng( {
+          place_guess: placeGuess,
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          positional_accuracy: coords.accuracy
+        } );
+        setIsLoading( false );
+      };
+
+      // TODO: set geolocation fetch error
+      const failure = error => {
+        console.warn( error.code, error.message );
+        setIsLoading( false );
+      };
+
+      const options = { enableHighAccuracy: true, maximumAge: 0 };
+
+      Geolocation.getCurrentPosition( success, failure, options );
+    };
+    fetchLocation( );
+
+    return ( ) => {
+      isCurrent = false;
+    };
+  }, [skipPlaceGuess] );
 
   return {
     latLng,

--- a/src/sharedHooks/useUserLocation.js
+++ b/src/sharedHooks/useUserLocation.js
@@ -77,7 +77,7 @@ const useUserLocation = ( { skipPlaceGuess = false }: Props ): Object => {
       fetchPlaceGuess();
     }
     setIsLoading( false );
-  }, [latLng, fetchPlaceGuess, skipPlaceGuess] );
+  }, [fetchPlaceGuess, skipPlaceGuess] );
 
   return {
     latLng,

--- a/src/sharedHooks/useUserLocation.js
+++ b/src/sharedHooks/useUserLocation.js
@@ -10,15 +10,12 @@ const useUserLocation = ( ): Object => {
   const [latLng, setLatLng] = useState( null );
 
   // TODO: wrap this in PermissionsGate so permissions aren't requested at odd times
-  const requestiOSPermissions = async ( ): Promise<?string> => {
+  const requestiOSPermissions = ( ): string | null => {
     // TODO: test this on a real device
-    if ( Platform.OS === "ios" ) {
-      try {
-        const permission = await request( PERMISSIONS.IOS.LOCATION_WHEN_IN_USE );
-        return permission;
-      } catch ( e ) {
-        console.warn( e, ": error requesting iOS permissions" );
-      }
+    try {
+      return request( PERMISSIONS.IOS.LOCATION_WHEN_IN_USE );
+    } catch ( e ) {
+      console.warn( e, ": error requesting iOS permissions" );
     }
     return null;
   };

--- a/src/sharedHooks/useUserLocation.js
+++ b/src/sharedHooks/useUserLocation.js
@@ -31,10 +31,8 @@ const useUserLocation = ( ): Object => {
       }
 
       const success = async ( { coords } ) => {
-        console.log( isCurrent );
         if ( !isCurrent ) { return; }
         const placeGuess = await fetchPlaceName( coords.latitude, coords.longitude );
-        console.log( coords );
         setLatLng( {
           place_guess: placeGuess,
           latitude: coords.latitude,

--- a/src/sharedHooks/useUserLocation.js
+++ b/src/sharedHooks/useUserLocation.js
@@ -27,13 +27,17 @@ const useUserLocation = ( ): Object => {
     let isCurrent = true;
 
     const fetchLocation = async ( ) => {
-      const permissions = await requestiOSPermissions( );
-      // TODO: handle case where iOS permissions are not granted
-      if ( permissions !== "granted" ) { return; }
+      if ( Platform.OS === "ios" ) {
+        const permissions = await requestiOSPermissions( );
+        // TODO: handle case where iOS permissions are not granted
+        if ( permissions !== "granted" ) { return; }
+      }
 
       const success = async ( { coords } ) => {
+        console.log( isCurrent );
         if ( !isCurrent ) { return; }
         const placeGuess = await fetchPlaceName( coords.latitude, coords.longitude );
+        console.log( coords );
         setLatLng( {
           place_guess: placeGuess,
           latitude: coords.latitude,

--- a/tests/unit/components/ObsDetails/ObsDetails.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetails.test.js
@@ -88,7 +88,7 @@ const mockLatLng = factory( "DeviceLocation" );
 
 jest.mock( "sharedHooks/useUserLocation", ( ) => ( {
   __esModule: true,
-  default: ( ) => mockLatLng
+  default: ( ) => ( { latLng: mockLatLng } )
 } ) );
 
 describe( "ObsDetails", () => {


### PR DESCRIPTION
Mostly fixes #404 

Turns out it was just slow on Android. Updated the `useUserLocation` hook to optionally make the place guess which was causing an unnecessary  delay (both places which use `useUserLocation` do not use the place guess currently.