### PR TITLE
Consolidate vision returns

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -458,7 +458,7 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - VisionCameraPluginInatVision (2.0.0-beta.0):
+  - VisionCameraPluginInatVision (2.1.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -766,7 +766,7 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   VisionCamera: 523b49054bee9dace64189ab6631cb41e8b83fe0
-  VisionCameraPluginInatVision: cee8182ce3b30d4a7b84e6f9ab318b252cc16272
+  VisionCameraPluginInatVision: fe709128703108569c60cee63edbac3cb135f595
   Yoga: e29645ec5a66fb00934fad85338742d1c247d4cb
 
 PODFILE CHECKSUM: 77ed9526d4011b245ce5afa1ea331dea4c67d753

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -458,7 +458,7 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - VisionCameraPluginInatVision (1.1.0):
+  - VisionCameraPluginInatVision (2.0.0-beta.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -766,7 +766,7 @@ SPEC CHECKSUMS:
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   VisionCamera: 523b49054bee9dace64189ab6631cb41e8b83fe0
-  VisionCameraPluginInatVision: 5b0b033c61a771a2cde2e26288b701856db3af4d
+  VisionCameraPluginInatVision: cee8182ce3b30d4a7b84e6f9ab318b252cc16272
   Yoga: e29645ec5a66fb00934fad85338742d1c247d4cb
 
 PODFILE CHECKSUM: 77ed9526d4011b245ce5afa1ea331dea4c67d753

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "reassure": "^0.10.1",
         "sanitize-html": "^2.11.0",
         "use-debounce": "^9.0.4",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#consolidate-returns",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -25691,8 +25691,8 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "2.0.0-beta.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#197b96290689910b3249c61d5c1be3d3629ea2c2",
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#6ff615748c89643d10ae988987cdd52eed2ae68e",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -44778,8 +44778,8 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#197b96290689910b3249c61d5c1be3d3629ea2c2",
-      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#consolidate-returns",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#6ff615748c89643d10ae988987cdd52eed2ae68e",
+      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision",
       "requires": {}
     },
     "vlq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "reassure": "^0.10.1",
         "sanitize-html": "^2.11.0",
         "use-debounce": "^9.0.4",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#consolidate-returns",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -25691,8 +25691,8 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#37b79ef7e9712fa4bc67860e8ef13b8f4e23c9c9",
+      "version": "2.0.0-beta.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#197b96290689910b3249c61d5c1be3d3629ea2c2",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
@@ -44778,8 +44778,8 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vision-camera-plugin-inatvision": {
-      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#37b79ef7e9712fa4bc67860e8ef13b8f4e23c9c9",
-      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision",
+      "version": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#197b96290689910b3249c61d5c1be3d3629ea2c2",
+      "from": "vision-camera-plugin-inatvision@github:inaturalist/vision-camera-plugin-inatvision#consolidate-returns",
       "requires": {}
     },
     "vlq": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "reassure": "^0.10.1",
     "sanitize-html": "^2.11.0",
     "use-debounce": "^9.0.4",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#consolidate-returns",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "reassure": "^0.10.1",
     "sanitize-html": "^2.11.0",
     "use-debounce": "^9.0.4",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#consolidate-returns",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,7 +6,7 @@ import type { Node } from "react";
 import React, { useEffect } from "react";
 import { LogBox } from "react-native";
 import Realm from "realm";
-import { addARCameraFiles } from "sharedHelpers/cvModel";
+import { addARCameraFiles } from "sharedHelpers/cvModel.ts";
 import { log } from "sharedHelpers/logger";
 import {
   useCurrentUser,

--- a/src/components/Camera/ARCamera/FrameProcessorCamera.js
+++ b/src/components/Camera/ARCamera/FrameProcessorCamera.js
@@ -13,7 +13,7 @@ import {
 } from "react-native-vision-camera";
 // react-native-vision-camera v3
 // import { Worklets } from "react-native-worklets-core";
-import { modelPath, modelVersion, taxonomyPath } from "sharedHelpers/cvModel";
+import { modelPath, modelVersion, taxonomyPath } from "sharedHelpers/cvModel.ts";
 import { useDeviceOrientation } from "sharedHooks";
 import * as InatVision from "vision-camera-plugin-inatvision";
 

--- a/src/components/Camera/ARCamera/FrameProcessorCamera.js
+++ b/src/components/Camera/ARCamera/FrameProcessorCamera.js
@@ -87,13 +87,13 @@ const FrameProcessorCamera = ( {
       // react-native-vision-camera v2
       // Reminder: this is a worklet, running on the UI thread.
       try {
-        const results = InatVision.inatVision( frame, {
+        const result = InatVision.inatVision( frame, {
           version: modelVersion,
           modelPath,
           taxonomyPath,
           confidenceThreshold
         } );
-        REA.runOnJS( onTaxaDetected )( results );
+        REA.runOnJS( onTaxaDetected )( result );
       } catch ( classifierError ) {
         console.log( `Error: ${classifierError.message}` );
         REA.runOnJS( onClassifierError )( classifierError );

--- a/src/components/Camera/ARCamera/hooks/usePredictions.js
+++ b/src/components/Camera/ARCamera/hooks/usePredictions.js
@@ -3,70 +3,28 @@
 import {
   useState
 } from "react";
-import {
-  Platform
-} from "react-native";
 
 const usePredictions = ( ): Object => {
   const [result, setResult] = useState( null );
   const [modelLoaded, setModelLoaded] = useState( false );
 
-  const handleTaxaDetected = cvResults => {
-    if ( cvResults && !modelLoaded ) {
+  const handleTaxaDetected = cvResult => {
+    if ( cvResult && !modelLoaded ) {
       setModelLoaded( true );
     }
-    /*
-      Using FrameProcessorCamera results in this as cvResults atm on Android
-      [
-        {
-          "stateofmatter": [
-            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
-          ]
-        },
-        {
-          "order": [
-            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
-          ]
-        },
-        {
-          "species": [
-            {"ancestor_ids": [Array], "name": xx, "rank": xx, "score": xx, "taxon_id": xx}
-          ]
-        }
-      ]
-    */
-    /*
-      Using FrameProcessorCamera results in this as cvResults atm on iOS (= top prediction)
-      [
-        {"name": "Aves", "rank": 50, "score": 0.7627944946289062, "taxon_id": 3}
-      ]
-    */
-    const standardizePrediction = finestPrediction => ( {
-      taxon: {
-        rank_level: finestPrediction.rank,
-        id: Number( finestPrediction.taxon_id ),
-        name: finestPrediction.name
-      },
-      score: finestPrediction.score
-    } );
     let prediction = null;
-    let predictions = [];
-    if ( Platform.OS === "ios" ) {
-      if ( cvResults.length > 0 ) {
-        const finestPrediction = cvResults[cvResults.length - 1];
-        prediction = standardizePrediction( finestPrediction );
-      }
-    } else {
-      predictions = cvResults
-        ?.map( r => {
-          const rank = Object.keys( r )[0];
-          return r[rank][0];
-        } )
-        .sort( ( a, b ) => a.rank - b.rank );
-      if ( predictions.length > 0 ) {
-        const finestPrediction = predictions[0];
-        prediction = standardizePrediction( finestPrediction );
-      }
+    const { predictions } = cvResult;
+    predictions.sort( ( a, b ) => a.rank_level - b.rank_level );
+    if ( predictions.length > 0 ) {
+      const finestPrediction = predictions[0];
+      prediction = {
+        taxon: {
+          rank_level: finestPrediction.rank_level,
+          id: finestPrediction.taxon_id,
+          name: finestPrediction.name
+        },
+        score: finestPrediction.score
+      };
     }
     setResult( prediction );
   };

--- a/src/components/Suggestions/hooks/useOfflineSuggestions.js
+++ b/src/components/Suggestions/hooks/useOfflineSuggestions.js
@@ -5,7 +5,7 @@ import {
   useState
 } from "react";
 import { Platform } from "react-native";
-import { predictImage } from "sharedHelpers/cvModel";
+import { predictImage } from "sharedHelpers/cvModel.ts";
 import { log } from "sharedHelpers/logger";
 
 const logger = log.extend( "useOfflineSuggestions" );

--- a/src/components/Suggestions/hooks/useOfflineSuggestions.js
+++ b/src/components/Suggestions/hooks/useOfflineSuggestions.js
@@ -4,7 +4,6 @@ import {
   useEffect,
   useState
 } from "react";
-import { Platform } from "react-native";
 import { predictImage } from "sharedHelpers/cvModel.ts";
 import { log } from "sharedHelpers/logger";
 
@@ -26,14 +25,12 @@ const useOfflineSuggestions = (
   useEffect( ( ) => {
     const predictOffline = async ( ) => {
       setLoadingOfflineSuggestions( true );
-      let predictions = [];
+      let rawPredictions = [];
       try {
         const result = await predictImage( selectedPhotoUri );
         // Android returns an object with a predictions key, while iOS returns an array because
         // currently Seek codebase as well expects different return types for each platform
-        predictions = Platform.OS === "android"
-          ? result.predictions
-          : result;
+        rawPredictions = result.predictions;
       } catch ( predictImageError ) {
         logger.error( "Error predicting image offline", predictImageError );
         throw predictImageError;
@@ -42,14 +39,14 @@ const useOfflineSuggestions = (
       // this is all temporary, since we ultimately want predictions
       // returned similarly to how we return them on web; this is returning a
       // single branch like on the AR Camera 2023-12-08
-      const formattedPredictions = predictions?.reverse( )
-        .filter( prediction => prediction.rank <= 40 )
+      const formattedPredictions = rawPredictions?.reverse( )
+        .filter( prediction => prediction.rank_level <= 40 )
         .map( prediction => ( {
           score: prediction.score,
           taxon: {
             id: Number( prediction.taxon_id ),
             name: prediction.name,
-            rank_level: prediction.rank
+            rank_level: prediction.rank_level
           }
         } ) );
       setOfflineSuggestions( formattedPredictions );

--- a/src/sharedHelpers/cvModel.ts
+++ b/src/sharedHelpers/cvModel.ts
@@ -1,4 +1,3 @@
-// @flow
 import i18next from "i18next";
 import { Alert, Platform } from "react-native";
 import Config from "react-native-config";
@@ -33,7 +32,7 @@ export const taxonomyPath: string = Platform.select( {
 
 export const modelVersion = Config.CV_MODEL_VERSION;
 
-export const predictImage = ( uri: string ): Promise<Object> => getPredictionsForImage( {
+export const predictImage = ( uri: string ) => getPredictionsForImage( {
   uri,
   modelPath,
   taxonomyPath,

--- a/tests/factories/ModelPrediction.js
+++ b/tests/factories/ModelPrediction.js
@@ -2,37 +2,15 @@ import { define } from "factoria";
 
 export default define( "ModelPrediction", faker => ( {
   name: faker.person.fullName( ),
-  rank: faker.helpers.arrayElement( [
+  rank_level: faker.helpers.arrayElement( [
     100,
     70,
     60,
-    57,
-    53,
     50,
-    47,
-    45,
-    44,
-    43,
     40,
-    37,
-    35,
-    34.5,
-    34,
-    33.5,
-    33,
-    32,
     30,
-    27,
-    26,
-    25,
-    24,
     20,
-    15,
-    13,
-    12,
-    11,
-    10,
-    5
+    10
   ] ),
   score: faker.number.float( { min: 0.8, max: 1 } ),
   taxon_id: faker.number.int( )

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -14,10 +14,12 @@ import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut, TEST_JWT } from "tests/helpers/user";
 import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
 
-const mockModelPrediction = factory( "ModelPrediction", {
+const mockModelResult = {
+  predictions: [factory( "ModelPrediction", {
   // useOfflineSuggestions will filter out taxa w/ rank_level > 40
-  rank: 20
-} );
+    rank_level: 20
+  } )]
+};
 
 // We're explicitly testing navigation here so we want react-navigation
 // working normally
@@ -305,14 +307,14 @@ describe( "Suggestions", ( ) => {
     async ( ) => {
       inatjs.computervision.score_image.mockResolvedValue( makeResponse( [] ) );
       getPredictionsForImage.mockImplementation(
-        async ( ) => ( [mockModelPrediction] )
+        async ( ) => ( mockModelResult )
       );
       const { observations } = await setupAppWithSignedInUser( );
       await navigateToSuggestionsForObservationViaObsEdit( observations[0] );
       const offlineNotice = await screen.findByText( "Viewing Offline Suggestions" );
       expect( offlineNotice ).toBeTruthy( );
       const topOfflineTaxonResultButton = await screen.findByTestId(
-        `SuggestionsList.taxa.${mockModelPrediction.taxon_id}.checkmark`
+        `SuggestionsList.taxa.${mockModelResult.predictions[0].taxon_id}.checkmark`
       );
       expect( topOfflineTaxonResultButton ).toBeTruthy( );
       await act( async ( ) => actor.press( topOfflineTaxonResultButton ) );

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -22,7 +22,7 @@ import {
 } from "./vision-camera/vision-camera";
 
 jest.mock( "vision-camera-plugin-inatvision", () => ( {
-  getPredictionsForImage: jest.fn( () => Promise.resolve( [] ) )
+  getPredictionsForImage: jest.fn( () => Promise.resolve( { predictions: [] } ) )
 } ) );
 
 jest.mock( "react-native-worklets-core", () => ( {


### PR DESCRIPTION
This unifies the return types of the vision plugin callback and prediction from files on Android and iOS. So, the PR removed platform-specific handling.

Closes #1115 