### PR TITLE
Bugfix: ObsEdit was blank after importing several photos

### DIFF
--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -16,6 +16,7 @@ import React, {
 import {
   RESULTS as PERMISSION_RESULTS
 } from "react-native-permissions";
+import fetchPlaceName from "sharedHelpers/fetchPlaceName";
 import useCurrentObservationLocation from "sharedHooks/useCurrentObservationLocation";
 
 import EvidenceSection from "./EvidenceSection";
@@ -31,7 +32,6 @@ const EvidenceSectionContainer = ( {
 }: Props ): Node => {
   const {
     currentObservation,
-
     updateObservationKeys,
     setPhotoEvidenceUris,
     photoEvidenceUris
@@ -160,6 +160,26 @@ const EvidenceSectionContainer = ( {
     const uris = data.map( obsPhoto => obsPhoto.photo?.url || obsPhoto.photo?.localFilePath );
     setPhotoEvidenceUris( uris );
   };
+
+  // Set the place_guess if not already set and coordinates are available.
+  // Note that at present this sets the place_guess for *any* obs that lacks
+  // it and has coords, including old obs, which might be a source of future
+  // bugs, but is also kind of something we want. Something to keep an eye
+  // on
+  useEffect( ( ) => {
+    async function setPlaceGuess( ) {
+      const placeGuess = await fetchPlaceName( latitude, longitude );
+      updateObservationKeys( { place_guess: placeGuess } );
+    }
+    if ( ( latitude && longitude ) && !currentObservation?.place_guess ) {
+      setPlaceGuess( );
+    }
+  }, [
+    currentObservation?.place_guess,
+    latitude,
+    longitude,
+    updateObservationKeys
+  ] );
 
   return (
     <EvidenceSection

--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -17,12 +17,13 @@ import { useDeviceOrientation } from "sharedHooks";
 import GroupPhotoImage from "./GroupPhotoImage";
 
 type Props = {
+  combinePhotos: Function,
   groupedPhotos: Array<Object>,
+  isCreatingObservations?: boolean,
+  navToObsEdit: Function,
+  removePhotos: Function,
   selectedObservations: Array<Object>,
   selectObservationPhotos: Function,
-  navToObsEdit: Function,
-  combinePhotos: Function,
-  removePhotos: Function,
   separatePhotos: Function,
   totalPhotos: number
 }
@@ -30,12 +31,13 @@ type Props = {
 const GUTTER = 15;
 
 const GroupPhotos = ( {
+  combinePhotos,
   groupedPhotos,
+  isCreatingObservations,
+  navToObsEdit,
+  removePhotos,
   selectedObservations,
   selectObservationPhotos,
-  navToObsEdit,
-  combinePhotos,
-  removePhotos,
   separatePhotos,
   totalPhotos
 }: Props ): Node => {
@@ -198,6 +200,7 @@ const GroupPhotos = ( {
           text={t( "IMPORT-X-OBSERVATIONS", { count: groupedPhotos.length } )}
           onPress={navToObsEdit}
           testID="GroupPhotos.next"
+          loading={isCreatingObservations}
         />
       </StickyToolbar>
     </ViewWrapper>

--- a/src/components/PhotoImporter/GroupPhotosContainer.js
+++ b/src/components/PhotoImporter/GroupPhotosContainer.js
@@ -16,6 +16,7 @@ const GroupPhotosContainer = ( ): Node => {
   const navigation = useNavigation( );
 
   const [selectedObservations, setSelectedObservations] = useState( [] );
+  const [isCreatingObservations, setIsCreatingObservations] = useState( false );
   const totalPhotos = groupedPhotos
     .reduce( ( count, current ) => count + current.photos.length, 0 );
 
@@ -124,8 +125,10 @@ const GroupPhotosContainer = ( ): Node => {
     setGroupedPhotos( removedFromGroup );
   };
 
-  const navToObsEdit = async () => {
-    createObservationsFromGroupedPhotos( groupedPhotos );
+  const navToObsEdit = async ( ) => {
+    setIsCreatingObservations( true );
+    await createObservationsFromGroupedPhotos( groupedPhotos );
+    setIsCreatingObservations( false );
     navigation.navigate( "ObsEdit", { lastScreen: "GroupPhotos" } );
   };
 
@@ -139,6 +142,7 @@ const GroupPhotosContainer = ( ): Node => {
       removePhotos={removePhotos}
       separatePhotos={separatePhotos}
       totalPhotos={totalPhotos}
+      isCreatingObservations={isCreatingObservations}
     />
   );
 };

--- a/src/providers/reducers/createObsReducer.js
+++ b/src/providers/reducers/createObsReducer.js
@@ -26,7 +26,6 @@ export const INITIAL_CREATE_OBS_STATE = {
 };
 
 const createObsReducer = ( state: Object, action: Function ): Object => {
-  console.log( action.type, "action in create obs reducer" );
   switch ( action.type ) {
     case "CLEAR_ADDITIONAL_EVIDENCE": {
       return {

--- a/src/sharedHelpers/fetchPlaceName.js
+++ b/src/sharedHelpers/fetchPlaceName.js
@@ -36,13 +36,15 @@ const setPlaceName = ( results: Array<Object> ): string => {
 };
 
 const fetchPlaceName = async ( lat: ?number, lng: ?number ): any => {
+  if ( !lat || !lng ) { return null; }
   const { isInternetReachable } = await NetInfo.fetch( );
-  if ( !lat || !lng || !isInternetReachable ) { return null; }
+  if ( !isInternetReachable ) { return null; }
   try {
     const results = await Geocoder.geocodePosition( { lat, lng } );
     if ( results.length === 0 || typeof results !== "object" ) { return null; }
     return setPlaceName( results );
-  } catch {
+  } catch ( geocoderError ) {
+    if ( !geocoderError?.message?.includes( "geocodePosition failed" ) ) throw geocoderError;
     return null;
   }
 };

--- a/src/sharedHelpers/parseExif.js
+++ b/src/sharedHelpers/parseExif.js
@@ -36,7 +36,7 @@ export const parseExifDateToLocalTimezone = ( datetime: string ): ?Date => {
 // Parses EXIF date time into a date object
 export const parseExif = async ( photoUri: ?string ): Promise<Object> => {
   try {
-    return await readExif( photoUri );
+    return readExif( photoUri );
   } catch ( e ) {
     console.error( e, "Couldn't parse EXIF" );
     return null;
@@ -52,7 +52,7 @@ interface ExifToWrite {
 export const writeExifToFile = async ( photoUri: ?string, exif: ExifToWrite ): Promise<Object> => {
   logger.debug( "writeExifToFile, photoUri: ", photoUri );
   try {
-    return await writeExif( photoUri, exif );
+    return writeExif( photoUri, exif );
   } catch ( e ) {
     console.error( e, "Couldn't write EXIF" );
     return null;

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -298,3 +298,12 @@ jest.mock( "react-native-exception-handler", () => ( {
     .fn()
     .mockImplementation( () => mockErrorHandler() )
 } ) );
+
+jest.mock( "react-native-geocoder-reborn", ( ) => ( {
+  geocodePosition: jest.fn( coord => [
+    `Somewhere near ${coord.lat}, ${coord.lng}`,
+    "Somewhere",
+    "Somewheria",
+    "SW"
+  ] )
+} ) );


### PR DESCRIPTION
The problem seemed to be reverse geocoding the coordinates for each observation before moving on to ObsEdit, i.e. when that threw an exception it kind of silently cause Promise.all not to resolve... which is not supposed to happen for a few reasons, foremost among them that we were catching the error and returning null instead. So I'm still confused about why exactly this was happening.

Regardless, geocoding is potentially slow and buggy, so IMO it's better to do it on ObsEdit than in the provider, and only do it when we need it, i.e. when the user is actually looking at the obs.

Some other minor changes

* Show loading indicator on GroupPhotos button while creating obs
* fetchPlaceName performs a null check on coords before making a network request to test connectivity
* More precise error handling
* Removed some redundant await statements
* Mocked react-native-geocoder-reborn in tests

Closes #857