### PR TITLE
Performance: simplify ObsEditProvider

### DIFF
--- a/src/components/AddObsModal.js
+++ b/src/components/AddObsModal.js
@@ -8,6 +8,7 @@ import { ObsEditContext } from "providers/contexts";
 import * as React from "react";
 import { Platform } from "react-native";
 import { useTheme } from "react-native-paper";
+import Observation from "realmModels/Observation";
 import { useTranslation } from "sharedHooks";
 
 type Props = {
@@ -27,17 +28,18 @@ const AddObsModal = ( { closeModal }: Props ): React.Node => {
 
   // Destructuring obsEdit means that we don't have to wrap every Jest test in ObsEditProvider
   const obsEditContext = React.useContext( ObsEditContext );
-  const createObservationNoEvidence = obsEditContext?.createObservationNoEvidence;
+  const updateObservations = obsEditContext?.updateObservations;
   const navigation = useNavigation( );
 
-  const navAndCloseModal = ( screen, params ) => {
+  const navAndCloseModal = async ( screen, params ) => {
     const resetObsEditContext = obsEditContext?.resetObsEditContext;
     // clear previous upload context before navigating
     if ( resetObsEditContext ) {
       resetObsEditContext( );
     }
     if ( screen === "ObsEdit" ) {
-      createObservationNoEvidence( );
+      const newObservation = await Observation.new( );
+      updateObservations( [newObservation] );
     }
     // access nested screen
     navigation.navigate( "CameraNavigator", {

--- a/src/components/Camera/CameraContainer.js
+++ b/src/components/Camera/CameraContainer.js
@@ -85,12 +85,15 @@ const CameraWithDevice = ( {
   const {
     currentObservation,
     cameraPreviewUris,
-    setCameraState,
+    deletePhotoFromObservation,
     evidenceToAdd,
     originalCameraUrisMap,
     numOfObsPhotos,
-    updateObservations,
-    setCameraRollUris
+    setCameraRollUris,
+    setCameraState,
+    setPhotoEvidenceUris,
+    totalObsPhotoUris,
+    updateObservations
   } = useContext( ObsEditContext );
   const navigation = useNavigation();
   // $FlowFixMe
@@ -435,6 +438,10 @@ const CameraWithDevice = ( {
             showZoomButton={device.isMultiCam}
             onZoomStart={onZoomStart}
             onZoomChange={onZoomChange}
+            totalObsPhotoUris={totalObsPhotoUris}
+            cameraPreviewUris={cameraPreviewUris}
+            deletePhotoFromObservation={deletePhotoFromObservation}
+            setPhotoEvidenceUris={setPhotoEvidenceUris}
           />
         )
         : (

--- a/src/components/Camera/StandardCamera/PhotoCarousel.js
+++ b/src/components/Camera/StandardCamera/PhotoCarousel.js
@@ -32,8 +32,7 @@ type Props = {
     value: number
   },
   setPhotoEvidenceUris: Function,
-  photoUris: Array<string>,
-  setSelectedPhotoIndex: Function
+  photoUris: Array<string>
 }
 
 export const SMALL_PHOTO_DIM = 42;
@@ -63,8 +62,7 @@ const PhotoCarousel = ( {
   isTablet,
   rotation,
   setPhotoEvidenceUris,
-  photoUris,
-  setSelectedPhotoIndex
+  photoUris
 }: Props ): Node => {
   const { t } = useTranslation( );
   const theme = useTheme( );
@@ -138,15 +136,13 @@ const PhotoCarousel = ( {
     if ( deletePhotoMode && deletePhoto ) {
       deletePhoto( item );
     } else {
-      setSelectedPhotoIndex( index );
       setPhotoEvidenceUris( [...photoUris] );
-      navigation.navigate( "MediaViewer" );
+      navigation.navigate( "MediaViewer", { index } );
     }
   }, [
     deletePhotoMode,
     photoUris,
     setPhotoEvidenceUris,
-    setSelectedPhotoIndex,
     deletePhoto,
     navigation
   ] );

--- a/src/components/Camera/StandardCamera/PhotoPreview.js
+++ b/src/components/Camera/StandardCamera/PhotoPreview.js
@@ -39,8 +39,7 @@ const PhotoPreview = ( {
   const {
     cameraPreviewUris: photoUris,
     deletePhotoFromObservation,
-    setPhotoEvidenceUris,
-    setSelectedPhotoIndex
+    setPhotoEvidenceUris
   } = useContext( ObsEditContext );
   const wrapperDim = isLargeScreen
     ? LARGE_PHOTO_DIM + LARGE_PHOTO_GUTTER * 2
@@ -107,7 +106,6 @@ const PhotoPreview = ( {
               isLargeScreen={isLargeScreen}
               isTablet={isTablet}
               isLandscapeMode={isLandscapeMode}
-              setSelectedPhotoIndex={setSelectedPhotoIndex}
             />
           )
       }

--- a/src/components/Camera/StandardCamera/PhotoPreview.js
+++ b/src/components/Camera/StandardCamera/PhotoPreview.js
@@ -1,10 +1,9 @@
 // @flow
 import classnames from "classnames";
 import { Text, View } from "components/styledComponents";
-import { t } from "i18next";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext } from "react";
+import React from "react";
+import { useTranslation } from "sharedHooks";
 
 import PhotoCarousel, {
   LARGE_PHOTO_DIM,
@@ -20,7 +19,10 @@ type Props = {
   isLandscapeMode?: boolean,
   isLargeScreen?: boolean,
   isTablet?: boolean,
-  takingPhoto: boolean
+  takingPhoto: boolean,
+  cameraPreviewUris: Function,
+  deletePhotoFromObservation: Function,
+  setPhotoEvidenceUris: Function
 }
 
 const STYLE = {
@@ -34,20 +36,15 @@ const PhotoPreview = ( {
   isLargeScreen,
   isTablet,
   rotation,
-  takingPhoto
+  takingPhoto,
+  cameraPreviewUris,
+  deletePhotoFromObservation,
+  setPhotoEvidenceUris
 }: Props ): Node => {
-  const {
-    cameraPreviewUris: photoUris,
-    deletePhotoFromObservation,
-    setPhotoEvidenceUris
-  } = useContext( ObsEditContext );
+  const { t } = useTranslation( );
   const wrapperDim = isLargeScreen
     ? LARGE_PHOTO_DIM + LARGE_PHOTO_GUTTER * 2
     : SMALL_PHOTO_DIM + SMALL_PHOTO_GUTTER * 2;
-
-  const deletePhoto = photoUri => {
-    deletePhotoFromObservation( photoUri );
-  };
 
   let noPhotosNotice = (
     <Text
@@ -94,12 +91,12 @@ const PhotoPreview = ( {
       style={[STYLE, dynamicStyle]}
     >
       {
-        photoUris.length === 0 && !takingPhoto
+        cameraPreviewUris.length === 0 && !takingPhoto
           ? noPhotosNotice
           : (
             <PhotoCarousel
-              deletePhoto={deletePhoto}
-              photoUris={photoUris}
+              deletePhoto={deletePhotoFromObservation}
+              photoUris={cameraPreviewUris}
               rotation={rotation}
               setPhotoEvidenceUris={setPhotoEvidenceUris}
               takingPhoto={takingPhoto}

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -5,10 +5,8 @@ import classnames from "classnames";
 import CameraView from "components/Camera/CameraView";
 import FadeInOutView from "components/Camera/FadeInOutView";
 import { View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
 import React, {
-  useContext,
   useEffect,
   useState
 } from "react";
@@ -55,6 +53,10 @@ type Props = {
   showZoomButton: boolean,
   onZoomStart?: Function,
   onZoomChange?: Function,
+  totalObsPhotoUris: number,
+  cameraPreviewUris: Function,
+  deletePhotoFromObservation: Function,
+  setPhotoEvidenceUris: Function
 };
 
 const StandardCamera = ( {
@@ -78,11 +80,12 @@ const StandardCamera = ( {
   zoomTextValue,
   showZoomButton,
   onZoomStart,
-  onZoomChange
+  onZoomChange,
+  totalObsPhotoUris,
+  cameraPreviewUris,
+  deletePhotoFromObservation,
+  setPhotoEvidenceUris
 }: Props ): Node => {
-  const {
-    totalObsPhotoUris
-  } = useContext( ObsEditContext );
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const disallowAddingPhotos = totalObsPhotoUris >= MAX_PHOTOS_ALLOWED;
@@ -125,6 +128,9 @@ const StandardCamera = ( {
         isLandscapeMode={isLandscapeMode}
         isLargeScreen={screenWidth > BREAKPOINTS.md}
         isTablet={isTablet}
+        cameraPreviewUris={cameraPreviewUris}
+        deletePhotoFromObservation={deletePhotoFromObservation}
+        setPhotoEvidenceUris={setPhotoEvidenceUris}
       />
       <View className="relative flex-1">
         {device && (

--- a/src/components/LocationPicker/Footer.js
+++ b/src/components/LocationPicker/Footer.js
@@ -3,22 +3,19 @@
 import { useNavigation } from "@react-navigation/native";
 import { Button } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext } from "react";
+import React from "react";
 import useTranslation from "sharedHooks/useTranslation";
 
 type Props = {
   keysToUpdate: Object,
-  goBackOnSave: boolean
+  goBackOnSave: boolean,
+  updateObservationKeys: Function
 };
 
-const Footer = ( { keysToUpdate, goBackOnSave }: Props ): Node => {
+const Footer = ( { keysToUpdate, goBackOnSave, updateObservationKeys }: Props ): Node => {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
-  const {
-    updateObservationKeys
-  } = useContext( ObsEditContext );
 
   return (
     <View className="h-[73px] justify-center">

--- a/src/components/LocationPicker/LocationPicker.js
+++ b/src/components/LocationPicker/LocationPicker.js
@@ -49,6 +49,7 @@ type Props = {
   toggleMapLayer: Function,
   updateLocationName: Function,
   updateRegion: Function,
+  updateObservationKeys: Function
 };
 
 const LocationPicker = ( {
@@ -67,7 +68,8 @@ const LocationPicker = ( {
   showCrosshairs,
   toggleMapLayer,
   updateLocationName,
-  updateRegion
+  updateRegion,
+  updateObservationKeys
 }: Props ): Node => {
   const theme = useTheme( );
   const { t } = useTranslation( );
@@ -152,6 +154,7 @@ const LocationPicker = ( {
       <Footer
         keysToUpdate={keysToUpdate}
         goBackOnSave={goBackOnSave}
+        updateObservationKeys={updateObservationKeys}
       />
     </ViewWrapper>
   );

--- a/src/components/LocationPicker/LocationPickerContainer.js
+++ b/src/components/LocationPicker/LocationPickerContainer.js
@@ -116,7 +116,10 @@ type Props = {
 
 const LocationPickerContainer = ( { route }: Props ): Node => {
   const mapViewRef = useRef( );
-  const { currentObservation } = useContext( ObsEditContext );
+  const {
+    currentObservation,
+    updateObservationKeys
+  } = useContext( ObsEditContext );
   const navigation = useNavigation( );
   const { goBackOnSave } = route.params;
 
@@ -236,6 +239,7 @@ const LocationPickerContainer = ( { route }: Props ): Node => {
       toggleMapLayer={toggleMapLayer}
       updateLocationName={updateLocationName}
       updateRegion={updateRegion}
+      updateObservationKeys={updateObservationKeys}
     />
   );
 };

--- a/src/components/MediaViewer/MediaViewer.js
+++ b/src/components/MediaViewer/MediaViewer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import classnames from "classnames";
 import { Heading4, TransparentCircleButton, WarningSheet } from "components/SharedComponents";
 import { SafeAreaView, View } from "components/styledComponents";
@@ -21,13 +21,13 @@ import PhotoSelector from "./PhotoSelector";
 
 const MediaViewer = ( ): Node => {
   const navigation = useNavigation( );
+  const { params } = useRoute( );
+  const [selectedPhotoIndex, setSelectedPhotoIndex] = useState( params?.index );
   const { t } = useTranslation( );
   const [warningSheet, setWarningSheet] = useState( false );
   const {
     deletePhotoFromObservation,
-    photoEvidenceUris,
-    selectedPhotoIndex,
-    setSelectedPhotoIndex
+    photoEvidenceUris
   } = useContext( ObsEditContext );
 
   const atFirstPhoto = selectedPhotoIndex === 0;

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -1,17 +1,24 @@
 // @flow
 
+import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
 import {
   Button, StickyToolbar
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
+import { ObsEditContext, RealmContext } from "providers/contexts";
 import type { Node } from "react";
 import React, { useContext, useEffect, useState } from "react";
+import Observation from "realmModels/Observation";
+import { writeExifToFile } from "sharedHelpers/parseExif";
+import uploadObservation from "sharedHelpers/uploadObservation";
 import useTranslation from "sharedHooks/useTranslation";
 
+import { log } from "../../../react-native-logs.config";
 import ImpreciseLocationSheet from "./Sheets/ImpreciseLocationSheet";
 import MissingEvidenceSheet from "./Sheets/MissingEvidenceSheet";
+
+const { useRealm } = RealmContext;
 
 const DESIRED_LOCATION_ACCURACY = 4000000;
 
@@ -24,17 +31,79 @@ const BottomButtons = ( {
   passesEvidenceTest,
   passesIdentificationTest
 }: Props ): Node => {
+  const navigation = useNavigation( );
   const { t } = useTranslation( );
+  const realm = useRealm( );
   const {
-    setNextScreen,
     currentObservation,
     unsavedChanges,
-    loading
+    loading,
+    currentObservationIndex,
+    observations,
+    cameraRollUris,
+    setCurrentObservationIndex
   } = useContext( ObsEditContext );
   const [showMissingEvidenceSheet, setShowMissingEvidenceSheet] = useState( false );
   const [showImpreciseLocationSheet, setShowImpreciseLocationSheet] = useState( false );
   const [allowUserToUpload, setAllowUserToUpload] = useState( false );
   const [buttonPressed, setButtonPressed] = useState( null );
+
+  const logger = log.extend( "ObsEditBottomButtons" );
+
+  const ensureRealm = ( ) => {
+    if ( !realm ) {
+      throw new Error( "Gack, tried to save an observation without realm!" );
+    }
+  };
+
+  const writeExifToCameraRollPhotos = async exif => {
+    if ( !cameraRollUris || cameraRollUris.length === 0 || !currentObservation ) {
+      return;
+    }
+    // Update all photos taken via the app with the new fetched location.
+    cameraRollUris.forEach( uri => {
+      logger.info( "writeExifToCameraRollPhotos, writing exif for uri: ", uri );
+      writeExifToFile( uri, exif );
+    } );
+  };
+
+  const saveObservation = async observation => {
+    ensureRealm( );
+    await writeExifToCameraRollPhotos( {
+      latitude: observation.latitude,
+      longitude: observation.longitude,
+      positional_accuracy: observation.positionalAccuracy
+    } );
+    return Observation.saveLocalObservationForUpload( observation, realm );
+  };
+
+  const setNextScreen = async ( { type }: Object ) => {
+    const savedObservation = await saveObservation( currentObservation );
+    const params = {};
+    if ( type === "upload" ) {
+      // $FlowIgnore
+      uploadObservation( savedObservation, realm );
+      params.uuid = savedObservation.uuid;
+    }
+
+    if ( observations.length === 1 ) {
+      // navigate to ObsList and start upload with uuid
+      navigation.navigate( "TabNavigator", {
+        screen: "ObservationsStackNavigator",
+        params: {
+          screen: "ObsList",
+          params
+        }
+      } );
+    } else if ( currentObservationIndex === observations.length - 1 ) {
+      observations.pop( );
+      setCurrentObservationIndex( currentObservationIndex - 1, observations );
+    } else {
+      observations.splice( currentObservationIndex, 1 );
+      // this seems necessary for rerendering the ObsEdit screen
+      setCurrentObservationIndex( currentObservationIndex, observations );
+    }
+  };
 
   useEffect(
     ( ) => {

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -54,12 +54,6 @@ const BottomButtons = ( {
 
   const logger = log.extend( "ObsEditBottomButtons" );
 
-  const ensureRealm = ( ) => {
-    if ( !realm ) {
-      throw new Error( "Gack, tried to save an observation without realm!" );
-    }
-  };
-
   const writeExifToCameraRollPhotos = async exif => {
     if ( !cameraRollUris || cameraRollUris.length === 0 || !currentObservation ) {
       return;
@@ -72,7 +66,6 @@ const BottomButtons = ( {
   };
 
   const saveObservation = async observation => {
-    ensureRealm( );
     await writeExifToCameraRollPhotos( {
       latitude: observation.latitude,
       longitude: observation.longitude,

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -6,9 +6,9 @@ import {
   Button, StickyToolbar
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { ObsEditContext, RealmContext } from "providers/contexts";
+import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Observation from "realmModels/Observation";
 import { writeExifToFile } from "sharedHelpers/parseExif";
 import uploadObservation from "sharedHelpers/uploadObservation";
@@ -24,24 +24,28 @@ const DESIRED_LOCATION_ACCURACY = 4000000;
 
 type Props = {
   passesEvidenceTest: boolean,
-  passesIdentificationTest: boolean
+  passesIdentificationTest: boolean,
+  observations: Array<Object>,
+  currentObservation: Object,
+  unsavedChanges: boolean,
+  currentObservationIndex: number,
+  cameraRollUris: Array<string>,
+  setCurrentObservationIndex: Function
 }
 
 const BottomButtons = ( {
   passesEvidenceTest,
-  passesIdentificationTest
+  passesIdentificationTest,
+  currentObservation,
+  unsavedChanges,
+  currentObservationIndex,
+  observations,
+  cameraRollUris,
+  setCurrentObservationIndex
 }: Props ): Node => {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const realm = useRealm( );
-  const {
-    currentObservation,
-    unsavedChanges,
-    currentObservationIndex,
-    observations,
-    cameraRollUris,
-    setCurrentObservationIndex
-  } = useContext( ObsEditContext );
   const [showMissingEvidenceSheet, setShowMissingEvidenceSheet] = useState( false );
   const [showImpreciseLocationSheet, setShowImpreciseLocationSheet] = useState( false );
   const [allowUserToUpload, setAllowUserToUpload] = useState( false );

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -37,7 +37,6 @@ const BottomButtons = ( {
   const {
     currentObservation,
     unsavedChanges,
-    loading,
     currentObservationIndex,
     observations,
     cameraRollUris,
@@ -47,6 +46,7 @@ const BottomButtons = ( {
   const [showImpreciseLocationSheet, setShowImpreciseLocationSheet] = useState( false );
   const [allowUserToUpload, setAllowUserToUpload] = useState( false );
   const [buttonPressed, setButtonPressed] = useState( null );
+  const [loading, setLoading] = useState( false );
 
   const logger = log.extend( "ObsEditBottomButtons" );
 
@@ -98,10 +98,12 @@ const BottomButtons = ( {
     } else if ( currentObservationIndex === observations.length - 1 ) {
       observations.pop( );
       setCurrentObservationIndex( currentObservationIndex - 1, observations );
+      setLoading( false );
     } else {
       observations.splice( currentObservationIndex, 1 );
       // this seems necessary for rerendering the ObsEdit screen
       setCurrentObservationIndex( currentObservationIndex, observations );
+      setLoading( false );
     }
   };
 
@@ -133,6 +135,7 @@ const BottomButtons = ( {
 
   const handlePress = type => {
     if ( showMissingEvidence( ) ) { return; }
+    setLoading( true );
     setButtonPressed( type );
     setNextScreen( { type } );
   };

--- a/src/components/ObsEdit/DatePicker.js
+++ b/src/components/ObsEdit/DatePicker.js
@@ -2,18 +2,17 @@
 
 import { Body3, DateTimePicker, INatIcon } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { createObservedOnStringForUpload, displayDateTimeObsEdit } from "sharedHelpers/dateAndTime";
 import useTranslation from "sharedHooks/useTranslation";
 
 type Props = {
-  currentObservation: Object
+  currentObservation: Object,
+  updateObservationKeys: Function
 }
 
-const DatePicker = ( { currentObservation }: Props ): Node => {
-  const { updateObservationKeys } = useContext( ObsEditContext );
+const DatePicker = ( { currentObservation, updateObservationKeys }: Props ): Node => {
   const { t } = useTranslation( );
   const [showModal, setShowModal] = useState( false );
 

--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -4,9 +4,8 @@ import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
 import { INatIcon } from "components/SharedComponents";
 import { Image, Pressable, View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useCallback, useContext } from "react";
+import React, { useCallback } from "react";
 import { ActivityIndicator } from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import DraggableFlatList, { ScaleDecorator } from "react-native-draggable-flatlist";
@@ -16,17 +15,16 @@ import colors from "styles/tailwindColors";
 type Props = {
   evidenceList: Array<string>,
   handleAddEvidence?: Function,
-  handleDragAndDrop: Function
+  handleDragAndDrop: Function,
+  savingPhoto: boolean
 }
 
 const EvidenceList = ( {
   evidenceList,
   handleAddEvidence,
-  handleDragAndDrop
+  handleDragAndDrop,
+  savingPhoto
 }: Props ): Node => {
-  const {
-    savingPhoto
-  } = useContext( ObsEditContext );
   const navigation = useNavigation( );
   const imageClass = "h-16 w-16 justify-center mx-1.5 rounded-lg";
 

--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -25,8 +25,7 @@ const EvidenceList = ( {
   handleDragAndDrop
 }: Props ): Node => {
   const {
-    savingPhoto,
-    setSelectedPhotoIndex
+    savingPhoto
   } = useContext( ObsEditContext );
   const navigation = useNavigation( );
   const imageClass = "h-16 w-16 justify-center mx-1.5 rounded-lg";
@@ -37,8 +36,7 @@ const EvidenceList = ( {
         onLongPress={drag}
         accessibilityRole="button"
         onPress={( ) => {
-          setSelectedPhotoIndex( getIndex( ) );
-          navigation.navigate( "MediaViewer" );
+          navigation.navigate( "MediaViewer", { index: getIndex( ) } );
         }}
         className={classnames( imageClass )}
         testID={`EvidenceList.${item.photo?.url || item.photo?.localFilePath}`}
@@ -53,7 +51,7 @@ const EvidenceList = ( {
         </View>
       </Pressable>
     </ScaleDecorator>
-  ), [navigation, setSelectedPhotoIndex] );
+  ), [navigation] );
 
   const renderFooter = useCallback( ( ) => {
     if ( savingPhoto ) {

--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -8,9 +8,8 @@ import {
 } from "components/SharedComponents";
 import LocationPermissionGate from "components/SharedComponents/LocationPermissionGate";
 import { Pressable, View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext } from "react";
+import React from "react";
 import { ActivityIndicator, useTheme } from "react-native-paper";
 import useTranslation from "sharedHooks/useTranslation";
 
@@ -19,6 +18,7 @@ import EvidenceList from "./EvidenceList";
 import AddEvidenceSheet from "./Sheets/AddEvidenceSheet";
 
 type Props = {
+  currentObservation: Object,
   evidenceList: Array<string>,
   handleDragAndDrop: Function,
   isFetchingLocation: boolean,
@@ -28,11 +28,14 @@ type Props = {
   onLocationPermissionDenied: Function,
   onLocationPermissionGranted: Function,
   passesEvidenceTest: Function,
+  savingPhoto: boolean,
   setShowAddEvidenceSheet: Function,
   showAddEvidenceSheet: boolean,
+  updateObservationKeys: Function
 }
 
 const EvidenceSection = ( {
+  currentObservation,
   evidenceList,
   handleDragAndDrop,
   isFetchingLocation,
@@ -42,14 +45,13 @@ const EvidenceSection = ( {
   onLocationPermissionDenied,
   onLocationPermissionGranted,
   passesEvidenceTest,
+  savingPhoto,
   setShowAddEvidenceSheet,
-  showAddEvidenceSheet
+  showAddEvidenceSheet,
+  updateObservationKeys
 }: Props ): Node => {
   const { t } = useTranslation( );
   const theme = useTheme( );
-  const {
-    currentObservation
-  } = useContext( ObsEditContext );
   const obsPhotos = currentObservation?.observationPhotos;
   const navigation = useNavigation( );
 
@@ -108,6 +110,7 @@ const EvidenceSection = ( {
         evidenceList={evidenceList}
         handleAddEvidence={( ) => setShowAddEvidenceSheet( true )}
         handleDragAndDrop={handleDragAndDrop}
+        savingPhoto={savingPhoto}
       />
       <Pressable
         accessibilityRole="button"
@@ -141,7 +144,10 @@ const EvidenceSection = ( {
           }
         </View>
       </Pressable>
-      <DatePicker currentObservation={currentObservation} />
+      <DatePicker
+        currentObservation={currentObservation}
+        updateObservationKeys={updateObservationKeys}
+      />
       <LocationPermissionGate
         permissionNeeded={locationPermissionNeeded}
         onPermissionGranted={onLocationPermissionGranted}

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -33,8 +33,8 @@ const EvidenceSectionContainer = ( {
   const {
     currentObservation,
     updateObservationKeys,
-    setPhotoEvidenceUris,
-    photoEvidenceUris
+    setPhotoEvidenceUris
+    // photoEvidenceUris
   } = useContext( ObsEditContext );
   const obsPhotos = currentObservation?.observationPhotos;
   const mountedRef = useRef( true );
@@ -62,13 +62,13 @@ const EvidenceSectionContainer = ( {
     };
   }, [] );
 
-  useEffect( ( ) => {
-    if ( obsPhotos?.length > photoEvidenceUris?.length ) {
-      setPhotoEvidenceUris( obsPhotos.map(
-        obsPhoto => obsPhoto.photo?.url || obsPhoto.photo?.localFilePath
-      ) );
-    }
-  }, [obsPhotos, photoEvidenceUris, setPhotoEvidenceUris] );
+  // useEffect( ( ) => {
+  //   if ( obsPhotos?.length > photoEvidenceUris?.length ) {
+  //     setPhotoEvidenceUris( obsPhotos.map(
+  //       obsPhoto => obsPhoto.photo?.url || obsPhoto.photo?.localFilePath
+  //     ) );
+  //   }
+  // }, [obsPhotos, photoEvidenceUris, setPhotoEvidenceUris] );
 
   const {
     hasLocation,

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -33,8 +33,8 @@ const EvidenceSectionContainer = ( {
   const {
     currentObservation,
     updateObservationKeys,
-    setPhotoEvidenceUris
-    // photoEvidenceUris
+    setPhotoEvidenceUris,
+    photoEvidenceUris
   } = useContext( ObsEditContext );
   const obsPhotos = currentObservation?.observationPhotos;
   const mountedRef = useRef( true );
@@ -62,13 +62,13 @@ const EvidenceSectionContainer = ( {
     };
   }, [] );
 
-  // useEffect( ( ) => {
-  //   if ( obsPhotos?.length > photoEvidenceUris?.length ) {
-  //     setPhotoEvidenceUris( obsPhotos.map(
-  //       obsPhoto => obsPhoto.photo?.url || obsPhoto.photo?.localFilePath
-  //     ) );
-  //   }
-  // }, [obsPhotos, photoEvidenceUris, setPhotoEvidenceUris] );
+  useEffect( ( ) => {
+    if ( obsPhotos?.length > photoEvidenceUris?.length ) {
+      setPhotoEvidenceUris( obsPhotos.map(
+        obsPhoto => obsPhoto.photo?.url || obsPhoto.photo?.localFilePath
+      ) );
+    }
+  }, [obsPhotos, photoEvidenceUris, setPhotoEvidenceUris] );
 
   const {
     hasLocation,

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -78,9 +78,14 @@ const EvidenceSectionContainer = ( {
     hasLocation,
     isFetchingLocation,
     permissionResult: locationPermissionResult
-  } = useCurrentObservationLocation( mountedRef, {
-    retry: shouldRetryCurrentObservationLocation
-  } );
+  } = useCurrentObservationLocation(
+    mountedRef,
+    currentObservation,
+    updateObservationKeys,
+    {
+      retry: shouldRetryCurrentObservationLocation
+    }
+  );
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -6,10 +6,10 @@ import {
   isFuture,
   parseISO
 } from "date-fns";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
 import React, {
-  useCallback, useContext, useEffect,
+  useCallback,
+  useEffect,
   useMemo,
   useRef, useState
 } from "react";
@@ -23,19 +23,23 @@ import EvidenceSection from "./EvidenceSection";
 
 type Props = {
   passesEvidenceTest: boolean,
-  setPassesEvidenceTest: Function
+  setPassesEvidenceTest: Function,
+  currentObservation: Object,
+  updateObservationKeys: Function,
+  setPhotoEvidenceUris: Function,
+  photoEvidenceUris: Array<string>,
+  savingPhoto: boolean
 }
 
 const EvidenceSectionContainer = ( {
   setPassesEvidenceTest,
-  passesEvidenceTest
+  passesEvidenceTest,
+  currentObservation,
+  updateObservationKeys,
+  setPhotoEvidenceUris,
+  photoEvidenceUris,
+  savingPhoto
 }: Props ): Node => {
-  const {
-    currentObservation,
-    updateObservationKeys,
-    setPhotoEvidenceUris,
-    photoEvidenceUris
-  } = useContext( ObsEditContext );
   const obsPhotos = currentObservation?.observationPhotos;
   const mountedRef = useRef( true );
 
@@ -183,6 +187,9 @@ const EvidenceSectionContainer = ( {
 
   return (
     <EvidenceSection
+      currentObservation={currentObservation}
+      savingPhoto={savingPhoto}
+      updateObservationKeys={updateObservationKeys}
       locationTextClassNames={locationTextClassNames}
       handleDragAndDrop={handleDragAndDrop}
       passesEvidenceTest={fullEvidenceTest}

--- a/src/components/ObsEdit/Header.js
+++ b/src/components/ObsEdit/Header.js
@@ -170,6 +170,7 @@ const Header = ( ): Node => {
           discardObservation={discardObservation}
           handleClose={( ) => setDiscardObservationSheetVisible( false )}
           navToObsList={navToObsList}
+          observations={observations}
         />
       )}
       {discardChangesSheetVisible && (

--- a/src/components/ObsEdit/Header.js
+++ b/src/components/ObsEdit/Header.js
@@ -3,10 +3,9 @@
 import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
 import { Heading2, KebabMenu } from "components/SharedComponents";
 import BackButton from "components/SharedComponents/Buttons/BackButton";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
 import React, {
-  useCallback, useContext, useEffect, useState
+  useCallback, useEffect, useState
 } from "react";
 import { BackHandler } from "react-native";
 import { Menu } from "react-native-paper";
@@ -16,13 +15,19 @@ import DeleteObservationSheet from "./Sheets/DeleteObservationSheet";
 import DiscardChangesSheet from "./Sheets/DiscardChangesSheet";
 import DiscardObservationSheet from "./Sheets/DiscardObservationSheet";
 
-const Header = ( ): Node => {
-  const {
-    observations,
-    updateObservations,
-    currentObservation,
-    unsavedChanges
-  } = useContext( ObsEditContext );
+type Props = {
+  observations: Array<Object>,
+  updateObservations: Function,
+  currentObservation: Object,
+  unsavedChanges: boolean
+}
+
+const Header = ( {
+  observations,
+  updateObservations,
+  currentObservation,
+  unsavedChanges
+}: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
   const { params } = useRoute( );
@@ -163,6 +168,8 @@ const Header = ( ): Node => {
         <DeleteObservationSheet
           handleClose={( ) => setDeleteSheetVisible( false )}
           navToObsList={navToObsList}
+          observations={observations}
+          currentObservation={currentObservation}
         />
       )}
       {discardObservationSheetVisible && (

--- a/src/components/ObsEdit/IdentificationSection.js
+++ b/src/components/ObsEdit/IdentificationSection.js
@@ -9,9 +9,9 @@ import {
   INatIconButton
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { ObsEditContext, RealmContext } from "providers/contexts";
+import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
 
@@ -19,17 +19,17 @@ const { useRealm } = RealmContext;
 
 type Props = {
   passesIdentificationTest: boolean,
-  setPassesIdentificationTest: Function
+  setPassesIdentificationTest: Function,
+  currentObservation: Object,
+  updateObservationKeys: Function
 }
 
 const IdentificationSection = ( {
   passesIdentificationTest,
-  setPassesIdentificationTest
+  setPassesIdentificationTest,
+  currentObservation,
+  updateObservationKeys
 }: Props ): Node => {
-  const {
-    currentObservation,
-    updateObservationKeys
-  } = useContext( ObsEditContext );
   const { t } = useTranslation( );
   const theme = useTheme( );
   const navigation = useNavigation( );

--- a/src/components/ObsEdit/MultipleObservationsArrows.js
+++ b/src/components/ObsEdit/MultipleObservationsArrows.js
@@ -2,17 +2,21 @@
 
 import { Heading2, INatIconButton } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext } from "react";
+import React from "react";
 import { useTranslation } from "sharedHooks";
 
-const MultipleObservationsArrows = ( ): Node => {
-  const {
-    currentObservationIndex,
-    setCurrentObservationIndex,
-    observations
-  } = useContext( ObsEditContext );
+type Props = {
+  currentObservationIndex: number,
+  setCurrentObservationIndex: Function,
+  observations: Array<Object>
+}
+
+const MultipleObservationsArrows = ( {
+  currentObservationIndex,
+  setCurrentObservationIndex,
+  observations
+}: Props ): Node => {
   const { t } = useTranslation( );
 
   const showNextObservation = ( ) => setCurrentObservationIndex( currentObservationIndex + 1 );

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -20,11 +20,19 @@ import OtherDataSection from "./OtherDataSection";
 
 const ObsEdit = ( ): Node => {
   const {
+    cameraRollUris,
     currentObservation,
+    currentObservationIndex,
+    loading,
     observations,
-    updateObservations,
+    photoEvidenceUris,
     resetObsEditContext,
-    loading
+    savingPhoto,
+    setCurrentObservationIndex,
+    setPhotoEvidenceUris,
+    unsavedChanges,
+    updateObservations,
+    updateObservationKeys
   } = useContext( ObsEditContext );
   const { params } = useRoute( );
   const localObservation = useLocalObservation( params?.uuid );
@@ -53,20 +61,41 @@ const ObsEdit = ( ): Node => {
     ? (
       <>
         <View testID="obs-edit" className="bg-white flex-1">
-          <Header />
+          <Header
+            observations={observations}
+            currentObservation={currentObservation}
+            unsavedChanges={unsavedChanges}
+            updateObservations={updateObservations}
+          />
           <KeyboardAwareScrollView className="bg-white mb-[80px]">
             {currentObservation && (
               <>
-                {observations.length > 1 && <MultipleObservationsArrows />}
+                {observations.length > 1 && (
+                  <MultipleObservationsArrows
+                    currentObservationIndex={currentObservationIndex}
+                    setCurrentObservationIndex={setCurrentObservationIndex}
+                    observations={observations}
+                  />
+                )}
                 <EvidenceSectionContainer
                   passesEvidenceTest={passesEvidenceTest}
                   setPassesEvidenceTest={setPassesEvidenceTest}
+                  currentObservation={currentObservation}
+                  updateObservationKeys={updateObservationKeys}
+                  setPhotoEvidenceUris={setPhotoEvidenceUris}
+                  photoEvidenceUris={photoEvidenceUris}
+                  savingPhoto={savingPhoto}
                 />
                 <IdentificationSection
                   passesIdentificationTest={passesIdentificationTest}
                   setPassesIdentificationTest={setPassesIdentificationTest}
+                  currentObservation={currentObservation}
+                  updateObservationKeys={updateObservationKeys}
                 />
-                <OtherDataSection />
+                <OtherDataSection
+                  currentObservation={currentObservation}
+                  updateObservationKeys={updateObservationKeys}
+                />
               </>
             )}
             {loading && <ActivityIndicator />}
@@ -75,6 +104,12 @@ const ObsEdit = ( ): Node => {
         <BottomButtons
           passesEvidenceTest={passesEvidenceTest}
           passesIdentificationTest={passesIdentificationTest}
+          currentObservation={currentObservation}
+          unsavedChanges={unsavedChanges}
+          currentObservationIndex={currentObservationIndex}
+          observations={observations}
+          cameraRollUris={cameraRollUris}
+          setCurrentObservationIndex={setCurrentObservationIndex}
         />
       </>
     )

--- a/src/components/ObsEdit/OtherDataSection.js
+++ b/src/components/ObsEdit/OtherDataSection.js
@@ -4,24 +4,26 @@ import {
   Body3, Heading4, INatIcon, TextInputSheet
 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import useTranslation from "sharedHooks/useTranslation";
 
 import GeoprivacySheet from "./Sheets/GeoprivacySheet";
 import WildStatusSheet from "./Sheets/WildStatusSheet";
 
-const OtherDataSection = ( ): Node => {
+type Props = {
+  currentObservation: Object,
+  updateObservationKeys: Function
+}
+
+const OtherDataSection = ( {
+  currentObservation,
+  updateObservationKeys
+}: Props ): Node => {
   const { t } = useTranslation( );
   const [showGeoprivacySheet, setShowGeoprivacySheet] = useState( false );
   const [showWildStatusSheet, setShowWildStatusSheet] = useState( false );
   const [showNotesSheet, setShowNotesSheet] = useState( false );
-
-  const {
-    currentObservation,
-    updateObservationKeys
-  } = useContext( ObsEditContext );
 
   const geoprivacyOptions = [{
     label: t( "Open" ),

--- a/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
+++ b/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
@@ -4,28 +4,28 @@ import { deleteObservation } from "api/observations";
 import {
   WarningSheet
 } from "components/SharedComponents";
-import { t } from "i18next";
-import { ObsEditContext, RealmContext } from "providers/contexts";
+import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useCallback, useContext } from "react";
-import useAuthenticatedMutation from "sharedHooks/useAuthenticatedMutation";
+import React, { useCallback } from "react";
+import { useAuthenticatedMutation, useTranslation } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
 type Props = {
   handleClose: Function,
-  navToObsList: Function
+  navToObsList: Function,
+  currentObservation: Object,
+  observations: Array<Object>
 }
 
 const DeleteObservationSheet = ( {
   handleClose,
-  navToObsList
+  navToObsList,
+  currentObservation,
+  observations
 }: Props ): Node => {
+  const { t } = useTranslation( );
   const realm = useRealm( );
-  const {
-    currentObservation,
-    observations
-  } = useContext( ObsEditContext );
   const { uuid } = currentObservation;
 
   const isSavedObservation = (

--- a/src/components/ObsEdit/Sheets/DiscardObservationSheet.js
+++ b/src/components/ObsEdit/Sheets/DiscardObservationSheet.js
@@ -28,14 +28,7 @@ const DiscardObservationSheet = ( {
 
   const multipleObservations = observations.length > 1;
 
-  const ensureRealm = ( ) => {
-    if ( !realm ) {
-      throw new Error( "Gack, tried to save an observation without realm!" );
-    }
-  };
-
   const saveAllObservations = async ( ) => {
-    ensureRealm( );
     await Promise.all( observations.map( async observation => {
       // Note that this should only happen after import when ObsEdit has
       // multiple observations to save, none of which should have

--- a/src/components/PhotoImporter/GroupPhotosContainer.js
+++ b/src/components/PhotoImporter/GroupPhotosContainer.js
@@ -5,13 +5,14 @@ import { t } from "i18next";
 import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
 import React, { useContext, useEffect, useState } from "react";
+import Observation from "realmModels/Observation";
 
 import GroupPhotos from "./GroupPhotos";
 import flattenAndOrderSelectedPhotos from "./helpers/groupPhotoHelpers";
 
 const GroupPhotosContainer = ( ): Node => {
   const {
-    createObservationsFromGroupedPhotos, groupedPhotos, setGroupedPhotos
+    updateObservations, groupedPhotos, setGroupedPhotos
   } = useContext( ObsEditContext );
   const navigation = useNavigation( );
 
@@ -127,7 +128,10 @@ const GroupPhotosContainer = ( ): Node => {
 
   const navToObsEdit = async ( ) => {
     setIsCreatingObservations( true );
-    await createObservationsFromGroupedPhotos( groupedPhotos );
+    const newObservations = await Promise.all( groupedPhotos.map(
+      ( { photos } ) => Observation.createObservationWithPhotos( photos )
+    ) );
+    updateObservations( newObservations );
     setIsCreatingObservations( false );
     navigation.navigate( "ObsEdit", { lastScreen: "GroupPhotos" } );
   };

--- a/src/components/SoundRecorder/SoundRecorder.js
+++ b/src/components/SoundRecorder/SoundRecorder.js
@@ -9,6 +9,7 @@ import React, { useContext, useState } from "react";
 import { Pressable, Text, View } from "react-native";
 // $FlowFixMe
 import AudioRecorderPlayer from "react-native-audio-recorder-player";
+import Observation from "realmModels/Observation";
 import useTranslation from "sharedHooks/useTranslation";
 import { textStyles, viewStyles } from "styles/soundRecorder/soundRecorder";
 
@@ -16,7 +17,7 @@ import { textStyles, viewStyles } from "styles/soundRecorder/soundRecorder";
 const audioRecorderPlayer = new AudioRecorderPlayer();
 
 const SoundRecorder = (): Node => {
-  const { addSound } = useContext( ObsEditContext );
+  const { updateObservations } = useContext( ObsEditContext );
   const navigation = useNavigation();
   const { t } = useTranslation();
   // https://www.npmjs.com/package/react-native-audio-recorder-player
@@ -37,6 +38,11 @@ const SoundRecorder = (): Node => {
   const [status, setStatus] = useState( "notStarted" );
 
   audioRecorderPlayer.setSubscriptionDuration( 0.09 ); // optional. Default is 0.1
+
+  const addSound = async ( ) => {
+    const newObservation = await Observation.createObsWithSounds( );
+    updateObservations( [newObservation] );
+  };
 
   const startRecording = async () => {
     try {

--- a/src/components/Suggestions/AddCommentPrompt.js
+++ b/src/components/Suggestions/AddCommentPrompt.js
@@ -5,16 +5,19 @@ import {
   INatIconButton,
   TextInputSheet
 } from "components/SharedComponents";
-import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocalObservation, useTranslation } from "sharedHooks";
 
-const AddCommentPrompt = ( ): Node => {
-  const {
-    setComment,
-    currentObservation
-  } = useContext( ObsEditContext );
+type Props = {
+  setComment: Function,
+  currentObservation: Object
+}
+
+const AddCommentPrompt = ( {
+  setComment,
+  currentObservation
+}: Props ): Node => {
   const [showAddCommentSheet, setShowAddCommentSheet] = useState( false );
   const uuid = currentObservation?.uuid;
   const localObservation = useLocalObservation( uuid );

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -8,7 +8,7 @@ import {
   View
 } from "components/styledComponents";
 import type { Node } from "react";
-import React from "react";
+import React, { useState } from "react";
 import {
   ActivityIndicator
 } from "react-native-paper";
@@ -27,16 +27,16 @@ type Props = {
   setSelectedPhotoUri: Function,
   nearbySuggestions: Array<Object>,
   onTaxonChosen: Function,
-  loading: boolean,
   loadingSuggestions: boolean
 };
 
 const Suggestions = ( {
   photoUris, selectedPhotoUri, setSelectedPhotoUri, nearbySuggestions, onTaxonChosen,
-  comment, loading, loadingSuggestions
+  comment, loadingSuggestions
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
+  const [loading, setLoading] = useState( false );
 
   return (
     <ScrollViewWrapper testID="suggestions">
@@ -65,7 +65,11 @@ const Suggestions = ( {
       <CommentBox comment={comment} />
       <SuggestionsList
         nearbySuggestions={nearbySuggestions}
-        onTaxonChosen={onTaxonChosen}
+        onTaxonChosen={id => {
+          setLoading( true );
+          onTaxonChosen( id );
+          setLoading( false );
+        }}
         loading={loadingSuggestions}
       />
       {nearbySuggestions?.length > 0 && (

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -8,7 +8,7 @@ import {
   View
 } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useState } from "react";
+import React from "react";
 import {
   ActivityIndicator
 } from "react-native-paper";
@@ -26,10 +26,12 @@ type Props = {
   selectedPhotoUri: string,
   setSelectedPhotoUri: Function,
   nearbySuggestions: Array<Object>,
-  onTaxonChosen: Function,
+  createId: Function,
   loadingSuggestions: boolean,
   setComment: Function,
-  currentObservation: Object
+  currentObservation: Object,
+  loading: boolean,
+  setLoading: Function
 };
 
 const Suggestions = ( {
@@ -37,15 +39,16 @@ const Suggestions = ( {
   selectedPhotoUri,
   setSelectedPhotoUri,
   nearbySuggestions,
-  onTaxonChosen,
+  createId,
   comment,
   loadingSuggestions,
   setComment,
-  currentObservation
+  currentObservation,
+  loading,
+  setLoading
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
-  const [loading, setLoading] = useState( false );
 
   return (
     <ScrollViewWrapper testID="suggestions">
@@ -77,12 +80,9 @@ const Suggestions = ( {
       <CommentBox comment={comment} />
       <SuggestionsList
         nearbySuggestions={nearbySuggestions}
-        onTaxonChosen={id => {
-          setLoading( true );
-          onTaxonChosen( id );
-          setLoading( false );
-        }}
-        loading={loadingSuggestions}
+        createId={createId}
+        loadingSuggestions={loadingSuggestions}
+        setLoading={setLoading}
       />
       {nearbySuggestions?.length > 0 && (
         <Attribution

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -27,12 +27,21 @@ type Props = {
   setSelectedPhotoUri: Function,
   nearbySuggestions: Array<Object>,
   onTaxonChosen: Function,
-  loadingSuggestions: boolean
+  loadingSuggestions: boolean,
+  setComment: Function,
+  currentObservation: Object
 };
 
 const Suggestions = ( {
-  photoUris, selectedPhotoUri, setSelectedPhotoUri, nearbySuggestions, onTaxonChosen,
-  comment, loadingSuggestions
+  photoUris,
+  selectedPhotoUri,
+  setSelectedPhotoUri,
+  nearbySuggestions,
+  onTaxonChosen,
+  comment,
+  loadingSuggestions,
+  setComment,
+  currentObservation
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
@@ -40,7 +49,10 @@ const Suggestions = ( {
 
   return (
     <ScrollViewWrapper testID="suggestions">
-      <AddCommentPrompt />
+      <AddCommentPrompt
+        setComment={setComment}
+        currentObservation={currentObservation}
+      />
       {loading && (
         <View
           className="absolute self-center z-10 pt-[30px]"

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -22,32 +22,30 @@ import SuggestionsList from "./SuggestionsList";
 
 type Props = {
   comment: string,
+  currentObservation: Object,
   loading: boolean,
   loadingSuggestions: boolean,
   nearbySuggestions: Array<Object>,
-  loadingSuggestions: boolean,
-  setComment: Function,
-  currentObservation: Object,
-  loading: boolean,
-  setLoading: Function,
   onTaxonChosen: Function,
   photoUris: Array<string>,
   selectedPhotoUri: string,
+  setComment: Function,
+  setLoading: Function,
   setSelectedPhotoUri: Function
 };
 
 const Suggestions = ( {
-  photoUris,
-  selectedPhotoUri,
-  setSelectedPhotoUri,
-  nearbySuggestions,
-  onTaxonChosen,
   comment,
-  loadingSuggestions,
-  setComment,
   currentObservation,
   loading,
-  setLoading
+  loadingSuggestions,
+  nearbySuggestions,
+  onTaxonChosen,
+  photoUris,
+  selectedPhotoUri,
+  setComment,
+  setLoading,
+  setSelectedPhotoUri
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -25,6 +25,7 @@ const SuggestionsContainer = ( ): Node => {
   const obsPhotos = currentObservation?.observationPhotos;
   const localObservation = useLocalObservation( uuid );
   const [selectedPhotoUri, setSelectedPhotoUri] = useState( photoEvidenceUris[0] );
+  const [loading, setLoading] = useState( false );
 
   useEffect( ( ) => {
     if ( obsPhotos?.length > photoEvidenceUris?.length ) {
@@ -60,12 +61,14 @@ const SuggestionsContainer = ( ): Node => {
       photoUris={photoEvidenceUris}
       selectedPhotoUri={selectedPhotoUri}
       setSelectedPhotoUri={setSelectedPhotoUri}
-      onTaxonChosen={createId}
+      createId={createId}
       comment={comment}
       setComment={setComment}
       currentObservation={currentObservation}
       nearbySuggestions={nearbySuggestions}
       loadingSuggestions={loadingSuggestions && photoEvidenceUris.length > 0}
+      loading={loading}
+      setLoading={setLoading}
     />
   );
 };

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -18,7 +18,8 @@ const SuggestionsContainer = ( ): Node => {
     currentObservation,
     createId,
     comment,
-    setPhotoEvidenceUris
+    setPhotoEvidenceUris,
+    setComment
   } = useContext( ObsEditContext );
   const uuid = currentObservation?.uuid;
   const obsPhotos = currentObservation?.observationPhotos;
@@ -61,6 +62,8 @@ const SuggestionsContainer = ( ): Node => {
       setSelectedPhotoUri={setSelectedPhotoUri}
       onTaxonChosen={createId}
       comment={comment}
+      setComment={setComment}
+      currentObservation={currentObservation}
       nearbySuggestions={nearbySuggestions}
       loadingSuggestions={loadingSuggestions && photoEvidenceUris.length > 0}
     />

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -17,7 +17,6 @@ const SuggestionsContainer = ( ): Node => {
     photoEvidenceUris,
     currentObservation,
     createId,
-    loading,
     comment,
     setPhotoEvidenceUris
   } = useContext( ObsEditContext );
@@ -62,7 +61,6 @@ const SuggestionsContainer = ( ): Node => {
       setSelectedPhotoUri={setSelectedPhotoUri}
       onTaxonChosen={createId}
       comment={comment}
-      loading={loading}
       nearbySuggestions={nearbySuggestions}
       loadingSuggestions={loadingSuggestions && photoEvidenceUris.length > 0}
     />

--- a/src/components/Suggestions/SuggestionsList.js
+++ b/src/components/Suggestions/SuggestionsList.js
@@ -28,16 +28,16 @@ const convertScoreToConfidence = score => {
 };
 
 type Props = {
+  loadingSuggestions: boolean,
   nearbySuggestions: Array<Object>,
   onTaxonChosen: Function,
-  loadingSuggestions: boolean,
   setLoading: Function
 };
 
 const SuggestionsList = ( {
+  loadingSuggestions,
   nearbySuggestions,
   onTaxonChosen,
-  loadingSuggestions,
   setLoading
 }: Props ): Node => {
   const { t } = useTranslation( );

--- a/src/components/Suggestions/SuggestionsList.js
+++ b/src/components/Suggestions/SuggestionsList.js
@@ -8,25 +8,48 @@ import React, { useCallback } from "react";
 import { ActivityIndicator } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
 
+const convertScoreToConfidence = score => {
+  if ( !score ) {
+    return null;
+  }
+  if ( score < 20 ) {
+    return 1;
+  }
+  if ( score < 40 ) {
+    return 2;
+  }
+  if ( score < 60 ) {
+    return 3;
+  }
+  if ( score < 80 ) {
+    return 4;
+  }
+  return 5;
+};
+
 type Props = {
   nearbySuggestions: Array<Object>,
-  onTaxonChosen: Function,
-  loading: boolean
+  createId: Function,
+  loadingSuggestions: boolean,
+  setLoading: Function
 };
 
 const SuggestionsList = ( {
   nearbySuggestions,
-  onTaxonChosen,
-  loading
+  createId,
+  loadingSuggestions,
+  setLoading
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
-  const onTaxonResultChosen = useCallback( taxon => {
-    onTaxonChosen( taxon );
+  const onTaxonResultChosen = useCallback( async taxon => {
+    setLoading( true );
+    await createId( taxon );
+    setLoading( false );
     navigation.goBack( );
-  }, [navigation, onTaxonChosen] );
+  }, [navigation, createId, setLoading] );
 
-  if ( loading ) {
+  if ( loadingSuggestions ) {
     return (
       <View className="justify-center items-center mt-5" testID="SuggestionsList.loading">
         <ActivityIndicator large />
@@ -50,25 +73,6 @@ const SuggestionsList = ( {
   }
 
   const topSuggestion = nearbySuggestions[0];
-
-  const convertScoreToConfidence = score => {
-    if ( !score ) {
-      return null;
-    }
-    if ( score < 20 ) {
-      return 1;
-    }
-    if ( score < 40 ) {
-      return 2;
-    }
-    if ( score < 60 ) {
-      return 3;
-    }
-    if ( score < 80 ) {
-      return 4;
-    }
-    return 5;
-  };
 
   return (
     <>

--- a/src/components/Suggestions/TaxonSearch.js
+++ b/src/components/Suggestions/TaxonSearch.js
@@ -23,7 +23,9 @@ import CommentBox from "./CommentBox";
 const TaxonSearch = ( ): Node => {
   const {
     createId,
-    comment
+    comment,
+    setComment,
+    currentObservation
   } = useContext( ObsEditContext );
   const [taxonQuery, setTaxonQuery] = useState( "" );
   const navigation = useNavigation( );
@@ -59,7 +61,10 @@ const TaxonSearch = ( ): Node => {
 
   return (
     <ViewWrapper className="flex-1">
-      <AddCommentPrompt />
+      <AddCommentPrompt
+        setComment={setComment}
+        currentObservation={currentObservation}
+      />
       <CommentBox comment={comment} />
       <SearchBar
         handleTextChange={setTaxonQuery}

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -236,23 +236,13 @@ const ObsEditProvider = ( { children }: Props ): Node => {
       evidenceToAdd: options?.evidenceToAdd || evidenceToAdd
     } );
 
-    const updatePhotoEvidenceUris = obsPhotos => {
-      if ( obsPhotos?.length > photoEvidenceUris?.length ) {
-        return obsPhotos.map(
-          obsPhoto => obsPhoto.photo?.url || obsPhoto.photo?.localFilePath
-        );
-      }
-      return [];
-    };
-
     const setPhotoImporterState = options => dispatch( {
       type: "SET_PHOTO_IMPORTER_STATE",
       galleryUris: options?.galleryUris || galleryUris,
       savingPhoto: options?.savingPhoto || savingPhoto,
       evidenceToAdd: options?.evidenceToAdd || evidenceToAdd,
       groupedPhotos: options?.groupedPhotos || groupedPhotos,
-      observations: options?.observations || observations,
-      photoEvidenceUris: updatePhotoEvidenceUris( options?.observations?.observationPhotos )
+      observations: options?.observations || observations
     } );
 
     return {

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -133,7 +133,10 @@ const ObsEditProvider = ( { children }: Props ): Node => {
     };
 
     const createId = async identification => {
-      const newIdentification = Identification.formatIdentification( identification, comment );
+      const newIdentification = Identification.new( {
+        taxon: identification,
+        body: comment
+      } );
       const createRemoteIdentification = localObservation?.wasSynced( );
       if ( createRemoteIdentification ) {
         return createIdentificationMutation.mutate( {

--- a/src/providers/ObsEditProvider.js
+++ b/src/providers/ObsEditProvider.js
@@ -35,7 +35,6 @@ const ObsEditProvider = ( { children }: Props ): Node => {
   const { t } = useTranslation( );
 
   const [state, dispatch] = useReducer( createObsReducer, INITIAL_CREATE_OBS_STATE );
-  console.log( state.evidenceToAdd, "evidence to add state in provider" );
 
   const {
     cameraPreviewUris,

--- a/src/providers/reducers/createObsReducer.js
+++ b/src/providers/reducers/createObsReducer.js
@@ -21,7 +21,6 @@ export const INITIAL_CREATE_OBS_STATE = {
   // $FlowIgnore
   photoEvidenceUris: [],
   savingPhoto: false,
-  selectedPhotoIndex: 0,
   unsavedChanges: false
 };
 
@@ -91,11 +90,6 @@ const createObsReducer = ( state: Object, action: Function ): Object => {
         ...state,
         groupedPhotos: action.groupedPhotos
       };
-    case "SET_LOADING":
-      return {
-        ...state,
-        loading: action.loading
-      };
     case "SET_OBSERVATIONS":
       return {
         ...state,
@@ -109,11 +103,6 @@ const createObsReducer = ( state: Object, action: Function ): Object => {
       return {
         ...state,
         photoEvidenceUris: action.photoEvidenceUris
-      };
-    case "SET_SELECTED_PHOTO_INDEX":
-      return {
-        ...state,
-        selectedPhotoIndex: action.selectedPhotoIndex
       };
     default:
       return state;

--- a/src/providers/reducers/createObsReducer.js
+++ b/src/providers/reducers/createObsReducer.js
@@ -25,7 +25,6 @@ export const INITIAL_CREATE_OBS_STATE = {
 };
 
 const createObsReducer = ( state: Object, action: Function ): Object => {
-  console.log( action.type, ": OBS REDUCER" );
   switch ( action.type ) {
     case "DELETE_PHOTO":
       return {

--- a/src/providers/reducers/createObsReducer.js
+++ b/src/providers/reducers/createObsReducer.js
@@ -26,14 +26,15 @@ export const INITIAL_CREATE_OBS_STATE = {
 };
 
 const createObsReducer = ( state: Object, action: Function ): Object => {
+  console.log( action.type, ": OBS REDUCER" );
   switch ( action.type ) {
-    case "CLEAR_ADDITIONAL_EVIDENCE": {
+    case "DELETE_PHOTO":
       return {
         ...state,
-        evidenceToAdd: [],
-        unsavedChanges: true
+        photoEvidenceUris: action.photoEvidenceUris,
+        cameraPreviewUris: action.cameraPreviewUris,
+        evidenceToAdd: action.evidenceToAdd
       };
-    }
     case "RESET_OBS_CREATE":
       return {
         ...state,
@@ -47,17 +48,22 @@ const createObsReducer = ( state: Object, action: Function ): Object => {
         observations: [],
         originalCameraUrisMap: {},
         photoEvidenceUris: [],
+        savingPhoto: false,
         unsavedChanges: false
-      };
-    case "SET_CAMERA_PREVIEW_URIS":
-      return {
-        ...state,
-        cameraPreviewUris: action.cameraPreviewUris
       };
     case "SET_CAMERA_ROLL_URIS":
       return {
         ...state,
-        cameraRollUris: action.cameraRollUris
+        cameraRollUris: action.cameraRollUris,
+        savingPhoto: false
+      };
+    case "SET_CAMERA_STATE":
+      return {
+        ...state,
+        originalCameraUrisMap: action.originalCameraUrisMap,
+        evidenceToAdd: action.evidenceToAdd,
+        cameraPreviewUris: action.cameraPreviewUris,
+        savingPhoto: action.evidenceToAdd.length > 0
       };
     case "SET_COMMENT":
       return {
@@ -71,17 +77,16 @@ const createObsReducer = ( state: Object, action: Function ): Object => {
         observations: action.observations || [],
         loading: false
       };
-    case "SET_EVIDENCE_TO_ADD":
+    case "SET_PHOTO_IMPORTER_STATE":
       return {
         ...state,
-        evidenceToAdd: action.evidenceToAdd
+        galleryUris: action.galleryUris,
+        evidenceToAdd: action.evidenceToAdd,
+        savingPhoto: action.evidenceToAdd.length > 0,
+        groupedPhotos: action.groupedPhotos,
+        observations: action.observations,
+        photoEvidenceUris: action.photoEvidenceUris
       };
-    case "SET_GALLERY_URIS":
-      return {
-        ...state,
-        galleryUris: action.galleryUris
-      };
-
     case "SET_GROUPED_PHOTOS":
       return {
         ...state,
@@ -92,39 +97,24 @@ const createObsReducer = ( state: Object, action: Function ): Object => {
         ...state,
         loading: action.loading
       };
-    case "SET_ORIGINAL_CAMERA_URIS_MAP":
-      return {
-        ...state,
-        originalCameraUrisMap: action.originalCameraUrisMap
-      };
     case "SET_OBSERVATIONS":
       return {
         ...state,
         observations: action.observations,
         unsavedChanges: action.unsavedChanges || false,
-        loading: false
+        loading: false,
+        evidenceToAdd: [],
+        savingPhoto: false
       };
     case "SET_PHOTO_EVIDENCE_URIS":
       return {
         ...state,
         photoEvidenceUris: action.photoEvidenceUris
       };
-    case "SET_SAVING_PHOTO":
-      return {
-        ...state,
-        savingPhoto: action.savingPhoto
-      };
     case "SET_SELECTED_PHOTO_INDEX":
       return {
         ...state,
         selectedPhotoIndex: action.selectedPhotoIndex
-      };
-    case "DELETE_PHOTO":
-      return {
-        ...state,
-        photoEvidenceUris: action.photoEvidenceUris,
-        cameraPreviewUris: action.cameraPreviewUris,
-        evidenceToAdd: action.evidenceToAdd
       };
     default:
       return state;

--- a/src/providers/reducers/createObsReducer.js
+++ b/src/providers/reducers/createObsReducer.js
@@ -84,8 +84,7 @@ const createObsReducer = ( state: Object, action: Function ): Object => {
         evidenceToAdd: action.evidenceToAdd,
         savingPhoto: action.evidenceToAdd.length > 0,
         groupedPhotos: action.groupedPhotos,
-        observations: action.observations,
-        photoEvidenceUris: action.photoEvidenceUris
+        observations: action.observations
       };
     case "SET_GROUPED_PHOTOS":
       return {

--- a/src/realmModels/Identification.js
+++ b/src/realmModels/Identification.js
@@ -1,4 +1,5 @@
 import { Realm } from "@realm/react";
+import rnUUID from "react-native-uuid";
 
 import Flag from "./Flag";
 import Taxon from "./Taxon";
@@ -42,6 +43,16 @@ class Identification extends Realm.Object {
     };
     return newId;
   }
+
+  static formatIdentification = ( taxon, comment ) => {
+    const newIdent = {
+      uuid: rnUUID.v4(),
+      body: comment,
+      taxon
+    };
+
+    return newIdent;
+  };
 
   static schema = {
     name: "Identification",

--- a/src/realmModels/Identification.js
+++ b/src/realmModels/Identification.js
@@ -44,11 +44,10 @@ class Identification extends Realm.Object {
     return newId;
   }
 
-  static formatIdentification = ( taxon, comment ) => {
+  static new = attrs => {
     const newIdent = {
-      uuid: rnUUID.v4(),
-      body: comment,
-      taxon
+      ...attrs,
+      uuid: rnUUID.v4( )
     };
 
     return newIdent;

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -1,6 +1,7 @@
 import { Realm } from "@realm/react";
 import uuid from "react-native-uuid";
 import { createObservedOnStringForUpload } from "sharedHelpers/dateAndTime";
+import { formatExifDateAsString, parseExif } from "sharedHelpers/parseExif";
 
 import Application from "./Application";
 import Comment from "./Comment";
@@ -262,6 +263,41 @@ class Observation extends Realm.Object {
     const obsList = Observation.filterUnsyncedObservations( realm );
     const unsyncedObs = obsList.filtered( `uuid == "${obs.uuid}"` );
     return unsyncedObs.length > 0;
+  };
+
+  static createObservationFromGalleryPhoto = async photo => {
+    const firstPhotoExif = await parseExif( photo?.image?.uri );
+
+    const { latitude, longitude } = firstPhotoExif;
+
+    const newObservation = {
+      latitude,
+      longitude,
+      observed_on_string: formatExifDateAsString( firstPhotoExif.date ) || null
+    };
+
+    if ( firstPhotoExif.positional_accuracy ) {
+      // $FlowIgnore
+      newObservation.positional_accuracy = firstPhotoExif.positional_accuracy;
+    }
+    return Observation.new( newObservation );
+  };
+
+  static createObservationWithPhotos = async photos => {
+    const newLocalObs = await Observation.createObservationFromGalleryPhoto( photos[0] );
+    newLocalObs.observationPhotos = await ObservationPhoto
+      .createObsPhotosWithPosition( photos, { position: 0 } );
+    return newLocalObs;
+  };
+
+  static appendObsPhotos = ( obsPhotos, currentObservation ) => {
+    // need empty case for when a user creates an observation with no photos,
+    // then tries to add photos to observation later
+    const currentObservationPhotos = currentObservation?.observationPhotos || [];
+
+    const updatedObs = currentObservation;
+    updatedObs.observationPhotos = [...currentObservationPhotos, ...obsPhotos];
+    return [updatedObs];
   };
 
   static schema = {

--- a/src/realmModels/ObservationPhoto.js
+++ b/src/realmModels/ObservationPhoto.js
@@ -65,6 +65,30 @@ class ObservationPhoto extends Realm.Object {
     };
   }
 
+  static createObsPhotosWithPosition = async ( photos, { position, local } ) => {
+    let photoPosition = position;
+    return Promise.all(
+      photos.map( async photo => {
+        const newPhoto = ObservationPhoto.new(
+          local
+            ? photo
+            : photo?.image?.uri,
+          photoPosition
+        );
+        photoPosition += 1;
+        return newPhoto;
+      } )
+    );
+  };
+
+  static deleteObservationPhoto = ( list, photo ) => {
+    const i = list.findIndex(
+      p => p.photo.localFilePath === photo || p.originalPhotoUri === photo
+    );
+    list.splice( i, 1 );
+    return list;
+  };
+
   static schema = {
     name: "ObservationPhoto",
     primaryKey: "uuid",

--- a/src/sharedHooks/useCurrentObservationLocation.js
+++ b/src/sharedHooks/useCurrentObservationLocation.js
@@ -69,12 +69,18 @@ const useCurrentObservationLocation = ( mountedRef: any, options: Object = { } )
       // If we're still receiving location updates and location is blank,
       // then we don't know where we are any more and the obs should update
       // to reflect that
-      updateObservationKeys( {
-        place_guess: location?.place_guess,
-        latitude: location?.latitude,
-        longitude: location?.longitude,
-        positional_accuracy: location?.positional_accuracy
-      } );
+      if ( location?.place_guess !== currentObservation.place_guess
+        || location?.latitude !== currentObservation.latitude
+        || location?.longitude !== currentObservation.longitude
+        || location?.positional_accuracy !== currentObservation.positional_accuracy
+      ) {
+        updateObservationKeys( {
+          place_guess: location?.place_guess,
+          latitude: location?.latitude,
+          longitude: location?.longitude,
+          positional_accuracy: location?.positional_accuracy
+        } );
+      }
 
       setFetchingLocation( false );
 

--- a/src/sharedHooks/useCurrentObservationLocation.js
+++ b/src/sharedHooks/useCurrentObservationLocation.js
@@ -4,9 +4,7 @@ import {
   LOCATION_PERMISSIONS,
   permissionResultFromMultiple
 } from "components/SharedComponents/PermissionGateContainer";
-import { ObsEditContext } from "providers/contexts";
 import {
-  useContext,
   useEffect,
   useState
 } from "react";
@@ -21,11 +19,12 @@ export const LOCATION_FETCH_INTERVAL = 1000;
 // isFetchingLocation to tell the consumer whether this process is happening.
 // If currentObservation is not new, it will not fetch location and return
 // information about the current observation's location
-const useCurrentObservationLocation = ( mountedRef: any, options: Object = { } ): Object => {
-  const {
-    currentObservation,
-    updateObservationKeys
-  } = useContext( ObsEditContext );
+const useCurrentObservationLocation = (
+  mountedRef: any,
+  currentObservation: Object,
+  updateObservationKeys: Function,
+  options: Object = { }
+): Object => {
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;
   const hasLocation = latitude || longitude;

--- a/tests/integration/ObsDetails.test.js
+++ b/tests/integration/ObsDetails.test.js
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { screen } from "@testing-library/react-native";
+import { screen, waitFor } from "@testing-library/react-native";
 import ObsDetailsContainer from "components/ObsDetails/ObsDetailsContainer";
 import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
@@ -74,7 +74,9 @@ describe( "ObsDetails", () => {
       ).toBeTruthy();
       expect( inatjs.observations.viewedUpdates ).toHaveBeenCalledTimes( 1 );
       // Expect the observation in realm to have been updated with comments_viewed = true
-      expect( observation.comments_viewed ).toBe( true );
+      await waitFor( ( ) => {
+        expect( observation.comments_viewed ).toBe( true );
+      } );
     } );
   } );
 } );

--- a/tests/unit/components/AddObsModal.test.js
+++ b/tests/unit/components/AddObsModal.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import AddObsModal from "components/AddObsModal";
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
@@ -24,13 +24,13 @@ jest.mock( "@react-navigation/native", () => {
 } );
 
 const mockResetObsEdit = jest.fn( );
-const mockCreateObservation = jest.fn( );
+const mockUpdateObservations = jest.fn( );
 
 const mockObsEditProvider = ( ) => ObsEditProvider.mockImplementation( ( { children } ) => (
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   <ObsEditContext.Provider value={{
     resetObsEditContext: mockResetObsEdit,
-    createObservationNoEvidence: mockCreateObservation
+    updateObservations: mockUpdateObservations
   }}
   >
     {children}
@@ -65,7 +65,9 @@ describe( "AddObsModal", ( ) => {
     expect( noEvidenceButton ).toBeTruthy( );
     fireEvent.press( noEvidenceButton );
     expect( mockResetObsEdit ).toHaveBeenCalledTimes( 1 );
-    expect( mockCreateObservation ).toHaveBeenCalledTimes( 1 );
+    await waitFor( ( ) => {
+      expect( mockUpdateObservations ).toHaveBeenCalledTimes( 1 );
+    } );
     expect( mockNavigate ).toHaveBeenCalledWith( "CameraNavigator", {
       screen: "ObsEdit"
     } );
@@ -84,7 +86,7 @@ describe( "AddObsModal", ( ) => {
     expect( arCameraButton ).toBeTruthy( );
     fireEvent.press( arCameraButton );
     expect( mockResetObsEdit ).toHaveBeenCalledTimes( 1 );
-    expect( mockCreateObservation ).not.toHaveBeenCalled( );
+    expect( mockUpdateObservations ).not.toHaveBeenCalled( );
     expect( mockNavigate ).toHaveBeenCalledWith( "CameraNavigator", {
       screen: "Camera",
       params: { camera: "AR" }

--- a/tests/unit/components/Camera/CameraContainer.test.js
+++ b/tests/unit/components/Camera/CameraContainer.test.js
@@ -35,7 +35,6 @@ jest.mock( "@react-navigation/native", () => {
 } );
 
 const mockValue = {
-  addCameraPhotosToCurrentObservation: jest.fn(),
   totalObsPhotoUris: 10,
   cameraPreviewUris: []
 };

--- a/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
+++ b/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
@@ -4,8 +4,6 @@ import DeleteObservationSheet from "components/ObsEdit/Sheets/DeleteObservationS
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import inatjs from "inaturalistjs";
-import { ObsEditContext } from "providers/contexts";
-import ObsEditProvider from "providers/ObsEditProvider";
 import React from "react";
 
 import factory from "../../../factory";
@@ -33,27 +31,13 @@ jest.mock( "@react-navigation/native", ( ) => {
   };
 } );
 
-// Mock ObservationProvider so it provides a specific array of observations
-// without any current observation or ability to update or fetch
-// observations
-const mockObsEditProviderWithObs = obs => ObsEditProvider.mockImplementation( ( { children } ) => (
-  // eslint-disable-next-line react/jsx-no-constructed-context-values
-  <ObsEditContext.Provider value={{
-    currentObservation: obs[0],
-    observations: obs
-  }}
-  >
-    {children}
-  </ObsEditContext.Provider>
-) );
-
-const renderDeleteSheet = ( ) => renderComponent(
-  <ObsEditProvider>
-    <DeleteObservationSheet
-      handleClose={( ) => jest.fn( )}
-      navToObsList={( ) => jest.fn( )}
-    />
-  </ObsEditProvider>
+const renderDeleteSheet = obs => renderComponent(
+  <DeleteObservationSheet
+    handleClose={( ) => jest.fn( )}
+    navToObsList={( ) => jest.fn( )}
+    currentObservation={obs[0]}
+    observations={obs}
+  />
 );
 
 const getLocalObservation = uuid => global.realm
@@ -77,8 +61,7 @@ describe( "delete observation", ( ) => {
       } );
       const localObservation = getLocalObservation( observations[0].uuid );
       expect( localObservation ).toBeTruthy( );
-      mockObsEditProviderWithObs( observations );
-      renderDeleteSheet( );
+      renderDeleteSheet( observations );
       const deleteButtonText = i18next.t( "DELETE" );
       const deleteButton = screen.queryByText( deleteButtonText );
       expect( deleteButton ).toBeTruthy( );
@@ -100,8 +83,7 @@ describe( "delete observation", ( ) => {
       } );
       const localObservation = getLocalObservation( observations[0].uuid );
       expect( localObservation ).toBeTruthy( );
-      mockObsEditProviderWithObs( observations );
-      renderDeleteSheet( );
+      renderDeleteSheet( observations );
       const deleteButtonText = i18next.t( "DELETE" );
       const deleteButton = await screen.findByText( deleteButtonText );
       expect( deleteButton ).toBeTruthy( );
@@ -121,8 +103,7 @@ describe( "delete observation", ( ) => {
       } );
       const localObservation = getLocalObservation( observations[0].uuid );
       expect( localObservation ).toBeTruthy( );
-      mockObsEditProviderWithObs( observations );
-      renderDeleteSheet( );
+      renderDeleteSheet( observations );
 
       const cancelButton = screen.queryByText( /CANCEL/ );
       expect( cancelButton ).toBeTruthy( );

--- a/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
+++ b/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
@@ -40,14 +40,6 @@ const mockObsEditProviderWithObs = obs => ObsEditProvider.mockImplementation( ( 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   <ObsEditContext.Provider value={{
     currentObservation: obs[0],
-    deleteLocalObservation: ( ) => {
-      global.realm.write( ( ) => {
-        const observation = global.realm.objectForPrimaryKey( "Observation", obs[0].uuid );
-        if ( observation ) {
-          global.realm.delete( observation );
-        }
-      } );
-    },
     observations: obs
   }}
   >

--- a/tests/unit/components/ObsEdit/EvidenceList.test.js
+++ b/tests/unit/components/ObsEdit/EvidenceList.test.js
@@ -1,9 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
 import EvidenceList from "components/ObsEdit/EvidenceList";
-import { ObsEditContext } from "providers/contexts";
-import INatPaperProvider from "providers/INatPaperProvider";
-import ObsEditProvider from "providers/ObsEditProvider";
 import React from "react";
 
 import factory from "../../../factory";
@@ -24,43 +21,27 @@ const observationPhotos = [
   } )
 ];
 
-jest.mock( "providers/ObsEditProvider" );
-const mockObsEditProvider = ( savingPhoto = false ) => ObsEditProvider
-  .mockImplementation( ( { children } ) => (
-  // eslint-disable-next-line react/jsx-no-constructed-context-values
-    <INatPaperProvider>
-      <ObsEditContext.Provider value={{
-        savingPhoto
-      }}
-      >
-        {children}
-      </ObsEditContext.Provider>
-    </INatPaperProvider>
-  ) );
-
 const renderEvidenceList = evidenceList => renderComponent(
-  <ObsEditProvider>
-    <EvidenceList evidenceList={evidenceList} />
-  </ObsEditProvider>
+  <EvidenceList
+    evidenceList={evidenceList}
+    savingPhoto
+  />
 );
 
 describe( "EvidenceList", ( ) => {
   it( "should display add evidence button", ( ) => {
-    mockObsEditProvider( );
     renderEvidenceList( observationPhotos );
 
     expect( screen.getByTestId( "EvidenceList.add" ) ).toBeVisible( );
   } );
 
   it( "should display loading wheel if photo is saving", ( ) => {
-    mockObsEditProvider( true );
     renderEvidenceList( observationPhotos );
 
     expect( screen.getByTestId( "EvidenceList.saving" ) ).toBeVisible( );
   } );
 
   it( "should render all observation photos", ( ) => {
-    mockObsEditProvider( );
     renderEvidenceList( observationPhotos );
 
     expect( screen.getByTestId( `EvidenceList.${observationPhotos[0].photo.url}` ) ).toBeVisible( );
@@ -68,7 +49,6 @@ describe( "EvidenceList", ( ) => {
   } );
 
   it( "should display an empty list when observation has no observation photos", ( ) => {
-    mockObsEditProvider( );
     renderEvidenceList( [] );
     expect( screen.getByTestId( "EvidenceList.add" ) ).toBeVisible( );
     expect( screen.queryByTestId( "ObsEdit.photo" ) ).toBeFalsy( );

--- a/tests/unit/components/ObsEdit/IdentificationSection.test.js
+++ b/tests/unit/components/ObsEdit/IdentificationSection.test.js
@@ -1,35 +1,17 @@
 import { screen } from "@testing-library/react-native";
 import IdentificationSection from "components/ObsEdit/IdentificationSection";
 import initI18next from "i18n/initI18next";
-import { ObsEditContext } from "providers/contexts";
-import INatPaperProvider from "providers/INatPaperProvider";
-import ObsEditProvider from "providers/ObsEditProvider";
 import React from "react";
 
 import factory from "../../../factory";
 import { renderComponent } from "../../../helpers/render";
 
-// Mock ObservationProvider so it provides a specific array of observations
-// without any current observation or ability to update or fetch
-// observations
-jest.mock( "providers/ObsEditProvider" );
-const mockObsEditProviderWithObs = obs => ObsEditProvider.mockImplementation( ( { children } ) => (
-  // eslint-disable-next-line react/jsx-no-constructed-context-values
-  <INatPaperProvider>
-    <ObsEditContext.Provider value={{
-      observations: obs,
-      currentObservation: obs[0]
-    }}
-    >
-      {children}
-    </ObsEditContext.Provider>
-  </INatPaperProvider>
-) );
-
-const renderIdentificationSection = ( ) => renderComponent(
-  <ObsEditProvider>
-    <IdentificationSection passesIdentificationTest />
-  </ObsEditProvider>
+const renderIdentificationSection = obs => renderComponent(
+  <IdentificationSection
+    passesIdentificationTest
+    observations={obs}
+    currentObservation={obs[0]}
+  />
 );
 
 describe( "IdentificationSection", () => {
@@ -43,8 +25,7 @@ describe( "IdentificationSection", () => {
         taxon: null
       } )
     ];
-    mockObsEditProviderWithObs( observations );
-    renderIdentificationSection( );
+    renderIdentificationSection( observations );
     expect( screen.getByTestId( "ObsEdit.Suggestions" ) ).toBeVisible( );
   } );
 
@@ -58,8 +39,7 @@ describe( "IdentificationSection", () => {
         }
       } )
     ];
-    mockObsEditProviderWithObs( observations );
-    renderIdentificationSection( );
+    renderIdentificationSection( observations );
     expect( screen.getByTestId( "ObsEdit.Suggestions" ) ).toBeVisible( );
   } );
 
@@ -72,8 +52,7 @@ describe( "IdentificationSection", () => {
         }
       } )
     ];
-    mockObsEditProviderWithObs( observations );
-    renderIdentificationSection( );
+    renderIdentificationSection( observations );
     expect( screen.queryByTestId( "ObsEdit.Suggestions" ) ).toBeFalsy( );
   } );
 } );

--- a/tests/unit/components/Suggestions/Suggestions.test.js
+++ b/tests/unit/components/Suggestions/Suggestions.test.js
@@ -1,15 +1,15 @@
 import { faker } from "@faker-js/faker";
 import {
+  fireEvent,
   screen, waitFor
 } from "@testing-library/react-native";
 import SuggestionsContainer from "components/Suggestions/SuggestionsContainer";
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
-import inatjs from "inaturalistjs";
 import { ObsEditContext } from "providers/contexts";
 import React from "react";
 
-import factory, { makeResponse } from "../../../factory";
+import factory from "../../../factory";
 import { renderComponent } from "../../../helpers/render";
 
 const mockTaxon = factory( "RemoteTaxon", {
@@ -34,6 +34,14 @@ const mockSuggestionsList = [{
   }
 }];
 
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: () => ( {
+    data: mockSuggestionsList,
+    isLoading: false
+  } )
+} ) );
+
 // Mock api call to observations
 jest.mock( "inaturalistjs" );
 
@@ -42,7 +50,8 @@ jest.mock( "@react-navigation/native", ( ) => {
   return {
     ...actualNav,
     useNavigation: ( ) => ( {
-      addListener: jest.fn( )
+      addListener: jest.fn( ),
+      goBack: jest.fn( )
     } )
   };
 } );
@@ -56,16 +65,18 @@ const mockUris = [
 
 const mockCreateId = jest.fn( );
 
-const renderSuggestions = ( loading = false, comment = "" ) => renderComponent(
+const renderSuggestions = ( comment = "" ) => renderComponent(
   <ObsEditContext.Provider value={{
     updateObservationKeys: jest.fn( ),
     photoEvidenceUris: mockUris,
     createId: mockCreateId,
-    loading,
     comment,
     currentObservation: {
-      uuid: faker.datatype.uuid( )
-    }
+      uuid: faker.datatype.uuid( ),
+      latitude: 41,
+      longitude: -143
+    },
+    setPhotoEvidenceUris: jest.fn( )
   }}
   >
     <SuggestionsContainer />
@@ -84,27 +95,38 @@ describe( "Suggestions", ( ) => {
     expect( suggestions ).toBeAccessible( );
   } );
 
+  it( "should fetch nearby suggestions for current photo", async ( ) => {
+    renderSuggestions( );
+    const taxonTopResult = screen.getByTestId(
+      `SuggestionsList.taxa.${mockSuggestionsList[0].taxon.id}`
+    );
+    await waitFor( ( ) => {
+      expect( taxonTopResult ).toBeVisible( );
+    } );
+  } );
+
   it( "should show loading wheel while id being created", async ( ) => {
-    renderSuggestions( true );
+    renderSuggestions( );
+    const taxonTopResult = screen.getByTestId(
+      `SuggestionsList.taxa.${mockSuggestionsList[0].taxon.id}`
+    );
+    await waitFor( ( ) => {
+      expect( taxonTopResult ).toBeVisible( );
+    } );
+    const taxonCheckmark = screen.getByTestId(
+      `SuggestionsList.taxa.${mockSuggestionsList[0].taxon.id}.checkmark`
+    );
+    fireEvent.press( taxonCheckmark );
     await waitFor( ( ) => {
       expect( screen.queryByTestId( "Suggestions.ActivityIndicator" ) ).toBeVisible( );
     } );
   } );
 
   it( "shows comment section if observation has comment", ( ) => {
-    renderSuggestions( false, "Comment added to observation" );
+    renderSuggestions( "Comment added to observation" );
     const commentSection = screen.getByText(
       i18next.t( "Your-identification-will-be-posted-with-the-following-comment" )
     );
     expect( commentSection ).toBeVisible( );
-  } );
-
-  it( "should fetch nearby suggestions for current photo", async ( ) => {
-    renderSuggestions( );
-    await waitFor( ( ) => {
-      inatjs.observations.observers.mockResolvedValue( makeResponse( [] ) );
-      inatjs.computervision.score_image.mockResolvedValue( makeResponse( mockSuggestionsList ) );
-      expect( inatjs.computervision.score_image ).toHaveBeenCalledTimes( 1 );
-    } );
   } );
 } );

--- a/tests/unit/components/Suggestions/SuggestionsList.test.js
+++ b/tests/unit/components/Suggestions/SuggestionsList.test.js
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { fireEvent, screen } from "@testing-library/react-native";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import SuggestionsList from "components/Suggestions/SuggestionsList";
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
@@ -30,12 +30,13 @@ const mockSuggestionsList = [{
   }
 }];
 
-const mockTaxonSelection = jest.fn( );
+const mockCreateId = jest.fn( );
 
 const renderSuggestionsList = ( ) => renderComponent(
   <SuggestionsList
     nearbySuggestions={mockSuggestionsList}
-    onTaxonChosen={mockTaxonSelection}
+    setLoading={jest.fn( )}
+    createId={mockCreateId}
   />
 );
 
@@ -75,7 +76,7 @@ describe( "SuggestionsList", ( ) => {
     renderComponent(
       <SuggestionsList
         nearbySuggestions={[]}
-        loading
+        loadingSuggestions
       />
     );
     const loading = screen.getByTestId( "SuggestionsList.loading" );
@@ -88,6 +89,8 @@ describe( "SuggestionsList", ( ) => {
     const checkmark = screen.getByTestId( `${testID}.checkmark` );
     expect( checkmark ).toBeVisible( );
     fireEvent.press( checkmark );
-    expect( mockTaxonSelection ).toHaveBeenCalled( );
+    await waitFor( ( ) => {
+      expect( mockCreateId ).toHaveBeenCalled( );
+    } );
   } );
 } );


### PR DESCRIPTION
This is a refactor which moves a lot of functionality out of ObsEditProvider and into the screens where state is needed. This PR has some performance gains, but the main purpose was to simplify ObsEditProvider enough to give us the option to explore a global state management library like [zustand](https://github.com/pmndrs/zustand).

I ran through profiling in Flipper, starting on the MyObservations screen, then:
- Adding an observation with no evidence
- Tapping add evidence button and adding a photo from the camera
- Tapping add evidence button and adding a photo from the gallery
- Saving and returning to MyObservations

At first, the total number of renders were the same as in main, with the number of renders caused by ObsEditProvider halved (12 instead of 22).

Then, I refactored so ObsEditContext is only called at the top level of a screen (i.e. in ObsEdit instead of in BottomButtons) and the relevant context is passed down as props. When I ran through the same profiling steps described above, the total renders during that profiling session were reduced to 149 from 194 (~25% less renders).