### PR TITLE
Minor style fixes for ObsDetails

### DIFF
--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -16,8 +16,8 @@ import {
 
 import ActivityTab from "./ActivityTab/ActivityTab";
 import FloatingButtons from "./ActivityTab/FloatingButtons";
-import CommunityTaxon from "./CommunityTaxon";
 import DetailsTab from "./DetailsTab/DetailsTab";
+import ObsDetailsHeader from "./ObsDetailsHeader";
 import PhotoDisplayContainer from "./PhotoDisplayContainer";
 
 type Props = {
@@ -77,7 +77,7 @@ const ObsDetails = ( {
       <StatusBar barStyle="light-content" backgroundColor="black" />
       <ScrollView
         testID={`ObsDetails.${uuid}`}
-        stickyHeaderIndices={[1]}
+        stickyHeaderIndices={[2]}
         scrollEventThrottle={16}
         className="bg-white"
       >
@@ -87,7 +87,7 @@ const ObsDetails = ( {
           isOnline={isOnline}
           belongsToCurrentUser={belongsToCurrentUser}
         />
-        <CommunityTaxon
+        <ObsDetailsHeader
           observation={observation}
           isOnline={isOnline}
         />
@@ -111,7 +111,6 @@ const ObsDetails = ( {
             <ActivityIndicator size="large" />
           </View>
         )}
-        <View className="pb-64" />
       </ScrollView>
       {showActivityTab && (
         <FloatingButtons

--- a/src/components/ObsDetails/ObsDetailsHeader.js
+++ b/src/components/ObsDetails/ObsDetailsHeader.js
@@ -45,7 +45,7 @@ const CommunityTaxon = ( {
   };
 
   return (
-    <>
+    <View className="bg-white">
       <View className="flex-row justify-between mx-[15px] mt-[13px]">
         <InlineUser user={observation?.user} isOnline={isOnline} />
         <DateDisplay
@@ -63,7 +63,7 @@ const CommunityTaxon = ( {
         </View>
       </View>
       <ObservationLocation observation={observation} classNameMargin="ml-3 mb-2" />
-    </>
+    </View>
   );
 };
 

--- a/tests/unit/components/ObsDetails/ObsDetailsHeader.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetailsHeader.test.js
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
-import CommunityTaxon from "components/ObsDetails/CommunityTaxon";
+import ObsDetailsHeader from "components/ObsDetails/ObsDetailsHeader";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
@@ -12,14 +12,14 @@ const mockTaxon = factory( "RemoteTaxon", {
   preferred_common_name: faker.person.fullName( )
 } );
 
-describe( "CommunityTaxon", () => {
+describe( "ObsDetailsHeader", () => {
   beforeAll( async ( ) => {
     await initI18next( );
   } );
 
   it( "displays unknown text if no taxon", async ( ) => {
     renderComponent(
-      <CommunityTaxon
+      <ObsDetailsHeader
         observation={{
           taxon: null
         }}
@@ -32,7 +32,7 @@ describe( "CommunityTaxon", () => {
 
   it( "displays taxon", async ( ) => {
     renderComponent(
-      <CommunityTaxon
+      <ObsDetailsHeader
         observation={{
           taxon: mockTaxon
         }}


### PR DESCRIPTION
* Renamed CommunityTaxon to ObsDetailsHeader since it has more info than just the community taxon
* Made tabs stick on scroll instead of header
* Removed weird spacer element at the bottom of the activity