### PR TITLE
484 - Create sticky toolbar

### DIFF
--- a/src/components/SharedComponents/FloatingActionBar.js
+++ b/src/components/SharedComponents/FloatingActionBar.js
@@ -5,14 +5,15 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import { Keyboard } from "react-native";
 import { useTheme } from "react-native-paper";
-import getShadowStyle from "styles/global";
+import { getShadowStyle } from "styles/global";
 
 const getShadow = shadowColor => getShadowStyle( {
   shadowColor,
   offsetWidth: 0,
   offsetHeight: 4,
-  opacity: 0.4,
-  radius: 4
+  shadowOpacity: 0.4,
+  shadowRadius: 4,
+  elevation: 5
 } );
 
 type Props = {

--- a/src/components/SharedComponents/StickyToolbar.js
+++ b/src/components/SharedComponents/StickyToolbar.js
@@ -1,0 +1,48 @@
+// @flow
+import classNames from "classnames";
+import { View } from "components/styledComponents";
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { useTheme } from "react-native-paper";
+
+const getShadow = shadowColor => StyleSheet.create( {
+  shadowColor,
+  shadowOffset: {
+    width: 0,
+    height: -2
+  },
+  // $FlowIssue[incompatible-shape]
+  shadowOpacity: 0.25,
+  // $FlowIssue[incompatible-shape]
+  shadowRadius: 2,
+  // $FlowIssue[incompatible-shape]
+  elevation: 5
+} );
+
+type Props = {
+  containerClass?: string,
+  children: React.Node
+}
+
+// Ensure this component is placed outside of scroll views
+
+const StickyToolbar = ( {
+  containerClass,
+  children
+}: Props ): React.Node => {
+  const theme = useTheme( );
+
+  return (
+    <View
+      className={classNames(
+        "absolute z-50 bg-white bottom-0 p-[15px] w-full",
+        containerClass
+      )}
+      style={getShadow( theme.colors.primary )}
+    >
+      {children}
+    </View>
+  );
+};
+
+export default StickyToolbar;

--- a/src/components/SharedComponents/StickyToolbar.js
+++ b/src/components/SharedComponents/StickyToolbar.js
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { View } from "components/styledComponents";
 import * as React from "react";
 import { useTheme } from "react-native-paper";
-import getShadowStyle from "sharedHelpers/getShadowStyle";
+import { getShadowStyle } from "styles/global";
 
 const getShadow = shadowColor => getShadowStyle( {
   shadowColor,

--- a/src/components/SharedComponents/StickyToolbar.js
+++ b/src/components/SharedComponents/StickyToolbar.js
@@ -9,8 +9,9 @@ const getShadow = shadowColor => getShadowStyle( {
   shadowColor,
   offsetWidth: 0,
   offsetHeight: -2,
-  opacity: 0.25,
-  radius: 2
+  shadowOpacity: 0.25,
+  shadowRadius: 2,
+  elevation: 5
 } );
 
 type Props = {

--- a/src/components/SharedComponents/StickyToolbar.js
+++ b/src/components/SharedComponents/StickyToolbar.js
@@ -2,21 +2,15 @@
 import classNames from "classnames";
 import { View } from "components/styledComponents";
 import * as React from "react";
-import { StyleSheet } from "react-native";
 import { useTheme } from "react-native-paper";
+import getShadowStyle from "sharedHelpers/getShadowStyle";
 
-const getShadow = shadowColor => StyleSheet.create( {
+const getShadow = shadowColor => getShadowStyle( {
   shadowColor,
-  shadowOffset: {
-    width: 0,
-    height: -2
-  },
-  // $FlowIssue[incompatible-shape]
-  shadowOpacity: 0.25,
-  // $FlowIssue[incompatible-shape]
-  shadowRadius: 2,
-  // $FlowIssue[incompatible-shape]
-  elevation: 5
+  offsetWidth: 0,
+  offsetHeight: -2,
+  opacity: 0.25,
+  radius: 2
 } );
 
 type Props = {

--- a/src/components/SharedComponents/index.js
+++ b/src/components/SharedComponents/index.js
@@ -9,6 +9,7 @@ export { default as INatIcon } from "./INatIcon";
 export { default as InlineUser } from "./InlineUser/InlineUser";
 export { default as ObservationLocation } from "./ObservationLocation";
 export { default as QualityGradeStatus } from "./QualityGradeStatus/QualityGradeStatus";
+export { default as StickyToolbar } from "./StickyToolbar";
 export { default as Tabs } from "./Tabs/Tabs";
 export { default as Body1 } from "./Typography/Body1";
 export { default as Body2 } from "./Typography/Body2";

--- a/src/components/UiLibrary.js
+++ b/src/components/UiLibrary.js
@@ -22,6 +22,7 @@ import {
   List2,
   ObservationLocation,
   QualityGradeStatus,
+  StickyToolbar,
   Subheading1,
   Tabs,
   UserIcon
@@ -378,6 +379,9 @@ const UiLibrary = () => {
           Useless spacer at the end because height in NativeWind is confusing.
         </Body1>
       </ScrollView>
+      <StickyToolbar>
+        <Heading2>StickyToolbar</Heading2>
+      </StickyToolbar>
     </ViewWithFooter>
   );
 };


### PR DESCRIPTION
#484 

Create sticky toolbar component

The toolbar also covers up the navbar in ui library page.

I don't think `15px` padding is necessary because that can be supplied via the `containerClass` prop. I'd imagine this component should become the wrapper for the `NavBar` component so styles stay consistent throughout the app.

<img width="349" alt="Screenshot 2023-02-23 at 5 04 35 PM" src="https://user-images.githubusercontent.com/13311268/221051168-c6f0b930-e58e-4cc7-8bfd-d57bd62aa86e.png">
