### PR TITLE
Remove conditional around setAllObsToUpload

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -185,7 +185,9 @@ const MyObservations = ( {
               testID="MyObservationsAnimatedList"
               numColumns={numColumns}
               horizontal={false}
-              keyExtractor={item => item.id || item.uuid}
+              // only used id as a fallback key because after upload
+              // react thinks we've rendered a second item w/ a duplicate key
+              keyExtractor={(item) => item.uuid || item.id}
               renderItem={renderItem}
               ListEmptyComponent={renderEmptyList}
               ItemSeparatorComponent={renderItemSeparator}

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -29,15 +29,11 @@ const useLocalObservations = ( ): Object => {
       // create an array of Realm objects... which will probably require some
       // degree of pagination in the future
       // setObservationList( _.compact( collection ) );
-      setObservationList( [...collection] );
+      setObservationList( collection );
 
       const unsyncedObs = Observation.filterUnsyncedObservations( realm );
 
-      if ( allObsToUpload.length < unsyncedObs.length ) {
-        setAllObsToUpload( Array.from( unsyncedObs ) );
-      } else if ( unsyncedObs.length === 0 ) {
-        setAllObsToUpload( [] );
-      }
+      setAllObsToUpload( Array.from( unsyncedObs ) );
     } );
     // eslint-disable-next-line consistent-return
     return ( ) => {

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -29,7 +29,7 @@ const useLocalObservations = ( ): Object => {
       // create an array of Realm objects... which will probably require some
       // degree of pagination in the future
       // setObservationList( _.compact( collection ) );
-      setObservationList( collection );
+      setObservationList( [...collection] );
 
       const unsyncedObs = Observation.filterUnsyncedObservations( realm );
 


### PR DESCRIPTION
I found if you had two unsynced observations and deleted one, it would crash.

I took out the conditional `if ( allObsToUpload.length < unsyncedObs.length ) {` because `allObsToUpload` seems as it should be a direct reflection of what is in realm, and this conditional allows cases where they aren't in sync.

If this is necessary I can look at other ways to fix this bug.