### PR TITLE
#634 - my observations header is jittery on Android when slow scrolling

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -91,14 +91,19 @@ const MyObservations = ( {
   // basing collapsible sticky header code off the example in this article
   // https://medium.com/swlh/making-a-collapsible-sticky-header-animations-with-react-native-6ad7763875c3
   const scrollY = useRef( new Animated.Value( 0 ) );
+
+  // On Android, the scroll view offset is a double (not an integer), and interpolation shouldn't be
+  // one-to-one, which causes a jittery header while slow scrolling (see issue #634).
+  // See here as well: https://stackoverflow.com/a/60898411/1233767
   const scrollYClamped = diffClamp(
     scrollY.current,
     0,
-    heightAboveToolbar
+    heightAboveToolbar * 2
   );
 
+  // Same as comment above (see here: https://stackoverflow.com/a/60898411/1233767)
   const offsetForHeader = scrollYClamped.interpolate( {
-    inputRange: [0, heightAboveToolbar],
+    inputRange: [0, heightAboveToolbar * 2],
     // $FlowIgnore
     outputRange: [0, -heightAboveToolbar]
   } );


### PR DESCRIPTION
closes #634 