### PR TITLE
Dark mode styling button changes

### DIFF
--- a/src/components/SharedComponents/Buttons/Button.js
+++ b/src/components/SharedComponents/Buttons/Button.js
@@ -96,15 +96,12 @@ const setStyles = ( {
 const setDarkStyles = ( {
   buttonClasses,
   textClasses,
-  isWarning,
   isPrimary,
   isFocus,
   disabled,
   forceDark
 } ) => {
-  if ( isWarning ) {
-    console.log( "nothing to add here" );
-  } else if ( isPrimary ) {
+  if ( isPrimary ) {
     buttonClasses.push(
       disabled
         ? ""
@@ -123,17 +120,6 @@ const setDarkStyles = ( {
           : ""
       );
     }
-  } else {
-    buttonClasses.push(
-      disabled
-        ? "dark:border-lightGray"
-        : "dark:border-white dark:bg-darkGray"
-    );
-    textClasses.push(
-      disabled
-        ? "dark:text-lightGray"
-        : "dark:text-white"
-    );
   }
 };
 
@@ -183,6 +169,7 @@ const Button = ( {
     isWarning,
     ignoreDark
   } );
+  // Dark mode styles can be set with this function, but si scheduled to be worked on post-MVP
   setDarkStyles( {
     buttonClasses,
     textClasses,

--- a/src/components/SharedComponents/Buttons/Button.js
+++ b/src/components/SharedComponents/Buttons/Button.js
@@ -61,10 +61,10 @@ const setStyles = ( {
   } else if ( isPrimary ) {
     buttonClasses.push( disabled
       ? "bg-darkGrayDisabled"
-      : "bg-darkGray dark:bg-white" );
+      : "bg-darkGray" );
     textClasses.push( disabled
-      ? "text-white/50 dark:text-darkGray/50"
-      : "text-white dark:text-darkGray" );
+      ? "text-white/50"
+      : "text-white" );
   } else if ( isFocus ) {
     if ( forceDark ) {
       buttonClasses.push( disabled
@@ -72,7 +72,7 @@ const setStyles = ( {
         : "bg-inatGreen" );
     } else {
       buttonClasses.push( disabled
-        ? "bg-inatGreenDisabled dark:bg-inatGreenDisabledDark"
+        ? "bg-inatGreenDisabled"
         : "bg-inatGreen" );
     }
   } else {
@@ -82,15 +82,59 @@ const setStyles = ( {
       textClasses.push( "text-darkGray" );
     } else {
       buttonClasses.push( disabled
-        ? "border-darkGrayDisabled dark:border-lightGray"
-        : "border-darkGray dark:border-white bg-white dark:bg-darkGray" );
+        ? "border-darkGrayDisabled"
+        : "border-darkGray bg-white" );
       textClasses.push( disabled
-        ? "text-darkGrayDisabled dark:text-lightGray"
-        : "text-darkGray dark:text-white" );
+        ? "text-darkGrayDisabled"
+        : "text-darkGray" );
     }
   }
 
   return { buttonClasses, textClasses };
+};
+
+const setDarkStyles = ( {
+  buttonClasses,
+  textClasses,
+  isWarning,
+  isPrimary,
+  isFocus,
+  disabled,
+  forceDark
+} ) => {
+  if ( isWarning ) {
+    console.log( "nothing to add here" );
+  } else if ( isPrimary ) {
+    buttonClasses.push(
+      disabled
+        ? ""
+        : "dark:bg-white"
+    );
+    textClasses.push(
+      disabled
+        ? "dark:text-darkGray/50"
+        : "dark:text-darkGray"
+    );
+  } else if ( isFocus ) {
+    if ( !forceDark ) {
+      buttonClasses.push(
+        disabled
+          ? "dark:bg-inatGreenDisabledDark"
+          : ""
+      );
+    }
+  } else {
+    buttonClasses.push(
+      disabled
+        ? "dark:border-lightGray"
+        : "dark:border-white dark:bg-darkGray"
+    );
+    textClasses.push(
+      disabled
+        ? "dark:text-lightGray"
+        : "dark:text-white"
+    );
+  }
 };
 
 const activityIndicatorColor = ( {
@@ -138,6 +182,15 @@ const Button = ( {
     isPrimary,
     isWarning,
     ignoreDark
+  } );
+  setDarkStyles( {
+    buttonClasses,
+    textClasses,
+    isWarning,
+    isPrimary,
+    isFocus,
+    disabled,
+    forceDark
   } );
 
   const theme = useTheme();

--- a/tests/unit/components/SharedComponents/Buttons/Button.dark.test.js
+++ b/tests/unit/components/SharedComponents/Buttons/Button.dark.test.js
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react-native";
+import { Button } from "components/SharedComponents";
+import React from "react";
+
+// Mock Appearance.getColorScheme()
+jest.mock( "react-native/Libraries/Utilities/Appearance", () => {
+  const actualAppearance = jest.requireActual( "react-native/Libraries/Utilities/Appearance" );
+  return {
+    ...actualAppearance,
+    getColorScheme: jest.fn( () => "dark" )
+  };
+} );
+
+// Mock nativewind useColorScheme()
+jest.mock( "nativewind", () => {
+  const actualNativewind = jest.requireActual( "nativewind" );
+  return {
+    ...actualNativewind,
+    useColorScheme: jest.fn( () => ( { colorScheme: "dark" } ) )
+  };
+} );
+
+describe.each( [["primary"], ["warning"], ["focus"], ["neutral"]] )(
+  "Button %s in dark mode",
+  level => {
+    it( "should render correctly", () => {
+      render( <Button level={level} text={`${level.toUpperCase()} BUTTON`} /> );
+
+      // Snapshot test
+      expect( screen ).toMatchSnapshot();
+    } );
+
+    it( "has no accessibility errors", () => {
+      const button = <Button level={level} text={`${level.toUpperCase()} BUTTON`} />;
+
+      expect( button ).toBeAccessible();
+    } );
+
+    describe( "when disabled", () => {
+      it( "should render correctly", () => {
+        render( <Button level={level} text={`${level.toUpperCase()} DISABLED`} disabled /> );
+
+        // Snapshot test
+        expect( screen ).toMatchSnapshot();
+      } );
+
+      it( "has no accessibility errors", () => {
+        const button = (
+          <Button level={level} text={`${level.toUpperCase()} DISABLED`} disabled />
+        );
+
+        expect( button ).toBeAccessible();
+      } );
+    } );
+  }
+);

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
@@ -1,0 +1,943 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button focus in dark mode should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "backgroundColor": "#74AC00",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "#ffffff",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    FOCUS BUTTON
+  </Text>
+</View>
+`;
+
+exports[`Button focus in dark mode when disabled should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "backgroundColor": "#B9D580",
+        },
+        {
+          "backgroundColor": "#3A5600",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "rgba(255, 255, 255, 0.5)",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    FOCUS DISABLED
+  </Text>
+</View>
+`;
+
+exports[`Button neutral in dark mode should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "borderBottomWidth": 1,
+          "borderLeftWidth": 1,
+          "borderRightWidth": 1,
+          "borderTopWidth": 1,
+        },
+        {
+          "borderBottomWidth": 3,
+          "borderLeftWidth": 3,
+          "borderRightWidth": 3,
+          "borderTopWidth": 3,
+        },
+        {
+          "borderBottomColor": "#454545",
+          "borderLeftColor": "#454545",
+          "borderRightColor": "#454545",
+          "borderTopColor": "#454545",
+        },
+        {
+          "borderBottomColor": "#ffffff",
+          "borderLeftColor": "#ffffff",
+          "borderRightColor": "#ffffff",
+          "borderTopColor": "#ffffff",
+        },
+        {
+          "backgroundColor": "#ffffff",
+        },
+        {
+          "backgroundColor": "#454545",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "#ffffff",
+              },
+              {
+                "color": "#454545",
+              },
+              {
+                "color": "#ffffff",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    NEUTRAL BUTTON
+  </Text>
+</View>
+`;
+
+exports[`Button neutral in dark mode when disabled should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "borderBottomWidth": 1,
+          "borderLeftWidth": 1,
+          "borderRightWidth": 1,
+          "borderTopWidth": 1,
+        },
+        {
+          "borderBottomWidth": 3,
+          "borderLeftWidth": 3,
+          "borderRightWidth": 3,
+          "borderTopWidth": 3,
+        },
+        {
+          "borderBottomColor": "#828181",
+          "borderLeftColor": "#828181",
+          "borderRightColor": "#828181",
+          "borderTopColor": "#828181",
+        },
+        {
+          "borderBottomColor": "#E8E8E8",
+          "borderLeftColor": "#E8E8E8",
+          "borderRightColor": "#E8E8E8",
+          "borderTopColor": "#E8E8E8",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "rgba(255, 255, 255, 0.5)",
+              },
+              {
+                "color": "#828181",
+              },
+              {
+                "color": "#E8E8E8",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    NEUTRAL DISABLED
+  </Text>
+</View>
+`;
+
+exports[`Button primary in dark mode should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "backgroundColor": "#454545",
+        },
+        {
+          "backgroundColor": "#ffffff",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "#ffffff",
+              },
+              {
+                "color": "#ffffff",
+              },
+              {
+                "color": "#454545",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    PRIMARY BUTTON
+  </Text>
+</View>
+`;
+
+exports[`Button primary in dark mode when disabled should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "backgroundColor": "#828181",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "rgba(255, 255, 255, 0.5)",
+              },
+              {
+                "color": "rgba(255, 255, 255, 0.5)",
+              },
+              {
+                "color": "rgba(69, 69, 69, 0.5)",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    PRIMARY DISABLED
+  </Text>
+</View>
+`;
+
+exports[`Button warning in dark mode should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": false,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "backgroundColor": "#9B1010",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "#ffffff",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    WARNING BUTTON
+  </Text>
+</View>
+`;
+
+exports[`Button warning in dark mode when disabled should render correctly 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "alignItems": "center",
+        },
+        {
+          "justifyContent": "center",
+        },
+        {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        },
+        {
+          "paddingBottom": 13,
+          "paddingTop": 13,
+        },
+        {
+          "borderBottomLeftRadius": 8,
+          "borderBottomRightRadius": 8,
+          "borderTopLeftRadius": 8,
+          "borderTopRightRadius": 8,
+        },
+        {
+          "backgroundColor": "#b06365",
+        },
+      ],
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Medium",
+        },
+        [
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 18,
+            },
+            {
+              "lineHeight": 19,
+            },
+            {
+              "fontWeight": "600",
+            },
+            {
+              "letterSpacing": 2,
+            },
+            {
+              "color": "#454545",
+            },
+            [
+              {
+                "textAlign": "center",
+              },
+              {
+                "color": "rgba(255, 255, 255, 0.5)",
+              },
+            ],
+          ],
+        ],
+      ]
+    }
+    testID="RNButton.text"
+  >
+    WARNING DISABLED
+  </Text>
+</View>
+`;

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
@@ -298,15 +298,6 @@ exports[`Button neutral in dark mode should render correctly 1`] = `
         {
           "backgroundColor": "#ffffff",
         },
-        {
-          "borderBottomColor": "#ffffff",
-          "borderLeftColor": "#ffffff",
-          "borderRightColor": "#ffffff",
-          "borderTopColor": "#ffffff",
-        },
-        {
-          "backgroundColor": "#454545",
-        },
       ],
     ]
   }
@@ -344,9 +335,6 @@ exports[`Button neutral in dark mode should render correctly 1`] = `
               },
               {
                 "color": "#454545",
-              },
-              {
-                "color": "#ffffff",
               },
             ],
           ],
@@ -436,12 +424,6 @@ exports[`Button neutral in dark mode when disabled should render correctly 1`] =
           "borderRightColor": "#828181",
           "borderTopColor": "#828181",
         },
-        {
-          "borderBottomColor": "#E8E8E8",
-          "borderLeftColor": "#E8E8E8",
-          "borderRightColor": "#E8E8E8",
-          "borderTopColor": "#E8E8E8",
-        },
       ],
     ]
   }
@@ -479,9 +461,6 @@ exports[`Button neutral in dark mode when disabled should render correctly 1`] =
               },
               {
                 "color": "#828181",
-              },
-              {
-                "color": "#E8E8E8",
               },
             ],
           ],

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
@@ -296,13 +296,13 @@ exports[`Button neutral in dark mode should render correctly 1`] = `
           "borderTopColor": "#454545",
         },
         {
+          "backgroundColor": "#ffffff",
+        },
+        {
           "borderBottomColor": "#ffffff",
           "borderLeftColor": "#ffffff",
           "borderRightColor": "#ffffff",
           "borderTopColor": "#ffffff",
-        },
-        {
-          "backgroundColor": "#ffffff",
         },
         {
           "backgroundColor": "#454545",


### PR DESCRIPTION
The current designs do (no longer?) have designs for dark mode for the neutral button. So, I have removed the dark mode styling for the neutral button from the app. This also closes #755.
I did add a snapshot test for dark mode buttons, even though we don't have overall designs on how a dark mode would look throughout the entire app. I have added the test to do TDD for this issue, and since now we have the test I would just leave it in as is.