### PR TITLE
Prevent PhotoCount from rendering with no count on scroll

### DIFF
--- a/src/components/PhotoImporter/GroupPhotoImage.js
+++ b/src/components/PhotoImporter/GroupPhotoImage.js
@@ -37,7 +37,6 @@ const GroupPhotoImage = ( {
         selected={isSelected}
         obsPhotosCount={item.photos.length}
         selectable
-        groupPhotos
       />
     </Pressable>
   );

--- a/src/components/SharedComponents/ObservationsFlashList/ObsImagePreview.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObsImagePreview.js
@@ -16,7 +16,6 @@ type SOURCE = {
 type Props = {
   children?: Node,
   className?: string,
-  groupPhotos?: boolean,
   hasSound?: boolean,
   height?: string,
   iconicTaxonName?: string,
@@ -36,7 +35,6 @@ type Props = {
 const ObsImagePreview = ( {
   children,
   className,
-  groupPhotos = false,
   hasSound = false,
   height = "h-[62px]",
   iconicTaxonName = "unknown",
@@ -78,12 +76,12 @@ const ObsImagePreview = ( {
           } )}
         >
           { !( isSmall && obsPhotosCount === 0 )
-            && <PhotoCount count={obsPhotosCount} groupPhotos={groupPhotos} /> }
+            && <PhotoCount count={obsPhotosCount} /> }
         </View>
       );
     }
     return null;
-  }, [isMultiplePhotosTop, isSmall, obsPhotosCount, groupPhotos] );
+  }, [isMultiplePhotosTop, isSmall, obsPhotosCount] );
 
   const renderSelectable = useCallback( ( ) => {
     if ( selectable ) {

--- a/src/components/SharedComponents/PhotoCount.js
+++ b/src/components/SharedComponents/PhotoCount.js
@@ -36,8 +36,12 @@ const PhotoCount = ( {
   const textStyle = {
     position: "absolute",
     zIndex: 10,
-    left: 5,
-    top: 6
+    paddingHorizontal: size === 50
+      ? 12.5
+      : 5,
+    top: size === 50
+      ? 22
+      : 6
   };
 
   return (

--- a/src/components/SharedComponents/PhotoCount.js
+++ b/src/components/SharedComponents/PhotoCount.js
@@ -1,43 +1,24 @@
 // @flow
 
-import { useIsFocused } from "@react-navigation/native";
 import { Body3, Body3Bold, INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Platform } from "react-native";
 import { useTheme } from "react-native-paper";
-import Svg, { ForeignObject, Path } from "react-native-svg";
+import Svg, { Path } from "react-native-svg";
 import { dropShadow } from "styles/global";
 
 type Props = {
   count: number,
-  groupPhotos: boolean,
   size?: number,
-  shadow?: boolean,
+  shadow?: boolean
 };
 
 const PhotoCount = ( {
-  count, groupPhotos, size, shadow
+  count, size, shadow
 }: Props ): Node => {
   const theme = useTheme( );
-  const isFocused = useIsFocused( );
-  const [idx, setIdx] = useState( 0 );
-
-  useEffect( ( ) => {
-    if ( isFocused ) {
-      setIdx( i => i + 1 );
-    }
-  }, [isFocused, setIdx] );
-
-  useEffect( ( ) => {
-    // we need a different tactic for updating the PhotoCount in GroupPhotos
-    // since the SVG remains in the same place with a new count;
-    // in ObsListItem we can use isFocused to update PhotoCounts rendered on screen
-    if ( count && groupPhotos ) {
-      setIdx( i => i + 1 );
-    }
-  }, [count, groupPhotos] );
 
   if ( count === 0 ) {
     return <INatIcon name="noevidence" size={size} color={theme.colors.inverseOnSurface} />;
@@ -52,11 +33,21 @@ const PhotoCount = ( {
     ? Body3
     : Body3Bold;
 
+  const textStyle = {
+    position: "absolute",
+    zIndex: 10,
+    left: 5,
+    top: 6
+  };
+
   return (
     <View
       style={[{ height: size, width: size }, shadow && dropShadow]}
       testID="photo-count"
     >
+      <TextComponent style={textStyle}>
+        {photoCount}
+      </TextComponent>
       <Svg
         height={size}
         width={size}
@@ -71,23 +62,12 @@ const PhotoCount = ( {
           fill={theme.colors.background}
         />
         <Path
-          // eslint-disable-next-line max-len
+        // eslint-disable-next-line max-len
           d="M15.364 3.636h-9.53A4 4 0 019.818 0H20a4 4 0 014 4v10.182a4 4 0 01-3.636 3.984v-9.53a5 5 0 00-5-5z"
           fill={theme.colors.background}
           clipRule="evenodd"
           fillRule="nonzero"
         />
-        <ForeignObject
-          x="5%"
-          y={Platform.OS === "ios"
-            ? "26%"
-            : "20%"}
-          key={idx}
-        >
-          <TextComponent className="text-center w-[16px]">
-            {photoCount}
-          </TextComponent>
-        </ForeignObject>
       </Svg>
     </View>
   );

--- a/src/components/UiLibrary.js
+++ b/src/components/UiLibrary.js
@@ -601,7 +601,7 @@ const UiLibrary = (): Node => {
         <Heading2 className="my-2">PhotoCount</Heading2>
         <View className="my-2 bg-lightGray p-2 rounded-lg flex-row justify-evenly">
           <PhotoCount count={0} />
-          <PhotoCount count={1} />
+          <PhotoCount count={2} />
           <PhotoCount count={12} size={50} />
           <PhotoCount count={1000} size={50} shadow />
         </View>

--- a/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
@@ -42,9 +42,9 @@ exports[`PhotoCount renders correctly 1`] = `
             "color": "#454545",
           },
           {
-            "left": 5,
+            "paddingHorizontal": 12.5,
             "position": "absolute",
-            "top": 6,
+            "top": 22,
             "zIndex": 10,
           },
         ],

--- a/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
@@ -24,6 +24,35 @@ exports[`PhotoCount renders correctly 1`] = `
   }
   testID="photo-count"
 >
+  <Text
+    style={
+      [
+        {
+          "fontFamily": "Whitney-Light",
+        },
+        [
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "fontWeight": "400",
+          },
+          {
+            "color": "#454545",
+          },
+          {
+            "left": 5,
+            "position": "absolute",
+            "top": 6,
+            "zIndex": 10,
+          },
+        ],
+      ]
+    }
+  >
+    7
+  </Text>
   <RNSVGSvgView
     align="xMidYMid"
     bbHeight="50"
@@ -94,50 +123,6 @@ exports[`PhotoCount renders correctly 1`] = `
           ]
         }
       />
-      <RNSVGForeignObject
-        fill={
-          {
-            "payload": 4278190080,
-            "type": 0,
-          }
-        }
-        height="100%"
-        width="100%"
-        x="5%"
-        y="26%"
-      >
-        <Text
-          style={
-            [
-              {
-                "fontFamily": "Whitney-Light",
-              },
-              [
-                {
-                  "fontSize": 14,
-                  "lineHeight": 18,
-                },
-                {
-                  "fontWeight": "400",
-                },
-                {
-                  "color": "#454545",
-                },
-                [
-                  {
-                    "textAlign": "center",
-                  },
-                  {
-                    "width": 16,
-                  },
-                ],
-              ],
-            ]
-          }
-        >
-          7
-        </Text>
-      </RNSVGForeignObject>
     </RNSVGGroup>
   </RNSVGSvgView>
 </View>


### PR DESCRIPTION
Closes #1073

- Removes the ForeignObject component from `react-native-svg`, which didn't re-render consistently
- TextComponent is now positioned on top of the SVG below, so it renders every time FlashList re-renders