### PR TITLE
Fixed obs deletion bug and allow edit when obs has no media

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -220,7 +220,7 @@ const MyObservations = ( {
             />
             <AnimatedFlashList
               contentContainerStyle={contentContainerStyle}
-              data={observations}
+              data={observations.filter( o => o.isValid() )}
               key={layout}
               estimatedItemSize={
                 layout === "grid"

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -25,7 +25,7 @@ import { formatISO } from "date-fns";
 import _ from "lodash";
 import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Alert, LogBox } from "react-native";
 import {
   ActivityIndicator,
@@ -231,6 +231,18 @@ const ObsDetails = (): Node => {
     }
   }, [observation, comments] );
 
+  const editButton = useMemo( ( ) => (
+    <IconButton
+      onPress={navToObsEdit}
+      icon="pencil"
+      textColor={colors.white}
+      className="absolute top-3 right-3"
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={t( "edit" )}
+    />
+  ), [navToObsEdit, t] );
+
   if ( !observation ) {
     return null;
   }
@@ -351,15 +363,7 @@ const ObsDetails = (): Node => {
             necessary ~~~kueda
           */}
           {/* TODO: a11y props are not passed down into this 3.party */}
-          <IconButton
-            onPress={navToObsEdit}
-            icon="pencil"
-            textColor={colors.white}
-            className="absolute top-3 right-3"
-            accessible
-            accessibilityRole="button"
-            accessibilityLabel={t( "edit" )}
-          />
+          { editButton }
           <IconButton
             icon="star-bold-outline"
             size={25}
@@ -385,6 +389,7 @@ const ObsDetails = (): Node => {
         accessible
         accessibilityLabel={t( "Observation-has-no-photos-and-no-sounds" )}
       >
+        { editButton }
         <IconMaterial
           color={colors.white}
           testID="ObsDetails.noImage"

--- a/src/sharedHooks/useInfiniteScroll.js
+++ b/src/sharedHooks/useInfiniteScroll.js
@@ -18,7 +18,8 @@ const useInfiniteScroll = ( ): Object => {
   const baseParams = {
     user_id: currentUser?.id,
     per_page: 50,
-    fields: Observation.FIELDS
+    fields: Observation.FIELDS,
+    ttl: -1
   };
 
   const {

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -29,14 +29,6 @@ const useLocalObservations = ( ): Object => {
     const obs = realm.objects( "Observation" );
     const localObservations = obs.sorted( "_created_at", true );
     localObservations.addListener( ( collection, _changes ) => {
-      if ( localObservations.length === 0 ) { return; }
-      // started hitting https://github.com/realm/realm-js/issues/4484 on
-      // 2022-09-13 for no reason i can discern Note that if you
-      // setObservationsList to collection, it is a Realm.Collection, not an
-      // array, which doesn't seem to work. _.compact or Array.from will
-      // create an array of Realm objects... which will probably require some
-      // degree of pagination in the future
-      // setObservationList( _.compact( collection ) );
       stagedObservationList.current = [...collection];
 
       const unsyncedObs = Observation.filterUnsyncedObservations( realm );

--- a/tests/factories/LocalObservation.js
+++ b/tests/factories/LocalObservation.js
@@ -25,5 +25,7 @@ export default define( "LocalObservation", faker => ( {
   // is this the right way to test this?
   needsSync: jest.fn( ),
   wasSynced: jest.fn( ),
-  observed_on_string: "2022-12-03T11:14:16"
+  observed_on_string: "2022-12-03T11:14:16",
+  // This is a Realm object method that we use to see if a record was deleted or not
+  isValid: jest.fn( () => true )
 } ) );


### PR DESCRIPTION
Obs deletion bug (#545) mostly has to do with Realm objects hanging around in memory when they're no longer in the database. I spent a long time trying to write a test that could see the custom header button menu we add via react-navigation but never got it to work.

I'm not sure #545 is really "done" since I didn't figure out a way to test it. If others think that needs to be tested... I'm open to advice, but if not I think it's worth merging this and closing that issue if this work doesn't have any negative side effects.

Closes #662 (edit button on obs detail when no media)