### PR TITLE
Increase pressable area of back button, Obs Edit

### DIFF
--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -89,7 +89,7 @@ const EvidenceSection = ( {
   };
 
   return (
-    <View className="mx-6 mt-6">
+    <View className="mx-6">
       <AddEvidenceSheet
         disableAddingMoreEvidence={obsPhotos?.length >= MAX_PHOTOS_ALLOWED}
         hidden={!showAddEvidenceSheet}

--- a/src/components/ObsEdit/Header.js
+++ b/src/components/ObsEdit/Header.js
@@ -146,7 +146,7 @@ const Header = ( {
   ), [kebabMenuVisible, observations, t, setDeleteSheetVisible] );
 
   return (
-    <View className="flex-row justify-between items-center mt-12">
+    <View className="flex-row justify-between items-center">
       {renderBackButton( )}
       {observations.length > 0 && renderHeaderTitle( )}
       <View className="mr-4">

--- a/src/components/ObsEdit/Header.js
+++ b/src/components/ObsEdit/Header.js
@@ -1,11 +1,11 @@
 // @flow
 
 import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
-import { Heading2, KebabMenu } from "components/SharedComponents";
-import BackButton from "components/SharedComponents/Buttons/BackButton";
+import { BackButton, Heading2, KebabMenu } from "components/SharedComponents";
+import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, {
-  useCallback, useEffect, useState
+  useCallback, useState
 } from "react";
 import { BackHandler } from "react-native";
 import { Menu } from "react-native-paper";
@@ -94,11 +94,20 @@ const Header = ( {
     }
   }, [currentObservation, navigation, unsavedChanges, params, navToObsDetails] );
 
-  const renderBackButton = useCallback( ( ) => (
-    <BackButton
-      onPress={handleBackButtonPress}
-    />
-  ), [handleBackButtonPress] );
+  const renderBackButton = useCallback( ( ) => {
+    const extraPadding = {
+      marginStart: 15,
+      paddingVertical: 18,
+      paddingEnd: 24
+    };
+    return (
+      <BackButton
+        onPress={handleBackButtonPress}
+        customStyles={extraPadding}
+        testID="ObsEdit.BackButton"
+      />
+    );
+  }, [handleBackButtonPress] );
 
   useFocusEffect(
     useCallback( ( ) => {
@@ -136,34 +145,13 @@ const Header = ( {
     </KebabMenu>
   ), [kebabMenuVisible, observations, t, setDeleteSheetVisible] );
 
-  useEffect( ( ) => {
-    const headerOptions = {
-      headerTitle: currentObservation
-        ? renderHeaderTitle
-        : "",
-      headerLeft: renderBackButton,
-      headerRight: renderKebabMenu
-    };
-
-    if ( typeof ( navigation?.setOptions ) === "function" ) {
-      navigation?.setOptions( headerOptions );
-    }
-  }, [
-    observations,
-    navigation,
-    renderKebabMenu,
-    renderBackButton,
-    renderHeaderTitle,
-    currentObservation
-  ] );
-
-  // prevent header from flickering if observations haven't loaded yet
-  if ( observations.length === 0 ) {
-    return null;
-  }
-
   return (
-    <>
+    <View className="flex-row justify-between items-center mt-12">
+      {renderBackButton( )}
+      {observations.length > 0 && renderHeaderTitle( )}
+      <View className="mr-4">
+        {observations.length > 0 && renderKebabMenu( )}
+      </View>
       {deleteSheetVisible && (
         <DeleteObservationSheet
           handleClose={( ) => setDeleteSheetVisible( false )}
@@ -184,10 +172,9 @@ const Header = ( {
         <DiscardChangesSheet
           discardChanges={discardChanges}
           handleClose={( ) => setDiscardChangesSheetVisible( false )}
-
         />
       )}
-    </>
+    </View>
   );
 };
 

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { useIsFocused, useRoute } from "@react-navigation/native";
-import { View } from "components/styledComponents";
+import { ViewWrapper } from "components/SharedComponents";
 import { ObsEditContext } from "providers/contexts";
 import type { Node } from "react";
 import React, {
@@ -60,7 +60,7 @@ const ObsEdit = ( ): Node => {
   return isFocused
     ? (
       <>
-        <View testID="obs-edit" className="bg-white flex-1">
+        <ViewWrapper testID="obs-edit">
           <Header
             observations={observations}
             currentObservation={currentObservation}
@@ -100,7 +100,7 @@ const ObsEdit = ( ): Node => {
             )}
             {loading && <ActivityIndicator />}
           </KeyboardAwareScrollView>
-        </View>
+        </ViewWrapper>
         <BottomButtons
           passesEvidenceTest={passesEvidenceTest}
           passesIdentificationTest={passesIdentificationTest}

--- a/src/components/SharedComponents/Buttons/BackButton.js
+++ b/src/components/SharedComponents/Buttons/BackButton.js
@@ -8,19 +8,25 @@ import colors from "styles/tailwindColors";
 type Props = {
   color?: string,
   onPress?: Function,
-  inCustomHeader?: boolean
+  inCustomHeader?: boolean,
+  customStyles?: Object,
+  testID?: string
 }
 
 const REACT_NAVIGATION_BACK_BUTTON_STYLE = {
-  marginStart: Platform.OS === "ios"
+  start: Platform.OS === "ios"
     ? -15
-    : 0
+    : 0,
+  minWidth: 44,
+  minHeight: 44
 };
 
 const BackButton = ( {
   color = colors.black,
   onPress,
-  inCustomHeader
+  inCustomHeader,
+  customStyles,
+  testID = "BackButton"
 }: Props ): Node => {
   const navigation = useNavigation();
   const tintColor = color || colors.black;
@@ -30,8 +36,12 @@ const BackButton = ( {
       <HeaderBackButton
         tintColor={tintColor}
         onPress={onPress || navigation.goBack}
-        // move backbutton to same margin as in react-navigation
-        style={!inCustomHeader && REACT_NAVIGATION_BACK_BUTTON_STYLE}
+        // move backbutton to same start as in react-navigation
+        style={[
+          !inCustomHeader && REACT_NAVIGATION_BACK_BUTTON_STYLE,
+          customStyles
+        ]}
+        testID={testID}
       />
     );
   }

--- a/src/navigation/StackNavigators/SharedStackScreens.js
+++ b/src/navigation/StackNavigators/SharedStackScreens.js
@@ -35,12 +35,7 @@ const SharedStackScreens = ( ): Node => (
     <Stack.Screen
       name="ObsEdit"
       component={ObsEdit}
-      options={{
-        ...removeBottomBorder,
-        ...blankHeaderTitle,
-        headerBackVisible: false,
-        headerTitleAlign: "center"
-      }}
+      options={hideHeader}
     />
     <Stack.Screen
       name="Suggestions"

--- a/tests/unit/components/ObsEdit/Header.test.js
+++ b/tests/unit/components/ObsEdit/Header.test.js
@@ -1,0 +1,79 @@
+import { screen } from "@testing-library/react-native";
+import Header from "components/ObsEdit/Header";
+import initI18next from "i18n/initI18next";
+import React from "react";
+
+import factory from "../../../factory";
+import { renderComponent } from "../../../helpers/render";
+
+const mockObservations = [
+  factory( "LocalObservation" ),
+  factory( "LocalObservation" )
+];
+
+describe( "Header", () => {
+  beforeAll( async ( ) => {
+    await initI18next( );
+  } );
+
+  it( "has no accessibility errors", () => {
+    const button = (
+      <Header
+        observations={mockObservations}
+      />
+    );
+
+    expect( button ).toBeAccessible();
+  } );
+
+  it( "renders a header title with 1 observation", async () => {
+    renderComponent(
+      <Header
+        observations={[mockObservations[1]]}
+      />
+    );
+
+    const headerText = await screen.findByText( /New Observation/ );
+
+    expect( headerText ).toBeVisible();
+  } );
+
+  it( "renders a header title with multiple observations", async () => {
+    renderComponent(
+      <Header
+        observations={mockObservations}
+      />
+    );
+
+    const headerText = await screen.findByText( /2 Observations/ );
+
+    expect( headerText ).toBeVisible();
+  } );
+
+  it( "renders a kebab menu", async () => {
+    renderComponent(
+      <Header
+        observations={mockObservations}
+      />
+    );
+
+    const kebabLabel = await screen.findByLabelText( /Menu/ );
+
+    expect( kebabLabel ).toBeVisible();
+  } );
+
+  it( "renders a back button with extra padding for accessibility", () => {
+    renderComponent(
+      <Header
+        observations={mockObservations}
+      />
+    );
+
+    const backButtonId = screen.getByTestId( "ObsEdit.BackButton" );
+
+    expect( backButtonId ).toBeVisible();
+    expect(
+      backButtonId
+    ).toHaveStyle( { paddingVertical: 18, paddingEnd: 24 } );
+  } );
+} );

--- a/tests/unit/components/SharedComponents/Buttons/BackButton.test.js
+++ b/tests/unit/components/SharedComponents/Buttons/BackButton.test.js
@@ -1,0 +1,10 @@
+import { BackButton } from "components/SharedComponents";
+import React from "react";
+
+describe( "BackButton", () => {
+  it( "has no accessibility errors", () => {
+    const button = <BackButton />;
+
+    expect( button ).toBeAccessible();
+  } );
+} );


### PR DESCRIPTION
Closes #907

- Use custom header rather than the react navigation header with setOptions, so we can control the padding around the back button