### PR TITLE
Allow password managers to fill in login fields

### DIFF
--- a/src/components/LoginSignUp/LoginForm.js
+++ b/src/components/LoginSignUp/LoginForm.js
@@ -80,21 +80,24 @@ const LoginForm = ( {
         accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
         autoComplete="email"
         headerText={t( "USERNAME-OR-EMAIL" )}
+        inputMode="email"
         keyboardType="email-address"
         onChangeText={text => setEmail( text )}
         testID="Login.email"
         // https://github.com/facebook/react-native/issues/39411#issuecomment-1817575790
         // textContentType prevents visual flickering, which is a temporary issue
         // in iOS 17
-        textContentType="oneTimeCode"
+        textContentType="emailAddress"
       />
       <LoginSignUpInputField
         accessibilityLabel={t( "PASSWORD" )}
+        autoComplete="current-password"
         headerText={t( "PASSWORD" )}
+        inputMode="text"
         onChangeText={text => setPassword( text )}
         secureTextEntry
         testID="Login.password"
-        textContentType="oneTimeCode"
+        textContentType="password"
       />
       <View className="mx-4">
         <Body2

--- a/src/components/LoginSignUp/LoginSignUpInputField.js
+++ b/src/components/LoginSignUp/LoginSignUpInputField.js
@@ -12,6 +12,7 @@ type Props = {
   accessibilityLabel: string,
   autoComplete?: string,
   headerText: string,
+  inputMode?: string,
   keyboardType?: string,
   onChangeText: Function,
   secureTextEntry?: boolean,
@@ -23,6 +24,7 @@ const LoginSignUpInputField = ( {
   accessibilityLabel,
   autoComplete,
   headerText,
+  inputMode,
   keyboardType,
   onChangeText,
   secureTextEntry = false,
@@ -41,6 +43,7 @@ const LoginSignUpInputField = ( {
         autoCapitalize="none"
         autoComplete={autoComplete}
         className="h-[45px] rounded-md"
+        inputMode={inputMode}
         keyboardType={keyboardType}
         onChangeText={onChangeText}
         secureTextEntry={secureTextEntry}

--- a/src/components/LoginSignUp/SignUpForm.js
+++ b/src/components/LoginSignUp/SignUpForm.js
@@ -27,22 +27,27 @@ const SignUpForm = ( { hideFooter }: Props ): Node => {
         accessibilityLabel={t( "EMAIL" )}
         autoComplete="email"
         headerText={t( "EMAIL" )}
+        inputMode="email"
         keyboardType="email-address"
         onChangeText={text => setEmail( text )}
         testID="Signup.email"
+        textContentType="emailAddress"
       />
       <LoginSignUpInputField
         accessibilityLabel={t( "USERNAME" )}
         headerText={t( "USERNAME" )}
         onChangeText={text => setUsername( text )}
         testID="Signup.username"
+        textContentType="username"
       />
       <LoginSignUpInputField
         accessibilityLabel={t( "PASSWORD" )}
+        autoComplete="new-password"
         headerText={t( "PASSWORD" )}
         onChangeText={text => setPassword( text )}
         secureTextEntry
         testID="Signup.password"
+        textContentType="newPassword"
       />
       <Button
         className="mt-[30px]"


### PR DESCRIPTION
Main required change here is `textContentType` prop in iOS.