### PR TITLE
Exploratory pr for native image picker

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -173,6 +173,7 @@ android {
         // Detox Android setup
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        vectorDrawables.useSupportLibrary = true
         // Detox end
 
         if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,16 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
+
+        maven {
+            url 'https://maven.google.com'
+        }
+
+
+        maven {
+            url "https://www.jitpack.io"
+        }
+
         mavenCentral {
             // We don't want to fetch react-native from Maven Central as there are
             // older versions over there.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -371,6 +371,15 @@ PODS:
     - React-Core
   - RNGestureHandler (2.8.0):
     - React-Core
+  - RNImageCropPicker (0.39.0):
+    - React-Core
+    - React-RCTImage
+    - RNImageCropPicker/QBImagePickerController (= 0.39.0)
+    - TOCropViewController
+  - RNImageCropPicker/QBImagePickerController (0.39.0):
+    - React-Core
+    - React-RCTImage
+    - TOCropViewController
   - RNLocalize (2.2.4):
     - React-Core
   - RNPermissions (3.6.1):
@@ -409,6 +418,7 @@ PODS:
     - React-Core
   - RNVectorIcons (9.2.0):
     - React-Core
+  - TOCropViewController (2.6.1)
   - VisionCamera (2.15.2):
     - React
     - React-callinvoker
@@ -481,6 +491,7 @@ DEPENDENCIES:
   - "RNFlashList (from `../node_modules/@shopify/flash-list`)"
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - RNLocalize (from `../node_modules/react-native-localize`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -494,6 +505,7 @@ SPEC REPOS:
   trunk:
     - fmt
     - libevent
+    - TOCropViewController
 
 EXTERNAL SOURCES:
   boost:
@@ -622,6 +634,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNImageCropPicker:
+    :path: "../node_modules/react-native-image-crop-picker"
   RNLocalize:
     :path: "../node_modules/react-native-localize"
   RNPermissions:
@@ -705,12 +719,14 @@ SPEC CHECKSUMS:
   RNFlashList: 7fbca4fc075484a9426f1610d648dbea2de94eb0
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
+  RNImageCropPicker: 14fe1c29298fb4018f3186f455c475ab107da332
   RNLocalize: 0df7970cfc60389f00eb62fd7c097dc75af3fb4f
   RNPermissions: dcdb7b99796bbeda6975a6e79ad519c41b251b1c
   RNReanimated: 2a91e85fcd343f8af3c58d3425b99fdd285590a5
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   RNSVG: ecd661f380a07ba690c9c5929c475a44f432d674
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
+  TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   VisionCamera: 4cfd685b1e671fea4aa0400905ab397f0e972210
   Yoga: 1f02ef4ce4469aefc36167138441b27d988282b1
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -371,12 +371,12 @@ PODS:
     - React-Core
   - RNGestureHandler (2.8.0):
     - React-Core
-  - RNImageCropPicker (0.39.0):
+  - RNImageCropPicker (0.38.0):
     - React-Core
     - React-RCTImage
-    - RNImageCropPicker/QBImagePickerController (= 0.39.0)
+    - RNImageCropPicker/QBImagePickerController (= 0.38.0)
     - TOCropViewController
-  - RNImageCropPicker/QBImagePickerController (0.39.0):
+  - RNImageCropPicker/QBImagePickerController (0.38.0):
     - React-Core
     - React-RCTImage
     - TOCropViewController
@@ -719,7 +719,7 @@ SPEC CHECKSUMS:
   RNFlashList: 7fbca4fc075484a9426f1610d648dbea2de94eb0
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
-  RNImageCropPicker: 14fe1c29298fb4018f3186f455c475ab107da332
+  RNImageCropPicker: ffbba608264885c241cbf3a8f78eb7aeeb978241
   RNLocalize: 0df7970cfc60389f00eb62fd7c097dc75af3fb4f
   RNPermissions: dcdb7b99796bbeda6975a6e79ad519c41b251b1c
   RNReanimated: 2a91e85fcd343f8af3c58d3425b99fdd285590a5

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "react-native-fs": "^2.19.0",
         "react-native-geocoder-reborn": "^0.9.0",
         "react-native-gesture-handler": "^2.8.0",
+        "react-native-image-crop-picker": "^0.39.0",
         "react-native-image-pan-zoom": "^2.1.12",
         "react-native-image-picker": "^4.7.3",
         "react-native-jwt-io": "^1.0.3",
@@ -18590,6 +18591,14 @@
       "version": "0.70.3",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
+    },
+    "node_modules/react-native-image-crop-picker": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.39.0.tgz",
+      "integrity": "sha512-4aANbQMrmU6zN/4b0rVBA7SbaZ3aa5JESm3Xk751sINybZMt1yz/9h95LkO7U0pbslHDo3ofXjG75PmQRP6a/w==",
+      "peerDependencies": {
+        "react-native": ">=0.40.0"
+      }
     },
     "node_modules/react-native-image-pan-zoom": {
       "version": "2.1.12",
@@ -37643,6 +37652,12 @@
       "version": "0.70.3",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
+    },
+    "react-native-image-crop-picker": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.39.0.tgz",
+      "integrity": "sha512-4aANbQMrmU6zN/4b0rVBA7SbaZ3aa5JESm3Xk751sINybZMt1yz/9h95LkO7U0pbslHDo3ofXjG75PmQRP6a/w==",
+      "requires": {}
     },
     "react-native-image-pan-zoom": {
       "version": "2.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "react-native-fs": "^2.19.0",
         "react-native-geocoder-reborn": "^0.9.0",
         "react-native-gesture-handler": "^2.8.0",
-        "react-native-image-crop-picker": "^0.39.0",
+        "react-native-image-crop-picker": "0.38.0",
         "react-native-image-pan-zoom": "^2.1.12",
         "react-native-image-picker": "^4.7.3",
         "react-native-jwt-io": "^1.0.3",
@@ -18593,9 +18593,9 @@
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
     },
     "node_modules/react-native-image-crop-picker": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.39.0.tgz",
-      "integrity": "sha512-4aANbQMrmU6zN/4b0rVBA7SbaZ3aa5JESm3Xk751sINybZMt1yz/9h95LkO7U0pbslHDo3ofXjG75PmQRP6a/w==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.38.0.tgz",
+      "integrity": "sha512-FaLASXOP7R23pi20vMiVlXl0Y7cwTdl7y7yBqrlrsSH9gl9ibsU5y4mYWPYRbe8x9F/3zPGUE+1F0Gj/QF/peg==",
       "peerDependencies": {
         "react-native": ">=0.40.0"
       }
@@ -37654,9 +37654,9 @@
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
     },
     "react-native-image-crop-picker": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.39.0.tgz",
-      "integrity": "sha512-4aANbQMrmU6zN/4b0rVBA7SbaZ3aa5JESm3Xk751sINybZMt1yz/9h95LkO7U0pbslHDo3ofXjG75PmQRP6a/w==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.38.0.tgz",
+      "integrity": "sha512-FaLASXOP7R23pi20vMiVlXl0Y7cwTdl7y7yBqrlrsSH9gl9ibsU5y4mYWPYRbe8x9F/3zPGUE+1F0Gj/QF/peg==",
       "requires": {}
     },
     "react-native-image-pan-zoom": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-native-fs": "^2.19.0",
     "react-native-geocoder-reborn": "^0.9.0",
     "react-native-gesture-handler": "^2.8.0",
-    "react-native-image-crop-picker": "^0.39.0",
+    "react-native-image-crop-picker": "0.38.0",
     "react-native-image-pan-zoom": "^2.1.12",
     "react-native-image-picker": "^4.7.3",
     "react-native-jwt-io": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-native-fs": "^2.19.0",
     "react-native-geocoder-reborn": "^0.9.0",
     "react-native-gesture-handler": "^2.8.0",
+    "react-native-image-crop-picker": "^0.39.0",
     "react-native-image-pan-zoom": "^2.1.12",
     "react-native-image-picker": "^4.7.3",
     "react-native-jwt-io": "^1.0.3",

--- a/src/components/AddObsModal.js
+++ b/src/components/AddObsModal.js
@@ -6,6 +6,7 @@ import { t } from "i18next";
 import { ObsEditContext } from "providers/contexts";
 import * as React from "react";
 import { IconButton, useTheme } from "react-native-paper";
+import ImagePicker from 'react-native-image-crop-picker';
 
 type Props = {
   closeModal: ( ) => void
@@ -32,7 +33,36 @@ const AddObsModal = ( { closeModal }: Props ): React.Node => {
     closeModal( );
   };
 
-  const navToPhotoGallery = ( ) => navAndCloseModal( "PhotoGallery" );
+  const navToPhotoGallery = async ( ) => {
+    const result = await ImagePicker.openPicker({
+      mediaType: "photo",
+      multiple: true,
+      maxFiles: 20,
+      includeExif: true,
+      loadingLabelText: ""
+    }).then(images => images.map(image => ({
+        timestamp: parseInt(image.creationDate),
+        type: "image",
+        location: {
+          altitude: image.exif["{GPS}"].Altitude || 0,
+          longitude: image.exif["{GPS}"].Longitude || null,
+          latitude: image.exif["{GPS}"].Latitude || null,
+          heading: image.exif["{GPS}"].ImgDirection || 0,
+          speed: image.exif["{GPS}"].Speed || 0
+        },
+        image: {
+          width: image.width,
+          height: image.height,
+          filename: image.filename,
+          fileSize: image.size,
+          playableDuration: null,
+          uri: `file://${image.path}`
+        }
+    })));
+
+    const foo = await obsEditContext.createObservationFromCleanGallery(result[0])
+    navigation.navigate( "ObsEdit", { lastScreen: "PhotoGallery" } );
+  };
 
   const navToSoundRecorder = ( ) => navAndCloseModal( "SoundRecorder" );
 

--- a/src/components/AddObsModal.js
+++ b/src/components/AddObsModal.js
@@ -5,8 +5,8 @@ import { Text, View } from "components/styledComponents";
 import { t } from "i18next";
 import { ObsEditContext } from "providers/contexts";
 import * as React from "react";
-import ImagePicker from "react-native-image-crop-picker";
 import { IconButton, useTheme } from "react-native-paper";
+import selectImagesFromGallery from "sharedHelpers/selectImagesFromGallery";
 
 type Props = {
   closeModal: ( ) => void
@@ -34,58 +34,15 @@ const AddObsModal = ( { closeModal }: Props ): React.Node => {
   };
 
   const navToPhotoGallery = async () => {
-    const selectedImages = await ImagePicker.openPicker({
-      mediaType: "photo",
-      multiple: true,
-      maxFiles: 20,
-      includeExif: true,
-      loadingLabelText: "",
-    }).then((images) =>
-      images.map((image) => {
-        const gpsData = image.exif["{GPS}"];
-        const latitudeNegative = gpsData.LatitudeRef === "S";
-        const longitudeNegative = gpsData.LongitudeRef === "W";
+    const selectedPhotos = await selectImagesFromGallery( { resize: true } );
 
-        let latitude = gpsData.Latitude ?? null;
-        let longitude = gpsData.Longitude ?? null;
-
-        if (latitude && latitudeNegative) {
-          latitude *= -1;
-        }
-
-        if (longitude && longitudeNegative) {
-          longitude *= -1;
-        }
-
-        return {
-          timestamp: parseInt(image.creationDate, 10),
-          type: "image",
-          location: {
-            altitude: gpsData.Altitude || 0,
-            longitude,
-            latitude,
-            heading: gpsData.ImgDirection || 0,
-            speed: gpsData.Speed || 0,
-          },
-          image: {
-            width: image.width,
-            height: image.height,
-            filename: image.filename,
-            fileSize: image.size,
-            playableDuration: null,
-            uri: `file://${image.path}`,
-          },
-        };
-      })
-    );
-
-    if (selectedImages.length === 1) {
-      obsEditContext.createObservationFromGallery(selectedImages[0]);
-      navigation.navigate("ObsEdit");
-      closeModal();
+    if ( selectedPhotos.length === 1 ) {
+      obsEditContext.createObservationFromGallery( selectedPhotos[0] );
+      navigation.navigate( "ObsEdit" );
+    } else {
+      navigation.navigate( "GroupPhotos", { selectedPhotos } );
     }
-
-    
+    closeModal();
   };
 
   const navToSoundRecorder = ( ) => navAndCloseModal( "SoundRecorder" );

--- a/src/components/ObsEdit/AddEvidenceModal.js
+++ b/src/components/ObsEdit/AddEvidenceModal.js
@@ -113,7 +113,7 @@ const AddEvidenceModal = ( {
               accessibilityHint={t( "Navigates-to-camera" )}
             />
             <EvidenceButton
-              icon="pencil"
+              icon="gallery"
               handlePress={onImportPhoto}
               disabled={disableAddingMoreEvidence}
               accessibilityLabel={t( "Bulk-importer" )}

--- a/src/components/ObsEdit/AddEvidenceModal.js
+++ b/src/components/ObsEdit/AddEvidenceModal.js
@@ -9,12 +9,15 @@ import { useNavigation } from "@react-navigation/native";
 import { MAX_PHOTOS_ALLOWED } from "components/Camera/StandardCamera";
 import { EvidenceButton } from "components/SharedComponents";
 import { Text, View } from "components/styledComponents";
+import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
 import React, {
-  useCallback, useEffect,
+  useCallback, useContext,
+  useEffect,
   useRef, useState
 } from "react";
 import { useTranslation } from "react-i18next";
+import selectImagesFromGallery from "sharedHelpers/selectImagesFromGallery";
 
 type Props = {
   showAddEvidenceModal: boolean,
@@ -30,6 +33,7 @@ const AddEvidenceModal = ( {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const bottomSheetModalRef = useRef( null );
+  const { addGalleryPhotosToCurrentObservation } = useContext( ObsEditContext );
 
   const [snapPoint, setSnapPoint] = useState( 150 );
 
@@ -61,7 +65,8 @@ const AddEvidenceModal = ( {
   );
 
   const onImportPhoto = async () => {
-    navigation.navigate( "PhotoGallery", { skipGroupPhotos: true } );
+    const selectedPhotos = await selectImagesFromGallery( { resize: true } );
+    addGalleryPhotosToCurrentObservation( selectedPhotos );
 
     bottomSheetModalRef.current?.dismiss();
   };

--- a/src/components/PhotoImporter/PhotoGallery.js
+++ b/src/components/PhotoImporter/PhotoGallery.js
@@ -183,6 +183,8 @@ const PhotoGallery = (): Node => {
       navToObsEdit();
       return;
     }
+
+    console.log( JSON.stringify( selectedPhotos, null, 2 ) );
     navigation.navigate( "GroupPhotos", { selectedPhotos } );
   };
 

--- a/src/components/PhotoImporter/PhotoGallery.js
+++ b/src/components/PhotoImporter/PhotoGallery.js
@@ -184,7 +184,6 @@ const PhotoGallery = (): Node => {
       return;
     }
 
-    console.log( JSON.stringify( selectedPhotos, null, 2 ) );
     navigation.navigate( "GroupPhotos", { selectedPhotos } );
   };
 

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -90,6 +90,26 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     photos.map( async photo => ObservationPhoto.new( photo?.image?.uri ) )
   ), [] );
 
+  const createObservationFromCleanGallery = useCallback( async photo => {
+    const newLocalObs = await createObservationFromCleanGalleryPhoto( photo );
+    newLocalObs.observationPhotos = await createObsPhotos( [photo] );
+    setObservations( [newLocalObs] );
+  }, [createObsPhotos, createObservationFromGalleryPhoto] );
+
+  const createObservationFromCleanGalleryPhoto = useCallback( async photo => {
+    const latitude = photo?.location?.latitude;
+    const longitude = photo?.location?.longitude;
+    const placeGuess = await fetchPlaceName( latitude, longitude );
+
+    const newObservation = {
+      latitude,
+      longitude,
+      place_guess: placeGuess,
+      observed_on_string: formatDateStringFromTimestamp( photo.timestamp )
+    };
+    return Observation.new( newObservation );
+  }, [] );
+
   const createObservationFromGalleryPhoto = useCallback( async photo => {
     const originalPhotoUri = photo?.image?.uri;
     const firstPhotoExif = await parseExif( originalPhotoUri );
@@ -317,6 +337,8 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     };
 
     return {
+      createObservationFromCleanGallery,
+      createObservationFromCleanGalleryPhoto,
       createObservationNoEvidence,
       addObservations,
       createObsWithCameraPhotos,
@@ -357,6 +379,8 @@ const ObsEditProvider = ( { children }: Props ): Node => {
       setUploadProgress
     };
   }, [
+    createObservationFromCleanGallery,
+    createObservationFromCleanGalleryPhoto,
     currentObservation,
     currentObservationIndex,
     observations,

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -90,13 +90,13 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     photos.map( async photo => ObservationPhoto.new( photo?.image?.uri ) )
   ), [] );
 
-  const createObservationFromCleanGallery = useCallback( async photo => {
-    const newLocalObs = await createObservationFromCleanGalleryPhoto( photo );
+  const createObservationFromGallery = useCallback( async photo => {
+    const newLocalObs = await createObservationFromGalleryPhoto( photo );
     newLocalObs.observationPhotos = await createObsPhotos( [photo] );
     setObservations( [newLocalObs] );
   }, [createObsPhotos, createObservationFromGalleryPhoto] );
 
-  const createObservationFromCleanGalleryPhoto = useCallback( async photo => {
+  const createObservationFromGalleryPhoto = useCallback( async photo => {
     const latitude = photo?.location?.latitude;
     const longitude = photo?.location?.longitude;
     const placeGuess = await fetchPlaceName( latitude, longitude );
@@ -107,30 +107,6 @@ const ObsEditProvider = ( { children }: Props ): Node => {
       place_guess: placeGuess,
       observed_on_string: formatDateStringFromTimestamp( photo.timestamp )
     };
-    return Observation.new( newObservation );
-  }, [] );
-
-  const createObservationFromGalleryPhoto = useCallback( async photo => {
-    const originalPhotoUri = photo?.image?.uri;
-    const firstPhotoExif = await parseExif( originalPhotoUri );
-    const exifDate = formatExifDateAsString( firstPhotoExif.date );
-
-    const observedOnDate = exifDate || formatDateStringFromTimestamp( photo.timestamp );
-    const latitude = firstPhotoExif.latitude || photo?.location?.latitude;
-    const longitude = firstPhotoExif.longitude || photo?.location?.longitude;
-    const placeGuess = await fetchPlaceName( latitude, longitude );
-
-    const newObservation = {
-      latitude,
-      longitude,
-      place_guess: placeGuess,
-      observed_on_string: observedOnDate
-    };
-
-    if ( firstPhotoExif.positional_accuracy ) {
-      // $FlowIgnore
-      newObservation.positional_accuracy = firstPhotoExif.positional_accuracy;
-    }
     return Observation.new( newObservation );
   }, [] );
 
@@ -146,11 +122,6 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     setObservations( newObservations );
   }, [createObsPhotos, createObservationFromGalleryPhoto] );
 
-  const createObservationFromGallery = useCallback( async photo => {
-    const newLocalObs = await createObservationFromGalleryPhoto( photo );
-    newLocalObs.observationPhotos = await createObsPhotos( [photo] );
-    setObservations( [newLocalObs] );
-  }, [createObsPhotos, createObservationFromGalleryPhoto] );
 
   const appendObsPhotos = useCallback( obsPhotos => {
     // need empty case for when a user creates an observation with no photos,
@@ -337,8 +308,8 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     };
 
     return {
-      createObservationFromCleanGallery,
-      createObservationFromCleanGalleryPhoto,
+      createObservationFromGallery,
+      createObservationFromGalleryPhoto,
       createObservationNoEvidence,
       addObservations,
       createObsWithCameraPhotos,
@@ -379,8 +350,6 @@ const ObsEditProvider = ( { children }: Props ): Node => {
       setUploadProgress
     };
   }, [
-    createObservationFromCleanGallery,
-    createObservationFromCleanGalleryPhoto,
     currentObservation,
     currentObservationIndex,
     observations,

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -13,7 +13,6 @@ import ObservationPhoto from "realmModels/ObservationPhoto";
 import Photo from "realmModels/Photo";
 import { formatDateStringFromTimestamp } from "sharedHelpers/dateAndTime";
 import fetchPlaceName from "sharedHelpers/fetchPlaceName";
-import { formatExifDateAsString, parseExif } from "sharedHelpers/parseExif";
 import useApiToken from "sharedHooks/useApiToken";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 
@@ -87,14 +86,8 @@ const ObsEditProvider = ( { children }: Props ): Node => {
   };
 
   const createObsPhotos = useCallback( async photos => Promise.all(
-    photos.map( async photo => ObservationPhoto.new( photo?.image?.uri ) )
+    photos.map( async photo => ObservationPhoto.new( photo?.image?.uri, undefined, true ) )
   ), [] );
-
-  const createObservationFromGallery = useCallback( async photo => {
-    const newLocalObs = await createObservationFromGalleryPhoto( photo );
-    newLocalObs.observationPhotos = await createObsPhotos( [photo] );
-    setObservations( [newLocalObs] );
-  }, [createObsPhotos, createObservationFromGalleryPhoto] );
 
   const createObservationFromGalleryPhoto = useCallback( async photo => {
     const latitude = photo?.location?.latitude;
@@ -122,6 +115,11 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     setObservations( newObservations );
   }, [createObsPhotos, createObservationFromGalleryPhoto] );
 
+  const createObservationFromGallery = useCallback( async photo => {
+    const newLocalObs = await createObservationFromGalleryPhoto( photo );
+    newLocalObs.observationPhotos = await createObsPhotos( [photo] );
+    setObservations( [newLocalObs] );
+  }, [createObsPhotos, createObservationFromGalleryPhoto] );
 
   const appendObsPhotos = useCallback( obsPhotos => {
     // need empty case for when a user creates an observation with no photos,
@@ -308,7 +306,6 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     };
 
     return {
-      createObservationFromGallery,
       createObservationFromGalleryPhoto,
       createObservationNoEvidence,
       addObservations,
@@ -350,6 +347,7 @@ const ObsEditProvider = ( { children }: Props ): Node => {
       setUploadProgress
     };
   }, [
+    createObservationFromGalleryPhoto,
     currentObservation,
     currentObservationIndex,
     observations,

--- a/src/realmModels/ObservationPhoto.js
+++ b/src/realmModels/ObservationPhoto.js
@@ -53,14 +53,14 @@ class ObservationPhoto extends Realm.Object {
     };
   }
 
-  static async new( uri ) {
-    const photo = await Photo.new( uri );
+  static async new( ...params ) {
+    const photo = await Photo.new( ...params );
     return {
       _created_at: new Date( ),
       _updated_at: new Date( ),
       uuid: uuid.v4( ),
       photo,
-      originalPhotoUri: uri
+      originalPhotoUri: params[0]
     };
   }
 

--- a/src/realmModels/Photo.js
+++ b/src/realmModels/Photo.js
@@ -71,7 +71,7 @@ class Photo extends Realm.Object {
   }
 
   static async new( uri, resizeOptions = {}, skipResize ) {
-    const localFilePath = skipResize ?  uri : await Photo.resizeImageForUpload( uri, resizeOptions );
+    const localFilePath = skipResize ? uri : await Photo.resizeImageForUpload( uri, resizeOptions );
 
     return {
       _created_at: new Date( ),

--- a/src/realmModels/Photo.js
+++ b/src/realmModels/Photo.js
@@ -70,8 +70,8 @@ class Photo extends Realm.Object {
     return uri;
   }
 
-  static async new( uri, resizeOptions = {} ) {
-    const localFilePath = await Photo.resizeImageForUpload( uri, resizeOptions );
+  static async new( uri, resizeOptions = {}, skipResize ) {
+    const localFilePath = skipResize ?  uri : await Photo.resizeImageForUpload( uri, resizeOptions );
 
     return {
       _created_at: new Date( ),

--- a/src/realmModels/Photo.js
+++ b/src/realmModels/Photo.js
@@ -70,7 +70,7 @@ class Photo extends Realm.Object {
     return uri;
   }
 
-  static async new( uri, resizeOptions = {}, skipResize ) {
+  static async new( uri, resizeOptions = {}, skipResize = false ) {
     const localFilePath = skipResize ? uri : await Photo.resizeImageForUpload( uri, resizeOptions );
 
     return {

--- a/src/sharedHelpers/selectImagesFromGallery.js
+++ b/src/sharedHelpers/selectImagesFromGallery.js
@@ -1,6 +1,68 @@
+import { Platform } from "react-native";
 import ImagePicker from "react-native-image-crop-picker";
 
-const selectImagesFromGallery = ( { resize } ) => {
+const handleIosImage = image => {
+  const gpsData = image.exif["{GPS}"];
+  const latitudeNegative = gpsData?.LatitudeRef === "S";
+  const longitudeNegative = gpsData?.LongitudeRef === "W";
+
+  let latitude = gpsData?.Latitude ?? null;
+  let longitude = gpsData?.Longitude ?? null;
+
+  if ( latitude && latitudeNegative ) {
+    latitude *= -1;
+  }
+
+  if ( longitude && longitudeNegative ) {
+    longitude *= -1;
+  }
+
+  return {
+    timestamp: parseInt( image.creationDate, 10 ),
+    type: "image",
+    location: {
+      altitude: gpsData?.Altitude || 0,
+      longitude,
+      latitude,
+      heading: gpsData?.ImgDirection || 0,
+      speed: gpsData?.Speed || 0
+    },
+    image: {
+      width: image.width,
+      height: image.height,
+      filename: image.filename,
+      fileSize: image.size,
+      playableDuration: null,
+      uri: `file://${image.path}`
+    }
+  };
+};
+
+const handleAndroidImage = image => {
+  const gpsData = image.exif;
+
+  return {
+    timestamp: parseInt( image.modificationDate, 10 ),
+    type: "image",
+    location: {
+      altitude: gpsData?.Altitude || 0,
+      longitude: gpsData?.Longitude,
+      latitude: gpsData?.Latitude,
+      heading: gpsData?.ImgDirection || 0,
+      speed: gpsData?.Speed || 0
+    },
+    image: {
+      width: image.width,
+      height: image.height,
+      filename: image.filename,
+      fileSize: image.size,
+      playableDuration: null,
+      uri: image.path
+    }
+  };
+};
+
+const selectImagesFromGallery = async ( { resize } ) => {
   const pickerParams = {
     mediaType: "photo",
     multiple: true,
@@ -14,42 +76,9 @@ const selectImagesFromGallery = ( { resize } ) => {
     pickerParams.compressImageMaxHeight = 2048;
   }
 
-  return ImagePicker.openPicker( pickerParams ).then( images => images.map( image => {
-    const gpsData = image.exif["{GPS}"];
-    const latitudeNegative = gpsData?.LatitudeRef === "S";
-    const longitudeNegative = gpsData?.LongitudeRef === "W";
+  const selectedImages = await ImagePicker.openPicker( pickerParams );
 
-    let latitude = gpsData?.Latitude ?? null;
-    let longitude = gpsData?.Longitude ?? null;
-
-    if ( latitude && latitudeNegative ) {
-      latitude *= -1;
-    }
-
-    if ( longitude && longitudeNegative ) {
-      longitude *= -1;
-    }
-
-    return {
-      timestamp: parseInt( image.creationDate, 10 ),
-      type: "image",
-      location: {
-        altitude: gpsData?.Altitude || 0,
-        longitude,
-        latitude,
-        heading: gpsData?.ImgDirection || 0,
-        speed: gpsData?.Speed || 0
-      },
-      image: {
-        width: image.width,
-        height: image.height,
-        filename: image.filename,
-        fileSize: image.size,
-        playableDuration: null,
-        uri: `file://${image.path}`
-      }
-    };
-  } ) );
+  return selectedImages.map( Platform === "ios" ? handleIosImage : handleAndroidImage );
 };
 
 export default selectImagesFromGallery;

--- a/src/sharedHelpers/selectImagesFromGallery.js
+++ b/src/sharedHelpers/selectImagesFromGallery.js
@@ -1,0 +1,55 @@
+import ImagePicker from "react-native-image-crop-picker";
+
+const selectImagesFromGallery = ( { resize } ) => {
+  const pickerParams = {
+    mediaType: "photo",
+    multiple: true,
+    maxFiles: 20,
+    includeExif: true,
+    loadingLabelText: ""
+  };
+
+  if ( resize ) {
+    pickerParams.compressImageMaxWidth = 2048;
+    pickerParams.compressImageMaxHeight = 2048;
+  }
+
+  return ImagePicker.openPicker( pickerParams ).then( images => images.map( image => {
+    const gpsData = image.exif["{GPS}"];
+    const latitudeNegative = gpsData?.LatitudeRef === "S";
+    const longitudeNegative = gpsData?.LongitudeRef === "W";
+
+    let latitude = gpsData?.Latitude ?? null;
+    let longitude = gpsData?.Longitude ?? null;
+
+    if ( latitude && latitudeNegative ) {
+      latitude *= -1;
+    }
+
+    if ( longitude && longitudeNegative ) {
+      longitude *= -1;
+    }
+
+    return {
+      timestamp: parseInt( image.creationDate, 10 ),
+      type: "image",
+      location: {
+        altitude: gpsData?.Altitude || 0,
+        longitude,
+        latitude,
+        heading: gpsData?.ImgDirection || 0,
+        speed: gpsData?.Speed || 0
+      },
+      image: {
+        width: image.width,
+        height: image.height,
+        filename: image.filename,
+        fileSize: image.size,
+        playableDuration: null,
+        uri: `file://${image.path}`
+      }
+    };
+  } ) );
+};
+
+export default selectImagesFromGallery;

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -16,7 +16,13 @@ import {
   mockUseCameraDevices
 } from "./vision-camera/vision-camera";
 
-jest.mock( "react-native-image-crop-picker" );
+jest.mock( "react-native-image-crop-picker", () => {
+  const MockedModule = {
+    openPicker: jest.fn( )
+  };
+  return MockedModule;
+} );
+
 jest.mock( "@sayem314/react-native-keep-awake" );
 jest.mock( "react-native/Libraries/EventEmitter/NativeEventEmitter" );
 

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -16,6 +16,7 @@ import {
   mockUseCameraDevices
 } from "./vision-camera/vision-camera";
 
+jest.mock( "react-native-image-crop-picker" );
 jest.mock( "@sayem314/react-native-keep-awake" );
 jest.mock( "react-native/Libraries/EventEmitter/NativeEventEmitter" );
 


### PR DESCRIPTION
#431

- [x] Get native photo picker working on Android
- [x] Get native photo picker working on iOS
- [x] Ensure native photo picker is used for importing new photos to Group Photos and selecting photos for an existing observation (i.e. on Obs Edit)
- [x] Ensure native photo picker allows selection of multiple photos
- [x] Check for compatibility issues on older devices. (For example, I believe iOS introduced a new[ Photos Picker](https://developer.apple.com/documentation/photokit/selecting_photos_and_videos_in_ios) that only works on iOS 15+, so we may need a different solution for phones with an older OS)
- [x] Make sure we can still get coordinates from exif data

## android
https://user-images.githubusercontent.com/13311268/221446206-eaba9e27-26ed-414e-b9db-5fa8664a8438.mov
## ios 14.5
https://user-images.githubusercontent.com/13311268/221471649-c38718c5-6f71-414b-b0fe-678fe98d5c85.mov
## ios
https://user-images.githubusercontent.com/13311268/221446207-40c11c0a-b081-486b-a098-3a93629d5623.mov

