### PR TITLE
Fix orientation of thumbnails and checkmark

### DIFF
--- a/src/components/Camera/PhotoPreview.js
+++ b/src/components/Camera/PhotoPreview.js
@@ -10,15 +10,13 @@ import React, { useContext, useState } from "react";
 type Props = {
   photoUris: Array<string>,
   setPhotoUris: Function,
-  savingPhoto: boolean,
-  deviceOrientation: string
+  savingPhoto: boolean
 }
 
 const PhotoPreview = ( {
   photoUris,
   setPhotoUris,
-  savingPhoto,
-  deviceOrientation
+  savingPhoto
 }: Props ): Node => {
   const { deletePhotoFromObservation } = useContext( ObsEditContext );
   const [initialPhotoSelected, setInitialPhotoSelected] = useState( null );
@@ -59,7 +57,6 @@ const PhotoPreview = ( {
           containerStyle="camera"
           setSelectedPhotoIndex={handleSelection}
           savingPhoto={savingPhoto}
-          deviceOrientation={deviceOrientation}
         />
       </View>
     </>

--- a/src/components/Camera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { useNavigation, useRoute } from "@react-navigation/native";
-import classnames from "classnames";
 import {
   Button, CloseButton, Heading4,
   List2
@@ -90,7 +89,7 @@ const StandardCamera = ( ): Node => {
     } else if ( _.camelCase( orientation ) === "landscapeLeft" ) {
       setImageOrientation( "landscapeRight" );
     } else {
-      setImageOrientation( orientation );
+      setImageOrientation( "portrait" );
     }
   };
 
@@ -205,7 +204,6 @@ const StandardCamera = ( ): Node => {
         photoUris={cameraPreviewUris}
         setPhotoUris={setCameraPreviewUris}
         savingPhoto={savingPhoto}
-        deviceOrientation={imageOrientation}
       />
       <View className="relative flex-1">
         {device && <CameraView device={device} camera={camera} orientation={imageOrientation} />}
@@ -243,13 +241,7 @@ const StandardCamera = ( ): Node => {
           containerColor={colors.white}
           size={50}
         />
-        <View
-          className={classnames( checkmarkClass, {
-            "rotate-0": imageOrientation === "portrait" && !isTablet,
-            "-rotate-90": imageOrientation === "landscapeLeft" && !isTablet,
-            "rotate-90": imageOrientation === "landscapeRight" && !isTablet
-          } )}
-        >
+        <View className={checkmarkClass}>
           {photosTaken && (
             <IconButton
               icon="checkmark"

--- a/src/components/MediaViewer/HorizontalScroll.js
+++ b/src/components/MediaViewer/HorizontalScroll.js
@@ -111,6 +111,7 @@ const HorizontalScroll = ( {
       />
       {!atFirstPhoto && (
         <Pressable
+          accessibilityRole="button"
           className="p-5 absolute top-1/2 -mt-24 left-0"
           onPress={handleArrowPressLeft}
         >
@@ -119,6 +120,7 @@ const HorizontalScroll = ( {
       )}
       {!atLastPhoto && (
         <Pressable
+          accessibilityRole="button"
           className="p-5 absolute top-1/2 -mt-24 right-0"
           onPress={handleArrowPressRight}
         >

--- a/src/components/SharedComponents/PhotoCarousel.js
+++ b/src/components/SharedComponents/PhotoCarousel.js
@@ -10,7 +10,6 @@ import {
   ActivityIndicator,
   FlatList
 } from "react-native";
-import DeviceInfo from "react-native-device-info";
 import LinearGradient from "react-native-linear-gradient";
 import Modal from "react-native-modal";
 import { IconButton, useTheme } from "react-native-paper";
@@ -26,7 +25,6 @@ type Props = {
   savingPhoto?: boolean,
   handleAddEvidence?: Function,
   showAddButton?: boolean,
-  deviceOrientation?: string,
   deletePhoto?: Function
 }
 
@@ -39,13 +37,11 @@ const PhotoCarousel = ( {
   savingPhoto,
   handleAddEvidence,
   showAddButton = false,
-  deviceOrientation,
   deletePhoto
 }: Props ): Node => {
   const theme = useTheme( );
   const [deletePhotoMode, setDeletePhotoMode] = useState( false );
   const imageClass = "h-16 w-16 justify-center mx-1.5 rounded-lg";
-  const isTablet = DeviceInfo.isTablet();
 
   useEffect( () => {
     if ( photoUris.length === 0 && deletePhotoMode ) {
@@ -99,11 +95,7 @@ const PhotoCarousel = ( {
             <ImageBackground
               source={{ uri: item }}
               testID="ObsEdit.photo"
-              className={classnames( "w-fit h-full flex items-center justify-center", {
-                "rotate-0": deviceOrientation === "portrait" && !isTablet,
-                "-rotate-90": deviceOrientation === "landscapeLeft" && !isTablet,
-                "rotate-90": deviceOrientation === "landscapeRight" && !isTablet
-              } )}
+              className="w-fit h-full flex items-center justify-center"
             >
               {deletePhotoMode && (
                 <LinearGradient


### PR DESCRIPTION
Closes #475

At the moment, I can rotate from portrait to landscape on iPhone but not an Android phone. I see this [line of code](https://github.com/inaturalist/iNaturalistReactNative/blob/38311ea3c7e43d2c3b55563102cf39164211bcdf/src/components/Camera/StandardCamera.js#L81) which makes me think we're intending to lock to portrait orientation on all phones and only show landscape mode on tablets. Is that correct? Either way, we should be consistent in which orientations we display across Android/iOS.