### PR TITLE
Fix overridden border radius

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,11 +21,11 @@ module.exports = {
         Roboto: ["Roboto"],
         monospace: ["monospace"],
         Menlo: ["Menlo"]
-      }
-    },
-    borderRadius: {
-      // tried using rem value here, but it wouldn't load on iOS or Android
-      DEFAULT: "7px"
+      },
+      borderRadius: {
+        // tried using rem value here, but it wouldn't load on iOS or Android
+        DEFAULT: "7px"
+      },
     },
     colors: {
       primary: "#77b300",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,7 @@ module.exports = {
       borderRadius: {
         // tried using rem value here, but it wouldn't load on iOS or Android
         DEFAULT: "7px"
-      },
+      }
     },
     colors: {
       primary: "#77b300",


### PR DESCRIPTION
Fixes overridden border radius. When setting [theme](https://tailwindcss.com/docs/theme#extending-the-default-theme) it just had to be in the `extend` property.

An issue was brought up in pr #410 regarding the border radius not being set.

Rounded images:
<img width="346" alt="Screenshot 2023-01-29 at 5 08 40 PM" src="https://user-images.githubusercontent.com/13311268/215361091-c44ace79-d552-4a75-a5ef-038ebca5f39e.png">

Button radius defaults to 7px:
<img width="347" alt="Screenshot 2023-01-29 at 5 08 26 PM" src="https://user-images.githubusercontent.com/13311268/215361095-a9313433-10fb-4b13-9730-e9c6aeca00fd.png">
