### PR TITLE
Add autofocus prop to SearchBar

### DIFF
--- a/src/components/SharedComponents/SearchBar.js
+++ b/src/components/SharedComponents/SearchBar.js
@@ -18,6 +18,7 @@ const getShadow = shadowColor => getShadowStyle( {
 } );
 
 type Props = {
+  autoFocus?: boolean,
   clearSearch?: Function,
   containerClass?: string,
   handleTextChange: Function,
@@ -31,6 +32,7 @@ type Props = {
 // Ensure this component is placed outside of scroll views
 
 const SearchBar = ( {
+  autoFocus = false,
   clearSearch,
   containerClass,
   handleTextChange,
@@ -78,6 +80,7 @@ const SearchBar = ( {
         ref={input}
         accessibilityLabel={t( "Search-for-a-taxon" )}
         activeUnderlineColor={theme.colors.primary}
+        autoFocus={autoFocus}
         dense
         keyboardType="default"
         mode="outlined"

--- a/src/components/Suggestions/TaxonSearch.js
+++ b/src/components/Suggestions/TaxonSearch.js
@@ -46,6 +46,7 @@ const TaxonSearch = ( ): Node => {
         value={taxonQuery}
         testID="SearchTaxon"
         containerClass="my-5 mx-4"
+        autoFocus={taxonQuery === ""}
       />
       <FlatList
         keyboardShouldPersistTaps="always"


### PR DESCRIPTION
Closes #914
- Search bar autofocuses when a user lands on TaxonSearch and the search input is empty