### PR TITLE
Show DQA when taxon is unknown

### DIFF
--- a/src/components/ObsDetails/DetailsTab/DetailsTab.js
+++ b/src/components/ObsDetails/DetailsTab/DetailsTab.js
@@ -204,7 +204,6 @@ const DetailsTab = ( { observation }: Props ): Node => {
         />
       </View>
       <Divider />
-
       <View className={`${sectionClass} flex-col`}>
         <Heading4 className={headingClass}>{t( "DATA-QUALITY" )}</Heading4>
         <View className="space-y-[15px]">

--- a/src/components/ObsDetails/DetailsTab/DetailsTab.js
+++ b/src/components/ObsDetails/DetailsTab/DetailsTab.js
@@ -233,8 +233,8 @@ const DetailsTab = ( { observation }: Props ): Node => {
                   observation.observationSounds || observation.sounds
                 ] ),
                 taxon: {
-                  id: observation.taxon.id,
-                  rank_level: observation.taxon.rank_level
+                  id: observation.taxon?.id,
+                  rank_level: observation.taxon?.rank_level
                 },
                 identifications: observation.identifications
               }


### PR DESCRIPTION
Closes #1212

- Fixes a crash when navigating from ObsDetails to DQA with unknown taxon
- Simplifies mockObservation in DQA tests and ensures this observation is being used in tests