### PR TITLE
Add Photo Permission Gate

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -688,7 +688,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 9af0c7125f20c5c5cb032eadbf66744693241dd8
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 4eb7ee83e8d0ad7e20a829485295ff48823c4e4c
@@ -765,4 +765,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 77ed9526d4011b245ce5afa1ea331dea4c67d753
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/ios/iNaturalistReactNative/Info.plist
+++ b/ios/iNaturalistReactNative/Info.plist
@@ -50,7 +50,7 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Record sound observations of nature.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Export and import ${PRODUCT_NAME} photos to and from your library.</string>
+	<string>Export ${PRODUCT_NAME} photos to your library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Export and import ${PRODUCT_NAME} photos to and from your library.</string>
 	<key>UIAppFonts</key>

--- a/src/components/Camera/ARCamera/ARCamera.js
+++ b/src/components/Camera/ARCamera/ARCamera.js
@@ -24,7 +24,7 @@ import {
 } from "../helpers";
 import ARCameraButtons from "./ARCameraButtons";
 import FrameProcessorCamera from "./FrameProcessorCamera";
-import useModelLoaded from "./hooks/useModelLoaded";
+import usePredictions from "./hooks/usePredictions";
 
 const isTablet = DeviceInfo.isTablet();
 
@@ -63,7 +63,7 @@ const ARCamera = ( {
   const {
     rotatableAnimatedStyle
   } = useRotation( );
-  const { result, modelLoaded, handleTaxaDetected } = useModelLoaded( );
+  const { result, modelLoaded, handleTaxaDetected } = usePredictions( );
   const {
     takePhoto,
     takePhotoOptions,

--- a/src/components/Camera/ARCamera/ARCamera.js
+++ b/src/components/Camera/ARCamera/ARCamera.js
@@ -2,10 +2,13 @@
 
 import classnames from "classnames";
 import FadeInOutView from "components/Camera/FadeInOutView";
+import useRotation from "components/Camera/hooks/useRotation";
+import useTakePhoto from "components/Camera/hooks/useTakePhoto";
+import useZoom from "components/Camera/hooks/useZoom";
 import { Body1, INatIcon, TaxonResult } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useEffect } from "react";
+import React from "react";
 import DeviceInfo from "react-native-device-info";
 import LinearGradient from "react-native-linear-gradient";
 import { useTheme } from "react-native-paper";
@@ -21,6 +24,7 @@ import {
 } from "../helpers";
 import ARCameraButtons from "./ARCameraButtons";
 import FrameProcessorCamera from "./FrameProcessorCamera";
+import useModelLoaded from "./hooks/useModelLoaded";
 
 const isTablet = DeviceInfo.isTablet();
 
@@ -33,52 +37,39 @@ const isTablet = DeviceInfo.isTablet();
 // };
 
 type Props = {
-  flipCamera: Function,
-  toggleFlash: Function,
-  takePhoto: Function,
-  rotatableAnimatedStyle: Object,
-  device: any,
   camera: any,
-  hasFlash: boolean,
-  takePhotoOptions: Object,
-  takingPhoto: boolean,
-  animatedProps: any,
-  changeZoom: Function,
-  zoomTextValue: string,
-  showZoomButton: boolean,
-  navToObsEdit: Function,
-  photoSaved: boolean,
-  onZoomStart?: Function,
-  onZoomChange?: Function,
-  result?: Object,
-  handleTaxaDetected: Function,
-  modelLoaded: boolean,
+  device: any,
+  flipCamera: Function,
+  handleCheckmarkPress: Function,
   isLandscapeMode: boolean
 };
 
 const ARCamera = ( {
-  flipCamera,
-  toggleFlash,
-  takePhoto,
-  rotatableAnimatedStyle,
-  device,
   camera,
-  hasFlash,
-  takePhotoOptions,
-  takingPhoto,
-  animatedProps,
-  changeZoom,
-  zoomTextValue,
-  showZoomButton,
-  navToObsEdit,
-  photoSaved,
-  onZoomStart,
-  onZoomChange,
-  result,
-  handleTaxaDetected,
-  modelLoaded,
+  device,
+  flipCamera,
+  handleCheckmarkPress,
   isLandscapeMode
 }: Props ): Node => {
+  const hasFlash = device?.hasFlash;
+  const {
+    animatedProps,
+    changeZoom,
+    onZoomChange,
+    onZoomStart,
+    showZoomButton,
+    zoomTextValue
+  } = useZoom( device );
+  const {
+    rotatableAnimatedStyle
+  } = useRotation( );
+  const { result, modelLoaded, handleTaxaDetected } = useModelLoaded( );
+  const {
+    takePhoto,
+    takePhotoOptions,
+    takingPhoto,
+    toggleFlash
+  } = useTakePhoto( camera, null, device );
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -92,11 +83,12 @@ const ARCamera = ( {
   // However, there is also some Exif and device orientation related code
   // that I have not checked. Anyway, those parts we would hoist into JS side if not done yet.
 
-  useEffect( ( ) => {
-    if ( photoSaved ) {
-      navToObsEdit( result?.taxon );
-    }
-  }, [photoSaved, navToObsEdit, result?.taxon] );
+  const handlePress = async ( ) => {
+    await takePhoto( );
+    handleCheckmarkPress( showPrediction
+      ? result.taxon
+      : null );
+  };
 
   return (
     <>
@@ -138,7 +130,7 @@ const ARCamera = ( {
             ? (
               <TaxonResult
                 taxon={result?.taxon}
-                handleCheckmarkPress={takePhoto}
+                handleCheckmarkPress={handlePress}
                 testID={`ARCamera.taxa.${result?.taxon?.id}`}
                 clearBackground
                 confidence={convertOfflineScoreToConfidence( result?.score )}
@@ -167,7 +159,7 @@ const ARCamera = ( {
       )}
       <FadeInOutView takingPhoto={takingPhoto} />
       <ARCameraButtons
-        takePhoto={takePhoto}
+        takePhoto={handlePress}
         rotatableAnimatedStyle={rotatableAnimatedStyle}
         toggleFlash={toggleFlash}
         flipCamera={flipCamera}

--- a/src/components/Camera/ARCamera/hooks/useModelLoaded.js
+++ b/src/components/Camera/ARCamera/hooks/useModelLoaded.js
@@ -1,0 +1,81 @@
+// @flow
+
+import {
+  useState
+} from "react";
+import {
+  Platform
+} from "react-native";
+
+const useModelLoaded = ( ): Object => {
+  const [result, setResult] = useState( null );
+  const [modelLoaded, setModelLoaded] = useState( false );
+
+  const handleTaxaDetected = cvResults => {
+    if ( cvResults && !modelLoaded ) {
+      setModelLoaded( true );
+    }
+    /*
+      Using FrameProcessorCamera results in this as cvResults atm on Android
+      [
+        {
+          "stateofmatter": [
+            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
+          ]
+        },
+        {
+          "order": [
+            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
+          ]
+        },
+        {
+          "species": [
+            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
+          ]
+        }
+      ]
+    */
+    /*
+      Using FrameProcessorCamera results in this as cvResults atm on iOS (= top prediction)
+      [
+        {"name": "Aves", "rank": 50, "score": 0.7627944946289062, "taxon_id": 3}
+      ]
+    */
+    const standardizePrediction = finestPrediction => ( {
+      taxon: {
+        rank_level: finestPrediction.rank,
+        id: Number( finestPrediction.taxon_id ),
+        name: finestPrediction.name
+      },
+      score: finestPrediction.score
+    } );
+    let prediction = null;
+    let predictions = [];
+    if ( Platform.OS === "ios" ) {
+      if ( cvResults.length > 0 ) {
+        const finestPrediction = cvResults[cvResults.length - 1];
+        prediction = standardizePrediction( finestPrediction );
+      }
+    } else {
+      predictions = cvResults
+        ?.map( r => {
+          const rank = Object.keys( r )[0];
+          return r[rank][0];
+        } )
+        .sort( ( a, b ) => a.rank - b.rank );
+      if ( predictions.length > 0 ) {
+        const finestPrediction = predictions[0];
+        prediction = standardizePrediction( finestPrediction );
+      }
+    }
+    setResult( prediction );
+  };
+
+  return {
+    handleTaxaDetected,
+    modelLoaded,
+    result
+  };
+};
+
+export default useModelLoaded;

--- a/src/components/Camera/ARCamera/hooks/usePredictions.js
+++ b/src/components/Camera/ARCamera/hooks/usePredictions.js
@@ -7,7 +7,7 @@ import {
   Platform
 } from "react-native";
 
-const useModelLoaded = ( ): Object => {
+const usePredictions = ( ): Object => {
   const [result, setResult] = useState( null );
   const [modelLoaded, setModelLoaded] = useState( false );
 
@@ -78,4 +78,4 @@ const useModelLoaded = ( ): Object => {
   };
 };
 
-export default useModelLoaded;
+export default usePredictions;

--- a/src/components/Camera/Buttons/GreenCheckmark.js
+++ b/src/components/Camera/Buttons/GreenCheckmark.js
@@ -9,17 +9,17 @@ import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
 type Props = {
-  navToObsEdit: Function
+  handleCheckmarkPress: Function
 }
 
 const GreenCheckmark = ( {
-  navToObsEdit
+  handleCheckmarkPress
 }: Props ): Node => {
   const { t } = useTranslation( );
 
   return (
     <INatIconButton
-      onPress={( ) => navToObsEdit( )}
+      onPress={handleCheckmarkPress}
       accessibilityLabel={t( "Checkmark" )}
       accessibilityHint={t( "Navigate-to-observation-edit-screen" )}
       disabled={false}

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -66,7 +66,7 @@ const CameraWithDevice = ( {
   const [modalWasClosed, setModalWasClosed] = useState( false );
 
   const {
-    createEvidenceForObsEdit
+    prepareStateForObsEdit
   } = usePrepareStateForObsEdit( addPhotoPermissionResult, addEvidence );
 
   const isLandscapeMode = [LANDSCAPE_LEFT, LANDSCAPE_RIGHT].includes( deviceOrientation );
@@ -83,12 +83,12 @@ const CameraWithDevice = ( {
     : "flex-col";
 
   const navToObsEdit = useCallback( async ( ) => {
-    await createEvidenceForObsEdit( taxonResult );
+    await prepareStateForObsEdit( taxonResult );
     if ( taxonResult ) {
       setTaxonResult( null );
     }
     navigation.navigate( "ObsEdit" );
-  }, [taxonResult, createEvidenceForObsEdit, navigation] );
+  }, [taxonResult, prepareStateForObsEdit, navigation] );
 
   const handleCheckmarkPress = localTaxon => {
     setTaxonResult( localTaxon?.id

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -64,7 +64,6 @@ const CameraWithDevice = ( {
   const [checkmarkTapped, setCheckmarkTapped] = useState( false );
   const [taxonResult, setTaxonResult] = useState( null );
   const [modalWasClosed, setModalWasClosed] = useState( false );
-  const [modalHidden, setModalHidden] = useState( false );
 
   const {
     createEvidenceForObsEdit
@@ -107,8 +106,7 @@ const CameraWithDevice = ( {
   };
 
   useEffect( ( ) => {
-    if ( checkmarkTapped
-      && ( modalHidden || modalWasClosed ) ) {
+    if ( checkmarkTapped && modalWasClosed ) {
       setCheckmarkTapped( false );
       setModalWasClosed( false );
       navToObsEdit( );
@@ -117,7 +115,6 @@ const CameraWithDevice = ( {
     navToObsEdit,
     checkmarkTapped,
     modalWasClosed,
-    modalHidden,
     addPhotoPermissionResult
   ] );
 
@@ -135,8 +132,7 @@ const CameraWithDevice = ( {
         onPermissionDenied={onPermissionDenied}
         withoutNavigation
         setModalWasClosed={setModalWasClosed}
-        setModalHidden={setModalHidden}
-        permissionNeeded={checkmarkTapped && addPhotoPermissionResult === null}
+        permissionNeeded={checkmarkTapped}
       />
       {cameraType === "Standard"
         ? (

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -106,7 +106,8 @@ const CameraWithDevice = ( {
   };
 
   useEffect( ( ) => {
-    if ( checkmarkTapped && modalWasClosed ) {
+    if ( checkmarkTapped
+        && ( modalWasClosed || addPhotoPermissionResult === "granted" ) ) {
       setCheckmarkTapped( false );
       setModalWasClosed( false );
       navToObsEdit( );

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -1,33 +1,19 @@
 // @flow
 
-import { CameraRoll } from "@react-native-camera-roll/camera-roll";
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import PermissionGateContainer, { WRITE_MEDIA_PERMISSIONS }
   from "components/SharedComponents/PermissionGateContainer";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, {
-  useCallback,
-  useMemo,
-  useRef,
-  useState
+  useCallback, useEffect, useRef, useState
 } from "react";
-import {
-  BackHandler,
-  Platform,
-  StatusBar
-} from "react-native";
+import { StatusBar } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import Orientation from "react-native-orientation-locker";
-import {
-  Extrapolate,
-  interpolate,
-  useAnimatedProps,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-  withTiming
-} from "react-native-reanimated";
+// import {
+//   RESULTS as PERMISSION_RESULTS
+// } from "react-native-permissions";
 // Temporarily using a fork so this is to avoid that eslint error. Need to
 // remove if/when we return to the main repo
 import {
@@ -36,35 +22,17 @@ import {
   // useCameraDevice
   // react-native-vision-camera v2
 } from "react-native-vision-camera";
-import Observation from "realmModels/Observation";
-import ObservationPhoto from "realmModels/ObservationPhoto";
-import Photo from "realmModels/Photo";
-import {
-  rotatePhotoPatch,
-  rotationLocalPhotoPatch,
-  rotationTempPhotoPatch
-} from "sharedHelpers/visionCameraPatches";
 import { useTranslation } from "sharedHooks";
 import useDeviceOrientation, {
   LANDSCAPE_LEFT,
-  LANDSCAPE_RIGHT,
-  PORTRAIT_UPSIDE_DOWN
+  LANDSCAPE_RIGHT
 } from "sharedHooks/useDeviceOrientation";
-import useStore from "stores/useStore";
 
-import { log } from "../../../react-native-logs.config";
 import ARCamera from "./ARCamera/ARCamera";
+import useCreateEvidence from "./hooks/useCreateEvidence";
 import StandardCamera from "./StandardCamera/StandardCamera";
 
 const isTablet = DeviceInfo.isTablet( );
-
-// This is taken from react-native-vision library itself: https://github.com/mrousavy/react-native-vision-camera/blob/9eed89aac6155eba155595f3e006707152550d0d/package/example/src/Constants.ts#L19 https://github.com/mrousavy/react-native-vision-camera/blob/9eed89aac6155eba155595f3e006707152550d0d/package/example/src/CameraPage.tsx#L34
-// The maximum zoom factor you should be able to zoom in
-const MAX_ZOOM_FACTOR = 20;
-// Used for calculating the final zoom by pinch gesture
-const SCALE_FULL_ZOOM = 3;
-
-const logger = log.extend( "CameraContainer" );
 
 type Props = {
   addEvidence: ?boolean,
@@ -91,338 +59,19 @@ const CameraWithDevice = ( {
   const { t } = useTranslation( );
   // $FlowFixMe
   const camera = useRef<Camera>( null );
-  const hasFlash = device?.hasFlash;
-  const initialPhotoOptions = {
-    enableShutterSound: true,
-    enableAutoStabilization: true,
-    qualityPrioritization: "quality",
-    ...( hasFlash && { flash: "off" } )
-  };
-  const [takePhotoOptions, setTakePhotoOptions] = useState( initialPhotoOptions );
   const { deviceOrientation } = useDeviceOrientation( );
-  const [showDiscardSheet, setShowDiscardSheet] = useState( false );
-  const [takingPhoto, setTakingPhoto] = useState( false );
-  const [photoSaved, setPhotoSaved] = useState( false );
-  const [result, setResult] = useState( null );
-  const [modelLoaded, setModelLoaded] = useState( false );
-  const setObservations = useStore( state => state.setObservations );
-  const updateObservations = useStore( state => state.updateObservations );
-  const evidenceToAdd = useStore( state => state.evidenceToAdd );
-  const cameraPreviewUris = useStore( state => state.cameraPreviewUris );
-  const galleryUris = useStore( state => state.galleryUris );
-  const currentObservation = useStore( state => state.currentObservation );
-  const setCameraState = useStore( state => state.setCameraState );
-  const setCameraRollUris = useStore( state => state.setCameraRollUris );
-  const originalCameraUrisMap = useStore( state => state.originalCameraUrisMap );
-  const currentObservationIndex = useStore( state => state.currentObservationIndex );
-  const observations = useStore( state => state.observations );
-  const [permissionGranted, setPermissionGranted] = useState( false );
-  const [showGalleryPermission, setShowGalleryPermission] = useState( false );
+  const [addPhotoPermissionResult, setAddPhotoPermissionResult] = useState( null );
+  const [checkmarkTapped, setCheckmarkTapped] = useState( false );
+  const [taxonResult, setTaxonResult] = useState( null );
+  const [modalWasClosed, setModalWasClosed] = useState( false );
 
-  const totalObsPhotoUris = useMemo(
-    ( ) => [...cameraPreviewUris, ...galleryUris].length,
-    [cameraPreviewUris, galleryUris]
-  );
+  const permissionNeeded = addPhotoPermissionResult === null && checkmarkTapped;
 
-  const numOfObsPhotos = currentObservation?.observationPhotos?.length || 0;
-
-  const zoom = useSharedValue( !device.isMultiCam
-    ? device.minZoom
-    : device.neutralZoom );
-  const startZoom = useSharedValue( !device.isMultiCam
-    ? device.minZoom
-    : device.neutralZoom );
-  const [zoomTextValue, setZoomTextValue] = useState( "1" );
+  const {
+    createEvidenceForObsEdit
+  } = useCreateEvidence( addPhotoPermissionResult, addEvidence );
 
   const isLandscapeMode = [LANDSCAPE_LEFT, LANDSCAPE_RIGHT].includes( deviceOrientation );
-
-  const { minZoom } = device;
-  const maxZoom = Math.min( device.maxZoom ?? 1, MAX_ZOOM_FACTOR );
-
-  const changeZoom = ( ) => {
-    const currentZoomValue = zoomTextValue;
-    if ( currentZoomValue === "1" ) {
-      zoom.value = withSpring( maxZoom );
-      setZoomTextValue( "3" );
-    } else if ( currentZoomValue === "3" ) {
-      zoom.value = withSpring( minZoom );
-      setZoomTextValue( ".5" );
-    } else {
-      zoom.value = withSpring( device.neutralZoom );
-      setZoomTextValue( "1" );
-    }
-  };
-
-  const onZoomStart = () => {
-    startZoom.value = zoom.value;
-  };
-
-  const onZoomChange = scale => {
-    // Calculate new zoom value (since scale factor is relative to initial pinch)
-    const newScale = interpolate(
-      scale,
-      [1 - 1 / SCALE_FULL_ZOOM, 1, SCALE_FULL_ZOOM],
-      [-1, 0, 1],
-      Extrapolate.CLAMP
-    );
-    const newZoom = interpolate(
-      newScale,
-      [-1, 0, 1],
-      [minZoom, startZoom.value, maxZoom],
-      Extrapolate.CLAMP
-    );
-    zoom.value = newZoom;
-  };
-
-  const animatedProps = useAnimatedProps(
-    () => ( { zoom: zoom.value } ),
-    [zoom]
-  );
-
-  const rotation = useSharedValue( 0 );
-  switch ( deviceOrientation ) {
-    case LANDSCAPE_LEFT:
-      rotation.value = -90;
-      break;
-    case LANDSCAPE_RIGHT:
-      rotation.value = 90;
-      break;
-    case PORTRAIT_UPSIDE_DOWN:
-      rotation.value = 180;
-      break;
-    default:
-      rotation.value = 0;
-  }
-  const rotatableAnimatedStyle = useAnimatedStyle(
-    () => ( {
-      transform: [
-        {
-          rotateZ: withTiming( `${-1 * ( rotation?.value || 0 )}deg` )
-        }
-      ]
-    } ),
-    [rotation.value]
-  );
-
-  const handleBackButtonPress = useCallback( ( ) => {
-    if ( cameraPreviewUris.length > 0 ) {
-      setShowDiscardSheet( true );
-    } else if ( backToObsEdit ) {
-      navigation.navigate( "ObsEdit" );
-    } else {
-      navigation.goBack( );
-    }
-  }, [backToObsEdit, setShowDiscardSheet, cameraPreviewUris, navigation] );
-
-  useFocusEffect(
-    // note: cannot use navigation.addListener to trigger bottom sheet in tab navigator
-    // since the screen is unfocused, not removed from navigation
-    useCallback( ( ) => {
-      // make sure an Android user cannot back out and accidentally discard photos
-      const onBackPress = ( ) => {
-        handleBackButtonPress( );
-        return true;
-      };
-
-      BackHandler.addEventListener( "hardwareBackPress", onBackPress );
-
-      return ( ) => BackHandler.removeEventListener( "hardwareBackPress", onBackPress );
-    }, [handleBackButtonPress] )
-  );
-
-  // Save URIs to camera gallery (if a photo was taken using the app,
-  // we want it accessible in the camera's folder, as if the user has taken those photos
-  // via their own camera app).
-  const savePhotosToCameraGallery = useCallback( async uris => {
-    if ( !permissionGranted ) { return false; }
-    const savedUris = await Promise.all( uris.map( async uri => {
-      // Find original camera URI of each scaled-down photo
-      const cameraUri = originalCameraUrisMap[uri];
-
-      if ( !cameraUri ) {
-        console.error( `Couldn't find original camera URI for: ${uri}` );
-      }
-      logger.info( "savePhotosToCameraGallery, saving cameraUri: ", cameraUri );
-      return CameraRoll.save( cameraUri, { type: "photo", album: "Camera" } );
-    } ) );
-
-    logger.info( "savePhotosToCameraGallery, savedUris: ", savedUris );
-    // Save these camera roll URIs, so later on observation editor can update
-    // the EXIF metadata of these photos, once we retrieve a location.
-    setCameraRollUris( savedUris );
-    return true;
-  }, [originalCameraUrisMap, setCameraRollUris, permissionGranted] );
-
-  const createObsWithCameraPhotos = useCallback( async ( localFilePaths, localTaxon ) => {
-    const newObservation = await Observation.new( );
-    newObservation.observationPhotos = await ObservationPhoto
-      .createObsPhotosWithPosition( localFilePaths, {
-        position: 0,
-        local: true
-      } );
-
-    if ( localTaxon ) {
-      newObservation.taxon = localTaxon;
-      newObservation.owners_identification_from_vision = true;
-    }
-    setObservations( [newObservation] );
-    logger.info(
-      "createObsWithCameraPhotos, calling savePhotosToCameraGallery with paths: ",
-      localFilePaths
-    );
-
-    return savePhotosToCameraGallery( localFilePaths );
-  }, [savePhotosToCameraGallery, setObservations] );
-
-  const createEvidenceForObsEdit = useCallback( async localTaxon => {
-    if ( addEvidence ) {
-      const obsPhotos = await ObservationPhoto
-        .createObsPhotosWithPosition( evidenceToAdd, {
-          position: numOfObsPhotos,
-          local: true
-        } );
-      const updatedCurrentObservation = Observation
-        .appendObsPhotos( obsPhotos, currentObservation );
-      observations[currentObservationIndex] = updatedCurrentObservation;
-      updateObservations( observations );
-      logger.info(
-        "addCameraPhotosToCurrentObservation, calling savePhotosToCameraGallery with paths: ",
-        evidenceToAdd
-      );
-      return savePhotosToCameraGallery( evidenceToAdd );
-    }
-    return createObsWithCameraPhotos( cameraPreviewUris, localTaxon );
-  }, [
-    createObsWithCameraPhotos,
-    cameraPreviewUris,
-    addEvidence,
-    evidenceToAdd,
-    numOfObsPhotos,
-    currentObservation,
-    savePhotosToCameraGallery,
-    updateObservations,
-    observations,
-    currentObservationIndex
-  ] );
-
-  const navToObsEdit = useCallback( async localTaxon => {
-    const evidenceCreated = await createEvidenceForObsEdit( localTaxon );
-    setPhotoSaved( false );
-
-    if ( evidenceCreated ) {
-      navigation.navigate( "ObsEdit" );
-    } else {
-      setShowGalleryPermission( true );
-    }
-  }, [
-    createEvidenceForObsEdit,
-    navigation
-  ] );
-
-  const takePhoto = async ( ) => {
-    setTakingPhoto( true );
-    const cameraPhoto = await camera.current.takePhoto( takePhotoOptions );
-
-    // Rotate the original photo depending on device orientation
-    const photoRotation = rotationTempPhotoPatch( cameraPhoto, deviceOrientation );
-    await rotatePhotoPatch( cameraPhoto, photoRotation );
-
-    // Get the rotation for the local photo
-    const rotationLocalPhoto = rotationLocalPhotoPatch( );
-
-    // Create a local copy photo of the original
-    const newPhoto = await Photo.new( cameraPhoto.path, {
-      rotation: rotationLocalPhoto
-    } );
-    const uri = newPhoto.localFilePath;
-
-    if ( addEvidence ) {
-      setCameraState( {
-        cameraPreviewUris: cameraPreviewUris.concat( [uri] ),
-        evidenceToAdd: [...evidenceToAdd, uri],
-        // Remember original (unresized) camera URI
-        originalCameraUrisMap: { ...originalCameraUrisMap, [uri]: cameraPhoto.path }
-      } );
-    } else {
-      setCameraState( {
-        cameraPreviewUris: cameraPreviewUris.concat( [uri] ),
-        // Remember original (unresized) camera URI
-        originalCameraUrisMap: { ...originalCameraUrisMap, [uri]: cameraPhoto.path }
-      } );
-    }
-    setTakingPhoto( false );
-    setPhotoSaved( true );
-  };
-
-  const handleTaxaDetected = cvResults => {
-    if ( cvResults && !modelLoaded ) {
-      setModelLoaded( true );
-    }
-    /*
-      Using FrameProcessorCamera results in this as cvResults atm on Android
-      [
-        {
-          "stateofmatter": [
-            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
-          ]
-        },
-        {
-          "order": [
-            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
-          ]
-        },
-        {
-          "species": [
-            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
-          ]
-        }
-      ]
-    */
-    /*
-      Using FrameProcessorCamera results in this as cvResults atm on iOS (= top prediction)
-      [
-        {"name": "Aves", "rank": 50, "score": 0.7627944946289062, "taxon_id": 3}
-      ]
-    */
-    // console.log( "cvResults :>> ", cvResults );
-    const standardizePrediction = finestPrediction => ( {
-      taxon: {
-        rank_level: finestPrediction.rank,
-        id: Number( finestPrediction.taxon_id ),
-        name: finestPrediction.name
-      },
-      score: finestPrediction.score
-    } );
-    let prediction = null;
-    let predictions = [];
-    if ( Platform.OS === "ios" ) {
-      if ( cvResults.length > 0 ) {
-        const finestPrediction = cvResults[cvResults.length - 1];
-        prediction = standardizePrediction( finestPrediction );
-      }
-    } else {
-      predictions = cvResults
-        ?.map( r => {
-          const rank = Object.keys( r )[0];
-          return r[rank][0];
-        } )
-        .sort( ( a, b ) => a.rank - b.rank );
-      if ( predictions.length > 0 ) {
-        const finestPrediction = predictions[0];
-        prediction = standardizePrediction( finestPrediction );
-      }
-    }
-    setResult( prediction );
-  };
-
-  const toggleFlash = ( ) => {
-    setTakePhotoOptions( {
-      ...takePhotoOptions,
-      flash: takePhotoOptions.flash === "on"
-        ? "off"
-        : "on"
-    } );
-  };
 
   const flipCamera = ( ) => {
     const newPosition = cameraPosition === "back"
@@ -435,90 +84,71 @@ const CameraWithDevice = ( {
     ? "flex-row"
     : "flex-col";
 
-  const onPermissionGranted = ( ) => {
-    setPermissionGranted( true );
+  const navToObsEdit = useCallback( async ( ) => {
+    await createEvidenceForObsEdit( taxonResult );
+    if ( taxonResult ) {
+      setTaxonResult( null );
+    }
     navigation.navigate( "ObsEdit" );
+  }, [taxonResult, createEvidenceForObsEdit, navigation] );
+
+  const handleCheckmarkPress = localTaxon => {
+    setTaxonResult( localTaxon?.id
+      ? localTaxon
+      : null );
+    setCheckmarkTapped( true );
+  };
+
+  const onPermissionGranted = ( ) => {
+    setAddPhotoPermissionResult( "granted" );
   };
 
   const onPermissionDenied = ( ) => {
-    setPermissionGranted( false );
-    navigation.navigate( "ObsEdit" );
+    setAddPhotoPermissionResult( "denied" );
   };
 
-  const onPermissionBlocked = ( ) => {
-    setPermissionGranted( false );
-    navigation.navigate( "ObsEdit" );
-  };
+  useEffect( ( ) => {
+    if ( modalWasClosed && checkmarkTapped ) {
+      setCheckmarkTapped( false );
+      setModalWasClosed( false );
+      navToObsEdit( );
+    }
+  }, [navToObsEdit, checkmarkTapped, modalWasClosed] );
 
   return (
     <View className={`flex-1 bg-black ${flexDirection}`}>
       <StatusBar hidden />
-      {showGalleryPermission && (
-        <PermissionGateContainer
-          permissions={WRITE_MEDIA_PERMISSIONS}
-          title={t( "Save-photos-to-your-gallery" )}
-          titleDenied={t( "Please-Allow-Gallery-Access" )}
-          body={t( "Save-photos-to-your-gallery-to-create-observations" )}
-          blockedPrompt={t( "Youve-previously-denied-add-photo-permissions" )}
-          buttonText={t( "ADD-PHOTOS" )}
-          icon="gallery"
-          image={require( "images/viviana-rishe-j2330n6bg3I-unsplash.jpg" )}
-          onPermissionGranted={onPermissionGranted}
-          onPermissionDenied={onPermissionDenied}
-          onPermissionBlocked={onPermissionBlocked}
-          withoutNavigation
-        />
-      )}
+      <PermissionGateContainer
+        permissions={WRITE_MEDIA_PERMISSIONS}
+        titleDenied={t( "Save-photos-to-your-gallery" )}
+        body={t( "iNaturalist-can-save-photos-you-take-in-the-app-to-your-devices-gallery" )}
+        buttonText={t( "SAVE-PHOTOS" )}
+        icon="gallery"
+        image={require( "images/birger-strahl-ksiGE4hMiso-unsplash.jpg" )}
+        onPermissionGranted={onPermissionGranted}
+        onPermissionDenied={onPermissionDenied}
+        withoutNavigation
+        permissionNeeded={permissionNeeded}
+        setModalWasClosed={setModalWasClosed}
+      />
       {cameraType === "Standard"
         ? (
           <StandardCamera
-            navToObsEdit={navToObsEdit}
-            flipCamera={flipCamera}
-            toggleFlash={toggleFlash}
-            takePhoto={takePhoto}
-            handleBackButtonPress={handleBackButtonPress}
-            rotatableAnimatedStyle={rotatableAnimatedStyle}
-            rotation={rotation}
-            isLandscapeMode={isLandscapeMode}
-            device={device}
+            addEvidence={addEvidence}
+            backToObsEdit={backToObsEdit}
             camera={camera}
-            hasFlash={hasFlash}
-            takePhotoOptions={takePhotoOptions}
-            setShowDiscardSheet={setShowDiscardSheet}
-            showDiscardSheet={showDiscardSheet}
-            takingPhoto={takingPhoto}
-            changeZoom={changeZoom}
-            animatedProps={animatedProps}
-            zoomTextValue={zoomTextValue}
-            showZoomButton={device.isMultiCam}
-            onZoomStart={onZoomStart}
-            onZoomChange={onZoomChange}
-            totalObsPhotoUris={totalObsPhotoUris}
-            cameraPreviewUris={cameraPreviewUris}
+            device={device}
+            flipCamera={flipCamera}
+            handleCheckmarkPress={handleCheckmarkPress}
+            isLandscapeMode={isLandscapeMode}
           />
         )
         : (
           <ARCamera
-            flipCamera={flipCamera}
-            toggleFlash={toggleFlash}
-            takePhoto={takePhoto}
-            rotatableAnimatedStyle={rotatableAnimatedStyle}
-            device={device}
             camera={camera}
-            hasFlash={hasFlash}
-            takePhotoOptions={takePhotoOptions}
-            takingPhoto={takingPhoto}
-            changeZoom={changeZoom}
-            animatedProps={animatedProps}
-            zoomTextValue={zoomTextValue}
-            showZoomButton={device.isMultiCam}
-            navToObsEdit={navToObsEdit}
-            photoSaved={photoSaved}
-            onZoomStart={onZoomStart}
-            onZoomChange={onZoomChange}
-            result={result}
-            handleTaxaDetected={handleTaxaDetected}
-            modelLoaded={modelLoaded}
+            device={device}
+            flipCamera={flipCamera}
+            handleCheckmarkPress={handleCheckmarkPress}
             isLandscapeMode={isLandscapeMode}
           />
         )}

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -64,8 +64,7 @@ const CameraWithDevice = ( {
   const [checkmarkTapped, setCheckmarkTapped] = useState( false );
   const [taxonResult, setTaxonResult] = useState( null );
   const [modalWasClosed, setModalWasClosed] = useState( false );
-
-  const permissionNeeded = addPhotoPermissionResult === null && checkmarkTapped;
+  const [modalHidden, setModalHidden] = useState( false );
 
   const {
     createEvidenceForObsEdit
@@ -108,12 +107,19 @@ const CameraWithDevice = ( {
   };
 
   useEffect( ( ) => {
-    if ( modalWasClosed && checkmarkTapped ) {
+    if ( checkmarkTapped
+      && ( modalHidden || modalWasClosed ) ) {
       setCheckmarkTapped( false );
       setModalWasClosed( false );
       navToObsEdit( );
     }
-  }, [navToObsEdit, checkmarkTapped, modalWasClosed] );
+  }, [
+    navToObsEdit,
+    checkmarkTapped,
+    modalWasClosed,
+    modalHidden,
+    addPhotoPermissionResult
+  ] );
 
   return (
     <View className={`flex-1 bg-black ${flexDirection}`}>
@@ -128,8 +134,8 @@ const CameraWithDevice = ( {
         onPermissionGranted={onPermissionGranted}
         onPermissionDenied={onPermissionDenied}
         withoutNavigation
-        permissionNeeded={permissionNeeded}
         setModalWasClosed={setModalWasClosed}
+        setModalHidden={setModalHidden}
       />
       {cameraType === "Standard"
         ? (

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -29,7 +29,7 @@ import useDeviceOrientation, {
 } from "sharedHooks/useDeviceOrientation";
 
 import ARCamera from "./ARCamera/ARCamera";
-import useCreateEvidence from "./hooks/useCreateEvidence";
+import usePrepareStateForObsEdit from "./hooks/usePrepareStateForObsEdit";
 import StandardCamera from "./StandardCamera/StandardCamera";
 
 const isTablet = DeviceInfo.isTablet( );
@@ -67,7 +67,7 @@ const CameraWithDevice = ( {
 
   const {
     createEvidenceForObsEdit
-  } = useCreateEvidence( addPhotoPermissionResult, addEvidence );
+  } = usePrepareStateForObsEdit( addPhotoPermissionResult, addEvidence );
 
   const isLandscapeMode = [LANDSCAPE_LEFT, LANDSCAPE_RIGHT].includes( deviceOrientation );
 

--- a/src/components/Camera/CameraWithDevice.js
+++ b/src/components/Camera/CameraWithDevice.js
@@ -136,6 +136,7 @@ const CameraWithDevice = ( {
         withoutNavigation
         setModalWasClosed={setModalWasClosed}
         setModalHidden={setModalHidden}
+        permissionNeeded={checkmarkTapped && addPhotoPermissionResult === null}
       />
       {cameraType === "Standard"
         ? (

--- a/src/components/Camera/StandardCamera/CameraNavButtons.js
+++ b/src/components/Camera/StandardCamera/CameraNavButtons.js
@@ -29,7 +29,7 @@ type Props = {
   disallowAddingPhotos: boolean,
   photosTaken: boolean,
   rotatableAnimatedStyle: Object,
-  navToObsEdit: Function
+  handleCheckmarkPress: Function
 }
 
 const CameraNavButtons = ( {
@@ -38,7 +38,7 @@ const CameraNavButtons = ( {
   disallowAddingPhotos,
   photosTaken,
   rotatableAnimatedStyle,
-  navToObsEdit
+  handleCheckmarkPress
 }: Props ): Node => !isTablet && (
   <View className="h-32 flex-row justify-between items-center">
     <CloseButton
@@ -59,7 +59,7 @@ const CameraNavButtons = ( {
           } )}
         >
           <GreenCheckmark
-            navToObsEdit={navToObsEdit}
+            handleCheckmarkPress={handleCheckmarkPress}
           />
         </Animated.View>
       )

--- a/src/components/Camera/StandardCamera/CameraOptionsButtons.js
+++ b/src/components/Camera/StandardCamera/CameraOptionsButtons.js
@@ -18,7 +18,7 @@ type Props = {
   disallowAddingPhotos: boolean,
   photosTaken: boolean,
   rotatableAnimatedStyle: Object,
-  navToObsEdit: Function,
+  handleCheckmarkPress: Function,
   toggleFlash: Function,
   flipCamera: Function,
   changeZoom: Function,
@@ -34,7 +34,7 @@ const CameraOptionsButtons = ( {
   disallowAddingPhotos,
   photosTaken,
   rotatableAnimatedStyle,
-  navToObsEdit,
+  handleCheckmarkPress,
   toggleFlash,
   flipCamera,
   hasFlash,
@@ -75,7 +75,7 @@ const CameraOptionsButtons = ( {
       disallowAddingPhotos={disallowAddingPhotos}
       photosTaken={photosTaken}
       rotatableAnimatedStyle={rotatableAnimatedStyle}
-      navToObsEdit={navToObsEdit}
+      handleCheckmarkPress={handleCheckmarkPress}
       toggleFlash={toggleFlash}
       flipCamera={flipCamera}
       hasFlash={hasFlash}

--- a/src/components/Camera/StandardCamera/hooks/useBackPress.js
+++ b/src/components/Camera/StandardCamera/hooks/useBackPress.js
@@ -1,0 +1,51 @@
+// @flow
+
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import {
+  useCallback,
+  useState
+} from "react";
+import {
+  BackHandler
+} from "react-native";
+import useStore from "stores/useStore";
+
+const useBackPress = ( backToObsEdit: ?boolean ): Object => {
+  const [showDiscardSheet, setShowDiscardSheet] = useState( false );
+  const navigation = useNavigation( );
+  const cameraPreviewUris = useStore( state => state.cameraPreviewUris );
+
+  const handleBackButtonPress = useCallback( ( ) => {
+    if ( cameraPreviewUris.length > 0 ) {
+      setShowDiscardSheet( true );
+    } else if ( backToObsEdit ) {
+      navigation.navigate( "ObsEdit" );
+    } else {
+      navigation.goBack( );
+    }
+  }, [backToObsEdit, setShowDiscardSheet, cameraPreviewUris, navigation] );
+
+  useFocusEffect(
+    // note: cannot use navigation.addListener to trigger bottom sheet in tab navigator
+    // since the screen is unfocused, not removed from navigation
+    useCallback( ( ) => {
+      // make sure an Android user cannot back out and accidentally discard photos
+      const onBackPress = ( ) => {
+        handleBackButtonPress( );
+        return true;
+      };
+
+      BackHandler.addEventListener( "hardwareBackPress", onBackPress );
+
+      return ( ) => BackHandler.removeEventListener( "hardwareBackPress", onBackPress );
+    }, [handleBackButtonPress] )
+  );
+
+  return {
+    handleBackButtonPress,
+    setShowDiscardSheet,
+    showDiscardSheet
+  };
+};
+
+export default useBackPress;

--- a/src/components/Camera/TabletButtons.js
+++ b/src/components/Camera/TabletButtons.js
@@ -42,7 +42,7 @@ type Props = {
   disallowAddingPhotos?: boolean,
   photosTaken?: boolean,
   rotatableAnimatedStyle: Object,
-  navToObsEdit?: Function,
+  handleCheckmarkPress?: Function,
   toggleFlash: Function,
   flipCamera: Function,
   changeZoom: Function,
@@ -72,7 +72,7 @@ const TabletButtons = ( {
   disallowAddingPhotos,
   photosTaken,
   rotatableAnimatedStyle,
-  navToObsEdit,
+  handleCheckmarkPress,
   toggleFlash,
   flipCamera,
   hasFlash,
@@ -125,7 +125,7 @@ const TabletButtons = ( {
           className={classnames( checkmarkClasses, "mb-[25px]" )}
         >
           <GreenCheckmark
-            navToObsEdit={navToObsEdit}
+            handleCheckmarkPress={handleCheckmarkPress}
           />
         </Animated.View>
       ) }

--- a/src/components/Camera/hooks/useCreateEvidence.js
+++ b/src/components/Camera/hooks/useCreateEvidence.js
@@ -1,0 +1,110 @@
+// @flow
+
+import { CameraRoll } from "@react-native-camera-roll/camera-roll";
+import {
+  useCallback
+} from "react";
+import Observation from "realmModels/Observation";
+import ObservationPhoto from "realmModels/ObservationPhoto";
+import useStore from "stores/useStore";
+
+import { log } from "../../../../react-native-logs.config";
+
+const logger = log.extend( "useCreateEvidence" );
+
+const useCreateEvidence = (
+  permissionGranted: ?string,
+  addEvidence: ?boolean
+): Object => {
+  const setObservations = useStore( state => state.setObservations );
+  const updateObservations = useStore( state => state.updateObservations );
+  const evidenceToAdd = useStore( state => state.evidenceToAdd );
+  const cameraPreviewUris = useStore( state => state.cameraPreviewUris );
+  const currentObservation = useStore( state => state.currentObservation );
+  const setCameraRollUris = useStore( state => state.setCameraRollUris );
+  const originalCameraUrisMap = useStore( state => state.originalCameraUrisMap );
+  const currentObservationIndex = useStore( state => state.currentObservationIndex );
+  const observations = useStore( state => state.observations );
+
+  const numOfObsPhotos = currentObservation?.observationPhotos?.length || 0;
+
+  // Save URIs to camera gallery (if a photo was taken using the app,
+  // we want it accessible in the camera's folder, as if the user has taken those photos
+  // via their own camera app).
+  const savePhotosToCameraGallery = useCallback( async uris => {
+    if ( permissionGranted !== "granted" ) { return; }
+    const savedUris = await Promise.all( uris.map( async uri => {
+      // Find original camera URI of each scaled-down photo
+      const cameraUri = originalCameraUrisMap[uri];
+
+      if ( !cameraUri ) {
+        console.error( `Couldn't find original camera URI for: ${uri}` );
+      }
+      logger.info( "savePhotosToCameraGallery, saving cameraUri: ", cameraUri );
+      return CameraRoll.save( cameraUri, { type: "photo", album: "Camera" } );
+    } ) );
+
+    logger.info( "savePhotosToCameraGallery, savedUris: ", savedUris );
+    // Save these camera roll URIs, so later on observation editor can update
+    // the EXIF metadata of these photos, once we retrieve a location.
+    setCameraRollUris( savedUris );
+  }, [originalCameraUrisMap, setCameraRollUris, permissionGranted] );
+
+  const createObsWithCameraPhotos = useCallback( async ( localFilePaths, localTaxon ) => {
+    const newObservation = await Observation.new( );
+    newObservation.observationPhotos = await ObservationPhoto
+      .createObsPhotosWithPosition( localFilePaths, {
+        position: 0,
+        local: true
+      } );
+
+    if ( localTaxon ) {
+      newObservation.taxon = localTaxon;
+      newObservation.owners_identification_from_vision = true;
+    }
+    setObservations( [newObservation] );
+    logger.info(
+      "createObsWithCameraPhotos, calling savePhotosToCameraGallery with paths: ",
+      localFilePaths
+    );
+
+    return savePhotosToCameraGallery( localFilePaths );
+  }, [savePhotosToCameraGallery, setObservations] );
+
+  const createEvidenceForObsEdit = useCallback( async localTaxon => {
+    if ( addEvidence ) {
+      const obsPhotos = await ObservationPhoto
+        .createObsPhotosWithPosition( evidenceToAdd, {
+          position: numOfObsPhotos,
+          local: true
+        } );
+      const updatedCurrentObservation = Observation
+        .appendObsPhotos( obsPhotos, currentObservation );
+      observations[currentObservationIndex] = updatedCurrentObservation;
+      updateObservations( observations );
+      logger.info(
+        "addCameraPhotosToCurrentObservation, calling savePhotosToCameraGallery with paths: ",
+        evidenceToAdd
+      );
+      return savePhotosToCameraGallery( evidenceToAdd );
+    }
+    return createObsWithCameraPhotos( cameraPreviewUris, localTaxon );
+  }, [
+    addEvidence,
+    cameraPreviewUris,
+    createObsWithCameraPhotos,
+    currentObservation,
+    currentObservationIndex,
+    evidenceToAdd,
+    numOfObsPhotos,
+    observations,
+    savePhotosToCameraGallery,
+    updateObservations
+  ] );
+
+  return {
+    createEvidenceForObsEdit: localTaxon => createEvidenceForObsEdit( localTaxon )
+  };
+};
+
+export default useCreateEvidence;

--- a/src/components/Camera/hooks/usePrepareStateForObsEdit.js
+++ b/src/components/Camera/hooks/usePrepareStateForObsEdit.js
@@ -70,7 +70,7 @@ const usePrepareStateForObsEdit = (
     return savePhotosToCameraGallery( localFilePaths );
   }, [savePhotosToCameraGallery, setObservations] );
 
-  const createEvidenceForObsEdit = useCallback( async localTaxon => {
+  const prepareStateForObsEdit = useCallback( async localTaxon => {
     if ( addEvidence ) {
       const obsPhotos = await ObservationPhoto
         .createObsPhotosWithPosition( evidenceToAdd, {
@@ -102,7 +102,7 @@ const usePrepareStateForObsEdit = (
   ] );
 
   return {
-    createEvidenceForObsEdit: localTaxon => createEvidenceForObsEdit( localTaxon )
+    prepareStateForObsEdit: localTaxon => prepareStateForObsEdit( localTaxon )
   };
 };
 

--- a/src/components/Camera/hooks/usePrepareStateForObsEdit.js
+++ b/src/components/Camera/hooks/usePrepareStateForObsEdit.js
@@ -6,13 +6,12 @@ import {
 } from "react";
 import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
+import { log } from "sharedHelpers/logger";
 import useStore from "stores/useStore";
 
-import { log } from "../../../../react-native-logs.config";
+const logger = log.extend( "usePrepareStateForObsEdit" );
 
-const logger = log.extend( "useCreateEvidence" );
-
-const useCreateEvidence = (
+const usePrepareStateForObsEdit = (
   permissionGranted: ?string,
   addEvidence: ?boolean
 ): Object => {
@@ -107,4 +106,4 @@ const useCreateEvidence = (
   };
 };
 
-export default useCreateEvidence;
+export default usePrepareStateForObsEdit;

--- a/src/components/Camera/hooks/useRotation.js
+++ b/src/components/Camera/hooks/useRotation.js
@@ -1,0 +1,48 @@
+// @flow
+
+import {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from "react-native-reanimated";
+import useDeviceOrientation, {
+  LANDSCAPE_LEFT,
+  LANDSCAPE_RIGHT,
+  PORTRAIT_UPSIDE_DOWN
+} from "sharedHooks/useDeviceOrientation";
+
+const useRotation = ( ): Object => {
+  const { deviceOrientation } = useDeviceOrientation( );
+
+  const rotation = useSharedValue( 0 );
+  switch ( deviceOrientation ) {
+    case LANDSCAPE_LEFT:
+      rotation.value = -90;
+      break;
+    case LANDSCAPE_RIGHT:
+      rotation.value = 90;
+      break;
+    case PORTRAIT_UPSIDE_DOWN:
+      rotation.value = 180;
+      break;
+    default:
+      rotation.value = 0;
+  }
+  const rotatableAnimatedStyle = useAnimatedStyle(
+    () => ( {
+      transform: [
+        {
+          rotateZ: withTiming( `${-1 * ( rotation?.value || 0 )}deg` )
+        }
+      ]
+    } ),
+    [rotation.value]
+  );
+
+  return {
+    rotatableAnimatedStyle,
+    rotation
+  };
+};
+
+export default useRotation;

--- a/src/components/Camera/hooks/useTakePhoto.js
+++ b/src/components/Camera/hooks/useTakePhoto.js
@@ -1,0 +1,83 @@
+// @flow
+
+import {
+  useState
+} from "react";
+import Photo from "realmModels/Photo";
+import {
+  rotatePhotoPatch,
+  rotationLocalPhotoPatch,
+  rotationTempPhotoPatch
+} from "sharedHelpers/visionCameraPatches";
+import useDeviceOrientation from "sharedHooks/useDeviceOrientation";
+import useStore from "stores/useStore";
+
+const useTakePhoto = ( camera: Object, addEvidence: ?boolean, device: Object ): Object => {
+  const { deviceOrientation } = useDeviceOrientation( );
+  const hasFlash = device?.hasFlash;
+  const initialPhotoOptions = {
+    enableShutterSound: true,
+    enableAutoStabilization: true,
+    qualityPrioritization: "quality",
+    ...( hasFlash && { flash: "off" } )
+  };
+  const [takePhotoOptions, setTakePhotoOptions] = useState( initialPhotoOptions );
+  const [takingPhoto, setTakingPhoto] = useState( false );
+
+  const setCameraState = useStore( state => state.setCameraState );
+  const originalCameraUrisMap = useStore( state => state.originalCameraUrisMap );
+  const evidenceToAdd = useStore( state => state.evidenceToAdd );
+  const cameraPreviewUris = useStore( state => state.cameraPreviewUris );
+
+  const takePhoto = async ( ) => {
+    setTakingPhoto( true );
+    const cameraPhoto = await camera.current.takePhoto( takePhotoOptions );
+
+    // Rotate the original photo depending on device orientation
+    const photoRotation = rotationTempPhotoPatch( cameraPhoto, deviceOrientation );
+    await rotatePhotoPatch( cameraPhoto, photoRotation );
+
+    // Get the rotation for the local photo
+    const rotationLocalPhoto = rotationLocalPhotoPatch( );
+
+    // Create a local copy photo of the original
+    const newPhoto = await Photo.new( cameraPhoto.path, {
+      rotation: rotationLocalPhoto
+    } );
+    const uri = newPhoto.localFilePath;
+
+    if ( addEvidence ) {
+      setCameraState( {
+        cameraPreviewUris: cameraPreviewUris.concat( [uri] ),
+        evidenceToAdd: [...evidenceToAdd, uri],
+        // Remember original (unresized) camera URI
+        originalCameraUrisMap: { ...originalCameraUrisMap, [uri]: cameraPhoto.path }
+      } );
+    } else {
+      setCameraState( {
+        cameraPreviewUris: cameraPreviewUris.concat( [uri] ),
+        // Remember original (unresized) camera URI
+        originalCameraUrisMap: { ...originalCameraUrisMap, [uri]: cameraPhoto.path }
+      } );
+    }
+    setTakingPhoto( false );
+  };
+
+  const toggleFlash = ( ) => {
+    setTakePhotoOptions( {
+      ...takePhotoOptions,
+      flash: takePhotoOptions.flash === "on"
+        ? "off"
+        : "on"
+    } );
+  };
+
+  return {
+    takePhoto,
+    takePhotoOptions,
+    takingPhoto,
+    toggleFlash
+  };
+};
+
+export default useTakePhoto;

--- a/src/components/Camera/hooks/useZoom.js
+++ b/src/components/Camera/hooks/useZoom.js
@@ -1,0 +1,82 @@
+// @flow
+
+import {
+  useState
+} from "react";
+import {
+  Extrapolate,
+  interpolate,
+  useAnimatedProps,
+  useSharedValue,
+  withSpring
+} from "react-native-reanimated";
+
+// This is taken from react-native-vision library itself: https://github.com/mrousavy/react-native-vision-camera/blob/9eed89aac6155eba155595f3e006707152550d0d/package/example/src/Constants.ts#L19 https://github.com/mrousavy/react-native-vision-camera/blob/9eed89aac6155eba155595f3e006707152550d0d/package/example/src/CameraPage.tsx#L34
+// The maximum zoom factor you should be able to zoom in
+const MAX_ZOOM_FACTOR = 20;
+// Used for calculating the final zoom by pinch gesture
+const SCALE_FULL_ZOOM = 3;
+
+const useZoom = ( device: Object ): Object => {
+  const zoom = useSharedValue( !device.isMultiCam
+    ? device.minZoom
+    : device.neutralZoom );
+  const startZoom = useSharedValue( !device.isMultiCam
+    ? device.minZoom
+    : device.neutralZoom );
+  const [zoomTextValue, setZoomTextValue] = useState( "1" );
+
+  const { minZoom } = device;
+  const maxZoom = Math.min( device.maxZoom ?? 1, MAX_ZOOM_FACTOR );
+
+  const changeZoom = ( ) => {
+    const currentZoomValue = zoomTextValue;
+    if ( currentZoomValue === "1" ) {
+      zoom.value = withSpring( maxZoom );
+      setZoomTextValue( "3" );
+    } else if ( currentZoomValue === "3" ) {
+      zoom.value = withSpring( minZoom );
+      setZoomTextValue( ".5" );
+    } else {
+      zoom.value = withSpring( device.neutralZoom );
+      setZoomTextValue( "1" );
+    }
+  };
+
+  const onZoomStart = () => {
+    startZoom.value = zoom.value;
+  };
+
+  const onZoomChange = scale => {
+    // Calculate new zoom value (since scale factor is relative to initial pinch)
+    const newScale = interpolate(
+      scale,
+      [1 - 1 / SCALE_FULL_ZOOM, 1, SCALE_FULL_ZOOM],
+      [-1, 0, 1],
+      Extrapolate.CLAMP
+    );
+    const newZoom = interpolate(
+      newScale,
+      [-1, 0, 1],
+      [minZoom, startZoom.value, maxZoom],
+      Extrapolate.CLAMP
+    );
+    zoom.value = newZoom;
+  };
+
+  const animatedProps = useAnimatedProps(
+    () => ( { zoom: zoom.value } ),
+    [zoom]
+  );
+
+  return {
+    animatedProps,
+    changeZoom,
+    onZoomChange,
+    onZoomStart,
+    showZoomButton: device.isMultiCam,
+    zoomTextValue
+  };
+};
+
+export default useZoom;

--- a/src/components/PhotoImporter/PhotoGallery.js
+++ b/src/components/PhotoImporter/PhotoGallery.js
@@ -179,7 +179,7 @@ const PhotoGallery = ( ): Node => {
           blockedPrompt={t( "Youve-previously-denied-gallery-permissions" )}
           buttonText={t( "CHOOSE-PHOTOS" )}
           icon="gallery"
-          image={require( "images/azmaan-baluch-_ra6NcejHVs-unsplash.jpg" )}
+          image={require( "images/viviana-rishe-j2330n6bg3I-unsplash.jpg" )}
           onPermissionGranted={onPermissionGranted}
         />
       )}

--- a/src/components/SharedComponents/PermissionGateContainer.js
+++ b/src/components/SharedComponents/PermissionGateContainer.js
@@ -51,21 +51,22 @@ export const LOCATION_PERMISSIONS: Array<string> = Platform.OS === "ios"
   : [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION];
 
 type Props = {
+  blockedPrompt?: string,
+  body?: string,
+  buttonText?: string,
   children?: Node,
-  permissions: Array<string>,
   icon?: string,
+  image?: Object,
+  onPermissionBlocked?: Function,
+  onPermissionDenied?: Function,
+  onPermissionGranted?: Function,
+  permissionNeeded?: boolean,
+  permissions: Array<string>,
+  setModalWasClosed?: Function,
+  testID?: string,
   title?: string,
   titleDenied: string,
-  body?: string,
-  blockedPrompt?: string,
-  buttonText?: string,
-  image?: Object,
-  permissionNeeded?: boolean,
-  onPermissionGranted?: Function,
-  onPermissionDenied?: Function,
-  onPermissionBlocked?: Function,
-  withoutNavigation?: boolean,
-  testID?: string
+  withoutNavigation?: boolean
 };
 
 export function permissionResultFromMultiple( multiResults: Object ): string {
@@ -104,10 +105,11 @@ const PermissionGateContainer = ( {
   onPermissionGranted,
   permissionNeeded = true,
   permissions,
+  setModalWasClosed,
+  testID,
   title,
   titleDenied,
-  withoutNavigation,
-  testID
+  withoutNavigation
 }: Props ): Node => {
   const [result, setResult] = useState( null );
   const [modalShown, setModalShown] = useState( false );
@@ -165,11 +167,15 @@ const PermissionGateContainer = ( {
 
   const closeModal = useCallback( ( ) => {
     setModalShown( false );
+    if ( setModalWasClosed ) {
+      setModalWasClosed( true );
+    }
     if ( !withoutNavigation ) navigation.goBack( );
   }, [
     navigation,
     setModalShown,
-    withoutNavigation
+    withoutNavigation,
+    setModalWasClosed
   ] );
 
   // If the result changes, notify the parent component

--- a/src/components/SharedComponents/PermissionGateContainer.js
+++ b/src/components/SharedComponents/PermissionGateContainer.js
@@ -62,6 +62,7 @@ type Props = {
   onPermissionGranted?: Function,
   permissionNeeded?: boolean,
   permissions: Array<string>,
+  setModalHidden?: Function,
   setModalWasClosed?: Function,
   testID?: string,
   title?: string,
@@ -105,6 +106,7 @@ const PermissionGateContainer = ( {
   onPermissionGranted,
   permissionNeeded = true,
   permissions,
+  setModalHidden,
   setModalWasClosed,
   testID,
   title,
@@ -142,6 +144,9 @@ const PermissionGateContainer = ( {
       setModalShown( true );
       return () => {};
     }
+    if ( setModalHidden ) {
+      setModalHidden( true );
+    }
     if ( !withoutNavigation ) {
       const unsubscribe = navigation.addListener( "focus", async () => {
         await checkPermission( );
@@ -156,6 +161,7 @@ const PermissionGateContainer = ( {
     navigation,
     permissionNeeded,
     result,
+    setModalHidden,
     withoutNavigation
   ] );
 

--- a/src/components/SharedComponents/PermissionGateContainer.js
+++ b/src/components/SharedComponents/PermissionGateContainer.js
@@ -42,6 +42,10 @@ export const READ_MEDIA_PERMISSIONS: Array<string> = Platform.OS === "ios"
   ? [PERMISSIONS.IOS.PHOTO_LIBRARY]
   : androidReadPermissions;
 
+export const WRITE_MEDIA_PERMISSIONS: Array<string> = Platform.OS === "ios"
+  ? [PERMISSIONS.IOS.PHOTO_LIBRARY_ADD_ONLY]
+  : androidReadPermissions;
+
 export const LOCATION_PERMISSIONS: Array<string> = Platform.OS === "ios"
   ? [PERMISSIONS.IOS.LOCATION_WHEN_IN_USE]
   : [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION];

--- a/src/components/SharedComponents/PermissionGateContainer.js
+++ b/src/components/SharedComponents/PermissionGateContainer.js
@@ -62,7 +62,6 @@ type Props = {
   onPermissionGranted?: Function,
   permissionNeeded?: boolean,
   permissions: Array<string>,
-  setModalHidden?: Function,
   setModalWasClosed?: Function,
   testID?: string,
   title?: string,
@@ -106,7 +105,6 @@ const PermissionGateContainer = ( {
   onPermissionGranted,
   permissionNeeded = true,
   permissions,
-  setModalHidden,
   setModalWasClosed,
   testID,
   title,
@@ -144,9 +142,6 @@ const PermissionGateContainer = ( {
       setModalShown( true );
       return () => {};
     }
-    if ( setModalHidden ) {
-      setModalHidden( true );
-    }
     if ( !withoutNavigation ) {
       const unsubscribe = navigation.addListener( "focus", async () => {
         await checkPermission( );
@@ -161,7 +156,6 @@ const PermissionGateContainer = ( {
     navigation,
     permissionNeeded,
     result,
-    setModalHidden,
     withoutNavigation
   ] );
 

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1439,6 +1439,5 @@ Native-to = Native to { $displayName }
 Source-List = <0>(Source List: </0><1>{ $source }</1><0>)</0>
 
 Save-photos-to-your-gallery = Save photos to your gallery
-Save-photos-to-your-gallery-to-create-observations = Save photos to your gallery to create observations
-ADD-PHOTOS = ADD PHOTOS
-Youve-previously-denied-add-photo-permissions = You've previously denied add photo permissions
+iNaturalist-can-save-photos-you-take-in-the-app-to-your-devices-gallery = iNaturalist can save photos you take in the app to your device’s gallery.
+SAVE-PHOTOS = SAVE PHOTOS

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1437,3 +1437,8 @@ Endemic-to = Endemic to { $displayName }
 Introduced-to = Introduced to { $displayName }
 Native-to = Native to { $displayName }
 Source-List = <0>(Source List: </0><1>{ $source }</1><0>)</0>
+
+Save-photos-to-your-gallery = Save photos to your gallery
+Save-photos-to-your-gallery-to-create-observations = Save photos to your gallery to create observations
+ADD-PHOTOS = ADD PHOTOS
+Youve-previously-denied-add-photo-permissions = You've previously denied add photo permissions

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1073,5 +1073,9 @@
   "Endemic-to": "Endemic to { $displayName }",
   "Introduced-to": "Introduced to { $displayName }",
   "Native-to": "Native to { $displayName }",
-  "Source-List": "<0>(Source List: </0><1>{ $source }</1><0>)</0>"
+  "Source-List": "<0>(Source List: </0><1>{ $source }</1><0>)</0>",
+  "Save-photos-to-your-gallery": "Save photos to your gallery",
+  "Save-photos-to-your-gallery-to-create-observations": "Save photos to your gallery to create observations",
+  "ADD-PHOTOS": "ADD PHOTOS",
+  "Youve-previously-denied-add-photo-permissions": "You've previously denied add photo permissions"
 }

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1075,7 +1075,6 @@
   "Native-to": "Native to { $displayName }",
   "Source-List": "<0>(Source List: </0><1>{ $source }</1><0>)</0>",
   "Save-photos-to-your-gallery": "Save photos to your gallery",
-  "Save-photos-to-your-gallery-to-create-observations": "Save photos to your gallery to create observations",
-  "ADD-PHOTOS": "ADD PHOTOS",
-  "Youve-previously-denied-add-photo-permissions": "You've previously denied add photo permissions"
+  "iNaturalist-can-save-photos-you-take-in-the-app-to-your-devices-gallery": "iNaturalist can save photos you take in the app to your device’s gallery.",
+  "SAVE-PHOTOS": "SAVE PHOTOS"
 }

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1439,6 +1439,5 @@ Native-to = Native to { $displayName }
 Source-List = <0>(Source List: </0><1>{ $source }</1><0>)</0>
 
 Save-photos-to-your-gallery = Save photos to your gallery
-Save-photos-to-your-gallery-to-create-observations = Save photos to your gallery to create observations
-ADD-PHOTOS = ADD PHOTOS
-Youve-previously-denied-add-photo-permissions = You've previously denied add photo permissions
+iNaturalist-can-save-photos-you-take-in-the-app-to-your-devices-gallery = iNaturalist can save photos you take in the app to your device’s gallery.
+SAVE-PHOTOS = SAVE PHOTOS

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1437,3 +1437,8 @@ Endemic-to = Endemic to { $displayName }
 Introduced-to = Introduced to { $displayName }
 Native-to = Native to { $displayName }
 Source-List = <0>(Source List: </0><1>{ $source }</1><0>)</0>
+
+Save-photos-to-your-gallery = Save photos to your gallery
+Save-photos-to-your-gallery-to-create-observations = Save photos to your gallery to create observations
+ADD-PHOTOS = ADD PHOTOS
+Youve-previously-denied-add-photo-permissions = You've previously denied add photo permissions

--- a/src/navigation/StackNavigators/AddObsStackNavigator.js
+++ b/src/navigation/StackNavigators/AddObsStackNavigator.js
@@ -46,7 +46,7 @@ const SoundRecorderWithPermission = ( ) => (
     blockedPrompt={t( "Youve-previously-denied-microphone-permissions" )}
     buttonText={t( "RECORD-SOUND" )}
     icon="microphone"
-    image={require( "images/viviana-rishe-j2330n6bg3I-unsplash.jpg" )}
+    image={require( "images/azmaan-baluch-_ra6NcejHVs-unsplash.jpg" )}
   >
     <SoundRecorder />
   </PermissionGateContainer>

--- a/tests/unit/components/Camera/ARCamera.test.js
+++ b/tests/unit/components/Camera/ARCamera.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react-native";
 import ARCamera from "components/Camera/ARCamera/ARCamera";
-import * as useModelLoaded from "components/Camera/ARCamera/hooks/useModelLoaded";
+import * as usePredictions from "components/Camera/ARCamera/hooks/usePredictions";
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
@@ -45,7 +45,7 @@ const mockModelLoaded = {
   result: null
 };
 
-jest.mock( "components/Camera/ARCamera/hooks/useModelLoaded", () => ( {
+jest.mock( "components/Camera/ARCamera/hooks/usePredictions", () => ( {
   __esModule: true,
   default: () => mockModelLoaded
 } ) );
@@ -63,7 +63,7 @@ describe( "AR Camera", ( ) => {
     await initI18next( );
   } );
   it( "shows a taxon prediction when result & rank_level < 40", async () => {
-    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+    jest.spyOn( usePredictions, "default" ).mockImplementation( () => ( {
       ...mockModelLoaded,
       result: {
         taxon: mockTaxonPrediction
@@ -77,7 +77,7 @@ describe( "AR Camera", ( ) => {
   } );
 
   it( "shows scan area text when rank_level > 40", async () => {
-    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+    jest.spyOn( usePredictions, "default" ).mockImplementation( () => ( {
       ...mockModelLoaded,
       modelLoaded: true,
       result: {
@@ -92,7 +92,7 @@ describe( "AR Camera", ( ) => {
   } );
 
   it( "shows loading text when model not yet loaded", async () => {
-    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+    jest.spyOn( usePredictions, "default" ).mockImplementation( () => ( {
       ...mockModelLoaded,
       modelLoaded: false
     } ) );
@@ -104,7 +104,7 @@ describe( "AR Camera", ( ) => {
   } );
 
   it( "displays taxon photo if taxon exists in realm", ( ) => {
-    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+    jest.spyOn( usePredictions, "default" ).mockImplementation( () => ( {
       ...mockModelLoaded,
       modelLoaded: true,
       result: {
@@ -129,7 +129,7 @@ describe( "AR Camera", ( ) => {
         url: null
       }
     } ) );
-    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+    jest.spyOn( usePredictions, "default" ).mockImplementation( () => ( {
       ...mockModelLoaded,
       modelLoaded: true,
       result: {

--- a/tests/unit/components/Camera/ARCamera.test.js
+++ b/tests/unit/components/Camera/ARCamera.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react-native";
 import ARCamera from "components/Camera/ARCamera/ARCamera";
+import * as useModelLoaded from "components/Camera/ARCamera/hooks/useModelLoaded";
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
@@ -38,18 +39,37 @@ jest.mock( "sharedHooks/useTaxon", () => ( {
   default: () => mockLocalTaxon
 } ) );
 
+const mockModelLoaded = {
+  handleTaxaDetected: jest.fn( ),
+  modelLoaded: false,
+  result: null
+};
+
+jest.mock( "components/Camera/ARCamera/hooks/useModelLoaded", () => ( {
+  __esModule: true,
+  default: () => mockModelLoaded
+} ) );
+
+jest.mock( "components/Camera/hooks/useZoom", () => ( {
+  __esModule: true,
+  default: () => ( {
+    animatedProps: {}
+  }
+  )
+} ) );
+
 describe( "AR Camera", ( ) => {
   beforeAll( async ( ) => {
     await initI18next( );
   } );
   it( "shows a taxon prediction when result & rank_level < 40", async () => {
-    render(
-      <ARCamera
-        result={{
-          taxon: mockTaxonPrediction
-        }}
-      />
-    );
+    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+      ...mockModelLoaded,
+      result: {
+        taxon: mockTaxonPrediction
+      }
+    } ) );
+    render( <ARCamera /> );
 
     const taxonResult = screen.getByTestId( `ARCamera.taxa.${mockTaxonPrediction.id}` );
 
@@ -57,14 +77,14 @@ describe( "AR Camera", ( ) => {
   } );
 
   it( "shows scan area text when rank_level > 40", async () => {
-    render(
-      <ARCamera
-        result={{
-          taxon: mockTaxonNoPrediction
-        }}
-        modelLoaded
-      />
-    );
+    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+      ...mockModelLoaded,
+      modelLoaded: true,
+      result: {
+        taxon: mockTaxonNoPrediction
+      }
+    } ) );
+    render( <ARCamera /> );
 
     const scanText = screen.getByText( i18next.t( "Scan-the-area-around-you-for-organisms" ) );
 
@@ -72,12 +92,11 @@ describe( "AR Camera", ( ) => {
   } );
 
   it( "shows loading text when model not yet loaded", async () => {
-    render(
-      <ARCamera
-        modelLoaded={false}
-        result={null}
-      />
-    );
+    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+      ...mockModelLoaded,
+      modelLoaded: false
+    } ) );
+    render( <ARCamera /> );
 
     const loadingText = screen.getByText( i18next.t( "Loading-iNaturalists-AR-Camera" ) );
 
@@ -85,14 +104,14 @@ describe( "AR Camera", ( ) => {
   } );
 
   it( "displays taxon photo if taxon exists in realm", ( ) => {
-    render(
-      <ARCamera
-        result={{
-          taxon: mockLocalTaxon
-        }}
-        modelLoaded
-      />
-    );
+    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+      ...mockModelLoaded,
+      modelLoaded: true,
+      result: {
+        taxon: mockLocalTaxon
+      }
+    } ) );
+    render( <ARCamera /> );
 
     const taxonPhoto = screen.getByTestId( "ObsList.photo" );
 
@@ -110,14 +129,14 @@ describe( "AR Camera", ( ) => {
         url: null
       }
     } ) );
-    render(
-      <ARCamera
-        result={{
-          taxon: mockLocalTaxon
-        }}
-        modelLoaded
-      />
-    );
+    jest.spyOn( useModelLoaded, "default" ).mockImplementation( () => ( {
+      ...mockModelLoaded,
+      modelLoaded: true,
+      result: {
+        taxon: mockLocalTaxon
+      }
+    } ) );
+    render( <ARCamera /> );
 
     const taxonIcon = screen.getByTestId( "IconicTaxonName.iconicTaxonIcon" );
 


### PR DESCRIPTION
Closes #830 

- Adds a permission gate for saving photos to library. Permission Gate appears when a user taps the checkmark on the Standard Camera or snaps a photo / taps the checkmark on the AR Camera
- Code cleanup: using shared hooks for zoom, rotation, etc. in camera library to make camera functionality easier to reason about