### PR TITLE
606 - Fix render blocking state change

### DIFF
--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -11,7 +11,7 @@ import useUploadObservations from "sharedHooks/useUploadObservations";
 import MyObservations from "./MyObservations";
 
 const MyObservationsContainer = (): Node => {
-  const { observationList: observations, allObsToUpload } = useLocalObservations();
+  const { observationList: observations, allObsToUpload } = useLocalObservations( );
   const uploadStatus = useUploadObservations( allObsToUpload );
   const [layout, setLayout] = useState( "list" );
   const { isLoading, fetchNextPage } = useInfiniteScroll();

--- a/src/components/SharedComponents/UserText.js
+++ b/src/components/SharedComponents/UserText.js
@@ -130,4 +130,5 @@ const UserText = ( {
   );
 };
 
+// Memoize to prevent excessive re-renders when HTML component is in a list
 export default React.memo( UserText, ( oldProps, newProps ) => isEqual( oldProps, newProps ) );

--- a/src/components/SharedComponents/UserText.js
+++ b/src/components/SharedComponents/UserText.js
@@ -6,6 +6,7 @@ import { Platform, useWindowDimensions } from "react-native";
 import HTML, { defaultSystemFonts } from "react-native-render-html";
 import WebView from "react-native-webview";
 import sanitizeHtml from "sanitize-html";
+import { isEqual } from 'lodash';
 
 const ALLOWED_TAGS = ( `
   a
@@ -130,4 +131,6 @@ const UserText = ( {
   );
 };
 
-export default UserText;
+export default React.memo(UserText, (oldProps, newProps) => {
+  return isEqual(oldProps, newProps)
+});

--- a/src/components/SharedComponents/UserText.js
+++ b/src/components/SharedComponents/UserText.js
@@ -130,4 +130,4 @@ const UserText = ( {
   );
 };
 
-export default React.memo( UserText );
+export default UserText;

--- a/src/components/SharedComponents/UserText.js
+++ b/src/components/SharedComponents/UserText.js
@@ -130,4 +130,4 @@ const UserText = ( {
   );
 };
 
-export default UserText;
+export default React.memo(UserText);

--- a/src/components/SharedComponents/UserText.js
+++ b/src/components/SharedComponents/UserText.js
@@ -130,4 +130,4 @@ const UserText = ( {
   );
 };
 
-export default React.memo(UserText);
+export default React.memo( UserText );

--- a/src/components/SharedComponents/UserText.js
+++ b/src/components/SharedComponents/UserText.js
@@ -1,12 +1,11 @@
 import linkifyHtml from "linkify-html";
-import { trim } from "lodash";
+import { isEqual, trim } from "lodash";
 import MarkdownIt from "markdown-it";
 import * as React from "react";
 import { Platform, useWindowDimensions } from "react-native";
 import HTML, { defaultSystemFonts } from "react-native-render-html";
 import WebView from "react-native-webview";
 import sanitizeHtml from "sanitize-html";
-import { isEqual } from 'lodash';
 
 const ALLOWED_TAGS = ( `
   a
@@ -131,6 +130,4 @@ const UserText = ( {
   );
 };
 
-export default React.memo(UserText, (oldProps, newProps) => {
-  return isEqual(oldProps, newProps)
-});
+export default React.memo( UserText, ( oldProps, newProps ) => isEqual( oldProps, newProps ) );

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -12,9 +12,9 @@ const { useRealm } = RealmContext;
 
 const useLocalObservations = ( ): Object => {
   const isFocused = useIsFocused( );
-  // use a ref as a temporary store because MyObservations page doesn't unmount on blue
-  // only updating state when focused will help prevent MyObservations from
-  // blocking other components from rendering
+  // Use refs to maintain state without triggering re-renders of hook consumers
+  // when they have lost focus, which prevents other
+  // views from rendering when they have focus.
   const stagedObservationList = useRef( [] );
   const stagedObsToUpload = useRef( [] );
   const [observationList, setObservationList] = useState( [] );

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -1,11 +1,12 @@
 // @flow
 
+import { useIsFocused } from "@react-navigation/native";
 import { RealmContext } from "providers/contexts";
 import {
-  useEffect, useState, useRef
+  useEffect, useRef,
+  useState
 } from "react";
 import Observation from "realmModels/Observation";
-import { useIsFocused } from "@react-navigation/native";
 
 const { useRealm } = RealmContext;
 
@@ -14,8 +15,8 @@ const useLocalObservations = ( ): Object => {
   // use a ref as a temporary store because MyObservations page doesn't unmount on blue
   // only updating state when focused will help prevent MyObservations from
   // blocking other components from rendering
-  const stagedObservationList = useRef([])
-  const stagedObsToUpload = useRef([])
+  const stagedObservationList = useRef( [] );
+  const stagedObsToUpload = useRef( [] );
   const [observationList, setObservationList] = useState( [] );
   const [allObsToUpload, setAllObsToUpload] = useState( [] );
 
@@ -36,18 +37,15 @@ const useLocalObservations = ( ): Object => {
       // create an array of Realm objects... which will probably require some
       // degree of pagination in the future
       // setObservationList( _.compact( collection ) );
-      const currentCollection = [...collection];
+      stagedObservationList.current = [...collection];
 
       const unsyncedObs = Observation.filterUnsyncedObservations( realm );
 
-      const currentObsToUpload = Array.from( unsyncedObs );
-
-      stagedObservationList.current = currentCollection;
-      stagedObsToUpload.current = currentObsToUpload;
+      stagedObsToUpload.current = Array.from( unsyncedObs );
 
       if ( isFocused ) {
-        setObservationList( currentCollection );
-        setAllObsToUpload( currentObsToUpload );
+        setObservationList( stagedObservationList.current );
+        setAllObsToUpload( stagedObsToUpload.current );
       }
     } );
     // eslint-disable-next-line consistent-return
@@ -57,12 +55,12 @@ const useLocalObservations = ( ): Object => {
     };
   }, [isFocused, allObsToUpload.length, realm] );
 
-  useEffect(( ) => {
+  useEffect( ( ) => {
     if ( isFocused ) {
       setObservationList( stagedObservationList.current );
       setAllObsToUpload( stagedObsToUpload.current );
     }
-  }, [isFocused])
+  }, [isFocused] );
 
   return {
     observationList,


### PR DESCRIPTION
#606 

https://github.com/inaturalist/iNaturalistReactNative/assets/13311268/418bb9d2-263d-418b-a43e-c5b5e4588d5c

My first pass at a fix was to make the `MyObservations` page unmount on blur, while it worked, it lost the scroll position.

Second pass around, I used a ref to prevent any downstream rerenders and would only rerender if `MyObservations` (or any consuming user of that hook) is focused. Let me know what you think of this solution as I don't think it's particularly straightforward so I left a comment about it in the code.

On another note, I think we should default to pages unmounting on blur unless there's a specific reason not to. I feel most of the pages are lightweight enough that initial render isn't that expensive and it should save on memory usage.