### PR TITLE
Improve Jest performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,12 @@
     "yargs": "^17.7.2"
   },
   "jest": {
+    "automock": false,
+    "moduleNameMapper": {
+      "\\.svg": "<rootDir>/tests/mocks/svgMock.js"
+    },
     "preset": "react-native",
+    "resetMocks": false,
     "setupFiles": [
       "./node_modules/react-native-gesture-handler/jestSetup.js",
       "<rootDir>/tests/jest.setup.js"
@@ -185,17 +190,13 @@
     "setupFilesAfterEnv": [
       "react-native-accessibility-engine",
       "<rootDir>/tests/jest.post-setup.js",
-      "<rootDir>/tests/realm.setup.js"
+      "<rootDir>/tests/realm.setup.js",
+      "<rootDir>/tests/helpers/globalSetup"
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?@react-native|react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base||(?!react-native-redash))|jest-runner"
     ],
-    "automock": false,
-    "resetMocks": false,
-    "verbose": true,
-    "moduleNameMapper": {
-      "\\.svg": "<rootDir>/tests/mocks/svgMock.js"
-    }
+    "verbose": true
   },
   "husky": {
     "hooks": {

--- a/tests/helpers/faker.js
+++ b/tests/helpers/faker.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
+import { faker } from "@faker-js/faker/locale/en";
+
+export default faker;

--- a/tests/helpers/globalSetup.js
+++ b/tests/helpers/globalSetup.js
@@ -1,0 +1,5 @@
+import initI18next from "i18n/initI18next";
+
+beforeAll( async ( ) => {
+  await initI18next( );
+} );

--- a/tests/integration/Explore.test.js
+++ b/tests/integration/Explore.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import ExploreContainer from "components/Explore/ExploreContainer";
-import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import React from "react";
 import factory, { makeResponse } from "tests/factory";
@@ -19,10 +18,6 @@ const mockRemoteObservation = factory( "RemoteObservation", {
 } );
 
 describe( "Explore", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should render", async ( ) => {
     inatjs.observations.search.mockResolvedValue( makeResponse( [mockRemoteObservation] ) );
     renderAppWithComponent( <ExploreContainer /> );

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -1,7 +1,7 @@
 // These test ensure that My Observation integrates with other systems like
 // remote data retrieval and local data persistence
 
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import MyObservationsContainer from "components/MyObservations/MyObservationsContainer";
 import { format } from "date-fns";

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -1,16 +1,15 @@
 // These test ensure that My Observation integrates with other systems like
 // remote data retrieval and local data persistence
 
-import faker from "tests/helpers/faker";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import MyObservationsContainer from "components/MyObservations/MyObservationsContainer";
 import { format } from "date-fns";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import inatjs from "inaturalistjs";
 import React from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import factory, { makeResponse } from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderAppWithComponent } from "tests/helpers/render";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
@@ -37,10 +36,6 @@ afterAll( uniqueRealmAfterAll );
 // /UNIQUE REALM SETUP
 
 describe( "MyObservations", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   // For some reason this interferes with the "should not make a request to
   // users/me" test below, can't figure out why ~~~kueda 20230105
   // TODO: this looks to me more like it should be covered by unit tests - @jtklein

--- a/tests/integration/ObsDetails.test.js
+++ b/tests/integration/ObsDetails.test.js
@@ -1,6 +1,5 @@
 import { screen, waitFor } from "@testing-library/react-native";
 import ObsDetailsContainer from "components/ObsDetails/ObsDetailsContainer";
-import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import React from "react";
 import Observation from "realmModels/Observation";
@@ -68,7 +67,6 @@ jest.mock( "@react-navigation/native", () => {
 
 describe( "ObsDetails", () => {
   beforeAll( async () => {
-    await initI18next();
     jest.useFakeTimers( );
     signIn( mockUser, { realm: global.mockRealms[__filename] } );
     Observation.upsertRemoteObservations( [mockObservation], global.mockRealms[__filename] );

--- a/tests/integration/ObsDetails/ActivityTab/ActivityHeaderContainer.test.js
+++ b/tests/integration/ObsDetails/ActivityTab/ActivityHeaderContainer.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import ActivityHeaderContainer from "components/ObsDetails/ActivityTab/ActivityHeaderContainer";
-import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import React from "react";
 import factory, { makeResponse } from "tests/factory";
@@ -32,10 +31,6 @@ afterAll( uniqueRealmAfterAll );
 const mockUser = factory( "LocalUser" );
 
 describe( "ActivityHeaderContainer", ( ) => {
-  beforeAll( async () => {
-    await initI18next( );
-  } );
-
   beforeEach( ( ) => {
     signIn( mockUser, { realm: global.mockRealms[__filename] } );
   } );

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import Geolocation from "@react-native-community/geolocation";
 import NetInfo from "@react-native-community/netinfo";
 import { screen, waitFor } from "@testing-library/react-native";

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -1,14 +1,13 @@
-import faker from "tests/helpers/faker";
 import Geolocation from "@react-native-community/geolocation";
 import NetInfo from "@react-native-community/netinfo";
 import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
-import initI18next from "i18n/initI18next";
 import fetchMock from "jest-fetch-mock";
 import React from "react";
 import { LOCATION_FETCH_INTERVAL } from "sharedHooks/useCurrentObservationLocation";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderAppWithComponent } from "tests/helpers/render";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
@@ -52,10 +51,6 @@ afterEach( ( ) => {
 } );
 
 describe( "ObsEdit offline", ( ) => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   beforeEach( ( ) => {
     // Turn on fetch mocks and make all fetch requests throw an error
     fetchMock.doMock( );

--- a/tests/integration/ObsEditWithoutProvider.test.js
+++ b/tests/integration/ObsEditWithoutProvider.test.js
@@ -1,11 +1,10 @@
-import faker from "tests/helpers/faker";
 import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import { LOCATION_FETCH_INTERVAL } from "sharedHooks/useCurrentObservationLocation";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const initialStoreState = useStore.getState( );
@@ -62,7 +61,6 @@ const mockTaxon = factory( "RemoteTaxon", {
 describe( "basic rendering", ( ) => {
   beforeAll( async () => {
     useStore.setState( initialStoreState, true );
-    await initI18next();
   } );
 
   it( "should render place_guess and latitude", ( ) => {
@@ -91,7 +89,6 @@ describe( "basic rendering", ( ) => {
 describe( "location fetching", () => {
   beforeAll( async () => {
     useStore.setState( initialStoreState, true );
-    await initI18next();
   } );
 
   beforeEach( () => {

--- a/tests/integration/ObsEditWithoutProvider.test.js
+++ b/tests/integration/ObsEditWithoutProvider.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
 import initI18next from "i18n/initI18next";

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -1,15 +1,14 @@
-import faker from "tests/helpers/faker";
 import {
   act,
   screen,
   userEvent,
   within
 } from "@testing-library/react-native";
-import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import Identification from "realmModels/Identification";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderAppWithObservations } from "tests/helpers/render";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut, TEST_JWT } from "tests/helpers/user";
@@ -48,7 +47,6 @@ afterAll( uniqueRealmAfterAll );
 const initialStoreState = useStore.getState( );
 beforeAll( async ( ) => {
   useStore.setState( initialStoreState, true );
-  await initI18next( );
   // userEvent recommends fake timers
   jest.useFakeTimers( );
 } );

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import {
   act,
   screen,

--- a/tests/integration/navigation/MediaViewer.test.js
+++ b/tests/integration/navigation/MediaViewer.test.js
@@ -3,7 +3,6 @@ import {
   screen,
   userEvent
 } from "@testing-library/react-native";
-import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
@@ -62,7 +61,6 @@ describe( "MediaViewer navigation", ( ) => {
   }
 
   beforeAll( async () => {
-    await initI18next();
     jest.useFakeTimers( );
   } );
 

--- a/tests/integration/navigation/ObsEdit.test.js
+++ b/tests/integration/navigation/ObsEdit.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import {
   screen,
   userEvent

--- a/tests/integration/navigation/ObsEdit.test.js
+++ b/tests/integration/navigation/ObsEdit.test.js
@@ -1,14 +1,13 @@
-import faker from "tests/helpers/faker";
 import {
   screen,
   userEvent
 } from "@testing-library/react-native";
-import initI18next from "i18n/initI18next";
 // import os from "os";
 // import path from "path";
 // import Realm from "realm";
 // import realmConfig from "realmModels/index";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import {
   renderAppWithObservations
 } from "tests/helpers/render";
@@ -56,7 +55,6 @@ describe( "ObsEdit", ( ) => {
   } );
 
   beforeAll( async () => {
-    await initI18next();
     jest.useFakeTimers( );
   } );
 

--- a/tests/integration/navigation/Suggestions.test.js
+++ b/tests/integration/navigation/Suggestions.test.js
@@ -3,7 +3,6 @@ import {
   screen,
   userEvent
 } from "@testing-library/react-native";
-import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
@@ -60,7 +59,6 @@ describe( "Suggestions", ( ) => {
   }
 
   beforeAll( async () => {
-    await initI18next();
     // userEvent recommends fake timers
     jest.useFakeTimers( );
   } );

--- a/tests/integration/sharedHooks/useObservationsUpdates.test.js
+++ b/tests/integration/sharedHooks/useObservationsUpdates.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { renderHook } from "@testing-library/react-native";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import useObservationsUpdates from "sharedHooks/useObservationsUpdates";

--- a/tests/integration/sharedHooks/useTaxon.test.js
+++ b/tests/integration/sharedHooks/useTaxon.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { renderHook } from "@testing-library/react-native";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { useTaxon } from "sharedHooks";

--- a/tests/performance/MyObservations.perf-test.js
+++ b/tests/performance/MyObservations.perf-test.js
@@ -1,5 +1,5 @@
 // ComponentUnderTest.perf-test.tsx
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import MyObservations from "components/MyObservations/MyObservations";
 import initI18next from "i18n/initI18next";
 import React from "react";

--- a/tests/performance/MyObservations.perf-test.js
+++ b/tests/performance/MyObservations.perf-test.js
@@ -1,11 +1,10 @@
 // ComponentUnderTest.perf-test.tsx
-import faker from "tests/helpers/faker";
 import MyObservations from "components/MyObservations/MyObservations";
-import initI18next from "i18n/initI18next";
 import React from "react";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { measurePerformance } from "reassure";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 
 jest.setTimeout( 60_000 );
 
@@ -74,10 +73,6 @@ jest.mock( "sharedHooks/useObservationsUpdates", () => ( {
 } ) );
 
 describe( "MyObservations Performance", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   test( "Test list loading time in MyObservations", async () => {
     await measurePerformance( <MyObservations
       observations={mockObservations}

--- a/tests/unit/components/About.test.js
+++ b/tests/unit/components/About.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import About from "components/About";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import Mailer from "react-native-mail";
 import { renderComponent } from "tests/helpers/render";
@@ -10,10 +9,6 @@ jest.mock( "react-native-mail", ( ) => ( {
 } ) );
 
 describe( "email logs button", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should open the native email client", async ( ) => {
     renderComponent( <About /> );
     const debugLogButton = await screen.findByText( /EMAIL DEBUG LOGS/ );

--- a/tests/unit/components/AddObsModal.test.js
+++ b/tests/unit/components/AddObsModal.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import AddObsModal from "components/AddObsModal";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
 // eslint-disable-next-line import/no-unresolved
@@ -25,10 +24,6 @@ jest.mock( "react-native/Libraries/Utilities/Platform", ( ) => ( {
 } ) );
 
 describe( "AddObsModal", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   afterEach( () => {
     jest.clearAllMocks( );
   } );

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { screen } from "@testing-library/react-native";
 import initI18next from "i18n/initI18next";
 import CustomTabBarContainer from "navigation/BottomTabNavigator/CustomTabBarContainer";

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -1,11 +1,10 @@
-import faker from "tests/helpers/faker";
 import { screen } from "@testing-library/react-native";
-import initI18next from "i18n/initI18next";
 import CustomTabBarContainer from "navigation/BottomTabNavigator/CustomTabBarContainer";
 import React from "react";
 import * as useCurrentUser from "sharedHooks/useCurrentUser";
 import * as useIsConnected from "sharedHooks/useIsConnected";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockUser = factory( "LocalUser", {
@@ -26,10 +25,6 @@ jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
 } ) );
 
 describe( "CustomTabBar", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   beforeEach( ( ) => {
     jest.useFakeTimers();
   } );

--- a/tests/unit/components/Camera/ARCamera.test.js
+++ b/tests/unit/components/Camera/ARCamera.test.js
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react-native";
 import ARCamera from "components/Camera/ARCamera/ARCamera";
 import * as usePredictions from "components/Camera/ARCamera/hooks/usePredictions";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
 import * as useTaxon from "sharedHooks/useTaxon";
@@ -59,9 +58,6 @@ jest.mock( "components/Camera/hooks/useZoom", () => ( {
 } ) );
 
 describe( "AR Camera", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
   it( "shows a taxon prediction when result & rank_level < 40", async () => {
     jest.spyOn( usePredictions, "default" ).mockImplementation( () => ( {
       ...mockModelLoaded,

--- a/tests/unit/components/Camera/CameraContainer.test.js
+++ b/tests/unit/components/Camera/CameraContainer.test.js
@@ -2,7 +2,6 @@ import {
   fireEvent, render, screen
 } from "@testing-library/react-native";
 import CameraContainer from "components/Camera/CameraContainer";
-import initI18next from "i18n/initI18next";
 import INatPaperProvider from "providers/INatPaperProvider";
 import React from "react";
 import { View } from "react-native";
@@ -61,7 +60,6 @@ const renderCameraContainer = () => render(
 
 describe( "CameraContainer", ( ) => {
   beforeAll( async ( ) => {
-    await initI18next();
     jest.useFakeTimers( );
   } );
 

--- a/tests/unit/components/Camera/PhotoCarousel.test.js
+++ b/tests/unit/components/Camera/PhotoCarousel.test.js
@@ -2,7 +2,6 @@ import {
   fireEvent, render, screen, waitFor
 } from "@testing-library/react-native";
 import PhotoCarousel from "components/Camera/StandardCamera/PhotoCarousel";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import useStore from "stores/useStore";
 
@@ -18,7 +17,6 @@ const mockPhotoUris = [
 describe( "PhotoCarousel", ( ) => {
   beforeAll( async () => {
     useStore.setState( initialStoreState, true );
-    await initI18next( );
   } );
   // There were some tests of photo sizes responding to the isLargeScreen prop
   // but somewhat dynamic tailwind classes don't seem to create style props

--- a/tests/unit/components/DisplayTaxonName.test.js
+++ b/tests/unit/components/DisplayTaxonName.test.js
@@ -1,10 +1,9 @@
-import faker from "tests/helpers/faker";
 import { render, screen } from "@testing-library/react-native";
 import { DisplayTaxonName } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 
 const capitalizeFirstLetter = s => s.charAt( 0 ).toUpperCase( ) + s.slice( 1 );
 
@@ -44,10 +43,6 @@ const uncapitalizedTaxon = factory( "LocalTaxon", {
 } );
 
 describe( "DisplayTaxonName", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   describe( "when common name is first", ( ) => {
     test( "renders correct taxon for species", ( ) => {
       render( <DisplayTaxonName taxon={speciesTaxon} /> );

--- a/tests/unit/components/DisplayTaxonName.test.js
+++ b/tests/unit/components/DisplayTaxonName.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { render, screen } from "@testing-library/react-native";
 import { DisplayTaxonName } from "components/SharedComponents";
 import initI18next from "i18n/initI18next";

--- a/tests/unit/components/Explore/IdentifiersView.test.js
+++ b/tests/unit/components/Explore/IdentifiersView.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import ExploreFlashList from "components/Explore/ExploreFlashList";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -16,10 +15,6 @@ jest.mock( "sharedHooks/useInfiniteScroll", () => ( {
 } ) );
 
 describe( "IdentifiersView", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should show a footer loading wheel when new identifiers are fetched", ( ) => {
     renderComponent(
       <ExploreFlashList

--- a/tests/unit/components/Explore/MapView.test.js
+++ b/tests/unit/components/Explore/MapView.test.js
@@ -1,7 +1,6 @@
 import { screen, userEvent } from "@testing-library/react-native";
 import * as useMapLocation from "components/Explore/hooks/useMapLocation";
 import MapView from "components/Explore/MapView";
-import initI18next from "i18n/initI18next";
 import { ExploreProvider } from "providers/ExploreContext.tsx";
 import React from "react";
 import factory from "tests/factory";
@@ -30,7 +29,6 @@ const exploreMap = (
 
 describe( "MapView", () => {
   beforeAll( async ( ) => {
-    await initI18next( );
     // userEvent recommends fake timers
     jest.useFakeTimers( );
   } );

--- a/tests/unit/components/Explore/ObservationsView.test.js
+++ b/tests/unit/components/Explore/ObservationsView.test.js
@@ -1,7 +1,6 @@
 import { screen } from "@testing-library/react-native";
 import ObservationsFlashList
   from "components/SharedComponents/ObservationsFlashList/ObservationsFlashList";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import { renderComponent } from "tests/helpers/render";
 
@@ -17,10 +16,6 @@ jest.mock( "sharedHooks/useInfiniteObservationsScroll", () => ( {
 } ) );
 
 describe( "ObservationsView", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should show a footer loading wheel when new observations are fetched", ( ) => {
     renderComponent(
       <ObservationsFlashList

--- a/tests/unit/components/Explore/TaxonGridItem.test.js
+++ b/tests/unit/components/Explore/TaxonGridItem.test.js
@@ -3,7 +3,6 @@ import {
   screen
 } from "@testing-library/react-native";
 import TaxonGridItem from "components/Explore/TaxonGridItem";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -23,10 +22,6 @@ jest.mock( "@react-navigation/native", () => {
 } );
 
 describe( "TaxonGridItem", ( ) => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   it( "should be accessible", ( ) => {
     const taxonGridItem = (
       <TaxonGridItem

--- a/tests/unit/components/LocationPicker/LocationPicker.test.js
+++ b/tests/unit/components/LocationPicker/LocationPicker.test.js
@@ -1,9 +1,9 @@
-import { faker } from "@faker-js/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import LocationPicker from "components/LocationPicker/LocationPicker";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const observations = [

--- a/tests/unit/components/LocationPicker/LocationPicker.test.js
+++ b/tests/unit/components/LocationPicker/LocationPicker.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import LocationPicker from "components/LocationPicker/LocationPicker";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
@@ -52,10 +51,6 @@ const renderLocationPicker = region => renderComponent(
 );
 
 describe( "LocationPicker", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it(
     "should display latitude corresponding with location name",
     async ( ) => {

--- a/tests/unit/components/MediaViewer/MediaViewer.test.js
+++ b/tests/unit/components/MediaViewer/MediaViewer.test.js
@@ -1,15 +1,10 @@
 import { screen } from "@testing-library/react-native";
 import MediaViewer from "components/MediaViewer/MediaViewer";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
 
 describe( "MediaViewer", ( ) => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   describe( "without media", ( ) => {
     it( "should not have accessibility errors", async () => {
       renderComponent( <MediaViewer /> );

--- a/tests/unit/components/Messages/Messages.test.js
+++ b/tests/unit/components/Messages/Messages.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { NavigationContainer } from "@react-navigation/native";
 import { render, screen } from "@testing-library/react-native";
 import Messages from "components/Messages/Messages";

--- a/tests/unit/components/Messages/Messages.test.js
+++ b/tests/unit/components/Messages/Messages.test.js
@@ -2,7 +2,7 @@ import faker from "tests/helpers/faker";
 import { NavigationContainer } from "@react-navigation/native";
 import { render, screen } from "@testing-library/react-native";
 import Messages from "components/Messages/Messages";
-import initI18next from "i18n/initI18next";
+
 import INatPaperProvider from "providers/INatPaperProvider";
 import React from "react";
 import factory from "tests/factory";
@@ -54,9 +54,7 @@ jest.mock( "@tanstack/react-query", ( ) => ( {
 } ) );
 
 describe( "Messages", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "should not have accessibility errors", () => {
     const messages = (

--- a/tests/unit/components/MyObservations/Announcements.test.js
+++ b/tests/unit/components/MyObservations/Announcements.test.js
@@ -1,6 +1,5 @@
 import { screen, waitFor } from "@testing-library/react-native";
 import Announcements from "components/MyObservations/Announcements";
-import initI18next from "i18n/initI18next";
 import inaturalistjs from "inaturalistjs";
 import React from "react";
 import { renderComponent } from "tests/helpers/render";
@@ -47,10 +46,6 @@ jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
 const containerID = "announcements-container";
 
 describe( "Announcements", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   beforeEach( ( ) => {
     inaturalistjs.announcements.search.mockReturnValue( Promise.resolve( {
       total_results: 0,

--- a/tests/unit/components/MyObservations/MyObservations.test.js
+++ b/tests/unit/components/MyObservations/MyObservations.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import MyObservations from "components/MyObservations/MyObservations";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import DeviceInfo from "react-native-device-info";
 import useDeviceOrientation from "sharedHooks/useDeviceOrientation";
@@ -60,7 +59,6 @@ jest.mock( "sharedHooks/useDeviceOrientation", ( ) => ( {
 
 describe( "MyObservations", () => {
   beforeAll( async () => {
-    await initI18next();
     jest.useFakeTimers( );
   } );
 

--- a/tests/unit/components/MyObservations/ToolbarContainer.test.js
+++ b/tests/unit/components/MyObservations/ToolbarContainer.test.js
@@ -1,7 +1,6 @@
 import { screen } from "@testing-library/react-native";
 import * as useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations";
 import ToolbarContainer from "components/MyObservations/ToolbarContainer";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
 import { renderComponent } from "tests/helpers/render";
@@ -34,10 +33,6 @@ const uploadState = {
 };
 
 describe( "Toolbar", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   it( "displays a pending upload", async () => {
     renderComponent( <ToolbarContainer
       numUnuploadedObs={1}

--- a/tests/unit/components/MyObservations/useDeleteObservations.test.js
+++ b/tests/unit/components/MyObservations/useDeleteObservations.test.js
@@ -1,6 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations";
-import initI18next from "i18n/initI18next";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
@@ -31,10 +30,6 @@ const getLocalObservation = uuid => global.realm
   .objectForPrimaryKey( "Observation", uuid );
 
 describe( "handle deletions", ( ) => {
-  beforeEach( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should not make deletion API call for unsynced observations", async ( ) => {
     const deleteSpy = jest.spyOn( global.realm, "delete" );
     safeRealmWrite(

--- a/tests/unit/components/MyObservations/useDeleteObservations.test.js
+++ b/tests/unit/components/MyObservations/useDeleteObservations.test.js
@@ -1,9 +1,9 @@
-import { faker } from "@faker-js/faker";
 import { renderHook, waitFor } from "@testing-library/react-native";
 import useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations";
 import initI18next from "i18n/initI18next";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 
 const mockMutate = jest.fn();
 jest.mock( "sharedHooks/useAuthenticatedMutation", ( ) => ( {

--- a/tests/unit/components/ObsDetails/ActivityHeaderKebabMenu.test.js
+++ b/tests/unit/components/ObsDetails/ActivityHeaderKebabMenu.test.js
@@ -1,7 +1,7 @@
 import faker from "tests/helpers/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import ActivityHeader from "components/ObsDetails/ActivityTab/ActivityHeader";
-import initI18next from "i18n/initI18next";
+
 import { t } from "i18next";
 import React from "react";
 import factory from "tests/factory";
@@ -14,9 +14,7 @@ const mockUser = factory( "LocalUser", {
 } );
 
 describe( "ActivityHeaderKebabMenu", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "renders kebab menu buttons", async ( ) => {
     const mockId = factory( "LocalIdentification", {

--- a/tests/unit/components/ObsDetails/ActivityHeaderKebabMenu.test.js
+++ b/tests/unit/components/ObsDetails/ActivityHeaderKebabMenu.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import ActivityHeader from "components/ObsDetails/ActivityTab/ActivityHeader";
 import initI18next from "i18n/initI18next";

--- a/tests/unit/components/ObsDetails/ActivityItem.test.js
+++ b/tests/unit/components/ObsDetails/ActivityItem.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import ActivityItem from "components/ObsDetails/ActivityTab/ActivityItem";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -16,9 +16,7 @@ const mockIdentification = factory( "LocalIdentification", {
 } );
 
 describe( "ActivityItem", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
   it( "renders", async ( ) => {
     renderComponent(
       <ActivityItem

--- a/tests/unit/components/ObsDetails/ActivityTab.test.js
+++ b/tests/unit/components/ObsDetails/ActivityTab.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import ActivityTab from "components/ObsDetails/ActivityTab/ActivityTab";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -50,7 +49,6 @@ jest.mock( "sharedHooks/useAuthenticatedMutation", () => ( {
 
 describe( "ActivityTab", () => {
   it( "renders", async ( ) => {
-    await initI18next( );
     renderComponent(
       <ActivityTab
         observation={mockObservation}

--- a/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
+++ b/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
@@ -2,7 +2,7 @@ import faker from "tests/helpers/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import DQAVoteButtons from "components/ObsDetails/DetailsTab/DQAVoteButtons";
 import DQAContainer from "components/ObsDetails/DQAContainer";
-import initI18next from "i18n/initI18next";
+
 import { t } from "i18next";
 import React from "react";
 import { View } from "react-native";
@@ -94,9 +94,7 @@ jest.mock( "@react-navigation/native", () => {
 } );
 
 describe( "Data Quality Assessment", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
   test( "renders correct quality grade status", async ( ) => {
     renderComponent( <DQAContainer qualityGrade={mockObservation.quality_grade} /> );
 
@@ -185,9 +183,7 @@ describe( "Data Quality Assessment", ( ) => {
 } );
 
 describe( "DQA Vote Buttons", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
   test( "renders DQA vote buttons", async ( ) => {
     renderComponent( <DQAContainer observation={mockObservation} /> );
 

--- a/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
+++ b/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import DQAVoteButtons from "components/ObsDetails/DetailsTab/DQAVoteButtons";
 import DQAContainer from "components/ObsDetails/DQAContainer";

--- a/tests/unit/components/ObsDetails/DetailsTab.test.js
+++ b/tests/unit/components/ObsDetails/DetailsTab.test.js
@@ -1,7 +1,7 @@
 import faker from "tests/helpers/faker";
 import { screen } from "@testing-library/react-native";
 import DetailsTab from "components/ObsDetails/DetailsTab/DetailsTab";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import { View } from "react-native";
 import factory from "tests/factory";
@@ -42,9 +42,7 @@ jest.mock( "components/ObsDetails/DetailsTab/Attribution", () => ( {
 const baseUrl = "https://api.inaturalist.org/v2/grid/{z}/{x}/{y}.png";
 
 describe( "DetailsTab", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
   test( "should show description of observation", async ( ) => {
     renderComponent( <DetailsTab observation={mockObservation} /> );
 

--- a/tests/unit/components/ObsDetails/DetailsTab.test.js
+++ b/tests/unit/components/ObsDetails/DetailsTab.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { screen } from "@testing-library/react-native";
 import DetailsTab from "components/ObsDetails/DetailsTab/DetailsTab";
 import initI18next from "i18n/initI18next";

--- a/tests/unit/components/ObsDetails/FaveButton.test.js
+++ b/tests/unit/components/ObsDetails/FaveButton.test.js
@@ -1,13 +1,11 @@
 import FaveButton from "components/ObsDetails/FaveButton";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
 
 describe( "FaveButton", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "should survive no currentUser", ( ) => {
     expect(

--- a/tests/unit/components/ObsDetails/Flags.test.js
+++ b/tests/unit/components/ObsDetails/Flags.test.js
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react-native";
 import FlagItemModal from "components/ObsDetails/FlagItemModal";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -46,9 +46,7 @@ jest.mock( "react-native-keyboard-aware-scroll-view", () => {
 } );
 
 describe( "Flags", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   // it( "renders activity item with Flag Button", async ( ) => {
   //   renderComponent(

--- a/tests/unit/components/ObsDetails/HeaderKebabMenu.test.js
+++ b/tests/unit/components/ObsDetails/HeaderKebabMenu.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import HeaderKebabMenu from "components/ObsDetails/HeaderKebabMenu";
-import initI18next from "i18n/initI18next";
+
 import i18next from "i18next";
 import React from "react";
 import { Platform, Share } from "react-native";
@@ -19,9 +19,7 @@ const observationId = 1234;
 const url = `https://www.inaturalist.org/observations/${observationId}`;
 
 describe( "HeaderKebabMenu", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "renders and opens kebab menu share button", async ( ) => {
     renderComponent( <HeaderKebabMenu observationId={observationId} /> );

--- a/tests/unit/components/ObsDetails/ObsDetails.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetails.test.js
@@ -1,8 +1,6 @@
-import faker from "tests/helpers/faker";
 import { useRoute } from "@react-navigation/native";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import ObsDetailsContainer from "components/ObsDetails/ObsDetailsContainer";
-import initI18next from "i18n/initI18next";
 import i18next, { t } from "i18next";
 import React from "react";
 import { View } from "react-native";
@@ -12,6 +10,7 @@ import * as useCurrentUser from "sharedHooks/useCurrentUser";
 import useIsConnected from "sharedHooks/useIsConnected";
 import * as useLocalObservation from "sharedHooks/useLocalObservation";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockObservation = factory( "LocalObservation", {
@@ -153,7 +152,6 @@ const renderObsDetails = ( ) => renderComponent(
 
 describe( "ObsDetails", () => {
   beforeAll( async () => {
-    await initI18next();
     jest.useFakeTimers( );
   } );
 

--- a/tests/unit/components/ObsDetails/ObsDetails.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetails.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { useRoute } from "@react-navigation/native";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import ObsDetailsContainer from "components/ObsDetails/ObsDetailsContainer";

--- a/tests/unit/components/ObsDetails/ObsDetailsHeader.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetailsHeader.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import ObsDetailsHeader from "components/ObsDetails/ObsDetailsHeader";
-import initI18next from "i18n/initI18next";
+
 import i18next from "i18next";
 import React from "react";
 import factory from "tests/factory";
@@ -16,9 +16,7 @@ jest.mock( "react-native/Libraries/Utilities/Platform", ( ) => ( {
 } ) );
 
 describe( "ObsDetailsHeader", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "shows options menu when viewing someone else's observation", async ( ) => {
     renderComponent(

--- a/tests/unit/components/ObsDetails/ObsDetailsOverview.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetailsOverview.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { screen } from "@testing-library/react-native";
 import ObsDetailsOverview from "components/ObsDetails/ObsDetailsOverview";
 import initI18next from "i18n/initI18next";

--- a/tests/unit/components/ObsDetails/ObsDetailsOverview.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetailsOverview.test.js
@@ -1,7 +1,7 @@
 import faker from "tests/helpers/faker";
 import { screen } from "@testing-library/react-native";
 import ObsDetailsOverview from "components/ObsDetails/ObsDetailsOverview";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -13,9 +13,7 @@ const mockTaxon = factory( "RemoteTaxon", {
 } );
 
 describe( "ObsDetailsOverview", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "displays unknown text if no taxon", async ( ) => {
     renderComponent(

--- a/tests/unit/components/ObsDetails/ObsMedia.test.js
+++ b/tests/unit/components/ObsDetails/ObsMedia.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { render, screen } from "@testing-library/react-native";
 import ObsMedia from "components/ObsDetails/ObsMedia";
 import initI18next from "i18n/initI18next";

--- a/tests/unit/components/ObsDetails/ObsMedia.test.js
+++ b/tests/unit/components/ObsDetails/ObsMedia.test.js
@@ -1,7 +1,7 @@
 import faker from "tests/helpers/faker";
 import { render, screen } from "@testing-library/react-native";
 import ObsMedia from "components/ObsDetails/ObsMedia";
-import initI18next from "i18n/initI18next";
+
 import _ from "lodash";
 import React from "react";
 import factory from "tests/factory";
@@ -48,9 +48,7 @@ const expectedImageSource = [
 ];
 
 describe( "ObsMedia", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   // it.todo( "should not have accessibility errors" );
   // it( "should not have accessibility errors", async () => {

--- a/tests/unit/components/ObsDetails/Sheets/WithdrawIDSheet.test.js
+++ b/tests/unit/components/ObsDetails/Sheets/WithdrawIDSheet.test.js
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react-native";
 import WithdrawIDSheet from "components/ObsDetails/Sheets/WithdrawIDSheet";
-import initI18next from "i18n/initI18next";
+
 import { t } from "i18next";
 import React from "react";
 import factory from "tests/factory";
@@ -16,9 +16,7 @@ const mockMutate = jest.fn();
 const mockHandleClose = jest.fn();
 
 describe( "WithdrawIDSheet", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "renders sheet correctly", async ( ) => {
     renderComponent(

--- a/tests/unit/components/ObsEdit/BottomButtons.test.js
+++ b/tests/unit/components/ObsEdit/BottomButtons.test.js
@@ -1,6 +1,6 @@
-import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
 import BottomButtons from "components/ObsEdit/BottomButtons";
+import faker from "tests/helpers/faker";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import * as useCurrentUser from "sharedHooks/useCurrentUser";

--- a/tests/unit/components/ObsEdit/BottomButtons.test.js
+++ b/tests/unit/components/ObsEdit/BottomButtons.test.js
@@ -1,10 +1,9 @@
 import { screen } from "@testing-library/react-native";
 import BottomButtons from "components/ObsEdit/BottomButtons";
-import faker from "tests/helpers/faker";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import * as useCurrentUser from "sharedHooks/useCurrentUser";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockObservation = factory( "LocalObservation", {
@@ -19,10 +18,6 @@ jest.mock( "sharedHooks/useCurrentUser", () => ( {
 } ) );
 
 describe( "BottomButtons", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "has no accessibility errors", () => {
     const bottomButtons = (
       <BottomButtons />

--- a/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
+++ b/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import DeleteObservationSheet from "components/ObsEdit/Sheets/DeleteObservationSheet";
 import initI18next from "i18n/initI18next";
@@ -7,6 +6,7 @@ import inatjs from "inaturalistjs";
 import React from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const observations = [factory( "LocalObservation", {

--- a/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
+++ b/tests/unit/components/ObsEdit/DeleteObservationSheet.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import DeleteObservationSheet from "components/ObsEdit/Sheets/DeleteObservationSheet";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import inatjs from "inaturalistjs";
 import React from "react";
@@ -34,8 +33,6 @@ const getLocalObservation = uuid => global.realm
 
 describe( "delete observation", ( ) => {
   beforeAll( async ( ) => {
-    await initI18next( );
-
     safeRealmWrite( global.realm, ( ) => {
       global.realm.create( "Observation", currentObservation );
     }, "write Observation, DeleteObservationSheet test" );

--- a/tests/unit/components/ObsEdit/Header.test.js
+++ b/tests/unit/components/ObsEdit/Header.test.js
@@ -1,9 +1,9 @@
-import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
 import Header from "components/ObsEdit/Header";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockObservations = [

--- a/tests/unit/components/ObsEdit/Header.test.js
+++ b/tests/unit/components/ObsEdit/Header.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import Header from "components/ObsEdit/Header";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
@@ -12,10 +11,6 @@ const mockObservations = [
 ];
 
 describe( "Header", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "has no accessibility errors", () => {
     const button = (
       <Header

--- a/tests/unit/components/ObsEdit/IdentificationSection.test.js
+++ b/tests/unit/components/ObsEdit/IdentificationSection.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import IdentificationSection from "components/ObsEdit/IdentificationSection";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -42,10 +41,6 @@ const renderIdentificationSection = ( obs, index = 0, resetState = false ) => re
 );
 
 describe( "IdentificationSection", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should show IconicTaxonChooser when there is no identification", ( ) => {
     const observations = [
       factory( "RemoteObservation", {

--- a/tests/unit/components/ObsEdit/ObsEdit.test.js
+++ b/tests/unit/components/ObsEdit/ObsEdit.test.js
@@ -1,10 +1,10 @@
-import { faker } from "@faker-js/faker";
 import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const initialStoreState = useStore.getState( );

--- a/tests/unit/components/ObsEdit/ObsEdit.test.js
+++ b/tests/unit/components/ObsEdit/ObsEdit.test.js
@@ -1,6 +1,5 @@
 import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
@@ -47,7 +46,6 @@ const renderObsEdit = ( ) => renderComponent( <ObsEdit /> );
 describe( "ObsEdit", () => {
   beforeAll( async ( ) => {
     useStore.setState( initialStoreState, true );
-    await initI18next( );
   } );
 
   it( "should not have accessibility errors", async () => {

--- a/tests/unit/components/ObsEdit/OtherDataSection.test.js
+++ b/tests/unit/components/ObsEdit/OtherDataSection.test.js
@@ -1,14 +1,9 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import OtherDataSection from "components/ObsEdit/OtherDataSection";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import { renderComponent } from "tests/helpers/render";
 
 describe( "OtherDataSection", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "has no accessibility errors", () => {
     const otherData = (
       <OtherDataSection />

--- a/tests/unit/components/PhotoImporter/GroupPhotosContainer.test.js
+++ b/tests/unit/components/PhotoImporter/GroupPhotosContainer.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import GroupPhotosContainer from "components/PhotoImporter/GroupPhotosContainer";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import useStore from "stores/useStore";
 import { renderComponent } from "tests/helpers/render";
@@ -31,7 +30,6 @@ const mockGroupedPhotos = [{
 describe( "GroupPhotosContainer", ( ) => {
   beforeAll( async ( ) => {
     useStore.setState( initialStoreState, true );
-    await initI18next( );
   } );
 
   afterEach( () => {

--- a/tests/unit/components/ProjectDetails/ProjectDetails.test.js
+++ b/tests/unit/components/ProjectDetails/ProjectDetails.test.js
@@ -1,9 +1,9 @@
-import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
 import ProjectDetailsContainer from "components/ProjectDetails/ProjectDetailsContainer";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockProject = factory( "RemoteProject", {

--- a/tests/unit/components/ProjectDetails/ProjectDetails.test.js
+++ b/tests/unit/components/ProjectDetails/ProjectDetails.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import ProjectDetailsContainer from "components/ProjectDetails/ProjectDetailsContainer";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
@@ -33,9 +32,6 @@ jest.mock( "@react-navigation/native", ( ) => {
 } );
 
 describe( "ProjectDetails", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
   test( "should not have accessibility errors", async ( ) => {
     renderComponent( <ProjectDetailsContainer /> );
     const projectDetails = await screen.findByTestId( "project-details" );

--- a/tests/unit/components/Projects/Projects.test.js
+++ b/tests/unit/components/Projects/Projects.test.js
@@ -1,9 +1,8 @@
-import faker from "tests/helpers/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import ProjectsContainer from "components/Projects/ProjectsContainer";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockedNavigate = jest.fn( );
@@ -52,7 +51,6 @@ jest.mock( "react-native-paper", () => {
 
 describe( "Projects", ( ) => {
   beforeAll( async ( ) => {
-    await initI18next( );
     jest.useFakeTimers( );
   } );
 

--- a/tests/unit/components/Projects/Projects.test.js
+++ b/tests/unit/components/Projects/Projects.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import ProjectsContainer from "components/Projects/ProjectsContainer";
 import initI18next from "i18n/initI18next";

--- a/tests/unit/components/QualityGradeStatus/__snapshots__/QualityGradeStatus.test.js.snap
+++ b/tests/unit/components/QualityGradeStatus/__snapshots__/QualityGradeStatus.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Quality Grade casual should render correctly 1`] = `
 <View>
   <SvgMock
+    accessibilityLabel="Quality Grade Casual"
     accessible={true}
     color="rgba(103, 80, 164, 1)"
     opacity={1}
@@ -14,6 +15,7 @@ exports[`Quality Grade casual should render correctly 1`] = `
 exports[`Quality Grade needs_id should render correctly 1`] = `
 <View>
   <SvgMock
+    accessibilityLabel="Quality Grade Needs ID"
     accessible={true}
     color="rgba(103, 80, 164, 1)"
     opacity={1}
@@ -25,6 +27,7 @@ exports[`Quality Grade needs_id should render correctly 1`] = `
 exports[`Quality Grade research should render correctly 1`] = `
 <View>
   <SvgMock
+    accessibilityLabel="Quality Grade Research Grade"
     accessible={true}
     color="rgba(103, 80, 164, 1)"
     opacity={1}

--- a/tests/unit/components/Search/Search.taxa.test.js
+++ b/tests/unit/components/Search/Search.taxa.test.js
@@ -1,8 +1,8 @@
-import { faker } from "@faker-js/faker";
 import { fireEvent, screen } from "@testing-library/react-native";
 import Search from "components/Search/Search";
 import React from "react";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockedNavigate = jest.fn( );

--- a/tests/unit/components/SharedComponents/ActivityCount/ActivityCount.test.js
+++ b/tests/unit/components/SharedComponents/ActivityCount/ActivityCount.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react-native";
 import { ActivityCount } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 
 const count = 1;
@@ -8,9 +8,6 @@ const icon = "comments";
 const testID = "some_id";
 
 describe( "ActivityCount", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
 
   it( "renders reliably", () => {
     // Snapshot test

--- a/tests/unit/components/SharedComponents/ActivityCount/CommentsCount.test.js
+++ b/tests/unit/components/SharedComponents/ActivityCount/CommentsCount.test.js
@@ -1,14 +1,11 @@
 import { render, screen } from "@testing-library/react-native";
 import { CommentsCount } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 
 const count = 1;
 
 describe( "CommentsCount", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
 
   it( "renders default reliably", () => {
     // Snapshot test

--- a/tests/unit/components/SharedComponents/ActivityCount/IdentificationsCount.test.js
+++ b/tests/unit/components/SharedComponents/ActivityCount/IdentificationsCount.test.js
@@ -1,14 +1,11 @@
 import { render, screen } from "@testing-library/react-native";
 import { IdentificationsCount } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 
 const count = 1;
 
 describe( "IdentificationsCount", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
 
   it( "renders default reliably", () => {
     // Snapshot test

--- a/tests/unit/components/SharedComponents/Checkbox.test.js
+++ b/tests/unit/components/SharedComponents/Checkbox.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { Checkbox } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import colors from "styles/tailwindColors";
 import { renderComponent } from "tests/helpers/render";
@@ -21,9 +21,7 @@ const rerenderCheckmarkComponent = checked => {
 };
 
 describe( "Checkbox", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "renders reliably", () => {
     render( <Checkbox text="Checkmark text" /> );

--- a/tests/unit/components/SharedComponents/DateDisplay.test.js
+++ b/tests/unit/components/SharedComponents/DateDisplay.test.js
@@ -1,11 +1,8 @@
 import { DateDisplay } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
 import React from "react";
 
 describe( "DateDisplay", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "should be accessible", () => {
     expect( <DateDisplay dateString="2023-12-14T21:07:41+00:00" /> ).toBeAccessible( );

--- a/tests/unit/components/SharedComponents/DisplayTaxon.test.js
+++ b/tests/unit/components/SharedComponents/DisplayTaxon.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import { DisplayTaxon } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -23,10 +22,6 @@ const taxonWithIconicTaxonPhoto = factory( "LocalTaxon", {
 } );
 
 describe( "DisplayTaxon", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should be accessible", () => {
     expect( <DisplayTaxon taxon={mockTaxon} handlePress={( ) => { }} /> ).toBeAccessible( );
   } );

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { InlineUser } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 
@@ -30,9 +30,6 @@ jest.mock(
 );
 
 describe( "InlineUser", ( ) => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
 
   it( "should not have accessibility erros", () => {
     const inlineUser = <InlineUser user={mockUser} />;

--- a/tests/unit/components/SharedComponents/Map.test.js
+++ b/tests/unit/components/SharedComponents/Map.test.js
@@ -1,6 +1,6 @@
-import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
 import { Map } from "components/SharedComponents";
+import faker from "tests/helpers/faker";
 import React from "react";
 import { renderComponent } from "tests/helpers/render";
 

--- a/tests/unit/components/SharedComponents/ObservationLocation.test.js
+++ b/tests/unit/components/SharedComponents/ObservationLocation.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react-native";
 import { ObservationLocation } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 
@@ -47,9 +47,7 @@ const testData = [
 ];
 
 describe( "ObservationLocation", () => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "should be accessible", () => {
     const mockObservation = factory( "RemoteObservation" );

--- a/tests/unit/components/SharedComponents/ObservationsFlashList/ObsGridItem.test.js
+++ b/tests/unit/components/SharedComponents/ObservationsFlashList/ObsGridItem.test.js
@@ -1,14 +1,9 @@
 import { render, screen } from "@testing-library/react-native";
 import ObsGridItem from "components/SharedComponents/ObservationsFlashList/ObsGridItem";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 
 describe( "ObsGridItem", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   describe( "for an observation with a photo", ( ) => {
     const observationWithPhoto = factory( "LocalObservation", {
       observationPhotos: [factory( "LocalObservationPhoto" )]

--- a/tests/unit/components/SharedComponents/ObservationsFlashList/ObsStatus.test.js
+++ b/tests/unit/components/SharedComponents/ObservationsFlashList/ObsStatus.test.js
@@ -2,7 +2,6 @@ import {
   screen
 } from "@testing-library/react-native";
 import ObsStatus from "components/SharedComponents/ObsStatus";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -20,10 +19,6 @@ const mockObservation = factory( "LocalObservation", {
 } );
 
 describe( "ObsStatus", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   it( "displays count for current ids, not withdrawn ids", () => {
     renderComponent(
       <ObsStatus

--- a/tests/unit/components/SharedComponents/ObservationsFlashList/ObsUploadStatus.test.js
+++ b/tests/unit/components/SharedComponents/ObservationsFlashList/ObsUploadStatus.test.js
@@ -2,7 +2,6 @@ import {
   screen
 } from "@testing-library/react-native";
 import ObsUploadStatus from "components/SharedComponents/ObservationsFlashList/ObsUploadStatus";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
 import factory from "tests/factory";
@@ -19,10 +18,6 @@ const mockEditedObservation = factory( "LocalObservation", {
 } );
 
 describe( "ObsUploadStatus", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   it( "displays a pending upload for an unsynced observation", () => {
     renderComponent(
       <ObsUploadStatus

--- a/tests/unit/components/SharedComponents/ObservationsFlashList/ObsUploadStatus.test.js
+++ b/tests/unit/components/SharedComponents/ObservationsFlashList/ObsUploadStatus.test.js
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import {
   screen
 } from "@testing-library/react-native";
@@ -7,6 +6,7 @@ import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockUnsyncedObservation = factory( "LocalObservation", {

--- a/tests/unit/components/SharedComponents/PermissionGate.test.js
+++ b/tests/unit/components/SharedComponents/PermissionGate.test.js
@@ -1,13 +1,11 @@
 import { render, screen } from "@testing-library/react-native";
 import PermissionGate from "components/SharedComponents/PermissionGate";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import { RESULTS } from "react-native-permissions";
 
 describe( "PermissionGate", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "should show the GRANT PERMISSION button when permission unknown", ( ) => {
     render(

--- a/tests/unit/components/SharedComponents/Tabs/Tabs.test.js
+++ b/tests/unit/components/SharedComponents/Tabs/Tabs.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { Tabs } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
 import React from "react";
 
 const TAB_1 = "TAB_1";
@@ -22,10 +21,6 @@ const tabs = [
 ];
 
 describe( "Tabs", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   it( "should render correctly", () => {
     render( <Tabs tabs={tabs} activeId={TAB_1} /> );
 

--- a/tests/unit/components/SharedComponents/TaxonResult.test.js
+++ b/tests/unit/components/SharedComponents/TaxonResult.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react-native";
 import { TaxonResult } from "components/SharedComponents";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 
 const mockTaxon = {
@@ -17,9 +17,6 @@ jest.mock( "sharedHooks/useTaxon", () => ( {
 } ) );
 
 describe( "TaxonResult", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
 
   it( "should render correctly", () => {
     render(

--- a/tests/unit/components/SharedComponents/UploadStatus/__snapshots__/UploadStatus.test.js.snap
+++ b/tests/unit/components/SharedComponents/UploadStatus/__snapshots__/UploadStatus.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`UploadStatus displays progress bar when progress is greater than 5% correctly 1`] = `
 <View
-  accessibilityLabel="Upload-Progress"
+  accessibilityLabel="Upload 50 percent complete"
   accessible={true}
 >
   <View>
     <View
-      accessibilityLabel="Upload-in-progress"
+      accessibilityLabel="Upload in progress"
       style={
         [
           [
@@ -57,12 +57,12 @@ exports[`UploadStatus displays progress bar when progress is greater than 5% cor
 
 exports[`UploadStatus displays progress bar when progress is less than 5% correctly 1`] = `
 <View
-  accessibilityLabel="Saved-Observation"
+  accessibilityLabel="Saved observation, in queue to upload"
   accessible={true}
 >
   <View>
     <View
-      accessibilityLabel="Upload-in-progress"
+      accessibilityLabel="Upload in progress"
       style={
         [
           [

--- a/tests/unit/components/SharedComponents/UserListItem.test.js
+++ b/tests/unit/components/SharedComponents/UserListItem.test.js
@@ -4,7 +4,7 @@ import {
 } from "@testing-library/react-native";
 import { UserListItem } from "components/SharedComponents";
 import faker from "tests/helpers/faker";
-import initI18next from "i18n/initI18next";
+
 import React from "react";
 import factory from "tests/factory";
 import { renderComponent } from "tests/helpers/render";
@@ -27,9 +27,6 @@ jest.mock( "@react-navigation/native", () => {
 } );
 
 describe( "UserListItem", ( ) => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
 
   it( "should be accessible", ( ) => {
     const userListItem = (

--- a/tests/unit/components/SharedComponents/UserListItem.test.js
+++ b/tests/unit/components/SharedComponents/UserListItem.test.js
@@ -1,9 +1,9 @@
-import { faker } from "@faker-js/faker";
 import {
   fireEvent,
   screen
 } from "@testing-library/react-native";
 import { UserListItem } from "components/SharedComponents";
+import faker from "tests/helpers/faker";
 import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";

--- a/tests/unit/components/Suggestions/Attribution.test.js
+++ b/tests/unit/components/Suggestions/Attribution.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import Attribution from "components/Suggestions/Attribution";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
@@ -16,9 +15,7 @@ const renderAttribution = ( ) => renderComponent(
 );
 
 describe( "Attribution", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
+
 
   it( "should show attributions", async ( ) => {
     renderAttribution( );

--- a/tests/unit/components/Suggestions/Attribution.test.js
+++ b/tests/unit/components/Suggestions/Attribution.test.js
@@ -1,8 +1,8 @@
-import { faker } from "@faker-js/faker";
 import { screen } from "@testing-library/react-native";
 import Attribution from "components/Suggestions/Attribution";
 import initI18next from "i18n/initI18next";
 import React from "react";
+import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockObservers = [

--- a/tests/unit/components/Suggestions/Suggestions.test.js
+++ b/tests/unit/components/Suggestions/Suggestions.test.js
@@ -4,7 +4,6 @@ import {
   waitFor
 } from "@testing-library/react-native";
 import Suggestions from "components/Suggestions/Suggestions";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
 import useStore from "stores/useStore";
@@ -29,7 +28,6 @@ const mockSuggestionsList = [{
 describe( "Suggestions", ( ) => {
   beforeAll( async ( ) => {
     useStore.setState( initialStoreState, true );
-    await initI18next( );
   } );
 
   test( "should not have accessibility errors", async ( ) => {

--- a/tests/unit/components/Suggestions/TaxonSearch.test.js
+++ b/tests/unit/components/Suggestions/TaxonSearch.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import TaxonSearch from "components/Suggestions/TaxonSearch";
-import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import inatjs from "inaturalistjs";
 import React from "react";
@@ -57,10 +56,6 @@ jest.mock( "react-native-paper", () => {
 } );
 
 describe( "TaxonSearch", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   test( "should not have accessibility errors", async ( ) => {
     const taxonSearch = (
       <TaxonSearch />

--- a/tests/unit/components/TaxonDetails/TaxonDetails.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetails.test.js
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import { NavigationContainer } from "@react-navigation/native";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import TaxonDetails from "components/TaxonDetails/TaxonDetails";
@@ -8,6 +7,7 @@ import React from "react";
 import { Linking } from "react-native";
 import Photo from "realmModels/Photo";
 import factory from "tests/factory";
+import faker from "tests/helpers/faker";
 // Mock inaturalistjs so we can make some fake responses
 jest.mock( "inaturalistjs" );
 

--- a/tests/unit/components/TaxonDetails/TaxonDetails.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetails.test.js
@@ -1,7 +1,6 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import TaxonDetails from "components/TaxonDetails/TaxonDetails";
-import initI18next from "i18n/initI18next";
 import INatPaperProvider from "providers/INatPaperProvider";
 import React from "react";
 import { Linking } from "react-native";
@@ -74,9 +73,6 @@ jest.mock(
 );
 
 describe( "TaxonDetails", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
   test( "renders taxon details from API call", async ( ) => {
     renderTaxonDetails( );
     expect( screen.getByTestId( `TaxonDetails.${mockTaxon.id}` ) ).toBeTruthy( );

--- a/tests/unit/components/TaxonDetails/TaxonDetailsTitle.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetailsTitle.test.js
@@ -1,13 +1,8 @@
 import TaxonDetailsTitle from "components/TaxonDetails/TaxonDetailsTitle";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 
 describe( "TaxonDetailsTitle", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   it( "should be accessible with a taxon", ( ) => {
     expect( <TaxonDetailsTitle taxon={factory( "LocalTaxon" )} /> ).toBeAccessible( );
   } );

--- a/tests/unit/components/TaxonDetails/Taxonomy.test.js
+++ b/tests/unit/components/TaxonDetails/Taxonomy.test.js
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import Taxonomy from "components/TaxonDetails/Taxonomy";
-import initI18next from "i18n/initI18next";
 import React from "react";
 import factory from "tests/factory";
 
@@ -39,10 +38,6 @@ const currentTaxon = factory( "RemoteTaxon", {
 } );
 
 describe( "Taxonomy", ( ) => {
-  beforeAll( async ( ) => {
-    await initI18next( );
-  } );
-
   test( "renders current taxon", ( ) => {
     render( <Taxonomy taxon={currentTaxon} /> );
 

--- a/tests/unit/components/UserProfile/UserProfile.test.js
+++ b/tests/unit/components/UserProfile/UserProfile.test.js
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react-native";
 import UserProfile from "components/UserProfile/UserProfile";
-import initI18next from "i18n/initI18next";
 import { t } from "i18next";
 import React from "react";
 import factory from "tests/factory";
@@ -43,10 +42,6 @@ jest.mock(
 jest.mock( "components/UserProfile/UserDescription" );
 
 describe( "UserProfile", () => {
-  beforeAll( async () => {
-    await initI18next();
-  } );
-
   it( "should render inside mocked container for testing", () => {
     renderComponent( <UserProfile /> );
     expect( screen.getByTestId( "UserProfile" ) ).toBeTruthy();

--- a/tests/unit/helpers/dateAndTime.test.js
+++ b/tests/unit/helpers/dateAndTime.test.js
@@ -16,10 +16,6 @@ const remoteComment = factory( "RemoteComment", {
 
 describe( "formatApiDatetime", ( ) => {
   describe( "in default locale", ( ) => {
-    beforeAll( async ( ) => {
-      await initI18next( );
-    } );
-
     it( "should return missing date string if no date is present", async ( ) => {
       expect( formatApiDatetime( null, i18next.t ) ).toEqual( "Missing Date" );
     } );

--- a/tests/unit/helpers/photoExif.test.js
+++ b/tests/unit/helpers/photoExif.test.js
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import faker from "tests/helpers/faker";
 import { readExif } from "react-native-exif-reader";
 import {
   formatExifDateAsString,


### PR DESCRIPTION
Speed up run-time of Jest tests by ~25% by: 

- Importing faker library with locale of English (600 KB) instead of using global import (5 MB). This is a [known bug](https://fakerjs.dev/guide/localization.html#individual-localized-packages). With this change, I'm seeing `npm run test` complete in about 45-50s when it was previously around 68s.

I also added a globalSetup file where we can initiate i18next before all tests run, instead of needing to remember this on every individual test file. 