### PR TITLE
Try to test server availability before trying e2e tests

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -129,6 +129,13 @@ jobs:
         $ANDROID_HOME/platform-tools/adb emu geo fix -121.45356 46.51119 4392 12
         echo "Emulator started"
 
+    - name: Ensure servers are running
+      run: |
+        # is rails running?
+        curl -I --fail "https://staging.inaturalist.org/ping"
+        # is node running & is ES working?
+        curl -I --fail "https://stagingapi.inaturalist.org/v2/taxa"
+
     # Start the Android e2e tests with extensive logging and screen captures for failing tests
     - name: Android Detox
       run: npm run e2e:test:android -- --take-screenshots failing --record-videos failing -l debug

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -100,10 +100,17 @@ jobs:
     # Install prerequisites for detox and build app, and test
     - run: brew tap wix/brew
     - run: brew install applesimutils
-    
+
     - name: Build test app
       run: npm run e2e:build:ios
-    
+
+    - name: Ensure servers are running
+      run: |
+        # is rails running?
+        curl -I --fail "https://staging.inaturalist.org/ping"
+        # is node running & is ES working?
+        curl -I --fail "https://stagingapi.inaturalist.org/v2/taxa"
+
     - name: Run e2e test
       run: npm run e2e:test:ios -- --cleanup --take-screenshots failing --record-videos failing -l debug
     


### PR DESCRIPTION
Some of our recent e2e test failures were due to services not working on staging, which took me a little bit to debug. If that happens again, this should cause e2e tests to fail in a more informative manner.