### PR TITLE
Utilize floating action bar and sticky toolbar in group photos ui

### DIFF
--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -1,7 +1,9 @@
 // @flow
 
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { Body2, Button } from "components/SharedComponents";
+import {
+  Body2, Button, FloatingActionBar, StickyToolbar
+} from "components/SharedComponents";
 import ViewWrapper from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import { t } from "i18next";
@@ -184,35 +186,43 @@ const GroupPhotos = (): Node => {
         testID="GroupPhotos.list"
         ListEmptyComponent={loadingWheel}
       />
-      {selectedObservations.length > 0 && (
-        <Appbar.Header className="bg-white m-5">
-          <Appbar.Action
-            icon="combine"
-            onPress={() => combinePhotos()}
-            disabled={noObsSelected || oneObsSelected}
-            accessibilityLabel={t( "Combine-Photos" )}
-          />
-          <Appbar.Action
-            icon="separate"
-            onPress={() => separatePhotos()}
-            disabled={!obsWithMultiplePhotosSelected}
-            accessibilityLabel={t( "Separate-Photos" )}
-          />
-          <Appbar.Action
-            icon="trash-outline"
-            onPress={() => removePhotos()}
-            disabled={noObsSelected}
-            accessibilityLabel={t( "Remove-Photos" )}
-          />
-        </Appbar.Header>
-      )}
-      <Button
-        className="mx-5"
-        level="focus"
-        text={t( "UPLOAD-X-OBSERVATIONS", { count: observations.length } )}
-        onPress={navToObsEdit}
-        testID="GroupPhotos.next"
-      />
+      <FloatingActionBar
+        show={selectedObservations.length > 0}
+        position="bottomStart"
+        containerClass="bottom-[100px] ml-1 rounded-md"
+      >
+        <View className="rounded-md overflow-hidden">
+          <Appbar.Header>
+            <Appbar.Action
+              icon="combine"
+              onPress={() => combinePhotos()}
+              disabled={noObsSelected || oneObsSelected}
+              accessibilityLabel={t( "Combine-Photos" )}
+            />
+            <Appbar.Action
+              icon="separate"
+              onPress={() => separatePhotos()}
+              disabled={!obsWithMultiplePhotosSelected}
+              accessibilityLabel={t( "Separate-Photos" )}
+            />
+            <Appbar.Action
+              icon="trash-outline"
+              onPress={() => removePhotos()}
+              disabled={noObsSelected}
+              accessibilityLabel={t( "Remove-Photos" )}
+            />
+          </Appbar.Header>
+        </View>
+      </FloatingActionBar>
+      <StickyToolbar>
+        <Button
+          className="mt-2 mx-4"
+          level="focus"
+          text={t( "UPLOAD-X-OBSERVATIONS", { count: observations.length } )}
+          onPress={navToObsEdit}
+          testID="GroupPhotos.next"
+        />
+      </StickyToolbar>
     </ViewWrapper>
   );
 };

--- a/src/components/PhotoImporter/PhotoGallery.js
+++ b/src/components/PhotoImporter/PhotoGallery.js
@@ -5,9 +5,9 @@ import useCameraRollPhotos from "components/PhotoImporter/hooks/useCameraRollPho
 import usePhotoAlbums from "components/PhotoImporter/hooks/usePhotoAlbums";
 import PhotoAlbumPicker from "components/PhotoImporter/PhotoAlbumPicker";
 import PhotoGalleryImage from "components/PhotoImporter/PhotoGalleryImage";
-import { Button } from "components/SharedComponents";
+import { Button, StickyToolbar } from "components/SharedComponents";
 import ViewWrapper from "components/SharedComponents/ViewWrapper";
-import { Text, View } from "components/styledComponents";
+import { Text } from "components/styledComponents";
 import { t } from "i18next";
 import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
@@ -236,14 +236,15 @@ const PhotoGallery = (): Node => {
         extraData={rerenderList}
       />
       {totalSelected > 0 && (
-        <View className="h-16 mt-2 mx-4">
+        <StickyToolbar>
           <Button
+            className="mt-2 mx-4"
             level="focus"
             text={t( "Import-X-photos", { count: totalSelected || 0 } )}
             onPress={navToNextScreen}
             testID="PhotoGallery.createObsButton"
           />
-        </View>
+        </StickyToolbar>
       )}
       <Snackbar visible={showAlert} onDismiss={() => setShowAlert( false )}>
         {t( "You-can-only-upload-20-media" )}

--- a/src/components/SharedComponents/FloatingActionBar.js
+++ b/src/components/SharedComponents/FloatingActionBar.js
@@ -7,15 +7,14 @@ import { Animated, Keyboard } from "react-native";
 import { useTheme } from "react-native-paper";
 import { getShadowStyle } from "styles/global";
 
-const getShadow = (shadowColor) =>
-  getShadowStyle({
-    shadowColor,
-    offsetWidth: 0,
-    offsetHeight: 4,
-    shadowOpacity: 0.4,
-    shadowRadius: 4,
-    elevation: 5,
-  });
+const getShadow = shadowColor => getShadowStyle( {
+  shadowColor,
+  offsetWidth: 0,
+  offsetHeight: 4,
+  shadowOpacity: 0.4,
+  shadowRadius: 4,
+  elevation: 5
+} );
 
 type Props = {
   position: "topStart" | "topEnd" | "bottomStart" | "bottomEnd",
@@ -27,66 +26,66 @@ type Props = {
 
 // Ensure this component is placed outside of scroll views
 
-const FloatingActionBar = ({
+const FloatingActionBar = ( {
   position = "bottomEnd",
   endY = null,
   containerClass,
   children,
-  show,
-}: Props): React.Node => {
+  show
+}: Props ): React.Node => {
   const theme = useTheme();
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-  const [keyboardOpen, setKeyboardOpen] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState( 0 );
+  const [keyboardOpen, setKeyboardOpen] = useState( false );
   const isBottom = position === "bottomEnd" || position === "bottomStart";
   const start = isBottom ? 100 : -100;
   const animate = useMemo(
-    () => new Animated.Value(show ? start : 0),
+    () => new Animated.Value( show ? start : 0 ),
     [start, show]
   );
 
-  useEffect(() => {
+  useEffect( () => {
     const showSubscription = Keyboard.addListener(
       "keyboardDidShow",
-      (event) => {
-        setKeyboardHeight(event.endCoordinates.height);
-        setKeyboardOpen(true);
+      event => {
+        setKeyboardHeight( event.endCoordinates.height );
+        setKeyboardOpen( true );
       }
     );
-    const hideSubscription = Keyboard.addListener("keyboardDidHide", () => {
-      setKeyboardOpen(false);
-    });
+    const hideSubscription = Keyboard.addListener( "keyboardDidHide", () => {
+      setKeyboardOpen( false );
+    } );
 
     return () => {
       showSubscription.remove();
       hideSubscription.remove();
     };
-  }, []);
+  }, [] );
 
-  useEffect(() => {
+  useEffect( () => {
     const sharedParams = {
       velocity: 1,
       tension: 2,
       friction: 8,
-      useNativeDriver: true,
+      useNativeDriver: true
     };
 
     const toValue = show ? 0 : start;
 
-    Animated.spring(animate, {
+    Animated.spring( animate, {
       ...sharedParams,
-      toValue,
-    }).start();
-  }, [keyboardOpen, keyboardHeight, position, show, animate, start]);
+      toValue
+    } ).start();
+  }, [keyboardOpen, keyboardHeight, position, show, animate, start] );
 
   const effectiveKeyboardHeight = keyboardOpen ? keyboardHeight : 0;
 
   const positionStyle = {};
 
-  if (position.includes("bottom")) {
-    positionStyle.bottom = (endY ?? 0) + effectiveKeyboardHeight;
+  if ( position.includes( "bottom" ) ) {
+    positionStyle.bottom = ( endY ?? 0 ) + effectiveKeyboardHeight;
   }
 
-  if (position.includes("End")) {
+  if ( position.includes( "End" ) ) {
     positionStyle.right = 0;
   }
 
@@ -98,12 +97,12 @@ const FloatingActionBar = ({
         position: "absolute",
         zIndex: 50,
         transform: [{ translateY: animate }],
-        ...positionStyle,
+        ...positionStyle
       }}
     >
       <View
-        className={classNames("bg-white", containerClass)}
-        style={getShadow(theme.colors.primary)}
+        className={classNames( "bg-white", containerClass )}
+        style={getShadow( theme.colors.primary )}
       >
         {children}
       </View>

--- a/src/components/SharedComponents/FloatingActionBar.js
+++ b/src/components/SharedComponents/FloatingActionBar.js
@@ -7,14 +7,15 @@ import { Animated, Keyboard } from "react-native";
 import { useTheme } from "react-native-paper";
 import { getShadowStyle } from "styles/global";
 
-const getShadow = shadowColor => getShadowStyle( {
-  shadowColor,
-  offsetWidth: 0,
-  offsetHeight: 4,
-  shadowOpacity: 0.4,
-  shadowRadius: 4,
-  elevation: 5
-} );
+const getShadow = (shadowColor) =>
+  getShadowStyle({
+    shadowColor,
+    offsetWidth: 0,
+    offsetHeight: 4,
+    shadowOpacity: 0.4,
+    shadowRadius: 4,
+    elevation: 5,
+  });
 
 type Props = {
   position: "topStart" | "topEnd" | "bottomStart" | "bottomEnd",
@@ -26,87 +27,86 @@ type Props = {
 
 // Ensure this component is placed outside of scroll views
 
-const FloatingActionBar = ( {
+const FloatingActionBar = ({
   position = "bottomEnd",
   endY = null,
   containerClass,
   children,
-  show
-}: Props ): React.Node => {
+  show,
+}: Props): React.Node => {
   const theme = useTheme();
-  const [keyboardHeight, setKeyboardHeight] = useState( 0 );
-  const [keyboardOpen, setKeyboardOpen] = useState( false );
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [keyboardOpen, setKeyboardOpen] = useState(false);
   const isBottom = position === "bottomEnd" || position === "bottomStart";
   const start = isBottom ? 100 : -100;
-  const animateIn = useMemo( () => new Animated.Value( start ), [start] );
-  const animateOut = useMemo( () => new Animated.Value( 0 ), [] );
+  const animate = useMemo(
+    () => new Animated.Value(show ? start : 0),
+    [start, show]
+  );
 
-  useEffect( () => {
+  useEffect(() => {
     const showSubscription = Keyboard.addListener(
       "keyboardDidShow",
-      event => {
-        setKeyboardHeight( event.endCoordinates.height );
-        setKeyboardOpen( true );
+      (event) => {
+        setKeyboardHeight(event.endCoordinates.height);
+        setKeyboardOpen(true);
       }
     );
-    const hideSubscription = Keyboard.addListener( "keyboardDidHide", () => {
-      setKeyboardOpen( false );
-    } );
+    const hideSubscription = Keyboard.addListener("keyboardDidHide", () => {
+      setKeyboardOpen(false);
+    });
 
     return () => {
       showSubscription.remove();
       hideSubscription.remove();
     };
-  }, [] );
+  }, []);
 
-  useEffect( () => {
+  useEffect(() => {
     const sharedParams = {
       velocity: 1,
       tension: 2,
       friction: 8,
-      useNativeDriver: true
+      useNativeDriver: true,
     };
 
-    if ( show ) {
-      Animated.spring( animateIn, {
-        ...sharedParams,
-        toValue: 0
-      } ).start();
-    } else {
-      Animated.spring( animateOut, {
-        ...sharedParams,
-        toValue: start
-      } ).start();
-    }
-  }, [
-    keyboardOpen,
-    keyboardHeight,
-    position,
-    show,
-    animateIn,
-    animateOut,
-    start
-  ] );
+    const toValue = show ? 0 : start;
+
+    Animated.spring(animate, {
+      ...sharedParams,
+      toValue,
+    }).start();
+  }, [keyboardOpen, keyboardHeight, position, show, animate, start]);
 
   const effectiveKeyboardHeight = keyboardOpen ? keyboardHeight : 0;
+
+  const positionStyle = {};
+
+  if (position.includes("bottom")) {
+    positionStyle.bottom = (endY ?? 0) + effectiveKeyboardHeight;
+  }
+
+  if (position.includes("End")) {
+    positionStyle.right = 0;
+  }
 
   return (
     <Animated.View
       /* eslint-disable-next-line react-native/no-inline-styles */
       style={{
+        overflow: "visible",
         position: "absolute",
         zIndex: 50,
-        transform: [{ translateY: show ? animateIn : animateOut }],
-        ...( position === "bottomEnd" || position === "bottomStart"
-          ? { bottom: ( endY ?? 0 ) + effectiveKeyboardHeight }
-          : {} ),
-        ...( position === "bottomEnd" || position === "topEnd"
-          ? { right: 0 }
-          : {} ),
-        ...getShadow( theme.colors.primary )
+        transform: [{ translateY: animate }],
+        ...positionStyle,
       }}
     >
-      <View className={classNames( "bg-white", containerClass )}>{children}</View>
+      <View
+        className={classNames("bg-white", containerClass)}
+        style={getShadow(theme.colors.primary)}
+      >
+        {children}
+      </View>
     </Animated.View>
   );
 };

--- a/src/components/SharedComponents/FloatingActionBar.js
+++ b/src/components/SharedComponents/FloatingActionBar.js
@@ -2,8 +2,8 @@
 import classNames from "classnames";
 import { View } from "components/styledComponents";
 import * as React from "react";
-import { useEffect, useState } from "react";
-import { Keyboard } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { Animated, Keyboard } from "react-native";
 import { useTheme } from "react-native-paper";
 import { getShadowStyle } from "styles/global";
 
@@ -19,58 +19,95 @@ const getShadow = shadowColor => getShadowStyle( {
 type Props = {
   position: "topStart" | "topEnd" | "bottomStart" | "bottomEnd",
   containerClass?: string,
-  children: React.Node
-}
+  endY?: number | null,
+  children: React.Node,
+  show: boolean,
+};
 
 // Ensure this component is placed outside of scroll views
 
 const FloatingActionBar = ( {
   position = "bottomEnd",
+  endY = null,
   containerClass,
-  children
+  children,
+  show
 }: Props ): React.Node => {
-  const theme = useTheme( );
+  const theme = useTheme();
   const [keyboardHeight, setKeyboardHeight] = useState( 0 );
   const [keyboardOpen, setKeyboardOpen] = useState( false );
+  const isBottom = position === "bottomEnd" || position === "bottomStart";
+  const start = isBottom ? 100 : -100;
+  const animateIn = useMemo( () => new Animated.Value( start ), [start] );
+  const animateOut = useMemo( () => new Animated.Value( 0 ), [] );
 
-  useEffect( ( ) => {
-    const showSubscription = Keyboard.addListener( "keyboardDidShow", event => {
-      setKeyboardHeight( event.endCoordinates.height );
-      setKeyboardOpen( true );
-    } );
-    const hideSubscription = Keyboard.addListener( "keyboardDidHide", ( ) => {
+  useEffect( () => {
+    const showSubscription = Keyboard.addListener(
+      "keyboardDidShow",
+      event => {
+        setKeyboardHeight( event.endCoordinates.height );
+        setKeyboardOpen( true );
+      }
+    );
+    const hideSubscription = Keyboard.addListener( "keyboardDidHide", () => {
       setKeyboardOpen( false );
     } );
 
-    return ( ) => {
-      showSubscription.remove( );
-      hideSubscription.remove( );
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
     };
   }, [] );
 
-  const isBottom = position === "bottomEnd" || position === "bottomStart";
+  useEffect( () => {
+    const sharedParams = {
+      velocity: 1,
+      tension: 2,
+      friction: 8,
+      useNativeDriver: true
+    };
+
+    if ( show ) {
+      Animated.spring( animateIn, {
+        ...sharedParams,
+        toValue: 0
+      } ).start();
+    } else {
+      Animated.spring( animateOut, {
+        ...sharedParams,
+        toValue: start
+      } ).start();
+    }
+  }, [
+    keyboardOpen,
+    keyboardHeight,
+    position,
+    show,
+    animateIn,
+    animateOut,
+    start
+  ] );
+
+  const effectiveKeyboardHeight = keyboardOpen ? keyboardHeight : 0;
 
   return (
-    <View
-      className={classNames(
-        "absolute z-50 bg-white rounded-lg",
-        containerClass,
-        {
-          "top-0 left-0": position === "topStart",
-          "top-0 right-0": position === "topEnd",
-          "left-0": position === "bottomStart",
-          "right-0": position === "bottomEnd"
-        }
-      )}
+    <Animated.View
+      /* eslint-disable-next-line react-native/no-inline-styles */
       style={{
-        ...getShadow( theme.colors.primary ),
-        ...( isBottom ? {
-          bottom: keyboardOpen ? keyboardHeight : 0
-        } : {} )
+        position: "absolute",
+        zIndex: 50,
+        transform: [{ translateY: show ? animateIn : animateOut }],
+        ...( position === "bottomEnd" || position === "bottomStart"
+          ? { bottom: ( endY ?? 0 ) + effectiveKeyboardHeight }
+          : {} ),
+        ...( position === "bottomEnd" || position === "topEnd"
+          ? { right: 0 }
+          : {} ),
+        ...getShadow( theme.colors.primary )
       }}
     >
-      {children}
-    </View>
+      <View className={classNames( "bg-white", containerClass )}>{children}</View>
+    </Animated.View>
   );
 };
 

--- a/src/components/UiLibrary.js
+++ b/src/components/UiLibrary.js
@@ -55,8 +55,10 @@ const UiLibrary = (): Node => {
   return (
     <ViewWrapper>
       <FloatingActionBar
-        position="bottomStart"
-        containerClass="mx-4 px-2 my-[100px]"
+        position="bottomEnd"
+        containerClass="mx-4 px-2 rounded-md"
+        endY={200}
+        show
       >
         <Heading2 className="my-2">Floating Action Bar</Heading2>
         <IconButton className="mx-auto" icon="star-bold-outline" mode="contained" />


### PR DESCRIPTION
#480 
- [x] Add a StickyToolbar with a single button that says "IMPORT X OBSERVATIONS" where X is the number of observations; should take the user to ObsEdit (equivalent of current "Next" button)
- [x] Add a FloatingToolbar with group, split, and delete buttons
- [x] FloatingToolbar should only appear when you've selected an observation, should animate in from behind the StickyToolbar
- [x] group button should group selected observations into a single observation **(current behavior)**
- [x] split button should ungroup all selected observations so all their photos are separate observations **(current behavior)**
- [x] delete button should remove the selected observations and delete selected photo records **(current behavior)**


### Floating toolbar animate in + out
https://user-images.githubusercontent.com/13311268/224524027-362f17fd-b4e9-43f6-b2ec-3f77838c9d86.mov

### Sticky toolbar in select photos
<img width="732" alt="Screenshot 2023-03-11 at 10 07 09 PM" src="https://user-images.githubusercontent.com/13311268/224524075-a51d3656-9c33-4fcd-b1e3-fa404bfa07cf.png">

### Issues
1. #517 persists on any shadow on this page for android
2. I think toolbar should remain open after you complete an action like group or separate
