### PR TITLE
Update activity list when on non current user ObsDetail screen

### DIFF
--- a/src/components/AddID/AddID.js
+++ b/src/components/AddID/AddID.js
@@ -18,13 +18,14 @@ import TaxonSearch from "./TaxonSearch";
 type Props = {
   setComment: Function,
   comment: string,
-  clearSearch: boolean,
+  taxonSearch: string,
+  setTaxonSearch: Function,
   createId: Function,
   loading: boolean
 };
 
 const AddID = ( {
-  setComment, comment, clearSearch, createId, loading
+  setComment, comment, taxonSearch, setTaxonSearch, createId, loading
 }: Props ): Node => {
   const { t } = useTranslation( );
   const [showAddCommentSheet, setShowAddCommentSheet] = useState( false );
@@ -79,7 +80,11 @@ const AddID = ( {
             <ActivityIndicator large />
           </View>
         )}
-        <TaxonSearch clearSearch={clearSearch} createId={createId} />
+        <TaxonSearch
+          taxonSearch={taxonSearch}
+          setTaxonSearch={setTaxonSearch}
+          createId={createId}
+        />
       </View>
     </ViewWrapper>
   );

--- a/src/components/AddID/TaxonSearch.js
+++ b/src/components/AddID/TaxonSearch.js
@@ -8,23 +8,24 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { FlatList } from "react-native";
 import Taxon from "realmModels/Taxon";
 import { useTranslation } from "sharedHooks";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 
 type Props = {
-  clearSearch: boolean,
+  taxonSearch: string,
+  setTaxonSearch: Function,
   createId: Function
 };
 
 const TaxonSearch = ( {
-  clearSearch,
+  taxonSearch,
+  setTaxonSearch,
   createId
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const [taxonSearch, setTaxonSearch] = useState( "" );
   const { data: taxonList } = useAuthenticatedQuery(
     ["fetchSearchResults", taxonSearch],
     optsWithAuth => fetchSearchResults(
@@ -38,14 +39,6 @@ const TaxonSearch = ( {
       optsWithAuth
     )
   );
-
-  useEffect( ( ) => {
-    // this clears search whenever a user is coming from ObsEdit
-    // but maintains current search when a user navigates to TaxonDetails and back
-    if ( clearSearch ) {
-      setTaxonSearch( "" );
-    }
-  }, [clearSearch] );
 
   const renderEmptyComponent = ( ) => (
     <Body2 className="self-center">

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -118,7 +118,7 @@ const ObsDetailsContainer = ( ): Node => {
 
   const queryClient = useQueryClient( );
 
-  const { data: remoteObservation, refetch: refetchRemoteObservation }
+  const { data: remoteObservation, refetch: refetchRemoteObservation, isRefetching }
   = useAuthenticatedQuery(
     ["fetchRemoteObservation", uuid],
     optsWithAuth => fetchRemoteObservation(
@@ -127,11 +127,16 @@ const ObsDetailsContainer = ( ): Node => {
         fields: Observation.FIELDS
       },
       optsWithAuth
-    )
+    ),
+    {
+      keepPreviousData: false
+    }
   );
 
   const localObservation = useLocalObservation( uuid );
   const observation = localObservation || remoteObservation;
+
+  const belongsToCurrentUser = observation?.user?.login === currentUser?.login;
 
   useEffect( ( ) => {
     if ( !observationShown ) {
@@ -141,6 +146,17 @@ const ObsDetailsContainer = ( ): Node => {
       } );
     }
   }, [observation, observationShown] );
+
+  useEffect( ( ) => {
+    // if observation does not belong to current user, show
+    // new activity items after a refetch
+    if ( remoteObservation && !isRefetching ) {
+      dispatch( {
+        type: "ADD_ACTIVITY_ITEM",
+        observationShown: remoteObservation
+      } );
+    }
+  }, [remoteObservation, isRefetching] );
 
   const tabs = [
     {
@@ -193,15 +209,19 @@ const ObsDetailsContainer = ( ): Node => {
     ( commentParams, optsWithAuth ) => createComment( commentParams, optsWithAuth ),
     {
       onSuccess: data => {
-        realm?.write( ( ) => {
-          const localComments = localObservation?.comments;
-          const newComment = data[0];
-          newComment.user = currentUser;
-          const realmComment = realm?.create( "Comment", newComment );
-          localComments.push( realmComment );
-        } );
-        const updatedLocalObservation = realm.objectForPrimaryKey( "Observation", uuid );
-        dispatch( { type: "ADD_ACTIVITY_ITEM", observationShown: updatedLocalObservation } );
+        if ( belongsToCurrentUser ) {
+          realm?.write( ( ) => {
+            const localComments = localObservation?.comments;
+            const newComment = data[0];
+            newComment.user = currentUser;
+            const realmComment = realm?.create( "Comment", newComment );
+            localComments.push( realmComment );
+          } );
+          const updatedLocalObservation = realm.objectForPrimaryKey( "Observation", uuid );
+          dispatch( { type: "ADD_ACTIVITY_ITEM", observationShown: updatedLocalObservation } );
+        } else {
+          refetchRemoteObservation( );
+        }
       },
       onError: e => {
         let error = null;
@@ -230,19 +250,23 @@ const ObsDetailsContainer = ( ): Node => {
     ( idParams, optsWithAuth ) => createIdentification( idParams, optsWithAuth ),
     {
       onSuccess: data => {
-        realm?.write( ( ) => {
-          const localIdentifications = localObservation?.identifications;
-          const newIdentification = data[0];
-          newIdentification.user = currentUser;
-          newIdentification.taxon = realm?.objectForPrimaryKey(
-            "Taxon",
-            newIdentification.taxon.id
-          ) || newIdentification.taxon;
-          const realmIdentification = realm?.create( "Identification", newIdentification );
-          localIdentifications.push( realmIdentification );
-        } );
-        const updatedLocalObservation = realm.objectForPrimaryKey( "Observation", uuid );
-        dispatch( { type: "ADD_ACTIVITY_ITEM", observationShown: updatedLocalObservation } );
+        if ( belongsToCurrentUser ) {
+          realm?.write( ( ) => {
+            const localIdentifications = localObservation?.identifications;
+            const newIdentification = data[0];
+            newIdentification.user = currentUser;
+            newIdentification.taxon = realm?.objectForPrimaryKey(
+              "Taxon",
+              newIdentification.taxon.id
+            ) || newIdentification.taxon;
+            const realmIdentification = realm?.create( "Identification", newIdentification );
+            localIdentifications.push( realmIdentification );
+          } );
+          const updatedLocalObservation = realm.objectForPrimaryKey( "Observation", uuid );
+          dispatch( { type: "ADD_ACTIVITY_ITEM", observationShown: updatedLocalObservation } );
+        } else {
+          refetchRemoteObservation( );
+        }
       },
       onError: e => {
         let error = null;
@@ -268,9 +292,9 @@ const ObsDetailsContainer = ( ): Node => {
 
   const navToAddID = ( ) => {
     navigation.navigate( "AddID", {
-      clearSearch: true,
       observationUUID: uuid,
-      createRemoteIdentification: true
+      createRemoteIdentification: true,
+      belongsToCurrentUser
     } );
   };
 

--- a/src/components/ObsEdit/IdentificationSection.js
+++ b/src/components/ObsEdit/IdentificationSection.js
@@ -38,9 +38,7 @@ const IdentificationSection = ( ): Node => {
     } );
   };
 
-  const navToAddID = ( ) => navigation.navigate( "AddID", {
-    clearSearch: true
-  } );
+  const navToAddID = ( ) => navigation.navigate( "AddID" );
 
   useEffect( ( ) => {
     if ( hasIdentification ) {


### PR DESCRIPTION
Related to [#719](https://github.com/inaturalist/iNaturalistReactNative/issues/719) and [#721](https://github.com/inaturalist/iNaturalistReactNative/issues/721) -- another fix for correctly reloading the activity list when on a user page that does not belong to the app user.

Example: go to Explore, pick a species, visit the ObsDetail page, try to create a comment, id, or agree with an id