### PR TITLE
Community taxon opt out notice

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -688,7 +688,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 9af0c7125f20c5c5cb032eadbf66744693241dd8
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: d06bbe89e3a89ee90c4deab1c84bf306ffa5ed37

--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -8,8 +8,8 @@ import handleError from "./error";
 const MESSAGE_FIELDS = {
   subject: true,
   body: true,
-  from_user: User.USER_FIELDS,
-  to_user: User.USER_FIELDS
+  from_user: User.FIELDS,
+  to_user: User.FIELDS
 };
 
 const PARAMS = {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -46,6 +46,8 @@ type Props = {
 const App = ( { children }: Props ): Node => {
   const navigation = useNavigation( );
   const realm = useRealm( );
+  logger.debug( "[App.js] Need to open Realm in another app?" );
+  logger.debug( "[App.js] realm.path: ", realm?.path );
   const currentUser = useCurrentUser( );
   useIconicTaxa( { reload: true } );
   const { i18n } = useTranslation( );

--- a/src/components/Explore/Header/Header.js
+++ b/src/components/Explore/Header/Header.js
@@ -102,7 +102,8 @@ const Header = ( {
                     updateTaxonName( taxonText );
                   }
                 }}
-                value={taxonName || t( "All-organisms" )}
+                value={taxonName}
+                placeholder={t( "All-organisms" )}
                 testID="Explore.taxonSearch"
                 containerClass="w-[250px]"
                 input={taxonInput}
@@ -138,7 +139,8 @@ const Header = ( {
                     updatePlaceName( placeText );
                   }
                 }}
-                value={placeName || t( "Worldwide" )}
+                value={placeName}
+                placeholder={t( "Worldwide" )}
                 testID="Explore.placeSearch"
                 containerClass="w-[250px]"
                 input={placeInput}

--- a/src/components/Explore/IdentifiersView.js
+++ b/src/components/Explore/IdentifiersView.js
@@ -35,7 +35,7 @@ const IdentifiersView = ( {
       ...queryParams,
       fields: {
         identifications_count: true,
-        user: User.USER_FIELDS
+        user: User.FIELDS
       }
     }
   );

--- a/src/components/Explore/ObserversView.js
+++ b/src/components/Explore/ObserversView.js
@@ -34,7 +34,7 @@ const ObserversView = ( {
     {
       ...queryParams,
       fields: {
-        user: User.USER_FIELDS
+        user: User.FIELDS
       }
     }
   );

--- a/src/components/ObsDetails/DetailsTab/Attribution.js
+++ b/src/components/ObsDetails/DetailsTab/Attribution.js
@@ -9,41 +9,40 @@ type Props = {
   observation: Object
 }
 
+const renderRestrictions = ( licenseCode: string ) => {
+  switch ( licenseCode ) {
+    case "cc0":
+      return t( "no-rights-reserved-cc0" );
+    case "cc-by":
+      return t( "attribution-cc-by" );
+    case "cc-by-sa":
+      return t( "attribution-cc-by-sa" );
+    case "cc-by-nc":
+      return t( "attribution-cc-by-nc" );
+    case "cc-by-nd":
+      return t( "attribution-cc-by-nd" );
+    case "cc-by-nc-sa":
+      return t( "attribution-cc-by-nc-sa" );
+    case "cc-by-nc-nd":
+      return t( "attribution-cc-by-nc-nd" );
+    default:
+      return t( "all-rights-reserved" );
+  }
+};
+
 // lifted from web:
 // https://github.com/inaturalist/inaturalist/blob/768b9263931ebeea229bbc47d8442ca6b0377d45/app/webpack/shared/components/observation_attribution.jsx
 const Attribution = ( { observation }: Props ): Node => {
   const { user } = observation;
-  const licenseCode = observation.license_code;
-  const copyrightAttribution = user
+  const userName = user
     ? ( user.name || user.login )
     : t( "unknown" );
-
-  const renderRestrictions = ( ) => {
-    switch ( licenseCode ) {
-      case "cc0":
-        return t( "no-rights-reserved-cc0" );
-      case "cc-by":
-        return t( "attribution-cc-by" );
-      case "cc-by-sa":
-        return t( "attribution-cc-by-sa" );
-      case "cc-by-nc":
-        return t( "attribution-cc-by-nc" );
-      case "cc-by-nd":
-        return t( "attribution-cc-by-nd" );
-      case "cc-by-nc-sa":
-        return t( "attribution-cc-by-nc-sa" );
-      case "cc-by-nc-nd":
-        return t( "attribution-cc-by-nc-nd" );
-      default:
-        return t( "all-rights-reserved" );
-    }
-  };
 
   return (
     <Body4>
       {t( "Observation-Attribution", {
-        attribution: copyrightAttribution,
-        restrictions: renderRestrictions( )
+        userName,
+        restrictions: renderRestrictions( observation.license_code )
       } )}
     </Body4>
   );

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -90,6 +90,7 @@ const ObsDetails = ( {
         <ObsDetailsHeader
           observation={observation}
           isOnline={isOnline}
+          belongsToCurrentUser={belongsToCurrentUser}
         />
         <View className="bg-white">
           <Tabs tabs={tabs} activeId={currentTabId} />

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -151,7 +151,7 @@ const ObsDetailsContainer = ( ): Node => {
     }
   );
 
-  const observation = localObservation || remoteObservation;
+  const observation = localObservation || Observation.mapApiToRealm( remoteObservation );
 
   // In theory the only sitiation in which an observation would not have a
   // user is when a user is not signed but has made a new observation in the

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -157,8 +157,28 @@ const ObsDetailsContainer = ( ): Node => {
   // user is when a user is not signed but has made a new observation in the
   // app. Also in theory that user should not be able to get to ObsDetail for
   // those observations, just ObsEdit. But.... let's be safe.
-  const belongsToCurrentUser = observation?.user?.id === currentUser?.id
-    || ( !observation?.user && !observation?.id );
+  const belongsToCurrentUser = (
+    observation?.user?.id === currentUser?.id
+    || ( !observation?.user && !observation?.id )
+  );
+
+  // Update local copy of a user's own observation
+  useEffect( ( ) => {
+    if (
+      remoteObservation
+      && currentUser
+      && remoteObservation?.user?.id === currentUser.id
+    ) {
+      Observation.upsertRemoteObservations(
+        [remoteObservation],
+        realm
+      );
+    }
+  }, [
+    currentUser,
+    realm,
+    remoteObservation
+  ] );
 
   useFocusEffect(
     // this ensures activity items load after a user taps suggest id
@@ -341,12 +361,14 @@ const ObsDetailsContainer = ( ): Node => {
   useEffect( ( ) => {
     if (
       remoteObservation
+      && currentUser
       && localObservation?.unviewed( )
       && !markViewedMutation.isLoading
     ) {
       markViewedMutation.mutate( { id: uuid } );
     }
   }, [
+    currentUser,
     localObservation,
     markViewedMutation,
     remoteObservation,

--- a/src/components/ObsDetails/ObsDetailsHeader.js
+++ b/src/components/ObsDetails/ObsDetailsHeader.js
@@ -2,6 +2,7 @@
 import { useNavigation } from "@react-navigation/native";
 import {
   Body1,
+  Body4,
   DateDisplay, DisplayTaxon, InlineUser, ObservationLocation
 } from "components/SharedComponents";
 import ObsStatus from "components/SharedComponents/ObservationsFlashList/ObsStatus";
@@ -13,11 +14,13 @@ import {
 } from "sharedHooks";
 
 type Props = {
+  belongsToCurrentUser?: boolean,
   observation: Object,
   isOnline: boolean,
 }
 
 const ObsDetailsHeader = ( {
+  belongsToCurrentUser,
   observation,
   isOnline
 }: Props ): Node => {
@@ -54,7 +57,7 @@ const ObsDetailsHeader = ( {
           }
         />
       </View>
-      <View className="flex-row my-[11px] mx-3">
+      <View className="flex-row my-[11px] mx-3 items-center">
         <View className="shrink">
           {showTaxon()}
         </View>
@@ -62,6 +65,20 @@ const ObsDetailsHeader = ( {
           <ObsStatus layout="vertical" observation={observation} />
         </View>
       </View>
+      {
+        (
+          observation.prefersCommunityTaxon === false
+          || observation.user?.prefers_community_taxa === false
+        ) && (
+          <Body4 className="mx-3 mt-0 mb-2 italic">
+            {
+              belongsToCurrentUser
+                ? t( "You-have-opted-out-of-the-Community-Taxon" )
+                : t( "This-observer-has-opted-out-of-the-Community-Taxon" )
+            }
+          </Body4>
+        )
+      }
       <ObservationLocation observation={observation} classNameMargin="mx-3 mb-2" />
     </View>
   );

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -514,7 +514,7 @@ none = none
 No-photos-found = No photos found. If this is your first time opening the app and giving permissions, try restarting the app.
 
 # license code
-no-rights-reserved-cc0-cc0 = no rights reserved (CC0) (CC0)
+no-rights-reserved-cc0 = no rights reserved (CC0)
 
 # Header for observation description on observation detail
 NOTES = NOTES
@@ -542,7 +542,7 @@ Obscured-observation-location-map-description = This observation’s location is
 
 Observation = Observation
 
-Observation-Attribution = Observation: © {$attribution} · {$restrictions}
+Observation-Attribution = Observation: © {$userName} · {$restrictions}
 
 OBSERVATIONS = OBSERVATIONS
 

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1475,3 +1475,6 @@ IDENTIFIERS = IDENTIFIERS
 OBSERVERS = OBSERVERS
 All-organisms = All organisms
 Worldwide = Worldwide
+
+This-observer-has-opted-out-of-the-Community-Taxon = This observer has opted out of the Community Taxon
+You-have-opted-out-of-the-Community-Taxon = You have opted out of the Community Taxon

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -311,9 +311,9 @@
   "No-model-found": "No model found",
   "none": "none",
   "No-photos-found": "No photos found. If this is your first time opening the app and giving permissions, try restarting the app.",
-  "no-rights-reserved-cc0-cc0": {
+  "no-rights-reserved-cc0": {
     "comment": "license code",
-    "val": "no rights reserved (CC0) (CC0)"
+    "val": "no rights reserved (CC0)"
   },
   "NOTES": {
     "comment": "Header for observation description on observation detail",
@@ -336,7 +336,7 @@
     "val": "This observation’s location is obscured. You are seeing a randomized point within the obscuration polygon."
   },
   "Observation": "Observation",
-  "Observation-Attribution": "Observation: © { $attribution } · { $restrictions }",
+  "Observation-Attribution": "Observation: © { $userName } · { $restrictions }",
   "OBSERVATIONS": "OBSERVATIONS",
   "Observations": "Observations",
   "Observations-created-on-iNaturalist": "Observations created on iNaturalist are used by scientists around the world.",

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1097,5 +1097,7 @@
   "IDENTIFIERS": "IDENTIFIERS",
   "OBSERVERS": "OBSERVERS",
   "All-organisms": "All organisms",
-  "Worldwide": "Worldwide"
+  "Worldwide": "Worldwide",
+  "This-observer-has-opted-out-of-the-Community-Taxon": "This observer has opted out of the Community Taxon",
+  "You-have-opted-out-of-the-Community-Taxon": "You have opted out of the Community Taxon"
 }

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -514,7 +514,7 @@ none = none
 No-photos-found = No photos found. If this is your first time opening the app and giving permissions, try restarting the app.
 
 # license code
-no-rights-reserved-cc0-cc0 = no rights reserved (CC0) (CC0)
+no-rights-reserved-cc0 = no rights reserved (CC0)
 
 # Header for observation description on observation detail
 NOTES = NOTES
@@ -542,7 +542,7 @@ Obscured-observation-location-map-description = This observation’s location is
 
 Observation = Observation
 
-Observation-Attribution = Observation: © {$attribution} · {$restrictions}
+Observation-Attribution = Observation: © {$userName} · {$restrictions}
 
 OBSERVATIONS = OBSERVATIONS
 

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1475,3 +1475,6 @@ IDENTIFIERS = IDENTIFIERS
 OBSERVERS = OBSERVERS
 All-organisms = All organisms
 Worldwide = Worldwide
+
+This-observer-has-opted-out-of-the-Community-Taxon = This observer has opted out of the Community Taxon
+You-have-opted-out-of-the-Community-Taxon = You have opted out of the Community Taxon

--- a/src/realmModels/Comment.js
+++ b/src/realmModels/Comment.js
@@ -10,7 +10,7 @@ class Comment extends Realm.Object {
     created_at: true,
     flags: Flag.FLAG_FIELDS,
     id: true,
-    user: User && User.USER_FIELDS
+    user: User && User.FIELDS
   };
 
   static schema = {

--- a/src/realmModels/Identification.js
+++ b/src/realmModels/Identification.js
@@ -17,7 +17,7 @@ class Identification extends Realm.Object {
     taxon: Taxon.TAXON_FIELDS,
     updated_at: true,
     // $FlowFixMe
-    user: User && ( { ...User.USER_FIELDS, id: true } ),
+    user: User && ( { ...User.FIELDS, id: true } ),
     uuid: true,
     vision: true
   };
@@ -31,10 +31,10 @@ class Identification extends Realm.Object {
     };
   }
 
-  static mapApiToRealm( id ) {
+  static mapApiToRealm( id, realm = null ) {
     const newId = {
       ...id,
-      taxon: Taxon.mapApiToRealm( id.taxon )
+      taxon: Taxon.mapApiToRealm( id.taxon, realm )
     };
     return newId;
   }

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -151,7 +151,7 @@ class Observation extends Realm.Object {
       privateLongitude: obs.private_geojson && obs.private_geojson.coordinates
                       && obs.private_geojson.coordinates[0],
       observationPhotos,
-      prefersCommunityTaxon: obs.preferences?.prefers_community_taxon,
+      prefers_community_taxon: obs.preferences?.prefers_community_taxon,
       taxon
     };
 
@@ -341,7 +341,7 @@ class Observation extends Realm.Object {
       species_guess: "string?",
       place_guess: { type: "string", mapTo: "placeGuess", optional: true },
       positional_accuracy: "double?",
-      prefers_community_taxon: { type: "bool", mapTo: "prefersCommunityTaxon", optional: true },
+      prefers_community_taxon: "bool?",
       quality_grade: { type: "string", mapTo: "qualityGrade", optional: true },
       taxon: "Taxon?",
       // datetime when the observer observed the organism; user-editable, but

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -39,13 +39,21 @@ class Observation extends Realm.Object {
     sounds: ObservationSound.OBSERVATION_SOUNDS_FIELDS,
     taxon: Taxon.TAXON_FIELDS,
     time_observed_at: true,
-    user: User && User.USER_FIELDS,
+    user: User && {
+      ...User.FIELDS,
+      preferences: {
+        prefers_community_taxa: true
+      }
+    },
     updated_at: true,
     viewer_trusted_by_observer: true,
     private_geojson: true,
     private_location: true,
     private_place_guess: true,
-    positional_accuracy: true
+    positional_accuracy: true,
+    preferences: {
+      prefers_community_taxon: true
+    }
   };
 
   static LIST_FIELDS = {
@@ -64,7 +72,7 @@ class Observation extends Realm.Object {
     quality_grade: true,
     taxon: Taxon.TAXON_FIELDS,
     time_observed_at: true,
-    user: User && User.USER_FIELDS
+    user: User && User.FIELDS
   };
 
   static async new( obs ) {
@@ -98,7 +106,7 @@ class Observation extends Realm.Object {
         obsToUpsert.forEach( obs => {
           realm.create(
             "Observation",
-            Observation.createOrModifyLocalObservation( obs, realm ),
+            Observation.mapApiToRealm( obs, realm ),
             "modified"
           );
         } );
@@ -106,17 +114,28 @@ class Observation extends Realm.Object {
     }
   }
 
-  static createOrModifyLocalObservation( obs, realm ) {
+  static mapApiToRealm( obs, realm = null ) {
+    if ( !obs ) return obs;
     const existingObs = realm?.objectForPrimaryKey( "Observation", obs.uuid );
     const taxon = obs.taxon
-      ? Taxon.mapApiToRealm( obs.taxon )
+      ? Taxon.mapApiToRealm( obs.taxon, realm )
       : null;
     const observationPhotos = (
       obs.observation_photos || obs.observationPhotos || []
-    ).map( obsPhoto => ObservationPhoto.mapApiToRealm( obsPhoto, existingObs ) );
+    ).map( obsPhoto => {
+      const mappedObsPhoto = ObservationPhoto.mapApiToRealm( obsPhoto, realm );
+      const existingObsPhoto = existingObs?.observationPhotos?.find(
+        op => op.uuid === obsPhoto.uuid
+      );
+      if ( !existingObsPhoto ) {
+        mappedObsPhoto._created_at = new Date( );
+        mappedObsPhoto.photo._created_at = new Date( );
+      }
+      return mappedObsPhoto;
+    } );
 
     const identifications = obs.identifications
-      ? obs.identifications.map( id => Identification.mapApiToRealm( id ) )
+      ? obs.identifications.map( id => Identification.mapApiToRealm( id, realm ) )
       : [];
 
     const localObs = {
@@ -132,8 +151,16 @@ class Observation extends Realm.Object {
       privateLongitude: obs.private_geojson && obs.private_geojson.coordinates
                       && obs.private_geojson.coordinates[0],
       observationPhotos,
+      prefersCommunityTaxon: obs.preferences?.prefers_community_taxon,
       taxon
     };
+
+    if ( localObs.user ) {
+      localObs.user.prefers_community_taxa = (
+        localObs.user.prefers_community_taxa
+        || localObs.user.preferences?.prefers_community_taxa
+      );
+    }
 
     if ( !existingObs ) {
       localObs._created_at = new Date( localObs.created_at );
@@ -314,6 +341,7 @@ class Observation extends Realm.Object {
       species_guess: "string?",
       place_guess: { type: "string", mapTo: "placeGuess", optional: true },
       positional_accuracy: "double?",
+      prefers_community_taxon: { type: "bool", mapTo: "prefersCommunityTaxon", optional: true },
       quality_grade: { type: "string", mapTo: "qualityGrade", optional: true },
       taxon: "Taxon?",
       // datetime when the observer observed the organism; user-editable, but

--- a/src/realmModels/ObservationPhoto.js
+++ b/src/realmModels/ObservationPhoto.js
@@ -20,18 +20,12 @@ class ObservationPhoto extends Realm.Object {
     return this._synced_at !== null;
   }
 
-  static mapApiToRealm( observationPhoto, existingObs ) {
-    const obsPhotos = existingObs?.observationPhotos;
-    const existingObsPhoto = obsPhotos?.find( p => p.uuid === observationPhoto.uuid );
-
+  static mapApiToRealm( observationPhoto, realm = null ) {
     const localObsPhoto = {
       ...observationPhoto,
       _synced_at: new Date( ),
-      photo: Photo.mapApiToRealm( observationPhoto.photo, existingObsPhoto )
+      photo: Photo.mapApiToRealm( observationPhoto.photo, realm )
     };
-    if ( !existingObsPhoto ) {
-      localObsPhoto._created_at = new Date( );
-    }
     return localObsPhoto;
   }
 

--- a/src/realmModels/Photo.js
+++ b/src/realmModels/Photo.js
@@ -13,14 +13,11 @@ class Photo extends Realm.Object {
 
   static photoUploadPath = `${RNFS.DocumentDirectoryPath}/photoUploads`;
 
-  static mapApiToRealm( photo, existingObsPhoto ) {
+  static mapApiToRealm( photo, _realm = null ) {
     const localPhoto = {
       ...photo,
       _synced_at: new Date( )
     };
-    if ( !existingObsPhoto ) {
-      localPhoto._created_at = new Date( );
-    }
     localPhoto.licenseCode = localPhoto.licenseCode || photo?.license_code;
     return localPhoto;
   }

--- a/src/realmModels/Taxon.js
+++ b/src/realmModels/Taxon.js
@@ -96,7 +96,7 @@ class Taxon extends Realm.Object {
     };
   }
 
-  static mapApiToRealm( taxon ) {
+  static mapApiToRealm( taxon, _realm = null ) {
     return {
       ...taxon,
       id: Number( taxon.id ),
@@ -108,7 +108,7 @@ class Taxon extends Realm.Object {
 
   static saveRemoteTaxon = async ( remoteTaxon, realm ) => {
     if ( remoteTaxon ) {
-      const localTaxon = Taxon.mapApiToRealm( remoteTaxon );
+      const localTaxon = Taxon.mapApiToRealm( remoteTaxon, realm );
       realm.write( ( ) => {
         realm.create( "Taxon", localTaxon, "modified" );
       } );

--- a/src/realmModels/User.js
+++ b/src/realmModels/User.js
@@ -1,7 +1,7 @@
 import { Realm } from "@realm/react";
 
 class User extends Realm.Object {
-  static USER_FIELDS = {
+  static FIELDS = {
     icon_url: true,
     id: true,
     login: true,
@@ -30,7 +30,8 @@ class User extends Realm.Object {
       signedIn: "bool?",
       locale: "string?",
       observations_count: "int?",
-      prefers_scientific_name_first: "bool?"
+      prefers_scientific_name_first: "bool?",
+      prefers_community_taxa: "bool?"
     }
   };
 }

--- a/src/realmModels/index.js
+++ b/src/realmModels/index.js
@@ -28,7 +28,7 @@ export default {
     User,
     Vote
   ],
-  schemaVersion: 43,
+  schemaVersion: 44,
   path: `${RNFS.DocumentDirectoryPath}/db.realm`,
   // https://github.com/realm/realm-js/pull/6076 embedded constraints
   migrationOptions: {

--- a/src/sharedHooks/useCurrentUser.js
+++ b/src/sharedHooks/useCurrentUser.js
@@ -1,13 +1,24 @@
 // @flow
 
 import { RealmContext } from "providers/contexts";
+import { useMemo } from "react";
 import User from "realmModels/User";
 
 const { useRealm } = RealmContext;
 
 const useCurrentUser = ( ): ?Object => {
   const realm = useRealm( );
-  return User.currentUser( realm );
+  const currentUser = User.currentUser( realm );
+  const currentUserIsValid = currentUser?.isValid( );
+  return useMemo( ( ) => {
+    if ( currentUserIsValid ) {
+      return currentUser;
+    }
+    return null;
+  }, [
+    currentUser,
+    currentUserIsValid
+  ] );
 };
 
 export default useCurrentUser;

--- a/src/sharedHooks/useUserMe.js
+++ b/src/sharedHooks/useUserMe.js
@@ -7,6 +7,7 @@ import useIsConnected from "sharedHooks/useIsConnected";
 const useUserMe = ( ): Object => {
   const currentUser = useCurrentUser( );
   const isConnected = useIsConnected( );
+  const enabled = !!isConnected && !!currentUser;
 
   const {
     data: remoteUser,
@@ -16,7 +17,7 @@ const useUserMe = ( ): Object => {
     ["fetchUserMe"],
     optsWithAuth => fetchUserMe( { }, optsWithAuth ),
     {
-      enabled: !!isConnected && !!currentUser
+      enabled
     }
   );
 

--- a/tests/helpers/user.js
+++ b/tests/helpers/user.js
@@ -19,6 +19,7 @@ async function signOut( options = {} ) {
   await RNSInfo.deleteItem( "jwtToken" );
   await RNSInfo.deleteItem( "jwtGeneratedAt" );
   await RNSInfo.deleteItem( "accessToken" );
+  inatjs.users.me.mockClear( );
 }
 
 async function signIn( user, options = {} ) {

--- a/tests/integration/ObsDetails.test.js
+++ b/tests/integration/ObsDetails.test.js
@@ -10,6 +10,7 @@ import realmConfig from "realmModels/index";
 import Observation from "realmModels/Observation";
 import factory, { makeResponse } from "tests/factory";
 import { renderAppWithComponent } from "tests/helpers/render";
+import { signIn, signOut } from "tests/helpers/user";
 
 // This is a bit crazy, but this ensures this test uses its own in-memory
 // database and doesn't interfere with the single, default in-memory database
@@ -69,6 +70,7 @@ const mockUpdate = factory( "RemoteUpdate", {
   comment_id: mockComment.id,
   viewed: false
 } );
+const mockUser = factory( "LocalUser" );
 
 // Mock api call to fetch observation so it looks like a remote copy exists
 inatjs.observations.fetch.mockResolvedValue( makeResponse( [mockObservation] ) );
@@ -99,11 +101,13 @@ describe( "ObsDetails", () => {
   beforeAll( async () => {
     await initI18next();
     jest.useFakeTimers( );
+    signIn( mockUser, { realm: global.mockRealms[__filename] } );
     Observation.upsertRemoteObservations( [mockObservation], global.mockRealms[__filename] );
   } );
 
   afterEach( () => {
     jest.clearAllMocks();
+    signOut( { realm: global.mockRealms[__filename] } );
   } );
 
   describe( "with an observation where we don't know if the user has viewed comments", ( ) => {

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -5,30 +5,76 @@ import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
 import initI18next from "i18n/initI18next";
 import fetchMock from "jest-fetch-mock";
+import os from "os";
+import path from "path";
 import React from "react";
+import Realm from "realm";
+import realmConfig from "realmModels/index";
 import { LOCATION_FETCH_INTERVAL } from "sharedHooks/useCurrentObservationLocation";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
-import { renderComponent } from "tests/helpers/render";
+import { renderAppWithComponent } from "tests/helpers/render";
 import { signIn, signOut } from "tests/helpers/user";
 
 const initialStoreState = useStore.getState( );
 
+// REALM SETUP
+const mockRealmConfig = {
+  schema: realmConfig.schema,
+  schemaVersion: realmConfig.schemaVersion,
+  // No need to actually write to disk
+  inMemory: true,
+  // For an in memory db path is basically a unique identifier, *but* Realm
+  // may still write some metadata to disk, so this needs to be a real, but
+  // temporary, path. In theory this should prevent this test from
+  // interacting with other tests
+  path: path.join( os.tmpdir( ), `${path.basename( __filename )}.realm` )
+};
+
+// Mock the config so that all code that runs during this test talks to the same database
+jest.mock( "realmModels/index", ( ) => ( {
+  __esModule: true,
+  default: mockRealmConfig
+} ) );
+
+jest.mock( "providers/contexts", ( ) => {
+  const originalModule = jest.requireActual( "providers/contexts" );
+  return {
+    __esModule: true,
+    ...originalModule,
+    RealmContext: {
+      ...originalModule.RealmContext,
+      useRealm: ( ) => global.mockRealms[__filename]
+    }
+  };
+} );
+
+// Open a realm connection and stuff it in global
+beforeAll( async ( ) => {
+  global.mockRealms = global.mockRealms || {};
+  global.mockRealms[__filename] = await Realm.open( mockRealmConfig );
+  useStore.setState( initialStoreState, true );
+} );
+
+// Ensure the realm connection gets closed
+afterAll( ( ) => {
+  global.mockRealms[__filename]?.close( );
+  jest.clearAllMocks( );
+} );
+// /REALM SETUP
+
 beforeEach( async ( ) => {
   useStore.setState( initialStoreState, true );
-  global.realm.write( ( ) => {
-    global.realm.deleteAll( );
-  } );
   const mockUser = factory( "LocalUser", {
     login: faker.internet.userName( ),
     iconUrl: faker.image.url( ),
     locale: "en"
   } );
-  await signIn( mockUser );
+  await signIn( mockUser, { realm: global.mockRealms[__filename] } );
 } );
 
 afterEach( ( ) => {
-  signOut( );
+  signOut( { realm: global.mockRealms[__filename] } );
   jest.clearAllMocks( );
 } );
 
@@ -68,7 +114,7 @@ describe( "ObsEdit offline", ( ) => {
         observationPhotos: []
       } );
       useStore.setState( { observations: [observation] } );
-      renderComponent(
+      renderAppWithComponent(
         <ObsEdit />
       );
       await waitFor( ( ) => {

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -9,4 +9,25 @@ describe( "Observation", ( ) => {
       ).toBeUndefined( );
     } );
   } );
+
+  describe( "mapApiToRealm", ( ) => {
+    it(
+      "should assign user.prefers_community_taxa from user.preferences.prefers_community_taxa",
+      ( ) => {
+        const mockApiObservation = {
+          user: {
+            preferences: {
+              prefers_community_taxa: false
+            }
+          }
+        };
+        expect(
+          Observation.mapApiToRealm( mockApiObservation ).user.prefers_community_taxa
+        ).toEqual( mockApiObservation.user.preferences.prefers_community_taxa );
+      }
+    );
+  } );
+  it( "should set _created_at to a date object without Realm", ( ) => {
+    expect( Observation.mapApiToRealm( { } )._created_at ).toBeInstanceOf( Date );
+  } );
 } );


### PR DESCRIPTION
* Shows notice when user or obs is opted out of Community Taxon on ObsDetails
  (closes #882)
* Unifies mapApiToRealm methods around a single interface
* Ensure that the remote obs used on ObsDetail is normalized to look like a
  local obs
* Ensure some tests that use signIn() have isolated Realm instances
* Update current user's obs from ObsDetails (closes #1045) 
* Fixed CC0 license display on ObsDetails (was not actually related to
  updating the local copy of the obs