### PR TITLE
Border on MediaViewer images Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inaturalistreactnative",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inaturalistreactnative",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/eslint-parser": "^7.21.3",

--- a/src/components/MediaViewer/PhotoSelector.js
+++ b/src/components/MediaViewer/PhotoSelector.js
@@ -30,23 +30,25 @@ const PhotoSelector = ( {
     <Pressable
       accessibilityRole="button"
       onPress={( ) => scrollToIndex( index )}
+      className={classnames(
+        "overflow-hidden",
+        {
+          "border border-white border-[3px]": selectedPhotoIndex === index
+        },
+        {
+          "mt-[18px]": isLargeScreen && isLandscapeMode,
+          "mt-[47px]": isLargeScreen && !isLandscapeMode
+        },
+        {
+          [`${smallPhotoClass}`]: !isLargeScreen,
+          [`${largePhotoClass}`]: isLargeScreen
+        }
+      )}
     >
       <Image
         source={{ uri: item }}
         accessibilityIgnoresInvertColors
-        className={classnames(
-          {
-            "border border-white border-[3px]": selectedPhotoIndex === index
-          },
-          {
-            "mt-[18px]": isLargeScreen && isLandscapeMode,
-            "mt-[47px]": isLargeScreen && !isLandscapeMode
-          },
-          {
-            [`${smallPhotoClass}`]: !isLargeScreen,
-            [`${largePhotoClass}`]: isLargeScreen
-          }
-        )}
+        className="w-full h-full"
       />
     </Pressable>
   );


### PR DESCRIPTION
The border needs to be added to the view around an Image, not the image itself. The React Native Image component does not support border styling, which oddly leads to borders showing up on iOS but not Android.

Closes #603 and closes #622 