### PR TITLE
Replace white screen with error boundary component

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,9 +57,7 @@ const queryClient = new QueryClient( {
 } );
 
 const errorHandler = ( error: Error, stackTrace: string ) => {
-  if ( error ) {
-    logger.error( `ErrorBoundary: ${error.toString( )} ${stackTrace}` );
-  }
+  logger.error( `ErrorBoundary: ${error.toString( )} ${stackTrace}` );
 };
 
 const AppWithProviders = ( ) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react-native-device-info": "^10.9.0",
         "react-native-draggable-flatlist": "^4.0.1",
         "react-native-email-link": "^1.14.7",
+        "react-native-error-boundary": "^1.2.4",
         "react-native-event-listeners": "^1.0.7",
         "react-native-exception-handler": "^2.10.10",
         "react-native-exif-reader": "github:inaturalist/react-native-exif-reader",
@@ -22954,6 +22955,21 @@
         "react-native": ">=0.40.0"
       }
     },
+    "node_modules/react-native-error-boundary": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-native-error-boundary/-/react-native-error-boundary-1.2.4.tgz",
+      "integrity": "sha512-PF5xn+3mGKk8uzf9GpOQa1kvxsG3Bs3XMwJZNqqUG//jC1FDp+WRGxg4r2sPG70MveSOQmQNuHnAycCPYQNg6g==",
+      "peerDependencies": {
+        "@types/react-native": ">=0.57.7",
+        "react": ">=16.6.0",
+        "react-native": ">=0.57.7"
+      },
+      "peerDependenciesMeta": {
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-event-listeners": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/react-native-event-listeners/-/react-native-event-listeners-1.0.7.tgz",
@@ -44071,6 +44087,12 @@
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/react-native-email-link/-/react-native-email-link-1.14.7.tgz",
       "integrity": "sha512-BHhakcPGkVgYeSXd/j/OICC9nGFHe0RFv7b3+PvNhstOyjXoUHBX+qftuUzNqFeeMcktfGMlzl2CacA6nKUvKQ==",
+      "requires": {}
+    },
+    "react-native-error-boundary": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-native-error-boundary/-/react-native-error-boundary-1.2.4.tgz",
+      "integrity": "sha512-PF5xn+3mGKk8uzf9GpOQa1kvxsG3Bs3XMwJZNqqUG//jC1FDp+WRGxg4r2sPG70MveSOQmQNuHnAycCPYQNg6g==",
       "requires": {}
     },
     "react-native-event-listeners": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-native-device-info": "^10.9.0",
     "react-native-draggable-flatlist": "^4.0.1",
     "react-native-email-link": "^1.14.7",
+    "react-native-error-boundary": "^1.2.4",
     "react-native-event-listeners": "^1.0.7",
     "react-native-exception-handler": "^2.10.10",
     "react-native-exif-reader": "github:inaturalist/react-native-exif-reader",


### PR DESCRIPTION
Closes #976

- We can add a custom Fallback error component if we want to customize what we show to the end user. For now, this uses the built-in error boundary component and logs the stack trace.