### PR TITLE
Add loading wheels to infinite scrolls in Explore

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -3,6 +3,7 @@
 import {
   BottomSheet,
   Button,
+  StickyView,
   ViewWrapper
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
@@ -18,13 +19,12 @@ import ObservationsViewBar from "./ObservationsViewBar";
 import ObserversView from "./ObserversView";
 import SpeciesView from "./SpeciesView";
 
-const { diffClamp } = Animated;
-
 type Props = {
-  exploreParams: Object,
-  region: Object,
-  exploreView: string,
   changeExploreView: Function,
+  exploreParams: Object,
+  exploreView: string,
+  isOnline: boolean,
+  region: Object,
   updateTaxon: Function,
   updatePlace: Function,
   updatePlaceName: Function,
@@ -32,10 +32,11 @@ type Props = {
 }
 
 const Explore = ( {
-  exploreParams,
-  region,
-  exploreView,
   changeExploreView,
+  exploreParams,
+  exploreView,
+  isOnline,
+  region,
   updateTaxon,
   updatePlace,
   updatePlaceName,
@@ -53,22 +54,6 @@ const Explore = ( {
   // basing collapsible sticky header code off the example in this article
   // https://medium.com/swlh/making-a-collapsible-sticky-header-animations-with-react-native-6ad7763875c3
   const scrollY = useRef( new Animated.Value( 0 ) );
-
-  // On Android, the scroll view offset is a double (not an integer), and interpolation shouldn't be
-  // one-to-one, which causes a jittery header while slow scrolling (see issue #634).
-  // See here as well: https://stackoverflow.com/a/60898411/1233767
-  const scrollYClamped = diffClamp(
-    scrollY.current,
-    0,
-    heightAboveFilters * 2
-  );
-
-  // Same as comment above (see here: https://stackoverflow.com/a/60898411/1233767)
-  const offsetForHeader = scrollYClamped.interpolate( {
-    inputRange: [0, heightAboveFilters * 2],
-    // $FlowIgnore
-    outputRange: [0, -heightAboveFilters]
-  } );
 
   const exploreViewText = {
     observations: t( "OBSERVATIONS" ),
@@ -113,23 +98,14 @@ const Explore = ( {
   return (
     <>
       <ViewWrapper testID="Explore">
-        <View className="flex-1">
-          {exploreView === "observations" && (
-            <ObservationsViewBar
-              observationsView={observationsView}
-              updateObservationsView={newView => setObservationsView( newView )}
-            />
-          )}
-          <Animated.View
-            // eslint-disable-next-line react-native/no-inline-styles
-            style={{
-              transform: [{ translateY: offsetForHeader }],
-              flex: 1,
-              width: "100%",
-              height: "100%",
-              flexGrow: 1
-            }}
-          >
+        <View className="overflow-hidden">
+          <StickyView scrollY={scrollY} heightAboveView={heightAboveFilters}>
+            {exploreView === "observations" && (
+              <ObservationsViewBar
+                observationsView={observationsView}
+                updateObservationsView={newView => setObservationsView( newView )}
+              />
+            )}
             <Header
               region={region}
               setShowExploreBottomSheet={setShowExploreBottomSheet}
@@ -152,26 +128,29 @@ const Explore = ( {
             )}
             {exploreView === "species" && (
               <SpeciesView
-                setHeaderRight={setHeaderRight}
                 handleScroll={handleScroll}
+                isOnline={isOnline}
+                setHeaderRight={setHeaderRight}
                 queryParams={queryParams}
               />
             )}
             {exploreView === "observers" && (
               <ObserversView
-                setHeaderRight={setHeaderRight}
                 handleScroll={handleScroll}
+                isOnline={isOnline}
+                setHeaderRight={setHeaderRight}
                 queryParams={queryParams}
               />
             )}
             {exploreView === "identifiers" && (
               <IdentifiersView
-                setHeaderRight={setHeaderRight}
                 handleScroll={handleScroll}
+                isOnline={isOnline}
+                setHeaderRight={setHeaderRight}
                 queryParams={queryParams}
               />
             )}
-          </Animated.View>
+          </StickyView>
         </View>
       </ViewWrapper>
       {showExploreBottomSheet && (

--- a/src/components/Explore/ExploreContainer.js
+++ b/src/components/Explore/ExploreContainer.js
@@ -3,6 +3,7 @@
 import { useRoute } from "@react-navigation/native";
 import type { Node } from "react";
 import React, { useEffect, useReducer } from "react";
+import { useIsConnected } from "sharedHooks";
 
 import Explore from "./Explore";
 
@@ -93,6 +94,7 @@ const reducer = ( state, action ) => {
 
 const ExploreContainer = ( ): Node => {
   const { params } = useRoute( );
+  const isOnline = useIsConnected( );
 
   const [state, dispatch] = useReducer( reducer, initialState );
 
@@ -170,6 +172,7 @@ const ExploreContainer = ( ): Node => {
       updatePlace={updatePlace}
       updatePlaceName={updatePlaceName}
       updateTaxonName={updateTaxonName}
+      isOnline={isOnline}
     />
   );
 };

--- a/src/components/Explore/ExploreFlashList.js
+++ b/src/components/Explore/ExploreFlashList.js
@@ -4,85 +4,91 @@ import InfiniteScrollLoadingWheel from "components/MyObservations/InfiniteScroll
 import { Body3 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React from "react";
+import React, { useCallback } from "react";
 import { ActivityIndicator, Animated } from "react-native";
 import { useTranslation } from "sharedHooks";
 
 const AnimatedFlashList = Animated.createAnimatedComponent( FlashList );
 
 type Props = {
-  testID: string,
-  handleScroll: Function,
-  isFetchingNextPage: boolean,
+  contentContainerStyle?: Object,
   data: Array<Object>,
-  renderItem: Function,
-  renderItemSeparator?: Function,
-  fetchNextPage: boolean,
   estimatedItemSize: number,
+  fetchNextPage: boolean,
+  handleScroll: Function,
+  hideLoadingWheel: boolean,
+  isFetchingNextPage: boolean,
+  isOnline: boolean,
   keyExtractor: Function,
   layout?: string,
-  contentContainerStyle?: Object,
   numColumns?: number,
-  status: string
+  renderItem: Function,
+  renderItemSeparator?: Function,
+  status: string,
+  testID: string
 };
 
 const ExploreFlashList = ( {
-  testID,
-  handleScroll,
-  isFetchingNextPage,
+  contentContainerStyle,
   data,
-  renderItem,
-  renderItemSeparator,
-  fetchNextPage,
   estimatedItemSize,
+  fetchNextPage,
+  handleScroll,
+  hideLoadingWheel,
+  isFetchingNextPage,
+  isOnline,
   keyExtractor,
   layout,
-  contentContainerStyle,
   numColumns,
-  status
+  renderItem,
+  renderItemSeparator,
+  status,
+  testID
 }: Props ): Node => {
   const { t } = useTranslation( );
 
-  const renderFooter = ( ) => (
+  const renderFooter = useCallback( ( ) => (
     <InfiniteScrollLoadingWheel
-      isFetchingNextPage={isFetchingNextPage}
+      hideLoadingWheel={hideLoadingWheel}
       layout={layout}
+      explore
+      isOnline={isOnline}
     />
-  );
+  ), [hideLoadingWheel, layout, isOnline] );
 
-  if ( !data || data.length === 0 ) {
-    return (
-      <View className="flex-1 justify-center items-center">
-        {status === "loading"
-          ? (
-            <ActivityIndicator size="large" />
-          )
-          : <Body3>{t( "No-results-found" )}</Body3>}
-      </View>
-    );
-  }
+  const renderEmptyComponent = useCallback( ( ) => (
+    <View className="flex-1 justify-center items-center">
+      {status === "loading"
+        ? (
+          <ActivityIndicator size="large" testID="ExploreFlashList.loading" />
+        )
+        : <Body3>{t( "No-results-found" )}</Body3>}
+    </View>
+  ), [status, t] );
+
+  const renderHeader = useCallback( ( ) => <View className="mt-[180px]" />, [] );
 
   return (
-    <View className="h-full mt-[180px]">
-      <AnimatedFlashList
-        contentContainerStyle={contentContainerStyle}
-        data={data}
-        estimatedItemSize={estimatedItemSize}
-        testID={testID}
-        horizontal={false}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-        ItemSeparatorComponent={renderItemSeparator}
-        ListFooterComponent={renderFooter}
-        initialNumToRender={5}
-        onEndReached={fetchNextPage}
-        onEndReachedThreshold={1}
-        refreshing={isFetchingNextPage}
-        onScroll={handleScroll}
-        accessible
-        numColumns={numColumns}
-      />
-    </View>
+    <AnimatedFlashList
+      contentContainerStyle={contentContainerStyle}
+      data={data}
+      estimatedItemSize={estimatedItemSize}
+      testID={testID}
+      horizontal={false}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ItemSeparatorComponent={renderItemSeparator}
+      ListFooterComponent={renderFooter}
+      ListEmptyComponent={renderEmptyComponent}
+      initialNumToRender={5}
+      onEndReached={fetchNextPage}
+      onEndReachedThreshold={1}
+      refreshing={isFetchingNextPage}
+      onScroll={handleScroll}
+      accessible
+      numColumns={numColumns}
+      ListHeaderComponent={renderHeader}
+    />
   );
 };
 

--- a/src/components/Explore/Header.js
+++ b/src/components/Explore/Header.js
@@ -80,7 +80,15 @@ const Header = ( {
   );
 
   return (
-    <View className="z-10 top-0 absolute w-full">
+    <View
+      className="z-10 top-0 absolute w-full"
+      onLayout={event => {
+        const {
+          height
+        } = event.nativeEvent.layout;
+        setHeightAboveFilters( height );
+      }}
+    >
       <Surface
         style={surfaceStyle}
         className="h-[175px]"
@@ -91,12 +99,7 @@ const Header = ( {
         >
           <View
             className="flex-row justify-between align-center"
-            onLayout={event => {
-              const {
-                height
-              } = event.nativeEvent.layout;
-              setHeightAboveFilters( height );
-            }}
+
           >
             <Button
               text={exploreViewButtonText}

--- a/src/components/Explore/IdentifiersView.js
+++ b/src/components/Explore/IdentifiersView.js
@@ -10,24 +10,26 @@ import { useInfiniteScroll, useTranslation } from "sharedHooks";
 import ExploreFlashList from "./ExploreFlashList";
 
 type Props = {
-  setHeaderRight: Function,
   handleScroll: Function,
-  queryParams: Object
+  isOnline: boolean,
+  queryParams: Object,
+  setHeaderRight: Function
 };
 
 const IdentifiersView = ( {
-  setHeaderRight,
   handleScroll,
-  queryParams
+  isOnline,
+  queryParams,
+  setHeaderRight
 }: Props ): Node => {
   const { t } = useTranslation( );
 
   const {
     data,
-    isFetchingNextPage,
     fetchNextPage,
-    totalResults,
-    status
+    isFetchingNextPage,
+    status,
+    totalResults
   } = useInfiniteScroll(
     "fetchIdentifiers",
     fetchIdentifiers,
@@ -58,16 +60,18 @@ const IdentifiersView = ( {
 
   return (
     <ExploreFlashList
-      testID="ExploreIdentifiersAnimatedList"
-      handleScroll={handleScroll}
-      isFetchingNextPage={isFetchingNextPage}
       data={data}
+      estimatedItemSize={98}
+      fetchNextPage={fetchNextPage}
+      handleScroll={handleScroll}
+      hideLoadingWheel={!isFetchingNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      isOnline={isOnline}
+      keyExtractor={item => item.user.id}
       renderItem={renderItem}
       renderItemSeparator={renderItemSeparator}
-      fetchNextPage={fetchNextPage}
-      estimatedItemSize={98}
-      keyExtractor={item => item.user.id}
       status={status}
+      testID="ExploreIdentifiersAnimatedList"
     />
   );
 };

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -2,11 +2,12 @@
 
 import {
   Map,
-  ObservationsFlashList
+  ObservationsFlashList,
+  ViewWrapper
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React from "react";
+import React, { useCallback } from "react";
 import { useInfiniteObservationsScroll, useIsConnected } from "sharedHooks";
 
 type Props = {
@@ -37,6 +38,8 @@ const ObservationsView = ( {
     tileMapParams.place_id = exploreParams?.place_id;
   }
 
+  const renderHeader = useCallback( ( ) => <View className="mt-[180px]" />, [] );
+
   return observationsView === "map"
     ? (
       <Map
@@ -51,7 +54,7 @@ const ObservationsView = ( {
       />
     )
     : (
-      <View className="h-full mt-[180px]">
+      <ViewWrapper>
         <ObservationsFlashList
           isFetchingNextPage={isFetchingNextPage}
           layout={observationsView}
@@ -62,8 +65,10 @@ const ObservationsView = ( {
           status={status}
           isOnline={isOnline}
           explore
+          hideLoadingWheel={!isFetchingNextPage}
+          renderHeader={renderHeader}
         />
-      </View>
+      </ViewWrapper>
     );
 };
 

--- a/src/components/Explore/ObserversView.js
+++ b/src/components/Explore/ObserversView.js
@@ -10,15 +10,17 @@ import { useInfiniteScroll, useTranslation } from "sharedHooks";
 import ExploreFlashList from "./ExploreFlashList";
 
 type Props = {
-  setHeaderRight: Function,
   handleScroll: Function,
-  queryParams: Object
+  isOnline: boolean,
+  queryParams: Object,
+  setHeaderRight: Function
 };
 
 const ObserversView = ( {
-  setHeaderRight,
   handleScroll,
-  queryParams
+  isOnline,
+  queryParams,
+  setHeaderRight
 }: Props ): Node => {
   const { t } = useTranslation( );
   const {
@@ -56,16 +58,18 @@ const ObserversView = ( {
 
   return (
     <ExploreFlashList
-      testID="ExploreObserversAnimatedList"
-      handleScroll={handleScroll}
-      isFetchingNextPage={isFetchingNextPage}
       data={data}
+      estimatedItemSize={98}
+      fetchNextPage={fetchNextPage}
+      handleScroll={handleScroll}
+      hideLoadingWheel={!isFetchingNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      isOnline={isOnline}
+      keyExtractor={item => item.user.id}
       renderItem={renderItem}
       renderItemSeparator={renderItemSeparator}
-      fetchNextPage={fetchNextPage}
-      estimatedItemSize={98}
-      keyExtractor={item => item.user.id}
       status={status}
+      testID="ExploreObserversAnimatedList"
     />
   );
 };

--- a/src/components/MyObservations/InfiniteScrollLoadingWheel.js
+++ b/src/components/MyObservations/InfiniteScrollLoadingWheel.js
@@ -9,20 +9,22 @@ import { ActivityIndicator } from "react-native";
 import { useTranslation } from "sharedHooks";
 
 type Props = {
-  isFetchingNextPage?: boolean,
-  currentUser?: ?Object,
   layout?: string,
-  isOnline?: boolean
+  isOnline?: boolean,
+  hideLoadingWheel: boolean,
+  explore: boolean
 }
 
 const InfiniteScrollLoadingWheel = ( {
-  isFetchingNextPage, currentUser, layout, isOnline
+  hideLoadingWheel, layout, isOnline, explore
 }: Props ): Node => {
   const { t } = useTranslation( );
 
-  const loadingWheelClass = "h-64 py-16";
-  if ( !isFetchingNextPage || !currentUser ) {
-    return <View className={loadingWheelClass} />;
+  const loadingWheelClass = explore
+    ? "h-[128px] py-16"
+    : "h-64 py-16";
+  if ( hideLoadingWheel ) {
+    return <View className={loadingWheelClass} testID="InfiniteScrollLoadingWheel.footerView" />;
   }
   return (
     <View className={classnames( loadingWheelClass, {
@@ -35,7 +37,7 @@ const InfiniteScrollLoadingWheel = ( {
             {t( "An-Internet-connection-is-required" )}
           </Body3>
         )
-        : <ActivityIndicator />}
+        : <ActivityIndicator testID="InfiniteScrollLoadingWheel.loading" />}
     </View>
   );
 };

--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -99,7 +99,6 @@ const MyObservations = ( {
               isFetchingNextPage={isFetchingNextPage}
               layout={layout}
               onEndReached={onEndReached}
-              currentUser={currentUser}
               testID="MyObservationsAnimatedList"
               handleScroll={handleScroll}
               renderEmptyList={renderEmptyList}
@@ -108,6 +107,7 @@ const MyObservations = ( {
               isOnline={isOnline}
               uploadSingleObservation={uploadSingleObservation}
               uploadState={uploadState}
+              hideLoadingWheel={!isFetchingNextPage || !currentUser}
             />
           </StickyView>
         </View>

--- a/tests/unit/components/Explore/IdentifiersView.test.js
+++ b/tests/unit/components/Explore/IdentifiersView.test.js
@@ -1,0 +1,86 @@
+import { screen } from "@testing-library/react-native";
+import ExploreFlashList from "components/Explore/ExploreFlashList";
+import initI18next from "i18n/initI18next";
+import React from "react";
+
+import factory from "../../../factory";
+import { renderComponent } from "../../../helpers/render";
+
+const mockIdentifiers = [factory( "RemoteUser" ), factory( "RemoteUser" )];
+
+jest.mock( "sharedHooks/useInfiniteScroll", () => ( {
+  __esModule: true,
+  default: () => ( {
+    data: mockIdentifiers,
+    isFetchingNextPage: true
+  } )
+} ) );
+
+describe( "IdentifiersView", () => {
+  beforeAll( async ( ) => {
+    await initI18next( );
+  } );
+
+  it( "should show a footer loading wheel when new identifiers are fetched", ( ) => {
+    renderComponent(
+      <ExploreFlashList
+        hideLoadingWheel={false}
+        isOnline
+      />
+    );
+
+    const loadingWheel = screen.getByTestId( "InfiniteScrollLoadingWheel.loading" );
+    expect( loadingWheel ).toBeVisible( );
+  } );
+
+  it( "should show no internet text when user is offline", ( ) => {
+    renderComponent(
+      <ExploreFlashList
+        hideLoadingWheel={false}
+        isOnline={false}
+      />
+    );
+
+    const noInternet = screen.getByText( /An Internet connection is required/ );
+    expect( noInternet ).toBeVisible( );
+  } );
+
+  it( "should show a footer view when loading wheel is hidden", ( ) => {
+    renderComponent(
+      <ExploreFlashList
+        hideLoadingWheel
+        isOnline
+      />
+    );
+
+    const footerView = screen.getByTestId( "InfiniteScrollLoadingWheel.footerView" );
+    expect( footerView ).toBeVisible( );
+  } );
+
+  it( "should show loading wheel before initial data loads", ( ) => {
+    renderComponent(
+      <ExploreFlashList
+        hideLoadingWheel
+        isOnline
+        data={[]}
+        status="loading"
+      />
+    );
+
+    const initialLoading = screen.getByTestId( "ExploreFlashList.loading" );
+    expect( initialLoading ).toBeVisible( );
+  } );
+
+  it( "should show no results text when no data is found", ( ) => {
+    renderComponent(
+      <ExploreFlashList
+        hideLoadingWheel
+        isOnline
+        data={[]}
+      />
+    );
+
+    const noResultsText = screen.getByText( /No results found/ );
+    expect( noResultsText ).toBeVisible( );
+  } );
+} );

--- a/tests/unit/components/Explore/ObservationsView.test.js
+++ b/tests/unit/components/Explore/ObservationsView.test.js
@@ -1,0 +1,87 @@
+import { screen } from "@testing-library/react-native";
+import ObservationsFlashList
+  from "components/SharedComponents/ObservationsFlashList/ObservationsFlashList";
+import initI18next from "i18n/initI18next";
+import React from "react";
+
+import { renderComponent } from "../../../helpers/render";
+
+const mockOnEndReached = jest.fn( );
+
+jest.mock( "sharedHooks/useInfiniteObservationsScroll", () => ( {
+  __esModule: true,
+  default: () => ( {
+    data: [],
+    isFetchingNextPage: true,
+    fetchNextPage: mockOnEndReached
+  } )
+} ) );
+
+describe( "ObservationsView", () => {
+  beforeAll( async ( ) => {
+    await initI18next( );
+  } );
+
+  it( "should show a footer loading wheel when new observations are fetched", ( ) => {
+    renderComponent(
+      <ObservationsFlashList
+        hideLoadingWheel={false}
+        isOnline
+      />
+    );
+
+    const loadingWheel = screen.getByTestId( "InfiniteScrollLoadingWheel.loading" );
+    expect( loadingWheel ).toBeVisible( );
+  } );
+
+  it( "should show no internet text when user is offline", ( ) => {
+    renderComponent(
+      <ObservationsFlashList
+        hideLoadingWheel={false}
+        isOnline={false}
+      />
+    );
+
+    const noInternet = screen.getByText( /An Internet connection is required/ );
+    expect( noInternet ).toBeVisible( );
+  } );
+
+  it( "should show a footer view when loading wheel is hidden", ( ) => {
+    renderComponent(
+      <ObservationsFlashList
+        hideLoadingWheel
+        isOnline
+      />
+    );
+
+    const footerView = screen.getByTestId( "InfiniteScrollLoadingWheel.footerView" );
+    expect( footerView ).toBeVisible( );
+  } );
+
+  it( "should show loading wheel before initial data loads", ( ) => {
+    renderComponent(
+      <ObservationsFlashList
+        hideLoadingWheel
+        isOnline
+        data={[]}
+        status="loading"
+      />
+    );
+
+    const initialLoading = screen.getByTestId( "ObservationsFlashList.loading" );
+    expect( initialLoading ).toBeVisible( );
+  } );
+
+  it( "should show no results text when no data is found", ( ) => {
+    renderComponent(
+      <ObservationsFlashList
+        hideLoadingWheel
+        isOnline
+        data={[]}
+      />
+    );
+
+    const noResultsText = screen.getByText( /No results found/ );
+    expect( noResultsText ).toBeVisible( );
+  } );
+} );


### PR DESCRIPTION
Closes #888

- shows infinite loading wheel on all explore view screens and MyObservations screen
- adds tests to check for loading wheel, empty state, no internet state
- refactoring for Explore screen based on MyObservations -- uses StickyView component to animate Explore header while scrolling, uses ListHeaderComponent and ListEmptyComponent, simplifies grid item calculations in SpeciesView