### PR TITLE
501 502 date dispaly location styling

### DIFF
--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -11,7 +11,7 @@ import {
 import DisplayTaxonName from "components/DisplayTaxonName";
 import ActivityHeader from "components/ObsDetails/ActivityHeader";
 import ObsStatus from "components/Observations/ObsStatus";
-import { Tabs } from "components/SharedComponents";
+import { ObservationLocation, Tabs } from "components/SharedComponents";
 import HideView from "components/SharedComponents/HideView";
 import PhotoScroll from "components/SharedComponents/PhotoScroll";
 import ScrollViewWrapper from "components/SharedComponents/ScrollViewWrapper";
@@ -44,7 +44,6 @@ import colors from "styles/tailwindColors";
 import ActivityTab from "./ActivityTab";
 import AddCommentModal from "./AddCommentModal";
 import DataTab from "./DataTab";
-import checkCamelAndSnakeCase from "./helpers/checkCamelAndSnakeCase";
 
 const { useRealm } = RealmContext;
 
@@ -334,23 +333,7 @@ const ObsDetails = (): Node => {
           {showTaxon()}
           <ObsStatus layout="vertical" observation={observation} />
         </View>
-        <View
-          className="flex-row ml-3"
-          accessible
-          accessibilityLabel={t( "Location" )}
-          accessibilityValue={{
-            text: checkCamelAndSnakeCase( observation, "placeGuess" )
-          }}
-        >
-          <IconMaterial
-            name="location-pin"
-            size={15}
-            color={theme.colors.primary}
-          />
-          <Text className="color-darkGray ml-2">
-            {checkCamelAndSnakeCase( observation, "placeGuess" )}
-          </Text>
-        </View>
+        <ObservationLocation observation={observation} classNameMargin="ml-3 mb-2" />
         <Tabs tabs={tabs} activeId={currentTabId} />
         <HideView show={currentTabId === ACTIVITY_TAB_ID}>
           <ActivityTab

--- a/src/components/SharedComponents/DateDisplay.js
+++ b/src/components/SharedComponents/DateDisplay.js
@@ -1,10 +1,9 @@
 // @flow
 import classNames from "classnames";
-import { Body4 } from "components/SharedComponents";
+import { Body4, INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { INatIcon } from "components/SharedComponents";
 import { formatApiDatetime } from "sharedHelpers/dateAndTime";
 
 type Props = {
@@ -17,7 +16,7 @@ const DateDisplay = ( { dateString, label, classNameMargin }: Props ): React.Nod
   const { t } = useTranslation( );
   return (
     <View className={classNames( "flex flex-row items-center", classNameMargin )}>
-     <INatIcon
+      <INatIcon
         name="date"
         size={13}
       />

--- a/src/components/SharedComponents/DateDisplay.js
+++ b/src/components/SharedComponents/DateDisplay.js
@@ -4,7 +4,7 @@ import { Body4 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import IconMaterial from "react-native-vector-icons/MaterialIcons";
+import { INatIcon } from "components/SharedComponents";
 import { formatApiDatetime } from "sharedHelpers/dateAndTime";
 
 type Props = {
@@ -17,7 +17,10 @@ const DateDisplay = ( { dateString, label, classNameMargin }: Props ): React.Nod
   const { t } = useTranslation( );
   return (
     <View className={classNames( "flex flex-row items-center", classNameMargin )}>
-      <IconMaterial name="watch-later" size={15} />
+     <INatIcon
+        name="date"
+        size={13}
+      />
       <Body4 className="ml-[5px]">
         {( label ? `${label} ` : "" ) + formatApiDatetime( dateString, t )}
       </Body4>

--- a/src/components/SharedComponents/INatIcon/index.js
+++ b/src/components/SharedComponents/INatIcon/index.js
@@ -34,7 +34,7 @@ const ALIASES = {
   copyrightcc: "copyright",
   currentlocation: "location-crosshairs",
   cv: "sparkly-label",
-  date: "clock",
+  date: "clock-outline",
   delete: "trash-outline",
   "downvote-active": "arrow-down-bold-circle",
   "downvote-inactive": "arrow-down-bold-circle-outline",

--- a/src/components/SharedComponents/ObservationLocation.js
+++ b/src/components/SharedComponents/ObservationLocation.js
@@ -26,11 +26,15 @@ const ObservationLocation = ( { observation, classNameMargin }: Props ): React.N
   }
 
   return (
-    <View className={classNames( "flex flex-row items-center", classNameMargin )}>
-      <INatIcon
-        name="location"
-        size={13}
-      />
+    <View
+      className={classNames( "flex flex-row items-center", classNameMargin )}
+      accessible
+      accessibilityLabel={t( "Location" )}
+      accessibilityValue={{
+        text: displayLocation
+      }}
+    >
+      <INatIcon name="location" size={13} />
       <Body4
         className="text-darkGray ml-[5px]"
         numberOfLines={1}

--- a/src/components/SharedComponents/ObservationLocation.js
+++ b/src/components/SharedComponents/ObservationLocation.js
@@ -1,11 +1,10 @@
 // @flow
 import classNames from "classnames";
 import checkCamelAndSnakeCase from "components/ObsDetails/helpers/checkCamelAndSnakeCase";
-import { Body4 } from "components/SharedComponents";
+import { Body4, INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { INatIcon } from "components/SharedComponents";
 
 type Props = {
   observation: Object,

--- a/src/components/SharedComponents/ObservationLocation.js
+++ b/src/components/SharedComponents/ObservationLocation.js
@@ -5,7 +5,7 @@ import { Body4 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import IconMaterial from "react-native-vector-icons/MaterialIcons";
+import { INatIcon } from "components/SharedComponents";
 
 type Props = {
   observation: Object,
@@ -28,7 +28,10 @@ const ObservationLocation = ( { observation, classNameMargin }: Props ): React.N
 
   return (
     <View className={classNames( "flex flex-row items-center", classNameMargin )}>
-      <IconMaterial name="location-pin" size={15} />
+      <INatIcon
+        name="location"
+        size={13}
+      />
       <Body4
         className="text-darkGray ml-[5px]"
         numberOfLines={1}


### PR DESCRIPTION
#501 & #502 

- [x] Replace MaterialIcon with the above icon, size 13x13 (date)
- [x] Replace MaterialIcon with the above icon, size 13x13 (location)


<img width="329" alt="Screenshot 2023-03-11 at 7 09 55 PM" src="https://user-images.githubusercontent.com/13311268/224518766-cc72be5f-3058-4b5a-ad4e-12f3ea506858.png">

obsdetail
<img width="329" alt="Screenshot 2023-03-11 at 7 17 30 PM" src="https://user-images.githubusercontent.com/13311268/224519007-a87d4d8a-089c-44df-9216-ca70dc2a6e40.png">


