### PR TITLE
Don't retry queries if the servers return 503 codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,19 +70,27 @@ const queryClient = new QueryClient( {
   defaultOptions: {
     queries: {
       retry: async ( failureCount, error ) => {
+        if ( error.status > 500 ) {
+          logger.warn( `${error.status} Error for query` );
+          return 0;
+        }
         if (
           // If this is an actual 408 Request Timeout error, we probably want to
           // retry... but this will probably never happen
           error.status === 408
           // If there's just no network at the moment, definitely retry
           || ( error instanceof TypeError && error.message.match( "Network request failed" ) )
-        ) return failureCount < 3;
+        ) {
+          return failureCount < 3;
+        }
         handleError( error, { throw: false } );
         if ( error.status === 401 || error.status === 403 ) {
           // If we get a 401 or 403, call getJWT
           // which has a timestamp check if we need to refresh the token
           const token = await getJWT( );
-          if ( token ) return failureCount < 2;
+          if ( token ) {
+            return failureCount < 2;
+          }
         }
         return false;
       }

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -10,10 +10,10 @@ class INatApiError extends Error {
   // HTTP status code of the server response
   status: number;
 
-  constructor( json ) {
+  constructor( json, status ) {
     super( JSON.stringify( json ) );
     this.json = json;
-    this.status = json.status;
+    this.status = status || json.status;
   }
 }
 // https://wbinnssmith.com/blog/subclassing-error-in-modern-javascript/
@@ -24,7 +24,7 @@ Object.defineProperty( INatApiError.prototype, "name", {
 const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( !e.response ) { throw e; }
   const errorText = await e.response.text( );
-  const error = new INatApiError( errorText );
+  const error = new INatApiError( errorText, e.response.status );
   // TODO: this will log all errors handled here to the log file, in a production build
   // we probably don't want to do that, so change this back to console.error at one point
   logger.error(
@@ -33,6 +33,7 @@ const handleError = async ( e: Object, options: Object = {} ): Object => {
   if ( options.throw ) {
     throw error;
   }
+  return null;
 };
 
 export default handleError;

--- a/src/sharedHooks/useAuthenticatedQuery.js
+++ b/src/sharedHooks/useAuthenticatedQuery.js
@@ -3,6 +3,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
 
+import { log } from "../../react-native-logs.config";
+
+const logger = log.extend( "useAuthenticatedQuery" );
+
 // Should work like React Query's useQuery except it calls the queryFunction
 // with an object that includes the JWT
 const useAuthenticatedQuery = (
@@ -20,6 +24,13 @@ const useAuthenticatedQuery = (
       api_token: apiToken
     };
     return queryFunction( options );
+  },
+  retry: ( failureCount, error ) => {
+    if ( error.status > 500 ) {
+      logger.warn( `${error.status} Error for query: `, queryKey );
+      return 0;
+    }
+    return 3;
   },
   ...queryOptions
 } );

--- a/src/sharedHooks/useObservationsUpdates.js
+++ b/src/sharedHooks/useObservationsUpdates.js
@@ -30,7 +30,7 @@ const useObservationsUpdates = ( enabled: boolean ): Object => {
     { enabled: !!enabled }
   );
 
-  if ( isError ) {
+  if ( isError && error?.status !== 503 ) {
     console.log( "Error fetching observation updates", error );
     throw error;
   }


### PR DESCRIPTION
This prevents the infinite retries I was seeing before, so maybe it's ok to merge as is, but there are definitely some open questions:

1) Why doesn't configuring the QueryClient suffice?
2) How might we consolidate this error handling?
3) How do we notify the user?