### PR TITLE
Add max width for bottom sheet as 500 pixel

### DIFF
--- a/src/components/SharedComponents/Sheets/BottomSheet.js
+++ b/src/components/SharedComponents/Sheets/BottomSheet.js
@@ -14,6 +14,7 @@ import React, {
   useMemo,
   useRef
 } from "react";
+import { Dimensions } from "react-native";
 import { useTranslation } from "sharedHooks";
 import { viewStyles } from "styles/sharedComponents/bottomSheet";
 
@@ -96,6 +97,13 @@ const StandardBottomSheet = ( {
     ? BottomSheet
     : BottomSheetModal;
 
+  const { width } = Dimensions.get( "window" );
+  const tabletMargin = {
+    marginHorizontal: width > 500
+      ? ( width - 500 ) / 2
+      : 0
+  };
+
   return (
     <BottomSheetComponent
       ref={sheetRef}
@@ -103,7 +111,7 @@ const StandardBottomSheet = ( {
       snapPoints={animatedSnapPoints}
       handleHeight={animatedHandleHeight}
       contentHeight={animatedContentHeight}
-      style={viewStyles.shadow}
+      style={[viewStyles.shadow, tabletMargin]}
       handleComponent={noHandle}
       backdropComponent={renderBackdrop}
       onChange={onChange || handleBackdropPress}


### PR DESCRIPTION
No matter the screen size, the bottom sheets should max out at a width of 500px and be bottom aligned and centered on the screen.