### PR TITLE
Cover camera ipad rotation

### DIFF
--- a/src/components/Camera/ARCamera/ARCamera.js
+++ b/src/components/Camera/ARCamera/ARCamera.js
@@ -51,7 +51,8 @@ type Props = {
   onZoomChange?: Function,
   result?: Object,
   handleTaxaDetected: Function,
-  modelLoaded: boolean
+  modelLoaded: boolean,
+  isLandscapeMode: boolean
 };
 
 const ARCamera = ( {
@@ -74,7 +75,8 @@ const ARCamera = ( {
   onZoomChange,
   result,
   handleTaxaDetected,
-  modelLoaded
+  modelLoaded,
+  isLandscapeMode
 }: Props ): Node => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -118,24 +120,31 @@ const ARCamera = ( {
   return (
     <>
       {device && (
-        <FrameProcessorCamera
-          cameraRef={camera}
-          device={device}
-          onTaxaDetected={handleTaxaDetected}
-          onClassifierError={handleClassifierError}
-          onDeviceNotSupported={handleDeviceNotSupported}
-          onCaptureError={handleCaptureError}
-          onCameraError={handleCameraError}
-          onLog={handleLog}
-          animatedProps={animatedProps}
-          onZoomStart={onZoomStart}
-          onZoomChange={onZoomChange}
-          takingPhoto={takingPhoto}
-        />
+        <View className="w-full h-full absolute z-0">
+          <FrameProcessorCamera
+            cameraRef={camera}
+            device={device}
+            onTaxaDetected={handleTaxaDetected}
+            onClassifierError={handleClassifierError}
+            onDeviceNotSupported={handleDeviceNotSupported}
+            onCaptureError={handleCaptureError}
+            onCameraError={handleCameraError}
+            onLog={handleLog}
+            animatedProps={animatedProps}
+            onZoomStart={onZoomStart}
+            onZoomChange={onZoomChange}
+            takingPhoto={takingPhoto}
+          />
+        </View>
       )}
       <LinearGradient
         colors={["#000000", "rgba(0, 0, 0, 0)"]}
-        locations={[0.001, 1]}
+        locations={[
+          0.001,
+          isTablet && isLandscapeMode
+            ? 0.3
+            : 1
+        ]}
         className="w-full"
       >
         <View

--- a/src/components/Camera/CameraContainer.js
+++ b/src/components/Camera/CameraContainer.js
@@ -388,6 +388,7 @@ const CameraWithDevice = ( {
             result={result}
             handleTaxaDetected={handleTaxaDetected}
             modelLoaded={modelLoaded}
+            isLandscapeMode={isLandscapeMode}
           />
         )}
     </View>

--- a/src/components/Camera/CameraView.js
+++ b/src/components/Camera/CameraView.js
@@ -166,8 +166,8 @@ const CameraView = ( {
   // which the Camera overflows its view
   return (
     <View className="overflow-hidden flex-1">
-      <GestureDetector gesture={Gesture.Exclusive( singleTap, pinchGesture )}>
-        <VeryBadIpadRotator>
+      <VeryBadIpadRotator>
+        <GestureDetector gesture={Gesture.Exclusive( singleTap, pinchGesture )}>
           <ReanimatedCamera
             // Shared props between StandardCamera and ARCamera
             photo
@@ -187,12 +187,12 @@ const CameraView = ( {
             animatedProps={animatedProps}
             resizeMode={resizeMode || "cover"}
           />
-        </VeryBadIpadRotator>
-      </GestureDetector>
-      <FocusSquare
-        singleTapToFocusAnimation={singleTapToFocusAnimation}
-        tappedCoordinates={tappedCoordinates}
-      />
+        </GestureDetector>
+        <FocusSquare
+          singleTapToFocusAnimation={singleTapToFocusAnimation}
+          tappedCoordinates={tappedCoordinates}
+        />
+      </VeryBadIpadRotator>
     </View>
   );
 };

--- a/src/components/Camera/CameraView.js
+++ b/src/components/Camera/CameraView.js
@@ -1,4 +1,6 @@
 import { useIsFocused } from "@react-navigation/native";
+import VeryBadIpadRotator from "components/SharedComponents/VeryBadIpadRotator";
+import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback, useRef, useState } from "react";
 import { Animated, StyleSheet } from "react-native";
@@ -8,7 +10,6 @@ import {
 import Reanimated from "react-native-reanimated";
 import { Camera } from "react-native-vision-camera";
 import {
-  iPadStylePatch,
   orientationPatch,
   pixelFormatPatch
 } from "sharedHelpers/visionCameraPatches";
@@ -157,37 +158,42 @@ const CameraView = ( {
     } );
 
   // react-native-vision-camera v3.3.1:
-  // iPad camera preview is wrong in anything else than portrait
-  const cameraStyle = iPadStylePatch( deviceOrientation );
+  // iPad camera preview is wrong in anything else than portrait, hence the
+  // VeryBadIpadRotator, which will rotate its contents us a style transform
+  // and adjust position accordingly
 
+  // Note that overflow-hidden handles what seems to be a bug in android in
+  // which the Camera overflows its view
   return (
-    <>
+    <View className="overflow-hidden flex-1">
       <GestureDetector gesture={Gesture.Exclusive( singleTap, pinchGesture )}>
-        <ReanimatedCamera
-          // Shared props between StandardCamera and ARCamera
-          photo
-          enableZoomGesture={false}
-          isActive={isActive}
-          style={[StyleSheet.absoluteFill, cameraStyle]}
-          onError={e => onError( e )}
-          // react-native-vision-camera v3.3.1: This prop is undocumented, but does work on iOS
-          // it does nothing on Android so we set it to null there
-          orientation={orientationPatch( deviceOrientation )}
-          ref={cameraRef}
-          device={device}
-          enableHighQualityPhotos
-          // Props for ARCamera only
-          frameProcessor={frameProcessor}
-          pixelFormat={pixelFormatPatch()}
-          animatedProps={animatedProps}
-          resizeMode={resizeMode || "cover"}
-        />
+        <VeryBadIpadRotator>
+          <ReanimatedCamera
+            // Shared props between StandardCamera and ARCamera
+            photo
+            enableZoomGesture={false}
+            isActive={isActive}
+            style={StyleSheet.absoluteFill}
+            onError={e => onError( e )}
+            // react-native-vision-camera v3.3.1: This prop is undocumented, but does work on iOS
+            // it does nothing on Android so we set it to null there
+            orientation={orientationPatch( deviceOrientation )}
+            ref={cameraRef}
+            device={device}
+            enableHighQualityPhotos
+            // Props for ARCamera only
+            frameProcessor={frameProcessor}
+            pixelFormat={pixelFormatPatch()}
+            animatedProps={animatedProps}
+            resizeMode={resizeMode || "cover"}
+          />
+        </VeryBadIpadRotator>
       </GestureDetector>
       <FocusSquare
         singleTapToFocusAnimation={singleTapToFocusAnimation}
         tappedCoordinates={tappedCoordinates}
       />
-    </>
+    </View>
   );
 };
 

--- a/src/components/Camera/StandardCamera/PhotoPreview.js
+++ b/src/components/Camera/StandardCamera/PhotoPreview.js
@@ -23,6 +23,12 @@ type Props = {
   takingPhoto: boolean
 }
 
+const STYLE = {
+  justifyContent: "center",
+  flex: 0,
+  flexShrink: 1
+};
+
 const PhotoPreview = ( {
   isLandscapeMode,
   isLargeScreen,
@@ -75,21 +81,18 @@ const PhotoPreview = ( {
     );
   }
 
-  const wrapperStyle = { justifyContent: "center" };
+  const dynamicStyle = {};
   if ( isTablet && isLandscapeMode ) {
-    // $FlowIssue[prop-missing]
-    wrapperStyle.width = wrapperDim;
+    dynamicStyle.width = wrapperDim;
   } else {
-    // $FlowIssue[prop-missing]
-    wrapperStyle.height = wrapperDim;
-    // $FlowIssue[prop-missing]
-    wrapperStyle.width = "100%";
+    dynamicStyle.height = wrapperDim;
+    dynamicStyle.width = "100%";
   }
 
   return (
     <View
       // eslint-disable-next-line react-native/no-inline-styles
-      style={wrapperStyle}
+      style={[STYLE, dynamicStyle]}
     >
       {
         photoUris.length === 0 && !takingPhoto

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { useNavigation } from "@react-navigation/native";
+import classnames from "classnames";
 import CameraView from "components/Camera/CameraView";
 import FadeInOutView from "components/Camera/FadeInOutView";
 import { View } from "components/styledComponents";
@@ -111,8 +112,13 @@ const StandardCamera = ( {
     await takePhoto( );
   };
 
+  const containerClasses = ["flex-1"];
+  if ( isTablet && isLandscapeMode ) {
+    containerClasses.push( "flex-row" );
+  }
+
   return (
-    <>
+    <View className={classnames( containerClasses )}>
       <PhotoPreview
         rotation={rotation}
         takingPhoto={takingPhoto}
@@ -132,7 +138,6 @@ const StandardCamera = ( {
             onDeviceNotSupported={handleDeviceNotSupported}
             onCaptureError={handleCaptureError}
             onCameraError={handleCameraError}
-            resizeMode="contain"
           />
         )}
         <FadeInOutView takingPhoto={takingPhoto} />
@@ -170,7 +175,7 @@ const StandardCamera = ( {
           setDismissChanges( true );
         }}
       />
-    </>
+    </View>
   );
 };
 

--- a/src/components/SharedComponents/VeryBadIpadRotator.js
+++ b/src/components/SharedComponents/VeryBadIpadRotator.js
@@ -1,0 +1,54 @@
+// This assumes that its contents are not rotated correctly on an iPad... for
+// whatever reason, and rotates them using a CSS transform and some munging
+// of the position. This is very much a kludge. It would be far preferrable
+// to fix whatever is causing the incorrect rotation. Originally a workaround
+// for https://github.com/mrousavy/react-native-vision-camera/issues/1891
+import { View } from "components/styledComponents";
+import React, { useRef, useState } from "react";
+import { iPadStylePatch } from "sharedHelpers/visionCameraPatches";
+import useDeviceOrientation from "sharedHooks/useDeviceOrientation";
+
+const VeryBadIpadRotator = ( { children } ) => {
+  const [dims, setDims] = useState( {} );
+  const { deviceOrientation } = useDeviceOrientation();
+  const containerRef = useRef( );
+
+  const innerStyle = iPadStylePatch( deviceOrientation );
+  innerStyle.flex = 1;
+  // courtesy of
+  // https://github.com/mrousavy/react-native-vision-camera/issues/1891#issuecomment-1746222690
+  if ( innerStyle.transform && dims.width && dims.height ) {
+    innerStyle.position = "absolute";
+    innerStyle.width = dims.height;
+    innerStyle.height = dims.width;
+    innerStyle.left = dims.width / 2 - dims.height / 2;
+    innerStyle.top = dims.height / 2 - dims.width / 2;
+  }
+  return (
+    <View
+      ref={containerRef}
+      className="relative flex-1"
+      onLayout={
+        // The outer container is essentially the layout as originally
+        // intended, and the inner view is the one that gets rotated and
+        // repositioned
+        ( ) => containerRef?.current?.measure(
+          ( x, y, w, h, pageX, pageY ) => setDims( {
+            x,
+            y,
+            width: w,
+            height: h,
+            pageX,
+            pageY
+          } )
+        )
+      }
+    >
+      <View style={innerStyle}>
+        {children}
+      </View>
+    </View>
+  );
+};
+
+export default VeryBadIpadRotator;


### PR DESCRIPTION
Per our meeting this week, the camera view now covers the visible area even though the photos it capture are the full device screen size. This improves the kludge around react-native-vision-camera's inability to handle rotation on an iPad by repositioning the rotated camera view so it fills its entire area.