### PR TITLE
Prevent login screen from flickering on iOS 17

### DIFF
--- a/src/components/LoginSignUp/ForgotPassword.js
+++ b/src/components/LoginSignUp/ForgotPassword.js
@@ -2,7 +2,6 @@
 
 import { useNavigation } from "@react-navigation/native";
 import { WarningSheet } from "components/SharedComponents";
-import { ScrollView } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React, { useState } from "react";
@@ -15,11 +14,6 @@ import {
 import ForgotPasswordForm from "./ForgotPasswordForm";
 import Header from "./Header";
 import LoginSignUpWrapper from "./LoginSignUpWrapper";
-
-const SCROLL_VIEW_STYLE = {
-  flex: 1,
-  justifyContent: "space-between"
-};
 
 const ForgotPassword = ( ): Node => {
   const navigation = useNavigation( );
@@ -48,15 +42,8 @@ const ForgotPassword = ( ): Node => {
           buttonType="focus"
         />
       )}
-      <ScrollView
-        keyboardShouldPersistTaps="always"
-        contentContainerStyle={SCROLL_VIEW_STYLE}
-      >
-        <Header />
-        <ForgotPasswordForm
-          reset={reset}
-        />
-      </ScrollView>
+      <Header />
+      <ForgotPasswordForm reset={reset} />
     </LoginSignUpWrapper>
   );
 };

--- a/src/components/LoginSignUp/ForgotPassword.js
+++ b/src/components/LoginSignUp/ForgotPassword.js
@@ -37,7 +37,7 @@ const ForgotPassword = ( ): Node => {
           secondButtonText={t( "BACK-TO-LOGIN" )}
           handleSecondButtonPress={( ) => {
             setShowSheet( false );
-            navigation.navigate( "LoginNavigator" );
+            navigation.navigate( "LoginNavigator", { screen: "Login" } );
           }}
           buttonType="focus"
         />

--- a/src/components/LoginSignUp/ForgotPasswordForm.js
+++ b/src/components/LoginSignUp/ForgotPasswordForm.js
@@ -26,7 +26,6 @@ const ForgotPasswordForm = ( { reset }: Props ): Node => {
         keyboardType="email-address"
         onChangeText={text => setEmail( text )}
         testID="Login.email"
-        value={email}
       />
       <Button
         level="focus"

--- a/src/components/LoginSignUp/ForgotPasswordForm.js
+++ b/src/components/LoginSignUp/ForgotPasswordForm.js
@@ -1,40 +1,33 @@
 // @flow
 
 import {
-  Button, Heading4
+  Button
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { TextInput, useTheme } from "react-native-paper";
+
+import LoginSignUpInputField from "./LoginSignUpInputField";
 
 type Props = {
-  handleInputFocus?: Function,
   reset: Function
 }
 
-const ForgotPasswordForm = ( { handleInputFocus, reset }: Props ): Node => {
+const ForgotPasswordForm = ( { reset }: Props ): Node => {
   const [email, setEmail] = useState( "" );
-  const theme = useTheme( );
 
   return (
     <View className="px-4 my-5 justify-end">
-      <View>
-        <Heading4 className="color-white mb-[11px]">{t( "USERNAME-OR-EMAIL" )}</Heading4>
-        <TextInput
-          accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
-          className="h-[45px] rounded-md"
-          onChangeText={text => setEmail( text )}
-          value={email}
-          autoComplete="email"
-          testID="Login.email"
-          autoCapitalize="none"
-          keyboardType="email-address"
-          selectionColor={theme.colors.tertiary}
-          onFocus={handleInputFocus}
-        />
-      </View>
+      <LoginSignUpInputField
+        accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
+        autoComplete="email"
+        headerText={t( "USERNAME-OR-EMAIL" )}
+        keyboardType="email-address"
+        onChangeText={text => setEmail( text )}
+        testID="Login.email"
+        value={email}
+      />
       <Button
         level="focus"
         text={t( "RESET-PASSWORD" )}

--- a/src/components/LoginSignUp/Header.js
+++ b/src/components/LoginSignUp/Header.js
@@ -9,27 +9,26 @@ import React from "react";
 
 type Props = {
   headerText?: string,
-  hideLogo?: boolean
+  hideHeader?: boolean
 }
 
-const Header = ( { headerText, hideLogo }: Props ): Node => (
-  <View className="shrink">
-    <View className="w-full items-center">
-      { !hideLogo && (
-        <Image
-          className="w-[234px] h-[43px]"
-          resizeMode="contain"
-          source={require( "images/inaturalist.png" )}
-          accessibilityIgnoresInvertColors
-        />
-      ) }
+const Header = ( { headerText, hideHeader }: Props ): Node => {
+  if ( hideHeader ) { return null; }
+  return (
+    <View className="w-full items-center shrink">
+      <Image
+        className="w-[234px] h-[43px]"
+        resizeMode="contain"
+        source={require( "images/inaturalist.png" )}
+        accessibilityIgnoresInvertColors
+      />
       {headerText && (
         <Body1 className="text-center color-white mt-[24px] max-w-[280px]">
           {headerText}
         </Body1>
       )}
     </View>
-  </View>
-);
+  );
+};
 
 export default Header;

--- a/src/components/LoginSignUp/LoginForm.js
+++ b/src/components/LoginSignUp/LoginForm.js
@@ -87,7 +87,6 @@ const LoginForm = ( {
         // textContentType prevents visual flickering, which is a temporary issue
         // in iOS 17
         textContentType="oneTimeCode"
-        value={email}
       />
       <LoginSignUpInputField
         accessibilityLabel={t( "PASSWORD" )}
@@ -95,7 +94,7 @@ const LoginForm = ( {
         onChangeText={text => setPassword( text )}
         secureTextEntry
         testID="Login.password"
-        value={password}
+        textContentType="oneTimeCode"
       />
       <View className="mx-4">
         <Body2

--- a/src/components/LoginSignUp/LoginForm.js
+++ b/src/components/LoginSignUp/LoginForm.js
@@ -83,6 +83,10 @@ const LoginForm = ( {
         keyboardType="email-address"
         onChangeText={text => setEmail( text )}
         testID="Login.email"
+        // https://github.com/facebook/react-native/issues/39411#issuecomment-1817575790
+        // textContentType prevents visual flickering, which is a temporary issue
+        // in iOS 17
+        textContentType="oneTimeCode"
         value={email}
       />
       <LoginSignUpInputField

--- a/src/components/LoginSignUp/LoginForm.js
+++ b/src/components/LoginSignUp/LoginForm.js
@@ -1,37 +1,36 @@
 // @flow
 
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import classnames from "classnames";
 import {
-  Body1, Body2, Button, Heading4, INatIcon,
-  List2
+  Body1, Body2, Button, INatIcon, List2
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { t } from "i18next";
 import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { Keyboard } from "react-native";
-import { TextInput, useTheme } from "react-native-paper";
+import { useTheme } from "react-native-paper";
 
 import {
   authenticateUser
 } from "./AuthenticationService";
 import Error from "./Error";
+import LoginSignUpInputField from "./LoginSignUpInputField";
 
 const { useRealm } = RealmContext;
 
 type Props = {
-  setLoggedIn: Function,
-  handleInputFocus?: Function,
-  emailConfirmed: ?boolean
+  hideFooter: boolean,
+  setLoggedIn: Function
 }
 
 const LoginForm = ( {
-  emailConfirmed,
-  handleInputFocus,
+  hideFooter,
   setLoggedIn
 }: Props ): Node => {
+  const { params } = useRoute( );
+  const emailConfirmed = params?.emailConfirmed;
   const realm = useRealm( );
   const navigation = useNavigation( );
   const [email, setEmail] = useState( "" );
@@ -59,59 +58,45 @@ const LoginForm = ( {
     navigation.getParent( )?.goBack( );
   };
 
-  return (
-    <View className="px-4 mt-[9px] justify-end grow">
-      <View className="mx-4">
-        <View className="mb-2">
-          {emailConfirmed && (
-            <View className="flex-row mb-5 items-center justify-center">
-              <View className="bg-white rounded-full">
-                <INatIcon
-                  name="checkmark-circle"
-                  color={theme.colors.secondary}
-                  size={19}
-                />
-              </View>
-              <List2 className="ml-3 text-white font-medium">
-                {t( "Your-email-is-confirmed" )}
-              </List2>
-            </View>
-          )}
-          <Heading4 className="color-white mb-[11px]">{t( "USERNAME-OR-EMAIL" )}</Heading4>
-          <TextInput
-            accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
-            className="h-[45px] rounded-md"
-            onChangeText={text => {
-              setError( null );
-              setEmail( text );
-            }}
-            value={email}
-            autoComplete="email"
-            testID="Login.email"
-            autoCapitalize="none"
-            keyboardType="email-address"
-            selectionColor={theme.colors.tertiary}
-            onFocus={handleInputFocus}
-          />
-        </View>
-        <Heading4 className="color-white mb-[11px] mt-[9px]">{t( "PASSWORD" )}</Heading4>
-        <TextInput
-          accessibilityLabel={t( "PASSWORD" )}
-          className="h-[45px] rounded-md"
-          onChangeText={text => {
-            setError( null );
-            setPassword( text );
-          }}
-          value={password}
-          secureTextEntry
-          autoCapitalize="none"
-          testID="Login.password"
-          selectionColor={theme.colors.tertiary}
-          onFocus={handleInputFocus}
+  const showEmailConfirmed = ( ) => (
+    <View className="flex-row mb-5 items-center justify-center mx-2">
+      <View className="bg-white rounded-full">
+        <INatIcon
+          name="checkmark-circle"
+          color={theme.colors.secondary}
+          size={19}
         />
+      </View>
+      <List2 className="ml-3 text-white font-medium">
+        {t( "Your-email-is-confirmed" )}
+      </List2>
+    </View>
+  );
+
+  return (
+    <View className="px-4 mt-[9px] justify-end">
+      {emailConfirmed && showEmailConfirmed( )}
+      <LoginSignUpInputField
+        accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
+        autoComplete="email"
+        headerText={t( "USERNAME-OR-EMAIL" )}
+        keyboardType="email-address"
+        onChangeText={text => setEmail( text )}
+        testID="Login.email"
+        value={email}
+      />
+      <LoginSignUpInputField
+        accessibilityLabel={t( "PASSWORD" )}
+        headerText={t( "PASSWORD" )}
+        onChangeText={text => setPassword( text )}
+        secureTextEntry
+        testID="Login.password"
+        value={password}
+      />
+      <View className="mx-4">
         <Body2
-          className="underline mt-[15px] self-end color-white"
           accessibilityRole="button"
+          className="underline mt-[15px] self-end color-white"
           onPress={( ) => navigation.navigate( "ForgotPassword" )}
         >
           {t( "Forgot-Password" )}
@@ -119,18 +104,18 @@ const LoginForm = ( {
         {error && <Error error={error} />}
       </View>
       <Button
-        level="focus"
-        text={t( "LOG-IN" )}
-        onPress={login}
         className={classnames( "mt-[30px]", {
           "mt-5": error
         } )}
         disabled={!email || !password}
-        testID="Login.loginButton"
-        loading={loading}
         forceDark
+        level="focus"
+        loading={loading}
+        onPress={login}
+        testID="Login.loginButton"
+        text={t( "LOG-IN" )}
       />
-      {!Keyboard.isVisible( ) && (
+      {!hideFooter && (
         <Body1
           className="color-white self-center mt-[30px] underline"
           onPress={( ) => navigation.navigate( "SignUp" )}

--- a/src/components/LoginSignUp/LoginSignUpInputField.js
+++ b/src/components/LoginSignUp/LoginSignUpInputField.js
@@ -16,8 +16,7 @@ type Props = {
   onChangeText: Function,
   secureTextEntry?: boolean,
   testID: string,
-  textContentType?: string,
-  value: string
+  textContentType?: string
 }
 
 const LoginSignUpInputField = ( {
@@ -28,8 +27,7 @@ const LoginSignUpInputField = ( {
   onChangeText,
   secureTextEntry = false,
   testID,
-  textContentType,
-  value
+  textContentType
 }: Props ): Node => {
   const theme = useTheme( );
 
@@ -49,7 +47,6 @@ const LoginSignUpInputField = ( {
         selectionColor={theme.colors.tertiary}
         testID={testID}
         textContentType={textContentType}
-        value={value}
       />
     </View>
   );

--- a/src/components/LoginSignUp/LoginSignUpInputField.js
+++ b/src/components/LoginSignUp/LoginSignUpInputField.js
@@ -1,0 +1,55 @@
+// @flow
+
+import {
+  Heading4
+} from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import type { Node } from "react";
+import React from "react";
+import { TextInput, useTheme } from "react-native-paper";
+
+type Props = {
+  accessibilityLabel: string,
+  autoComplete?: string,
+  headerText: string,
+  keyboardType?: string,
+  onChangeText: Function,
+  secureTextEntry?: boolean,
+  testID: string,
+  value: string
+}
+
+const LoginSignUpInputField = ( {
+  accessibilityLabel,
+  autoComplete,
+  headerText,
+  keyboardType,
+  onChangeText,
+  secureTextEntry = false,
+  testID,
+  value
+}: Props ): Node => {
+  const theme = useTheme( );
+
+  return (
+    <View className="mx-2">
+      <Heading4 className="color-white mt-[25px] mb-[11px]">
+        {headerText}
+      </Heading4>
+      <TextInput
+        accessibilityLabel={accessibilityLabel}
+        autoCapitalize="none"
+        autoComplete={autoComplete}
+        className="h-[45px] rounded-md"
+        keyboardType={keyboardType}
+        onChangeText={onChangeText}
+        secureTextEntry={secureTextEntry}
+        selectionColor={theme.colors.tertiary}
+        testID={testID}
+        value={value}
+      />
+    </View>
+  );
+};
+
+export default LoginSignUpInputField;

--- a/src/components/LoginSignUp/LoginSignUpInputField.js
+++ b/src/components/LoginSignUp/LoginSignUpInputField.js
@@ -16,6 +16,7 @@ type Props = {
   onChangeText: Function,
   secureTextEntry?: boolean,
   testID: string,
+  textContentType?: string,
   value: string
 }
 
@@ -27,6 +28,7 @@ const LoginSignUpInputField = ( {
   onChangeText,
   secureTextEntry = false,
   testID,
+  textContentType,
   value
 }: Props ): Node => {
   const theme = useTheme( );
@@ -46,6 +48,7 @@ const LoginSignUpInputField = ( {
         secureTextEntry={secureTextEntry}
         selectionColor={theme.colors.tertiary}
         testID={testID}
+        textContentType={textContentType}
         value={value}
       />
     </View>

--- a/src/components/LoginSignUp/LoginSignUpWrapper.js
+++ b/src/components/LoginSignUp/LoginSignUpWrapper.js
@@ -1,7 +1,7 @@
 // @flow
 
 import classnames from "classnames";
-import { ImageBackground, SafeAreaView } from "components/styledComponents";
+import { ImageBackground, SafeAreaView, ScrollView } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
 import {
@@ -13,7 +13,8 @@ import {
 type Props = {
   backgroundSource: any,
   children: any,
-  keyboardVerticalOffset?: number
+  keyboardVerticalOffset?: number,
+  scrollEnabled?: boolean
 }
 
 const KEYBOARD_AVOIDING_VIEW_STYLE = {
@@ -21,10 +22,16 @@ const KEYBOARD_AVOIDING_VIEW_STYLE = {
   flexGrow: 1
 };
 
+const SCROLL_VIEW_STYLE = {
+  flex: 1,
+  justifyContent: "space-between"
+};
+
 const LoginSignupWrapper = ( {
   backgroundSource,
   children,
-  keyboardVerticalOffset
+  keyboardVerticalOffset,
+  scrollEnabled = true
 }: Props ): Node => (
   <ImageBackground
     source={backgroundSource}
@@ -47,7 +54,13 @@ const LoginSignupWrapper = ( {
         behavior="padding"
         style={KEYBOARD_AVOIDING_VIEW_STYLE}
       >
-        {children}
+        <ScrollView
+          keyboardShouldPersistTaps="always"
+          contentContainerStyle={SCROLL_VIEW_STYLE}
+          scrollEnabled={scrollEnabled}
+        >
+          {children}
+        </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   </ImageBackground>

--- a/src/components/LoginSignUp/SignUp.js
+++ b/src/components/LoginSignUp/SignUp.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { ScrollView } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React from "react";
@@ -11,34 +10,27 @@ import LoginSignUpWrapper from "./LoginSignUpWrapper";
 import SignUpForm from "./SignUpForm";
 
 const TARGET_NON_KEYBOARD_HEIGHT = 440;
+const HIDE_HEADER_HEIGHT = 580;
 
-const SignUp = (): Node => {
-  const { nonKeyboardHeight } = useKeyboardInfo( );
+const SignUp = ( ): Node => {
+  const {
+    keyboardVerticalOffset,
+    nonKeyboardHeight
+  } = useKeyboardInfo( TARGET_NON_KEYBOARD_HEIGHT );
 
-  const hideHeader = nonKeyboardHeight < 580;
-
-  const keyboardVerticalOffset = nonKeyboardHeight < TARGET_NON_KEYBOARD_HEIGHT
-    ? nonKeyboardHeight - TARGET_NON_KEYBOARD_HEIGHT
-    : 30;
+  const hideHeader = nonKeyboardHeight < HIDE_HEADER_HEIGHT;
+  const hideFooter = nonKeyboardHeight < HIDE_HEADER_HEIGHT;
 
   return (
     <LoginSignUpWrapper
       backgroundSource={require( "images/frog.png" )}
       keyboardVerticalOffset={keyboardVerticalOffset}
     >
-      <ScrollView
-        keyboardShouldPersistTaps="always"
-        // eslint-disable-next-line react-native/no-inline-styles
-        contentContainerStyle={{
-          flex: 1,
-          justifyContent: "space-between"
-        }}
-      >
-        {!hideHeader && (
-          <Header headerText={t( "Join-the-largest-community-of-naturalists" )} />
-        )}
-        <SignUpForm />
-      </ScrollView>
+      <Header
+        headerText={t( "Join-the-largest-community-of-naturalists" )}
+        hideHeader={hideHeader}
+      />
+      <SignUpForm hideFooter={hideFooter} />
     </LoginSignUpWrapper>
   );
 };

--- a/src/components/LoginSignUp/SignUpConfirmation.js
+++ b/src/components/LoginSignUp/SignUpConfirmation.js
@@ -14,9 +14,11 @@ import { openInbox } from "react-native-email-link";
 import Header from "./Header";
 import LoginSignUpWrapper from "./LoginSignUpWrapper";
 
+const textClass = "color-white self-center text-center mt-5 px-10";
+
 const SignUpConfirmation = ( ): Node => {
   const navigation = useNavigation( );
-  const textClass = "color-white self-center text-center mt-5 px-10";
+
   return (
     <LoginSignUpWrapper backgroundSource={require( "images/pink_flower.png" )}>
       <View className="flex-1 justify-between">
@@ -40,7 +42,7 @@ const SignUpConfirmation = ( ): Node => {
           />
           <Body1
             className="color-white self-center mt-[30px] underline"
-            onPress={( ) => navigation.navigate( "LoginNavigator" )}
+            onPress={( ) => navigation.navigate( "LoginNavigator", { screen: "Login" } )}
           >
             {t( "Return-to-Login" )}
           </Body1>

--- a/src/components/LoginSignUp/SignUpForm.js
+++ b/src/components/LoginSignUp/SignUpForm.js
@@ -30,14 +30,12 @@ const SignUpForm = ( { hideFooter }: Props ): Node => {
         keyboardType="email-address"
         onChangeText={text => setEmail( text )}
         testID="Signup.email"
-        value={email}
       />
       <LoginSignUpInputField
         accessibilityLabel={t( "USERNAME" )}
         headerText={t( "USERNAME" )}
         onChangeText={text => setUsername( text )}
         testID="Signup.username"
-        value={username}
       />
       <LoginSignUpInputField
         accessibilityLabel={t( "PASSWORD" )}
@@ -45,7 +43,6 @@ const SignUpForm = ( { hideFooter }: Props ): Node => {
         onChangeText={text => setPassword( text )}
         secureTextEntry
         testID="Signup.password"
-        value={password}
       />
       <Button
         className="mt-[30px]"

--- a/src/components/LoginSignUp/SignUpForm.js
+++ b/src/components/LoginSignUp/SignUpForm.js
@@ -2,60 +2,55 @@
 
 import { useNavigation } from "@react-navigation/native";
 import {
-  Body1, Button, Heading4
+  Body1, Button
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { TextInput, useTheme } from "react-native-paper";
 
-const SignUpForm = ( ): Node => {
+import LoginSignUpInputField from "./LoginSignUpInputField";
+
+type Props = {
+  hideFooter: boolean
+}
+
+const SignUpForm = ( { hideFooter }: Props ): Node => {
   const navigation = useNavigation( );
   const [email, setEmail] = useState( "" );
   const [username, setUsername] = useState( "" );
   const [password, setPassword] = useState( "" );
-  const theme = useTheme( );
 
   return (
     <View className="px-4 mt-[9px] justify-end">
-      <View className="mx-4">
-        <Heading4 className="color-white mb-[11px]">{t( "EMAIL" )}</Heading4>
-        <TextInput
-          accessibilityLabel={t( "EMAIL" )}
-          className="h-[45px] rounded-md"
-          onChangeText={text => setEmail( text )}
-          value={email}
-          autoComplete="email"
-          testID="Signup.email"
-          autoCapitalize="none"
-          keyboardType="email-address"
-          selectionColor={theme.colors.tertiary}
-        />
-        <Heading4 className="color-white mb-[11px] mt-[9px]">{t( "USERNAME" )}</Heading4>
-        <TextInput
-          accessibilityLabel={t( "USERNAME" )}
-          className="h-[45px] rounded-md"
-          onChangeText={text => setUsername( text )}
-          value={username}
-          testID="Signup.username"
-          autoCapitalize="none"
-          selectionColor={theme.colors.tertiary}
-        />
-        <Heading4 className="color-white mb-[11px] mt-[9px]">{t( "PASSWORD" )}</Heading4>
-        <TextInput
-          accessibilityLabel={t( "PASSWORD" )}
-          className="h-[45px] rounded-md"
-          onChangeText={text => setPassword( text )}
-          value={password}
-          secureTextEntry
-          testID="Signup.password"
-          selectionColor={theme.colors.tertiary}
-        />
-      </View>
+      <LoginSignUpInputField
+        accessibilityLabel={t( "EMAIL" )}
+        autoComplete="email"
+        headerText={t( "EMAIL" )}
+        keyboardType="email-address"
+        onChangeText={text => setEmail( text )}
+        testID="Signup.email"
+        value={email}
+      />
+      <LoginSignUpInputField
+        accessibilityLabel={t( "USERNAME" )}
+        headerText={t( "USERNAME" )}
+        onChangeText={text => setUsername( text )}
+        testID="Signup.username"
+        value={username}
+      />
+      <LoginSignUpInputField
+        accessibilityLabel={t( "PASSWORD" )}
+        headerText={t( "PASSWORD" )}
+        onChangeText={text => setPassword( text )}
+        secureTextEntry
+        testID="Signup.password"
+        value={password}
+      />
       <Button
+        className="mt-[30px]"
+        disabled={!email || !password || !username}
         level="focus"
-        text={t( "CREATE-AN-ACCOUNT" )}
         onPress={( ) => {
           navigation.navigate( "LicensePhotos", {
             user: {
@@ -65,16 +60,17 @@ const SignUpForm = ( ): Node => {
             }
           } );
         }}
-        className="mt-[30px]"
-        disabled={!email || !password || !username}
         testID="Signup.signupButton"
+        text={t( "CREATE-AN-ACCOUNT" )}
       />
-      <Body1
-        className="color-white self-center mt-[30px] underline"
-        onPress={( ) => navigation.navigate( "LoginNavigator", { screen: "Login" } )}
-      >
-        {t( "Already-have-an-account" )}
-      </Body1>
+      {!hideFooter && (
+        <Body1
+          className="color-white self-center mt-[30px] underline"
+          onPress={( ) => navigation.navigate( "LoginNavigator", { screen: "Login" } )}
+        >
+          {t( "Already-have-an-account" )}
+        </Body1>
+      )}
     </View>
   );
 };

--- a/src/components/LoginSignUp/hooks/useLoginState.js
+++ b/src/components/LoginSignUp/hooks/useLoginState.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { isLoggedIn } from "components/LoginSignUp/AuthenticationService";
+import { useEffect, useState } from "react";
+
+const useLoginState = ( ): Object => {
+  const [loggedIn, setLoggedIn] = useState( false );
+
+  useEffect( ( ) => {
+    const fetchLoggedIn = async ( ) => {
+      const login = await isLoggedIn( );
+      if ( login !== loggedIn ) {
+        setLoggedIn( login );
+      }
+    };
+
+    fetchLoggedIn( );
+  }, [loggedIn] );
+
+  return {
+    loggedIn,
+    setLoggedIn
+  };
+};
+
+export default useLoginState;

--- a/src/components/SharedComponents/ObservationsFlashList/ObsStatus.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObsStatus.js
@@ -74,8 +74,6 @@ const ObsStatus = ( {
     return <QualityGradeStatus qualityGrade={qualityGrade} color={iconColor} />;
   }, [observation, theme, white] );
 
-  console.log( classNameMargin, "flex direction", margin );
-
   return (
     <View
       className={classNames( {

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -28,8 +28,6 @@ const SuggestionsContainer = ( ): Node => {
     longitude: currentObservation?.longitude
   } );
 
-  console.log( onlineSuggestions, loadingOnlineSuggestions, timedOut, "timed out status" );
-
   // skip to offline suggestions if internet connection is spotty
   const tryOfflineSuggestions = timedOut || (
     // Don't try offline while online is loading


### PR DESCRIPTION
Closes #940

Note: the issue seems to be coming from iOS 17 itself and how many times the keyboardWillChangeFrame event is fired. So added a few things to improve the issue here:

- let input fields maintain their own state, so the UI doesn't need to be rerendered as frequently
- textContentType='oneTimeCode' prevents the passwords bar from rendering immediately while a user is typing into the username/password fields
- hide the logo, header text, and footer text when the keyboard pops up on smaller devices, so that part of the UI doesn't jump around while a user is typing