### PR TITLE
Make explore observations layout persistent

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -129,7 +129,7 @@ const Explore = ( {
             {exploreView === "observations" && (
               <ObservationsViewBar
                 layout={layout}
-                updateObservationsView={newView => writeLayoutToStorage( newView )}
+                updateObservationsView={writeLayoutToStorage}
               />
             )}
             <INatIconButton

--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -14,6 +14,7 @@ import { useTheme } from "react-native-paper";
 import {
   useAuthenticatedQuery, useTranslation
 } from "sharedHooks";
+import useStoredLayout from "sharedHooks/useStoredLayout";
 
 import Header from "./Header/Header";
 import IdentifiersView from "./IdentifiersView";
@@ -57,7 +58,7 @@ const Explore = ( {
     observers: null,
     identifiers: null
   } );
-  const [observationsView, setObservationsView] = useState( "list" );
+  const { layout, writeLayoutToStorage } = useStoredLayout( "exploreObservationsLayout" );
 
   const updateCount = useCallback( newCount => {
     setCount( {
@@ -127,8 +128,8 @@ const Explore = ( {
             {renderHeader()}
             {exploreView === "observations" && (
               <ObservationsViewBar
-                observationsView={observationsView}
-                updateObservationsView={newView => setObservationsView( newView )}
+                layout={layout}
+                updateObservationsView={newView => writeLayoutToStorage( newView )}
               />
             )}
             <INatIconButton
@@ -145,7 +146,7 @@ const Explore = ( {
             {exploreView === "observations" && (
               <ObservationsView
                 exploreAPIParams={exploreAPIParams}
-                observationsView={observationsView}
+                layout={layout}
                 region={region}
               />
             )}

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -10,7 +10,7 @@ import MapView from "./MapView";
 type Props = {
   exploreAPIParams: Object,
   region: Object,
-  layout: ?string
+  layout: string
 }
 
 const ObservationsView = ( {

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -10,13 +10,13 @@ import MapView from "./MapView";
 type Props = {
   exploreAPIParams: Object,
   region: Object,
-  observationsView: string
+  layout: ?string
 }
 
 const ObservationsView = ( {
   exploreAPIParams,
   region,
-  observationsView
+  layout
 }: Props ): Node => {
   const params = {
     ...exploreAPIParams,
@@ -29,7 +29,9 @@ const ObservationsView = ( {
 
   const isOnline = useIsConnected( );
 
-  return observationsView === "map"
+  if ( !layout ) { return null; }
+
+  return layout === "map"
     ? (
       <MapView
         region={region}
@@ -44,7 +46,7 @@ const ObservationsView = ( {
         hideLoadingWheel={!isFetchingNextPage}
         isFetchingNextPage={isFetchingNextPage}
         isOnline={isOnline}
-        layout={observationsView}
+        layout={layout}
         onEndReached={fetchNextPage}
         status={status}
         testID="ExploreObservationsAnimatedList"

--- a/src/components/Explore/ObservationsViewBar.js
+++ b/src/components/Explore/ObservationsViewBar.js
@@ -8,19 +8,19 @@ import { getShadowForColor } from "styles/global";
 import colors from "styles/tailwindColors";
 
 type Props = {
-  observationsView: string,
+  layout: ?string,
   updateObservationsView: Function
 };
 
 const ObservationsViewBar = ( {
-  observationsView,
+  layout,
   updateObservationsView
 }: Props ): Node => {
   const theme = useTheme( );
 
   const buttonStyle = buttonValue => ( {
     minWidth: 55,
-    backgroundColor: buttonValue === observationsView
+    backgroundColor: buttonValue === layout
       ? colors.inatGreen
       : colors.white
   } );
@@ -28,7 +28,7 @@ const ObservationsViewBar = ( {
   return (
     <View className="bottom-5 absolute left-5 z-10">
       <SegmentedButtons
-        value={observationsView}
+        value={layout}
         onValueChange={updateObservationsView}
         theme={{
           colors: {

--- a/src/components/Explore/ObservationsViewBar.js
+++ b/src/components/Explore/ObservationsViewBar.js
@@ -8,7 +8,7 @@ import { getShadowForColor } from "styles/global";
 import colors from "styles/tailwindColors";
 
 type Props = {
-  layout: ?string,
+  layout: string,
   updateObservationsView: Function
 };
 

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { useAsyncStorage } from "@react-native-async-storage/async-storage";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { activateKeepAwake, deactivateKeepAwake } from "@sayem314/react-native-keep-awake";
 import {
@@ -27,6 +26,7 @@ import {
   useIsConnected,
   useLocalObservations,
   useObservationsUpdates,
+  useStoredLayout,
   useTranslation
 } from "sharedHooks";
 
@@ -124,11 +124,8 @@ const MyObservationsContainer = ( ): Node => {
   const { params: navParams } = useRoute( );
   const [state, dispatch] = useReducer( uploadReducer, INITIAL_UPLOAD_STATE );
   const { observationList: observations, allObsToUpload } = useLocalObservations( );
-  const {
-    getItem: getStoredLayout,
-    setItem: setStoredLayout
-  } = useAsyncStorage( "myObservationsLayout" );
-  const [layout, setLayout] = useState( null );
+  const { layout, writeLayoutToStorage } = useStoredLayout( "myObservationsLayout" );
+
   const isOnline = useIsConnected( );
 
   const currentUser = useCurrentUser();
@@ -163,26 +160,10 @@ const MyObservationsContainer = ( ): Node => {
 
   const [showLoginSheet, setShowLoginSheet] = useState( false );
 
-  const writeLayoutToStorage = useCallback( async newValue => {
-    await setStoredLayout( newValue );
-    setLayout( newValue );
-  }, [setStoredLayout] );
-
-  useEffect( ( ) => {
-    const readLayoutFromStorage = async ( ) => {
-      const storedLayout = await getStoredLayout( );
-      setLayout( storedLayout || "list" );
-    };
-
-    readLayoutFromStorage( );
-  }, [getStoredLayout, writeLayoutToStorage] );
-
   const toggleLayout = ( ) => {
-    if ( layout === "grid" ) {
-      writeLayoutToStorage( "list" );
-    } else {
-      writeLayoutToStorage( "grid" );
-    }
+    writeLayoutToStorage( layout === "grid"
+      ? "list"
+      : "grid" );
   };
 
   useEffect( ( ) => {

--- a/src/sharedHooks/index.js
+++ b/src/sharedHooks/index.js
@@ -14,6 +14,7 @@ export { default as useNumUnuploadedObservations } from "./useNumUnuploadedObser
 export { default as useObservationsUpdates } from "./useObservationsUpdates";
 export { default as useObservationUpdatesWhenFocused } from "./useObservationUpdatesWhenFocused";
 export { default as useShare } from "./useShare";
+export { default as useStoredLayout } from "./useStoredLayout";
 export { default as useTaxon } from "./useTaxon";
 export { default as useTranslation } from "./useTranslation";
 export { default as useUserLocation } from "./useUserLocation";

--- a/src/sharedHooks/useStoredLayout.js
+++ b/src/sharedHooks/useStoredLayout.js
@@ -1,0 +1,32 @@
+// @flow
+import { useAsyncStorage } from "@react-native-async-storage/async-storage";
+import { useCallback, useEffect, useState } from "react";
+
+const useStoredLayout = ( storageKey: string ): Object => {
+  const {
+    getItem: getStoredLayout,
+    setItem: setStoredLayout
+  } = useAsyncStorage( storageKey );
+  const [layout, setLayout] = useState( null );
+
+  const writeLayoutToStorage = useCallback( async newValue => {
+    await setStoredLayout( newValue );
+    setLayout( newValue );
+  }, [setStoredLayout] );
+
+  useEffect( ( ) => {
+    const readLayoutFromStorage = async ( ) => {
+      const storedLayout = await getStoredLayout( );
+      setLayout( storedLayout || "list" );
+    };
+
+    readLayoutFromStorage( );
+  }, [getStoredLayout, writeLayoutToStorage] );
+
+  return {
+    layout,
+    writeLayoutToStorage
+  };
+};
+
+export default useStoredLayout;


### PR DESCRIPTION
Closes #1052

- creates shared useStorageLayout hook to access and write to persistent storage