### PR TITLE
Bugfix: undead observations arose if sync happened too soon after death

### DIFF
--- a/src/components/MyObservations/hooks/useDeleteObservations.js
+++ b/src/components/MyObservations/hooks/useDeleteObservations.js
@@ -16,6 +16,7 @@ export const INITIAL_DELETION_STATE = {
   // $FlowIgnore
   deletions: [],
   deletionsComplete: false,
+  deletionsCompletedAt: null,
   deletionsInProgress: false,
   error: null
 };
@@ -43,7 +44,8 @@ const deletionReducer = ( state: Object, action: Function ): Object => {
       return {
         ...state,
         deletionsInProgress: false,
-        deletionsComplete: true
+        deletionsComplete: true,
+        deletionsCompletedAt: new Date( )
       };
     case "RESET_STATE":
       return INITIAL_DELETION_STATE;

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -5,7 +5,8 @@ import {
   ActivityIndicator,
   HideView,
   Tabs,
-  TextInputSheet
+  TextInputSheet,
+  WarningSheet
 } from "components/SharedComponents";
 import {
   SafeAreaView,
@@ -35,6 +36,7 @@ type Props = {
   addingActivityItem: Function,
   agreeIdSheetDiscardChanges: Function,
   belongsToCurrentUser: boolean,
+  confirmRemoteObsWasDeleted?: Function,
   currentTabId: string,
   currentUser: Object,
   hideCommentBox: Function,
@@ -47,6 +49,7 @@ type Props = {
   openCommentBox: Function,
   openCommentBox: Function,
   refetchRemoteObservation: Function,
+  remoteObsWasDeleted?: boolean,
   showActivityTab: boolean,
   showAgreeWithIdSheet: boolean,
   showCommentBox: Function,
@@ -59,6 +62,7 @@ const ObsDetails = ( {
   addingActivityItem,
   agreeIdSheetDiscardChanges,
   belongsToCurrentUser,
+  confirmRemoteObsWasDeleted,
   currentTabId,
   currentUser,
   hideCommentBox,
@@ -70,6 +74,7 @@ const ObsDetails = ( {
   onIDAgreePressed,
   openCommentBox,
   refetchRemoteObservation,
+  remoteObsWasDeleted,
   showActivityTab,
   showAgreeWithIdSheet,
   showCommentBox,
@@ -234,6 +239,23 @@ const ObsDetails = ( {
           confirm={textInput => onCommentAdded( textInput )}
         />
       )}
+      {/*
+        * FWIW, some situations in which this could happen are
+        * 1. User loaded obs in explore and it was deleted between then and
+          when they tapped on it
+        * 2. Some process fetched observations between when they were deleted
+          and the search index was updated to reflect that
+        *
+      */}
+      { remoteObsWasDeleted && confirmRemoteObsWasDeleted && (
+        <WarningSheet
+          handleClose={confirmRemoteObsWasDeleted}
+          headerText={t( "OBSERVATION-WAS-DELETED" )}
+          text={t( "Sorry-this-observation-was-deleted" )}
+          buttonText={t( "OK" )}
+          confirm={confirmRemoteObsWasDeleted}
+        />
+      ) }
     </SafeAreaView>
   );
 };

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -179,7 +179,7 @@ const ObsDetailsContainer = ( ): Node => {
   const confirmRemoteObsWasDeleted = useCallback( ( ) => {
     if ( localObservation ) {
       safeRealmWrite( realm, ( ) => {
-        // localObservation._deleted_at = new Date( );
+        localObservation._deleted_at = new Date( );
       }, "adding _deleted_at date in ObsDetailsContainer" );
     }
     if ( navigation.canGoBack( ) ) navigation.goBack( );

--- a/src/components/PhotoImporter/PhotoGallery.js
+++ b/src/components/PhotoImporter/PhotoGallery.js
@@ -16,13 +16,10 @@ import {
 import * as ImagePicker from "react-native-image-picker";
 import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
+import { sleep } from "sharedHelpers/util";
 import useStore from "stores/useStore";
 
 const MAX_PHOTOS_ALLOWED = 20;
-
-const sleep = ms => new Promise( resolve => {
-  setTimeout( resolve, ms );
-} );
 
 const PhotoGallery = ( ): Node => {
   const navigation = useNavigation( );

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1817,3 +1817,8 @@ Scientific-Name = Scientific Name
 INATURALIST-ACCOUNT-SETTINGS = INATURALIST ACCOUNT SETTINGS
 To-access-all-other-settings = To access all other account settings, click here:
 INATURALIST-SETTINGS = INATURALIST SETTINGS
+
+OBSERVATION-WAS-DELETED = OBSERVATION WAS DELETED
+Sorry-this-observation-was-deleted = Sorry, this observation was deleted
+# Generic confirmation, e.g. button on a warning alert
+OK = OK

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1329,5 +1329,11 @@
   "Scientific-Name": "Scientific Name",
   "INATURALIST-ACCOUNT-SETTINGS": "INATURALIST ACCOUNT SETTINGS",
   "To-access-all-other-settings": "To access all other account settings, click here:",
-  "INATURALIST-SETTINGS": "INATURALIST SETTINGS"
+  "INATURALIST-SETTINGS": "INATURALIST SETTINGS",
+  "OBSERVATION-WAS-DELETED": "OBSERVATION WAS DELETED",
+  "Sorry-this-observation-was-deleted": "Sorry, this observation was deleted",
+  "OK": {
+    "comment": "Generic confirmation, e.g. button on a warning alert",
+    "val": "OK"
+  }
 }

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1817,3 +1817,8 @@ Scientific-Name = Scientific Name
 INATURALIST-ACCOUNT-SETTINGS = INATURALIST ACCOUNT SETTINGS
 To-access-all-other-settings = To access all other account settings, click here:
 INATURALIST-SETTINGS = INATURALIST SETTINGS
+
+OBSERVATION-WAS-DELETED = OBSERVATION WAS DELETED
+Sorry-this-observation-was-deleted = Sorry, this observation was deleted
+# Generic confirmation, e.g. button on a warning alert
+OK = OK

--- a/src/sharedHelpers/logging.js
+++ b/src/sharedHelpers/logging.js
@@ -38,6 +38,11 @@ function reactQueryRetry( failureCount, error, options = {} ) {
       options
     );
   }
+  // 404 means the record does not exist, so no need to retry
+  if ( error.status === 404 ) {
+    shouldRetry = false;
+    logger.info( "reactQueryRetry, handling 404, not retrying" );
+  }
   handleError( error, {
     throw: false,
     onApiError: apiError => {

--- a/src/sharedHelpers/util.js
+++ b/src/sharedHelpers/util.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export const sleep = ms => new Promise( resolve => {
+  setTimeout( resolve, ms );
+} );


### PR DESCRIPTION
The main problem here was that the API was returning deleted observations when we pulled very soon after the deletions were requested, probably due to elasticsearch syncing issues. `ttl=-1` had no effect, so I don't think it's a caching problem in the API. Since this is out of a client's hands, my imperfect solution is to make the sync operation wait at least 10 seconds after deletion finished to fetch new observations.

This also adds logic to ObsDetails so that if you land on it and the observation was deleted, it tells you and then sends you back to where you were. In theory the first change should make the second unnecessary, but there are some other situations where this could happen, e.g. if you're looking at MyObs, delete an obs on the website, and then tap that obs in the app before the app knows to check for deleted records on the server.

Closes #694 