### PR TITLE
Show multiple common names consistently

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -20,7 +20,6 @@ const fetchSearchResults = async ( params: Object = {}, opts: Object = {} ): Pro
   try {
     const response = await inatjs.search( { ...PARAMS, ...params }, opts );
     if ( !response ) { return null; }
-    console.log( response?.results?.[0], "first result in search" );
     const records = response?.results?.map( result => {
       const recordType = mappedRecords[params.sources];
       return result[recordType];

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -20,6 +20,7 @@ const fetchSearchResults = async ( params: Object = {}, opts: Object = {} ): Pro
   try {
     const response = await inatjs.search( { ...PARAMS, ...params }, opts );
     if ( !response ) { return null; }
+    console.log( response?.results?.[0], "first result in search" );
     const records = response?.results?.map( result => {
       const recordType = mappedRecords[params.sources];
       return result[recordType];

--- a/src/sharedHooks/useTaxonSearch.js
+++ b/src/sharedHooks/useTaxonSearch.js
@@ -1,23 +1,22 @@
 // @flow
 
-import fetchSearchResults from "api/search";
-import Taxon from "realmModels/Taxon";
+import { searchTaxa } from "api/taxa";
 import { useAuthenticatedQuery } from "sharedHooks";
 
 const useTaxonSearch = ( taxonQuery: string ): Array<Object> => {
   const { data: taxonList } = useAuthenticatedQuery(
-    ["fetchSearchResults", taxonQuery],
-    optsWithAuth => fetchSearchResults(
+    ["fetchTaxa", taxonQuery],
+    optsWithAuth => searchTaxa(
       {
-        q: taxonQuery,
-        sources: "taxa",
-        fields: {
-          taxon: Taxon.TAXON_FIELDS
-        }
+        q: taxonQuery
       },
       optsWithAuth
-    )
+    ),
+    {
+      enabled: !!( taxonQuery.length > 0 )
+    }
   );
+  console.log( taxonList?.[0] );
   return taxonList;
 };
 

--- a/src/sharedHooks/useTaxonSearch.js
+++ b/src/sharedHooks/useTaxonSearch.js
@@ -16,7 +16,6 @@ const useTaxonSearch = ( taxonQuery: string ): Array<Object> => {
       enabled: !!( taxonQuery.length > 0 )
     }
   );
-  console.log( taxonList?.[0] );
   return taxonList;
 };
 

--- a/src/sharedHooks/useTaxonSearch.js
+++ b/src/sharedHooks/useTaxonSearch.js
@@ -5,7 +5,7 @@ import { useAuthenticatedQuery } from "sharedHooks";
 
 const useTaxonSearch = ( taxonQuery: string ): Array<Object> => {
   const { data: taxonList } = useAuthenticatedQuery(
-    ["fetchTaxa", taxonQuery],
+    ["fetchTaxonSuggestions", taxonQuery],
     optsWithAuth => searchTaxa(
       {
         q: taxonQuery

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -98,6 +98,7 @@ beforeEach( async ( ) => {
       user: mockUser
     } )]
   } );
+  inatjs.taxa.search.mockResolvedValue( makeResponse( [topSuggestion.taxon] ) );
   await signIn( mockUser, { realm: global.mockRealms[__filename] } );
 } );
 
@@ -114,10 +115,8 @@ describe( "TaxonSearch", ( ) => {
   const mockSearchResultTaxon = factory( "RemoteTaxon" );
 
   beforeEach( ( ) => {
-    inatjs.search.mockResolvedValue( makeResponse( [
-      {
-        taxon: mockSearchResultTaxon
-      }
+    inatjs.taxa.search.mockResolvedValue( makeResponse( [
+      mockSearchResultTaxon
     ] ) );
     inatjs.observations.observers.mockResolvedValue( makeResponse( [
       {
@@ -130,7 +129,7 @@ describe( "TaxonSearch", ( ) => {
   } );
 
   afterEach( ( ) => {
-    inatjs.search.mockReset( );
+    inatjs.taxa.search.mockReset( );
     inatjs.observations.observers.mockReset( );
     inatjs.taxa.fetch.mockReset( );
   } );

--- a/tests/integration/navigation/Suggestions.test.js
+++ b/tests/integration/navigation/Suggestions.test.js
@@ -131,10 +131,8 @@ describe( "Suggestions", ( ) => {
         await actor.press( searchButton );
         const searchInput = await screen.findByLabelText( "Search for a taxon" );
         const mockSearchResultTaxon = factory( "RemoteTaxon" );
-        inatjs.search.mockResolvedValue( makeResponse( [
-          {
-            taxon: mockSearchResultTaxon
-          }
+        inatjs.taxa.search.mockResolvedValue( makeResponse( [
+          mockSearchResultTaxon
         ] ) );
         await act(
           async ( ) => actor.type(

--- a/tests/unit/components/Suggestions/TaxonSearch.test.js
+++ b/tests/unit/components/Suggestions/TaxonSearch.test.js
@@ -69,7 +69,7 @@ describe( "TaxonSearch", ( ) => {
   } );
 
   it( "show taxon search results", async ( ) => {
-    inatjs.search.mockResolvedValue( makeResponse( mockTaxaList ) );
+    inatjs.taxa.search.mockResolvedValue( makeResponse( mockTaxaList ) );
     renderComponent( <TaxonSearch /> );
     const input = screen.getByTestId( "SearchTaxon" );
     const taxon = mockTaxaList[0];


### PR DESCRIPTION
Closes #1104

- Use taxa/search API instead of generic search API call, since this returns the expected results when a user has multiple common names enabled