### PR TITLE
Fix e2e android comment visibility

### DIFF
--- a/e2e/signedIn.e2e.js
+++ b/e2e/signedIn.e2e.js
@@ -96,11 +96,13 @@ describe( "Signed in user", () => {
     const commentModalSubmitButton = element( by.id( "ObsEdit.confirm" ) );
     await commentModalSubmitButton.tap();
     // Check that the comment is visible
+    await element( by.id( `ObsDetails.${uuid}` ) ).scrollTo( "bottom" );
     const comment = element( by.text( "This is a comment" ) );
     await waitFor( comment ).toBeVisible().withTimeout( 10000 );
     /*
     / 4. Delete the observation
     */
+    await element( by.id( `ObsDetails.${uuid}` ) ).scrollTo( "top" );
     const editButton = element( by.id( "ObsDetail.editButton" ) );
     await waitFor( editButton ).toBeVisible().withTimeout( 10000 );
     // Navigate to the edit screen


### PR DESCRIPTION
Needed because we added a [larger image](https://github.com/inaturalist/iNaturalistReactNative/commit/c35c2fa25eede4e8ada613b7a962e981184fda75) to the top of ObsDetails screens with no media, which sometimes pushes the comment below the fold. 