### PR TITLE
Fix for failing e2e tests when UTC is tomorrow relative to PST

### DIFF
--- a/src/sharedHelpers/fetchUserLocation.e2e-mock
+++ b/src/sharedHelpers/fetchUserLocation.e2e-mock
@@ -6,8 +6,16 @@ type UserLocation = {
 }
 const fetchUserLocation = async ( ): Promise<UserLocation> => new Promise( resolve => {
   setTimeout( ( ) => resolve( {
-    latitude: 37.7749,
-    longitude: -122.4194,
+    // Chuck's house. Note that the e2e tests run in a UTC environment, so the
+    // observed_on_string will be set to a UTC time. If these coordinates do
+    // fall within that time zone west of that (i.e. in the past),
+    // observation creation will fail during the period of the day when UTC
+    // time has crossed into the date after the date at these coordinates.
+    // The opposite (when local time is in a time zone behind the time zone of
+    // the coordinates) will not fail, but it might make an observation
+    // that's a day behind when you were expecting.
+    latitude: 51.3313127,
+    longitude: 0.0509862,
     positional_accuracy: 5
   } ), 1000 );
 } );


### PR DESCRIPTION
Our CI e2e tests were consistently failing in late afternoon PT, even though they passed locally. Seems that was because our e2e tests were mocking the current location as San Francisco, but the Github Actions runners are set to UTC, so for that part of the day when UTC is a day in the future relative to PST, the tests were failing because they were submitting observations with dates in UTC and locations in PST. The server sets the time zone based on the coordinates, so it was interpreting that UTC date as PST, and since it was in the future, it was failing. The e2e test would then tap on the observation and expect to see ObsDetail, but since the upload failed, it landed on ObsEdit and stalled.