### PR TITLE
850 location picker zoom

### DIFF
--- a/src/components/SharedComponents/Map.js
+++ b/src/components/SharedComponents/Map.js
@@ -156,7 +156,7 @@ const Map = ( {
   const [zoomToUserLocationRequested, setZoomToUserLocationRequested] = useState(
     startAtUserLocation
   );
-  useEffect( ( ) => {
+
   // Adapted from iNat Android LocationChooserActivity.java computeOffset function
   const EARTH_RADIUS = 6371000; // Earth radius in meters
   function metersToLatitudeDelta( meters, latitude ) {
@@ -168,6 +168,8 @@ const Map = ( {
     const latitudeDelta = ( latitudeDeltaRadians * 180 ) / Math.PI;
     return latitudeDelta;
   }
+
+  useEffect( ( ) => {
     if ( userLocation && zoomToUserLocationRequested && mapViewRef?.current ) {
       mapViewRef.current.animateToRegion( {
         latitude: userLocation.latitude,


### PR DESCRIPTION
Closes #850 
With this PR the location picker now zooms into the current location when pressing the current location button. How closely to zoom in depends on the current location's accuracy.

However, the changes have been applied to the Map component and are therefore also affecting the Explore page where the map now also zooms in when pressed on the current location. Maybe on Explore zooming in so close is not wanted though.