### PR TITLE
Multi frame smoothing repair

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -458,7 +458,7 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - VisionCameraPluginInatVision (1.1.0-beta.0):
+  - VisionCameraPluginInatVision (1.1.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -766,7 +766,7 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   VisionCamera: 523b49054bee9dace64189ab6631cb41e8b83fe0
-  VisionCameraPluginInatVision: b813d63c09e90202e8d2199dd0643ed0fefa3160
+  VisionCameraPluginInatVision: 5b0b033c61a771a2cde2e26288b701856db3af4d
   Yoga: e29645ec5a66fb00934fad85338742d1c247d4cb
 
 PODFILE CHECKSUM: 77ed9526d4011b245ce5afa1ea331dea4c67d753

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -458,7 +458,7 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - VisionCameraPluginInatVision (1.0.0):
+  - VisionCameraPluginInatVision (1.1.0-beta.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -766,7 +766,7 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   VisionCamera: 523b49054bee9dace64189ab6631cb41e8b83fe0
-  VisionCameraPluginInatVision: 44d9d092de8d7157fe0dd60ebab93f3826b5302c
+  VisionCameraPluginInatVision: b813d63c09e90202e8d2199dd0643ed0fefa3160
   Yoga: e29645ec5a66fb00934fad85338742d1c247d4cb
 
 PODFILE CHECKSUM: 77ed9526d4011b245ce5afa1ea331dea4c67d753

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "reassure": "^0.10.1",
         "sanitize-html": "^2.11.0",
         "use-debounce": "^9.0.4",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#multi-frame-smoothing-repair",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -25680,8 +25680,8 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "1.1.0-beta.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#6c40e64b65e6615628db3fb83968228262d508e7",
+      "version": "1.1.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#37b79ef7e9712fa4bc67860e8ef13b8f4e23c9c9",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -44739,8 +44739,8 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#6c40e64b65e6615628db3fb83968228262d508e7",
-      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#multi-frame-smoothing-repair",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#37b79ef7e9712fa4bc67860e8ef13b8f4e23c9c9",
+      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision",
       "requires": {}
     },
     "vlq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "reassure": "^0.10.1",
         "sanitize-html": "^2.11.0",
         "use-debounce": "^9.0.4",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#multi-frame-smoothing-repair",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -25680,8 +25680,8 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#8201318dbe21a2f0a67a32e61c242d2a544a6c0a",
+      "version": "1.1.0-beta.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#6c40e64b65e6615628db3fb83968228262d508e7",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -44739,8 +44739,8 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#8201318dbe21a2f0a67a32e61c242d2a544a6c0a",
-      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#6c40e64b65e6615628db3fb83968228262d508e7",
+      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#multi-frame-smoothing-repair",
       "requires": {}
     },
     "vlq": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "reassure": "^0.10.1",
     "sanitize-html": "^2.11.0",
     "use-debounce": "^9.0.4",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#multi-frame-smoothing-repair",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "reassure": "^0.10.1",
     "sanitize-html": "^2.11.0",
     "use-debounce": "^9.0.4",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#multi-frame-smoothing-repair",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/src/components/Camera/CameraView.js
+++ b/src/components/Camera/CameraView.js
@@ -184,6 +184,7 @@ const CameraView = ( {
             pixelFormat={pixelFormatPatch()}
             animatedProps={animatedProps}
             resizeMode={resizeMode || "cover"}
+            frameProcessorFps={1}
           />
         </GestureDetector>
         <FocusSquare


### PR DESCRIPTION
I think this addresses #1227 for iOS.

Uses a new version of the vision-plugin that repairs the functionality of storing the predictions of the last five frames and returns only the best one. This works on iOS only currently.

Also sets the target cycle of the frame processor to be one frame per second.

So, in other words, the ARCamera UI will display the best prediction of the last five frames which on a fast device equals to the past five seconds. (On slower devices processing the frame can take longer than one second in total.)
