### PR TITLE
398 inline user component

### DIFF
--- a/src/components/SharedComponents/InlineUser/InlineUser.js
+++ b/src/components/SharedComponents/InlineUser/InlineUser.js
@@ -1,7 +1,9 @@
 // @flow
 
 import { useNavigation } from "@react-navigation/native";
+// Directly imported, not from index.js to avoid circular dependency
 import Body3 from "components/SharedComponents/Typography/Body3";
+// Directly imported, not from index.js to avoid circular dependency
 import UserIcon from "components/SharedComponents/UserIcon/UserIcon";
 import {
   Pressable, View

--- a/src/components/SharedComponents/InlineUser/InlineUser.js
+++ b/src/components/SharedComponents/InlineUser/InlineUser.js
@@ -1,9 +1,10 @@
 // @flow
 
 import { useNavigation } from "@react-navigation/native";
+import Body3 from "components/SharedComponents/Typography/Body3";
 import UserIcon from "components/SharedComponents/UserIcon/UserIcon";
 import {
-  Pressable, Text, View
+  Pressable, View
 } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
@@ -59,7 +60,7 @@ const InlineUser = ( { user }: Props ): Node => {
       }}
     >
       <View className="mr-[7px]">{renderUserIcon()}</View>
-      <Text>{userHandle}</Text>
+      <Body3>{userHandle}</Body3>
     </Pressable>
   );
 };

--- a/src/components/SharedComponents/UserIcon/UserIcon.js
+++ b/src/components/SharedComponents/UserIcon/UserIcon.js
@@ -15,7 +15,7 @@ const UserIcon = ( { uri, small, active }: Props ): React.Node => {
   const size = small ? "w-[22px] h-[22px]" : "w-[40px] h-[40px]";
   const border = "border-[3px] border-inatGreen";
   const className = classNames( "rounded-full", size, active && border );
-  // For unknown reasons, the border doesn't show up on Android using nativewind classNames
+  // For unknown reasons, the green border doesn't show up on Android using nativewind classNames
   // but it works with style, might warrant further investigation or an issue in nativewind
   const style = { borderColor: colors.inatGreen, borderWidth: 3 };
   return (
@@ -24,6 +24,7 @@ const UserIcon = ( { uri, small, active }: Props ): React.Node => {
       className={className}
       style={active && style}
       source={uri}
+      accessibilityRole="image"
       accessibilityIgnoresInvertColors
     />
   );

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -33,6 +33,11 @@ jest.mock(
 );
 
 describe( "InlineUser", ( ) => {
+  it( "should not have accessibility erros", () => {
+    const inlineUser = <InlineUser user={snapshotUser} />;
+    expect( inlineUser ).toBeAccessible();
+  } );
+
   it( "renders reliably", () => {
     // Snapshot test
     render( <InlineUser user={consistentUser} /> );

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -34,7 +34,7 @@ jest.mock(
 
 describe( "InlineUser", ( ) => {
   it( "should not have accessibility erros", () => {
-    const inlineUser = <InlineUser user={snapshotUser} />;
+    const inlineUser = <InlineUser user={mockUser} />;
     expect( inlineUser ).toBeAccessible();
   } );
 

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -22,7 +22,7 @@ jest.mock( "@react-navigation/native", ( ) => {
 const mockUser = factory( "RemoteUser" );
 const mockUserWithoutImage = factory( "RemoteUser", { icon_url: null } );
 
-const consistentUser = { login: "some_login", icon_url: "some_icon_url" };
+const snapshotUser = { login: "some_login", icon_url: "some_icon_url" };
 
 jest.mock(
   "components/SharedComponents/UserIcon/UserIcon",
@@ -40,9 +40,8 @@ describe( "InlineUser", ( ) => {
 
   it( "renders reliably", () => {
     // Snapshot test
-    render( <InlineUser user={consistentUser} /> );
-    // TODO: Enable this test when Typography is used instead of Text
-    // expect( screen ).toMatchSnapshot();
+    render( <InlineUser user={snapshotUser} /> );
+    expect( screen ).toMatchSnapshot();
   } );
 
   it( "displays user handle and image correctly", async ( ) => {
@@ -101,7 +100,7 @@ describe( "InlineUser", ( ) => {
     // TODO: Enable this test when the offline icon is from our icon design font
     // it( "renders reliably", ( ) => {
     //   // Snapshot test
-    //   render( <InlineUser user={consistentUser} /> );
+    //   render( <InlineUser user={snapshotUser} /> );
     //   expect( screen ).toMatchSnapshot();
     // } );
   } );

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -56,17 +56,6 @@ describe( "InlineUser", ( ) => {
     expect( screen.queryByTestId( "InlineUser.NoInternetPicture" ) ).not.toBeTruthy( );
   } );
 
-  it( "displays user handle and and fallback image correctly", async ( ) => {
-    render( <InlineUser user={mockUserWithoutImage} /> );
-
-    expect( screen.getByText( `@${mockUserWithoutImage.login}` ) ).toBeTruthy();
-    // This icon appears after useIsConnected returns true
-    // so we have to use await and findByTestId
-    expect( await screen.findByTestId( "InlineUser.FallbackPicture" ) ).toBeTruthy();
-    expect( screen.queryByTestId( "mockUserIcon" ) ).not.toBeTruthy();
-    expect( screen.queryByTestId( "InlineUser.NoInternetPicture" ) ).not.toBeTruthy();
-  } );
-
   it( "fires onPress handler", ( ) => {
     render( <InlineUser user={mockUser} /> );
 
@@ -75,6 +64,19 @@ describe( "InlineUser", ( ) => {
 
     expect( mockNavigate )
       .toHaveBeenCalledWith( "UserProfile", { userId: mockUser.id } );
+  } );
+
+  describe( "when user has no icon set", () => {
+    it( "displays user handle and fallback image correctly", async ( ) => {
+      render( <InlineUser user={mockUserWithoutImage} /> );
+
+      expect( screen.getByText( `@${mockUserWithoutImage.login}` ) ).toBeTruthy();
+      // This icon appears after useIsConnected returns true
+      // so we have to use await and findByTestId
+      expect( await screen.findByTestId( "InlineUser.FallbackPicture" ) ).toBeTruthy();
+      expect( screen.queryByTestId( "mockUserIcon" ) ).not.toBeTruthy();
+      expect( screen.queryByTestId( "InlineUser.NoInternetPicture" ) ).not.toBeTruthy();
+    } );
   } );
 
   describe( "when offline", () => {

--- a/tests/unit/components/SharedComponents/InlineUser/__snapshots__/InlineUser.test.js.snap
+++ b/tests/unit/components/SharedComponents/InlineUser/__snapshots__/InlineUser.test.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InlineUser renders reliably 1`] = `
+<View
+  accessibilityHint="Navigates-to-user-profile"
+  accessibilityLabel="User"
+  accessibilityRole="link"
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Array [
+        Object {
+          "display": "flex",
+        },
+        Object {
+          "flexDirection": "row",
+        },
+        Object {
+          "alignItems": "center",
+        },
+      ],
+    ]
+  }
+  testID="InlineUser"
+>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "marginRight": 7,
+          },
+        ],
+      ]
+    }
+  >
+    <mockUserIcon
+      testID="mockUserIcon"
+    />
+  </View>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "Whitney-Light",
+        },
+        Array [
+          Object {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+        ],
+      ]
+    }
+  >
+    @some_login
+  </Text>
+</View>
+`;

--- a/tests/unit/components/SharedComponents/UserIcon/UserIcon.test.js
+++ b/tests/unit/components/SharedComponents/UserIcon/UserIcon.test.js
@@ -5,6 +5,11 @@ import React from "react";
 const mockUri = { uri: "some_uri" };
 
 describe( "UserIcon", () => {
+  it( "should not have accessibility erros", () => {
+    const userIcon = <UserIcon uri={mockUri} />;
+    expect( userIcon ).toBeAccessible();
+  } );
+
   it( "displays user image correctly", async () => {
     render( <UserIcon uri={mockUri} /> );
 

--- a/tests/unit/components/SharedComponents/UserIcon/UserIcon.test.js
+++ b/tests/unit/components/SharedComponents/UserIcon/UserIcon.test.js
@@ -9,7 +9,7 @@ describe( "UserIcon", () => {
     render( <UserIcon uri={mockUri} /> );
 
     // Check for image source
-    const profilePicture = await screen.findByTestId( "UserIcon.photo" );
+    const profilePicture = await screen.findByRole( "image" );
     expect( profilePicture ).toBeTruthy();
     expect( profilePicture.props.source ).toEqual( mockUri );
 

--- a/tests/unit/components/SharedComponents/UserIcon/__snapshots__/UserIcon.test.js.snap
+++ b/tests/unit/components/SharedComponents/UserIcon/__snapshots__/UserIcon.test.js.snap
@@ -3,6 +3,7 @@
 exports[`UserIcon displays active user image correctly 1`] = `
 <Image
   accessibilityIgnoresInvertColors={true}
+  accessibilityRole="image"
   source={
     Object {
       "uri": "some_uri",
@@ -49,6 +50,7 @@ exports[`UserIcon displays active user image correctly 1`] = `
 exports[`UserIcon displays small user image correctly 1`] = `
 <Image
   accessibilityIgnoresInvertColors={true}
+  accessibilityRole="image"
   source={
     Object {
       "uri": "some_uri",
@@ -79,6 +81,7 @@ exports[`UserIcon displays small user image correctly 1`] = `
 exports[`UserIcon displays user image correctly 1`] = `
 <Image
   accessibilityIgnoresInvertColors={true}
+  accessibilityRole="image"
   source={
     Object {
       "uri": "some_uri",


### PR DESCRIPTION
When finished this closes #398 .
Currently, we are still missing the icons to be used as fallback images for when a user has no icon set and when the device is offline. I can finish this up with the icons later.