### PR TITLE
Image recognition from local image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26716,7 +26716,7 @@
     },
     "node_modules/vision-camera-plugin-inatvision": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#144b33c5b9ac7f6b0aa96d910a2dccd8fd6f5364",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#350639f718fe0b5e14c8a7c0bb53cb7ecf929a4b",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -46623,7 +46623,7 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#144b33c5b9ac7f6b0aa96d910a2dccd8fd6f5364",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#350639f718fe0b5e14c8a7c0bb53cb7ecf929a4b",
       "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#image-prediction-from-file",
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "reassure": "^0.10.1",
         "sanitize-html": "^2.11.0",
         "use-debounce": "^9.0.4",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#2a08e232f4afec955b91a18e81d333355028b874",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#image-prediction-from-file",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -26716,8 +26716,7 @@
     },
     "node_modules/vision-camera-plugin-inatvision": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#2a08e232f4afec955b91a18e81d333355028b874",
-      "integrity": "sha512-4nFV/lT6VhqUjGE1pPbwI+swjsvi+AU+/eDDAsJdCUOlX9p+/0z2ldeq8nU9XXEpsyk51SXgn+j+yipxhr8J1w==",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#144b33c5b9ac7f6b0aa96d910a2dccd8fd6f5364",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -46624,9 +46623,8 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#2a08e232f4afec955b91a18e81d333355028b874",
-      "integrity": "sha512-4nFV/lT6VhqUjGE1pPbwI+swjsvi+AU+/eDDAsJdCUOlX9p+/0z2ldeq8nU9XXEpsyk51SXgn+j+yipxhr8J1w==",
-      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#2a08e232f4afec955b91a18e81d333355028b874",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#144b33c5b9ac7f6b0aa96d910a2dccd8fd6f5364",
+      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#image-prediction-from-file",
       "requires": {}
     },
     "vlq": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "reassure": "^0.10.1",
     "sanitize-html": "^2.11.0",
     "use-debounce": "^9.0.4",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#2a08e232f4afec955b91a18e81d333355028b874",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#image-prediction-from-file",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/src/components/Camera/ARCamera/FrameProcessorCamera.js
+++ b/src/components/Camera/ARCamera/FrameProcessorCamera.js
@@ -5,7 +5,6 @@ import React, {
   useEffect
 } from "react";
 import { Platform } from "react-native";
-import Config from "react-native-config";
 import * as REA from "react-native-reanimated";
 import {
   // react-native-vision-camera v3
@@ -14,7 +13,7 @@ import {
 } from "react-native-vision-camera";
 // react-native-vision-camera v3
 // import { Worklets } from "react-native-worklets-core";
-import { modelPath, taxonomyPath } from "sharedHelpers/cvModel";
+import { modelPath, modelVersion, taxonomyPath } from "sharedHelpers/cvModel";
 import { useDeviceOrientation } from "sharedHooks";
 import * as InatVision from "vision-camera-plugin-inatvision";
 
@@ -33,7 +32,6 @@ type Props = {
   takingPhoto: boolean,
 };
 
-const version = Config.CV_MODEL_VERSION;
 // Johannes: when I copied over the native code from the legacy react-native-camera on Android
 // this value had to be a string. On iOS I changed the API to also accept a string (was number).
 // Maybe, the intention would look clearer if we refactor to use a number here.
@@ -90,7 +88,7 @@ const FrameProcessorCamera = ( {
       // Reminder: this is a worklet, running on the UI thread.
       try {
         const results = InatVision.inatVision( frame, {
-          version,
+          version: modelVersion,
           modelPath,
           taxonomyPath,
           confidenceThreshold
@@ -120,7 +118,7 @@ const FrameProcessorCamera = ( {
       //   }
       // } );
     },
-    [version, confidenceThreshold, takingPhoto, deviceOrientation]
+    [modelVersion, confidenceThreshold, takingPhoto, deviceOrientation]
   );
 
   return (

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -9,12 +9,14 @@ import React, {
   useEffect, useState
 } from "react";
 import Identification from "realmModels/Identification";
+import { modelPath, taxonomyPath } from "sharedHelpers/cvModel";
 import flattenUploadParams from "sharedHelpers/flattenUploadParams";
 import {
   useAuthenticatedQuery,
   useLocalObservation
 } from "sharedHooks";
 import useStore from "stores/useStore";
+import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
 
 import Suggestions from "./Suggestions";
 
@@ -39,6 +41,15 @@ const SuggestionsContainer = ( ): Node => {
 
   const [loading, setLoading] = useState( false );
   const navigation = useNavigation();
+
+  getPredictionsForImage( {
+    uri: photoEvidenceUris[0],
+    modelPath,
+    taxonomyPath,
+    version: "2.4"
+  } ).then( predictions => {
+    console.log( "predictions :>> ", predictions );
+  } );
 
   useEffect( ( ) => {
     // If the photos are different, we need to display different photos

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -9,14 +9,13 @@ import React, {
   useEffect, useState
 } from "react";
 import Identification from "realmModels/Identification";
-import { modelPath, taxonomyPath } from "sharedHelpers/cvModel";
+import { predictImage } from "sharedHelpers/cvModel";
 import flattenUploadParams from "sharedHelpers/flattenUploadParams";
 import {
   useAuthenticatedQuery,
   useLocalObservation
 } from "sharedHooks";
 import useStore from "stores/useStore";
-import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
 
 import Suggestions from "./Suggestions";
 
@@ -42,14 +41,15 @@ const SuggestionsContainer = ( ): Node => {
   const [loading, setLoading] = useState( false );
   const navigation = useNavigation();
 
-  getPredictionsForImage( {
-    uri: photoEvidenceUris[0],
-    modelPath,
-    taxonomyPath,
-    version: "2.4"
-  } ).then( predictions => {
-    console.log( "predictions :>> ", predictions );
-  } );
+  // TODO: this block makes a prediction whenever the selected photo changes.
+  console.log( "selectedPhotoUri :>> ", selectedPhotoUri );
+  predictImage( selectedPhotoUri )
+    .then( predictions => {
+      console.log( "predictions :>> ", predictions );
+    } )
+    .catch( e => {
+      console.log( "e :>> ", e );
+    } );
 
   useEffect( ( ) => {
     // If the photos are different, we need to display different photos

--- a/src/sharedHelpers/cvModel.js
+++ b/src/sharedHelpers/cvModel.js
@@ -30,6 +30,8 @@ export const taxonomyPath: string = Platform.select( {
   android: `${RNFS.DocumentDirectoryPath}/${modelFiles.ANDROIDTAXONOMY}`
 } );
 
+export const modelVersion = Config.CV_MODEL_VERSION;
+
 const addCameraFilesAndroid = () => {
   const copyFilesAndroid = ( source, destination ) => {
     RNFS.copyFileAssets( source, destination )

--- a/src/sharedHelpers/cvModel.js
+++ b/src/sharedHelpers/cvModel.js
@@ -3,6 +3,7 @@ import i18next from "i18next";
 import { Alert, Platform } from "react-native";
 import Config from "react-native-config";
 import RNFS from "react-native-fs";
+import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
 
 import { log } from "../../react-native-logs.config";
 
@@ -31,6 +32,13 @@ export const taxonomyPath: string = Platform.select( {
 } );
 
 export const modelVersion = Config.CV_MODEL_VERSION;
+
+export const predictImage = ( uri: string ): Promise<Object> => getPredictionsForImage( {
+  uri,
+  modelPath,
+  taxonomyPath,
+  version: modelVersion
+} );
 
 const addCameraFilesAndroid = () => {
   const copyFilesAndroid = ( source, destination ) => {

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -19,7 +19,10 @@ import {
   mockUseCameraDevices
 } from "./vision-camera/vision-camera";
 
-jest.mock( "vision-camera-plugin-inatvision" );
+jest.mock( "vision-camera-plugin-inatvision", () => ( {
+  getPredictionsForImage: jest.fn( () => Promise.resolve( "Mocked cv prediction" ) )
+} ) );
+
 jest.mock( "react-native-worklets-core", () => ( {
   Worklets: {
     createRunInJsFn: jest.fn()


### PR DESCRIPTION
This PR adds an example usage of the function exposed from the vision-camera plugin to predict an image from disk.

package.json and -lock have a reference to the branch of the VCPlugin that exposes the function.

I have put a demo call of the function in the SuggestionsContainer. It runs on every render which is not the correct place for sure but it works every time the user changes the selected photo which is promising.

Android does not work. The error thrown is suggesting that the native side can not get the bitmap (It does work in Seek though and in the simple example app in the vision-plugin itself, so the problem might rather be the uri we have in state for the image, and can be punted to post-MVP.)