### PR TITLE
Image predictions uri fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25692,7 +25692,7 @@
     },
     "node_modules/vision-camera-plugin-inatvision": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#350639f718fe0b5e14c8a7c0bb53cb7ecf929a4b",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#8526519edd6983b59e3ecf826bb26220b0d85f51",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -44756,7 +44756,7 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#350639f718fe0b5e14c8a7c0bb53cb7ecf929a4b",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#8526519edd6983b59e3ecf826bb26220b0d85f51",
       "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#image-prediction-from-file",
       "requires": {}
     },

--- a/src/components/Suggestions/hooks/useOfflineSuggestions.js
+++ b/src/components/Suggestions/hooks/useOfflineSuggestions.js
@@ -35,16 +35,8 @@ const useOfflineSuggestions = (
           ? result.predictions
           : result;
       } catch ( predictImageError ) {
-        if ( predictImageError.message.match( /getWidth/ ) ) {
-          // TODO fix this. There's a bug in the android side of vision-camera-plugin-inatvision
-          logger.error(
-            `HACK working around failure to getWidth of ${selectedPhotoUri}`,
-            predictImageError
-          );
-          predictions = [];
-        } else {
-          throw predictImageError;
-        }
+        logger.error( "Error predicting image offline", predictImageError );
+        throw predictImageError;
       }
       // using the same rank level for displaying predictions in AR Camera
       // this is all temporary, since we ultimately want predictions

--- a/src/components/Suggestions/hooks/useOfflineSuggestions.js
+++ b/src/components/Suggestions/hooks/useOfflineSuggestions.js
@@ -4,6 +4,7 @@ import {
   useEffect,
   useState
 } from "react";
+import { Platform } from "react-native";
 import { predictImage } from "sharedHelpers/cvModel";
 import { log } from "sharedHelpers/logger";
 
@@ -27,7 +28,12 @@ const useOfflineSuggestions = (
       setLoadingOfflineSuggestions( true );
       let predictions = [];
       try {
-        predictions = await predictImage( selectedPhotoUri );
+        const result = await predictImage( selectedPhotoUri );
+        // Android returns an object with a predictions key, while iOS returns an array because
+        // currently Seek codebase as well expects different return types for each platform
+        predictions = Platform.OS === "android"
+          ? result.predictions
+          : result;
       } catch ( predictImageError ) {
         if ( predictImageError.message.match( /getWidth/ ) ) {
           // TODO fix this. There's a bug in the android side of vision-camera-plugin-inatvision


### PR DESCRIPTION
This PR includes a new version of the vision-camera-plugin-inatvision after a merged PR there should fix the problem with reading images from file given a uri as input. With this PR the error of trying to `getWidth` from a null should not happen anymore. https://github.com/inaturalist/vision-camera-plugin-inatvision/pull/11

This should fix #1038 but I was not able to reproduce the wrong = error state on my devices, so I would need a review if this fixes the error seen on @kueda 's device as well.
