### PR TITLE
Refactor BottomSheet to always use dynamic snap points

### DIFF
--- a/src/components/Camera/StandardCamera/DiscardChangesSheet.js
+++ b/src/components/Camera/StandardCamera/DiscardChangesSheet.js
@@ -23,7 +23,6 @@ const DiscardChangesSheet = ( {
   return (
     <WarningSheet
       handleClose={( ) => setShowDiscardSheet( false )}
-      snapPoints={[180]}
       headerText={t( "DISCARD-PHOTOS" )}
       text={t( "By-exiting-your-photos-will-not-be-saved" )}
       secondButtonText={t( "CANCEL" )}

--- a/src/components/LoginSignUp/ForgotPassword.js
+++ b/src/components/LoginSignUp/ForgotPassword.js
@@ -38,7 +38,6 @@ const ForgotPassword = ( ): Node => {
           handleClose={( ) => setShowSheet( false )}
           confirm={( ) => openInbox( )}
           headerText={t( "CHECK-YOUR-EMAIL" )}
-          snapPoints={[178]}
           text={t( "If-an-account-with-that-email-exists" )}
           buttonText={t( "OPEN-EMAIL" )}
           secondButtonText={t( "BACK-TO-LOGIN" )}

--- a/src/components/MediaViewer/MediaViewer.js
+++ b/src/components/MediaViewer/MediaViewer.js
@@ -114,7 +114,6 @@ const MediaViewer = ( ): Node => {
           handleClose={hideWarningSheet}
           confirm={deletePhoto}
           headerText={t( "DISCARD-MEDIA" )}
-          snapPoints={[178]}
           buttonText={t( "DISCARD" )}
           secondButtonText={t( "CANCEL" )}
           handleSecondButtonPress={hideWarningSheet}

--- a/src/components/MyObservations/LoginSheet.js
+++ b/src/components/MyObservations/LoginSheet.js
@@ -16,7 +16,6 @@ const LoginSheet = ( { setShowLoginSheet }: Props ): Node => {
 
   return (
     <WarningSheet
-      snapPoints={[165]}
       handleClose={( ) => setShowLoginSheet( false )}
       buttonType="focus"
       headerText={t( "PLEASE-LOG-IN" )}

--- a/src/components/ObsDetails/ActivityTab/ActivityHeader.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityHeader.js
@@ -146,7 +146,6 @@ const ActivityHeader = ( {
             handleClose={() => setShowEditCommentSheet( false )}
             headerText={t( "EDIT-COMMENT" )}
             initialInput={item.body}
-            snapPoints={[416]}
             confirm={textInput => updateCommentBody( textInput )}
           />
         )}
@@ -154,7 +153,6 @@ const ActivityHeader = ( {
           <WarningSheet
             handleClose={( ) => setShowDeleteCommentSheet( false )}
             headerText={t( "DELETE-COMMENT-QUESTION" )}
-            snapPoints={[148]}
             confirm={deleteComment}
             buttonText={t( "DELETE" )}
             handleSecondButtonPress={( ) => setShowDeleteCommentSheet( false )}

--- a/src/components/ObsDetails/DataQualityAssessment.js
+++ b/src/components/ObsDetails/DataQualityAssessment.js
@@ -412,9 +412,8 @@ const DataQualityAssessment = ( ): React.Node => {
         headerText={t( "ERROR-VOTING-IN-DQA" )}
         hidden={hideErrorSheet}
         hideCloseButton
-        snapPoints={["25"]}
       >
-        <View className="px-[26px] pt-[20px] flex-col space-y-[20px]">
+        <View className="px-[26px] py-[20px] flex-col space-y-[20px]">
           <List2 className="text-black">{t( "Error-voting-in-DQA-description" )}</List2>
           <Button
             text={t( "OK" )}

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -34,7 +34,7 @@ type Props = {
   activityItems: Array<Object>,
   showActivityTab: boolean,
   onIDAgreePressed: Function,
-  showAgreeWithIdSheet: Function,
+  showAgreeWithIdSheet: boolean,
   openCommentBox: Function,
   agreeIdSheetDiscardChanges: Function,
   onAgree: Function,
@@ -127,7 +127,6 @@ const ObsDetails = ( {
           handleClose={hideCommentBox}
           headerText={t( "ADD-OPTIONAL-COMMENT" )}
           textInputStyle={textInputStyle}
-          snapPoints={[416]}
           confirm={textInput => onCommentAdded( textInput )}
         />
       )}

--- a/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
+++ b/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
@@ -10,7 +10,7 @@ import {
 import { Text, View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 type Props = {
   onAgree:Function,
@@ -35,22 +35,12 @@ const AgreeWithIDSheet = ( {
   taxon
 }: Props ): Node => {
   const [comment, setComment] = useState( "" );
-  const [snapPoint, setSnapPoint] = useState( 263 );
   const [showCommentBox, setShowCommentBox] = useState( false );
-
-  useEffect( () => {
-    if ( comment.length !== 0 ) {
-      setSnapPoint( 393 );
-    } else {
-      setSnapPoint( 263 );
-    }
-  }, [comment] );
 
   return (
     <BottomSheet
       handleClose={handleClose}
       headerText={t( "AGREE-WITH-ID" )}
-      snapPoints={[snapPoint]}
       text={t( "By-exiting-changes-not-saved" )}
       buttonText={t( "DISCARD-CHANGES" )}
     >
@@ -72,7 +62,7 @@ const AgreeWithIDSheet = ( {
         )}
         {showTaxon( taxon )}
       </View>
-      <View className="flex-row justify-evenly mx-3">
+      <View className="flex-row justify-evenly mx-3 mb-3">
         {comment
           ? (
             <Button
@@ -111,7 +101,6 @@ const AgreeWithIDSheet = ( {
         <TextInputSheet
           handleClose={( ) => setShowCommentBox( false )}
           headerText={t( "ADD-OPTIONAL-COMMENT" )}
-          snapPoints={[416]}
           confirm={textInput => setComment( textInput )}
         />
       )}

--- a/src/components/ObsDetails/Sheets/WithdrawIDSheet.js
+++ b/src/components/ObsDetails/Sheets/WithdrawIDSheet.js
@@ -34,14 +34,13 @@ const WithdrawIDSheet = ( {
   <BottomSheet
     handleClose={handleClose}
     headerText={t( "WITHDRAW-ID-QUESTION" )}
-    snapPoints={[220]}
   >
     <View
       className="mx-[26px] space-y-[11px] my-[15px]"
     >
       {showTaxon( taxon )}
     </View>
-    <View className="flex-row justify-evenly mx-3">
+    <View className="flex-row justify-evenly mx-3 mb-3">
       <Button
         text={t( "CANCEL" )}
         onPress={( ) => {

--- a/src/components/ObsEdit/OtherDataSection.js
+++ b/src/components/ObsEdit/OtherDataSection.js
@@ -121,7 +121,6 @@ const OtherDataSection = ( {
           <TextInputSheet
             handleClose={( ) => setShowNotesSheet( false )}
             headerText={t( "NOTES" )}
-            snapPoints={[416]}
             placeholder={t( "Add-optional-notes" )}
             initialInput={currentObservation?.description}
             confirm={textInput => updateObservationKeys( {

--- a/src/components/ObsEdit/Sheets/AddEvidenceSheet.js
+++ b/src/components/ObsEdit/Sheets/AddEvidenceSheet.js
@@ -29,7 +29,6 @@ const AddEvidenceSheet = ( {
     <BottomSheet
       handleClose={onClose}
       headerText={t( "ADD-EVIDENCE" )}
-      snapPoints={[202]}
       hidden={hidden}
       onChange={position => {
         // -1 means the sheet is fully hidden... and in theory it's safe to navigate away

--- a/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
+++ b/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
@@ -65,7 +65,6 @@ const DeleteObservationSheet = ( {
       headerText={multipleObservations
         ? t( "DELETE-X-OBSERVATIONS", { count: observations.length } )
         : t( "DELETE-OBSERVATION" )}
-      snapPoints={[148]}
       handleSecondButtonPress={handleClose}
       secondButtonText={t( "CANCEL" )}
       confirm={( ) => {

--- a/src/components/ObsEdit/Sheets/DiscardChangesSheet.js
+++ b/src/components/ObsEdit/Sheets/DiscardChangesSheet.js
@@ -20,7 +20,6 @@ const DiscardChangesSheet = ( {
     handleClose={handleClose}
     confirm={discardChanges}
     headerText={t( "DISCARD-CHANGES" )}
-    snapPoints={[178]}
     text={t( "By-exiting-changes-not-saved" )}
     buttonText={t( "DISCARD-CHANGES" )}
   />

--- a/src/components/ObsEdit/Sheets/DiscardObservationSheet.js
+++ b/src/components/ObsEdit/Sheets/DiscardObservationSheet.js
@@ -45,7 +45,6 @@ const DiscardObservationSheet = ( {
       headerText={multipleObservations
         ? t( "DISCARD-X-OBSERVATIONS", { count: observations.length } )
         : t( "DISCARD-OBSERVATION" )}
-      snapPoints={[178]}
       text={multipleObservations
         ? t( "By-exiting-your-observations-not-saved" )
         : t( "By-exiting-observation-not-saved" )}

--- a/src/components/ObsEdit/Sheets/GeoprivacySheet.js
+++ b/src/components/ObsEdit/Sheets/GeoprivacySheet.js
@@ -41,7 +41,6 @@ const GeoprivacySheet = ( {
   return (
     <RadioButtonSheet
       headerText={t( "GEOPRIVACY" )}
-      snapPoints={[426]}
       confirm={checkBoxValue => {
         updateGeoprivacyStatus( checkBoxValue );
         handleClose( );

--- a/src/components/ObsEdit/Sheets/WildStatusSheet.js
+++ b/src/components/ObsEdit/Sheets/WildStatusSheet.js
@@ -36,7 +36,6 @@ const WildStatusSheet = ( {
   return (
     <RadioButtonSheet
       headerText={t( "WILD-STATUS" )}
-      snapPoints={[318]}
       confirm={checkBoxValue => {
         updateCaptiveStatus( checkBoxValue );
         handleClose( );

--- a/src/components/SharedComponents/Sheets/BottomSheet.js
+++ b/src/components/SharedComponents/Sheets/BottomSheet.js
@@ -18,12 +18,13 @@ import { useTranslation } from "sharedHooks";
 import { viewStyles } from "styles/sharedComponents/bottomSheet";
 
 type Props = {
-  children: any,
+  children: Node,
   hidden?: boolean,
   onChange?: Function,
   handleClose?: Function,
   hideCloseButton?: boolean,
-  headerText?: string
+  headerText?: string,
+  snapPoints?: any
 }
 
 const renderBackdrop = props => <BottomSheetStandardBackdrop props={props} />;
@@ -34,8 +35,13 @@ const StandardBottomSheet = ( {
   onChange = null,
   handleClose,
   hideCloseButton = false,
-  headerText
+  headerText,
+  snapPoints
 }: Props ): Node => {
+  if ( snapPoints ) {
+    throw new Error( "BottomSheet does not accept snapPoints as a prop." );
+  }
+
   const { t } = useTranslation( );
   const sheetRef = useRef( null );
 

--- a/src/components/SharedComponents/Sheets/BottomSheet.js
+++ b/src/components/SharedComponents/Sheets/BottomSheet.js
@@ -1,11 +1,18 @@
 // @flow
 
-import { BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  useBottomSheetDynamicSnapPoints
+} from "@gorhom/bottom-sheet";
 import { BottomSheetStandardBackdrop, Heading4, INatIconButton } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, {
-  useCallback, useEffect, useRef
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef
 } from "react";
 import { useTranslation } from "sharedHooks";
 import { viewStyles } from "styles/sharedComponents/bottomSheet";
@@ -13,21 +20,17 @@ import { viewStyles } from "styles/sharedComponents/bottomSheet";
 type Props = {
   children: any,
   hidden?: boolean,
-  snapPoints?: ( string|number )[],
   onChange?: Function,
   handleClose?: Function,
   hideCloseButton?: boolean,
   headerText?: string
 }
 
-const DEFAULT_SNAP_POINTS = ["45%"];
-
 const renderBackdrop = props => <BottomSheetStandardBackdrop props={props} />;
 
 const StandardBottomSheet = ( {
   children,
   hidden,
-  snapPoints = DEFAULT_SNAP_POINTS,
   onChange = null,
   handleClose,
   hideCloseButton = false,
@@ -35,6 +38,15 @@ const StandardBottomSheet = ( {
 }: Props ): Node => {
   const { t } = useTranslation( );
   const sheetRef = useRef( null );
+
+  const initialSnapPoints = useMemo( () => ["CONTENT_HEIGHT"], [] );
+
+  const {
+    animatedHandleHeight,
+    animatedSnapPoints,
+    animatedContentHeight,
+    handleContentLayout
+  } = useBottomSheetDynamicSnapPoints( initialSnapPoints );
 
   // eslint-disable-next-line
   const noHandle = ( ) => <></>;
@@ -62,13 +74,15 @@ const StandardBottomSheet = ( {
     <BottomSheetModal
       ref={sheetRef}
       index={0}
-      snapPoints={snapPoints}
+      snapPoints={animatedSnapPoints}
+      handleHeight={animatedHandleHeight}
+      contentHeight={animatedContentHeight}
       style={viewStyles.shadow}
       handleComponent={noHandle}
       backdropComponent={renderBackdrop}
       onChange={onChange}
     >
-      <BottomSheetView>
+      <BottomSheetView onLayout={handleContentLayout}>
         <View className="items-center">
           <Heading4 className="pt-7">{headerText}</Heading4>
         </View>

--- a/src/components/SharedComponents/Sheets/BottomSheet.js
+++ b/src/components/SharedComponents/Sheets/BottomSheet.js
@@ -1,6 +1,10 @@
 // @flow
 
-import BottomSheet, { BottomSheetModal, BottomSheetView, useBottomSheetDynamicSnapPoints } from "@gorhom/bottom-sheet";
+import BottomSheet, {
+  BottomSheetModal,
+  BottomSheetView,
+  useBottomSheetDynamicSnapPoints
+} from "@gorhom/bottom-sheet";
 import { BottomSheetStandardBackdrop, Heading4, INatIconButton } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.js
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.js
@@ -13,7 +13,6 @@ import useTranslation from "sharedHooks/useTranslation";
 type Props = {
   handleClose: Function,
   confirm: Function,
-  snapPoints: Array<number>,
   headerText: string,
   radioValues: Object,
   selectedValue?: any
@@ -22,7 +21,6 @@ type Props = {
 const RadioButtonSheet = ( {
   handleClose,
   confirm,
-  snapPoints,
   headerText,
   radioValues,
   selectedValue = "none"
@@ -64,14 +62,13 @@ const RadioButtonSheet = ( {
     <BottomSheet
       handleClose={handleClose}
       headerText={headerText}
-      snapPoints={snapPoints}
       onChange={position => {
         if ( position === -1 ) {
           handleClose( );
         }
       }}
     >
-      <View className="px-4 pt-[20px]">
+      <View className="p-5">
         {Object.keys( radioValues ).map( radioRow => radioButtonRow( radioRow ) )}
         <Button
           level="primary"

--- a/src/components/SharedComponents/Sheets/TextInputSheet.js
+++ b/src/components/SharedComponents/Sheets/TextInputSheet.js
@@ -18,7 +18,6 @@ import colors from "styles/tailwindColors";
     initialInput?: ?string,
     placeholder: string,
     headerText: string,
-    snapPoints: Array<Object>,
     textInputStyle?: Object
   }
 
@@ -28,7 +27,6 @@ const TextInputSheet = ( {
   initialInput = null,
   placeholder,
   headerText,
-  snapPoints,
   textInputStyle
 }: Props ): Node => {
   const textInputRef = useRef( );
@@ -55,7 +53,6 @@ const TextInputSheet = ( {
     <BottomSheet
       handleClose={handleClose}
       headerText={headerText}
-      snapPoints={snapPoints}
       onChange={position => {
         if ( position === -1 ) {
           handleClose();

--- a/src/components/SharedComponents/Sheets/TextSheet.js
+++ b/src/components/SharedComponents/Sheets/TextSheet.js
@@ -30,7 +30,6 @@ const TextSheet = ( {
     <BottomSheet
       handleClose={handleClose}
       headerText={headerText}
-      snapPoints={[256]}
       hideCloseButton
       onChange={position => {
         if ( position === -1 ) {

--- a/src/components/SharedComponents/Sheets/WarningSheet.js
+++ b/src/components/SharedComponents/Sheets/WarningSheet.js
@@ -13,7 +13,6 @@ type Props = {
   text?: string,
   buttonText: string,
   confirm: Function,
-  snapPoints: Array<number>,
   secondButtonText?: string,
   handleSecondButtonPress?: Function,
   buttonType?: string,
@@ -26,7 +25,6 @@ const WarningSheet = ( {
   text,
   buttonText,
   confirm,
-  snapPoints,
   secondButtonText,
   handleSecondButtonPress,
   buttonType,
@@ -35,7 +33,6 @@ const WarningSheet = ( {
   <BottomSheet
     handleClose={handleClose}
     headerText={headerText}
-    snapPoints={snapPoints}
     hidden={hidden}
     onChange={position => {
       if ( position === -1 ) {

--- a/src/components/Suggestions/AddCommentPrompt.js
+++ b/src/components/Suggestions/AddCommentPrompt.js
@@ -47,7 +47,6 @@ const AddCommentPrompt = ( {
     <TextInputSheet
       handleClose={( ) => setShowAddCommentSheet( false )}
       headerText={t( "ADD-OPTIONAL-COMMENT" )}
-      snapPoints={[416]}
       confirm={updateComment}
     />
   );


### PR DESCRIPTION
For all usages in the app of the BottomSheet component, or components derived from it, this PR removes the possibility to specify snapPoints as a prop, and replaces it with a hook to dynamically calculate them onLayout. In other words, all instances of bottom sheet will scale depending on the content to display.
This necessitated some changes in paddings at the bottom of existing bottom sheets.