### PR TITLE
Use API call for species seen checkmark

### DIFF
--- a/tests/unit/components/Explore/TaxonGridItem.test.js
+++ b/tests/unit/components/Explore/TaxonGridItem.test.js
@@ -21,6 +21,15 @@ jest.mock( "@react-navigation/native", () => {
   };
 } );
 
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: ( ) => ( {
+    data: {
+      total_results: 0
+    }
+  } )
+} ) );
+
 describe( "TaxonGridItem", ( ) => {
   it( "should be accessible", ( ) => {
     const taxonGridItem = (

--- a/tests/unit/components/SharedComponents/SpeciesSeenCheckmark.test.js
+++ b/tests/unit/components/SharedComponents/SpeciesSeenCheckmark.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react-native";
+import SpeciesSeenCheckmark from "components/SharedComponents/SpeciesSeenCheckmark";
+import React from "react";
+import { useAuthenticatedQuery } from "sharedHooks";
+
+const mockTaxon = {
+  id: 1,
+  name: "Aves",
+  preferred_common_name: "Birds",
+  rank: "family",
+  rank_level: 60
+};
+
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: jest.fn( () => ( {
+    data: {
+      total_results: 4
+    }
+  } ) )
+} ) );
+
+describe( "SpeciesSeenCheckmark", ( ) => {
+  it( "should render checkmark if user has previously seen species", ( ) => {
+    render(
+      <SpeciesSeenCheckmark taxon={mockTaxon} />
+    );
+    const checkmark = screen.getByTestId( "SpeciesSeenCheckmark" );
+    expect( checkmark ).toBeVisible( );
+  } );
+
+  it( "should not render checkmark if user has not seen species", ( ) => {
+    useAuthenticatedQuery.mockReturnValue( {
+      data: {
+        total_results: 0
+      }
+    } );
+    render(
+      <SpeciesSeenCheckmark taxon={mockTaxon} />
+    );
+    const checkmark = screen.queryByTestId( "SpeciesSeenCheckmark" );
+    expect( checkmark ).toBeFalsy( );
+  } );
+} );

--- a/tests/unit/components/TaxonDetails/TaxonDetailsTitle.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetailsTitle.test.js
@@ -2,6 +2,15 @@ import TaxonDetailsTitle from "components/TaxonDetails/TaxonDetailsTitle";
 import React from "react";
 import factory from "tests/factory";
 
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: ( ) => ( {
+    data: {
+      total_results: 0
+    }
+  } )
+} ) );
+
 describe( "TaxonDetailsTitle", ( ) => {
   it( "should be accessible with a taxon", ( ) => {
     expect( <TaxonDetailsTitle taxon={factory( "LocalTaxon" )} /> ).toBeAccessible( );


### PR DESCRIPTION
Closes #1197

- Note: the issue was written for Explore SpeciesView. This fix also changes the way we fetch the species seen checkmark on TaxonDetails, which I think we want for consistency across the app