### PR TITLE
Several changes to recent font updates

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -727,7 +727,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 9840513ec2766e31fb9e34c2dabb2c4671400fcd
@@ -810,4 +810,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 77ed9526d4011b245ce5afa1ea331dea4c67d753
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/ios/iNaturalistReactNative.xcodeproj/project.pbxproj
+++ b/ios/iNaturalistReactNative.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		42832120F7C944B980FD13BC /* Whitney-MediumItalic-Pro.otf in Resources */ = {isa = PBXBuildFile; fileRef = 097C2902AB1249AA9846CED3 /* Whitney-MediumItalic-Pro.otf */; };
 		4698CEACBD4F4A859CAB0694 /* Whitney-SemiboldItalic-Pro.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0DD877E5F25945BCB6707357 /* Whitney-SemiboldItalic-Pro.otf */; };
 		4FB3B444D46A4115B867B9CC /* inaturalisticons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EE004FD2EC174086A7AB2908 /* inaturalisticons.ttf */; };
-		5A8D64AB921678B40E0229C8 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		5A8D64AB921678B40E0229C8 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		70A78BDA30F54E5089C0E524 /* Whitney-Book-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 657E03B58B8E44588A5933FA /* Whitney-Book-Italic.otf */; };
 		73B478002C534272ABECB43A /* Whitney-Medium-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = DC9FE0074F1340B0A5F2EA35 /* Whitney-Medium-Italic.otf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
@@ -134,7 +134,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5A8D64AB921678B40E0229C8 /* (null) in Frameworks */,
+				5A8D64AB921678B40E0229C8 /* BuildFile in Frameworks */,
 				A019DB3A4661689827F5BB56 /* libPods-iNaturalistReactNative.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -979,11 +979,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -1052,11 +1048,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/src/components/SharedComponents/DisplayTaxonName.js
+++ b/src/components/SharedComponents/DisplayTaxonName.js
@@ -6,7 +6,7 @@ import {
 import ScientificName from "components/SharedComponents/ScientificName";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { generateTaxonPieces } from "sharedHelpers/taxon";
 import useTranslation from "sharedHooks/useTranslation";
 
@@ -54,7 +54,7 @@ const DisplayTaxonName = ( {
 }: Props ): Node => {
   const { t } = useTranslation( );
 
-  const textClass = useCallback( ( ) => {
+  const textClassName = useMemo( ( ) => {
     const textColorClass = color || "text-darkGray";
     if ( withdrawn ) {
       return "text-darkGray opacity-50 line-through";
@@ -115,7 +115,7 @@ const DisplayTaxonName = ( {
         } )}
       >
         <TopTextComponent
-          className={textClass( )}
+          className={textClassName}
           numberOfLines={setNumberOfLines( )}
           ellipsizeMode="tail"
         >
@@ -129,7 +129,7 @@ const DisplayTaxonName = ( {
                   rank={rank}
                   fontComponent={TopTextComponent}
                   isHorizontal={isHorizontal}
-                  textClass={textClass}
+                  textClassName={textClassName}
                   taxonId={taxon.id}
                   keyBase={keyBase}
                   isTitle
@@ -143,7 +143,7 @@ const DisplayTaxonName = ( {
 
         {
           commonName && (
-            <BottomTextComponent className={textClass( )}>
+            <BottomTextComponent className={textClassName}>
               {scientificNameFirst
                 ? commonName
                 : (
@@ -154,7 +154,7 @@ const DisplayTaxonName = ( {
                     rank={rank}
                     fontComponent={BottomTextComponent}
                     isHorizontal={isHorizontal}
-                    textClass={textClass}
+                    textClassName={textClassName}
                     taxonId={taxon.id}
                     keyBase={keyBase}
                   />
@@ -172,13 +172,13 @@ const DisplayTaxonName = ( {
     scientificNameFirst,
     small,
     taxon,
-    textClass,
+    textClassName,
     TopTextComponentProp
   ] );
 
   if ( !taxon ) {
     return (
-      <Body1 className={textClass( )} numberOfLines={1}>
+      <Body1 className={textClassName} numberOfLines={1}>
         {t( "unknown" )}
       </Body1>
     );

--- a/src/components/SharedComponents/ScientificName.js
+++ b/src/components/SharedComponents/ScientificName.js
@@ -7,21 +7,29 @@ import Taxon from "realmModels/Taxon";
 import INatTextMedium from "./Typography/INatTextMedium";
 
 type Props = {
-    scientificNamePieces: Object,
-    rankPiece: string,
-    rankLevel: number,
-    rank: string,
-    fontComponent: Object,
-    isHorizontal: boolean,
-    textClass: Function,
-    keyBase: string,
-    taxonId: string,
-    isTitle?: boolean
+  fontComponent: Object,
+  isHorizontal: boolean,
+  isTitle?: boolean,
+  keyBase: string,
+  rank: string,
+  rankLevel: number,
+  rankPiece: string,
+  scientificNamePieces: Object,
+  taxonId: string,
+  textClassName?: string
 };
 
 const ScientificName = ( {
-  scientificNamePieces, rankPiece, rankLevel, fontComponent,
-  isHorizontal, rank, textClass, keyBase, taxonId, isTitle
+  fontComponent,
+  isHorizontal,
+  isTitle,
+  keyBase,
+  rank,
+  rankLevel,
+  rankPiece,
+  scientificNamePieces,
+  taxonId,
+  textClassName
 }: Props ): Node => {
   const scientificNameArray = scientificNamePieces?.map( ( piece, index ) => {
     const isItalics = piece !== rankPiece && (
@@ -33,30 +41,24 @@ const ScientificName = ( {
     const text = piece + spaceChar;
     const FontComponent = fontComponent || INatTextMedium;
 
-    if ( isItalics ) {
-      return (
-        <FontComponent
-          // eslint-disable-next-line react/no-array-index-key
-          key={`DisplayTaxonName-${keyBase}-${taxonId}-${rankLevel}-${piece}-${index}`}
-          className={classNames( "italic font-normal", textClass( ), {
-            "font-light": !isTitle
-          } )}
-        >
-          {text}
-        </FontComponent>
-      );
-    }
     return (
       <FontComponent
-        // eslint-disable-next-line react/no-array-index-key
-        key={`DisplayTaxonName-${keyBase}-${taxonId}-${index}`}
+        key={`DisplayTaxonName-${keyBase}-${taxonId}-${rankLevel}-${piece}`}
+        className={classNames(
+          "font-normal",
+          textClassName,
+          {
+            "font-light": !isTitle,
+            italic: isItalics
+          }
+        )}
       >
         {text}
       </FontComponent>
     );
   } );
 
-  if ( rank && rankLevel > 10 ) {
+  if ( rank && rankLevel > Taxon.SPECIES_LEVEL ) {
     scientificNameArray.unshift( `${rank} ` );
   }
 

--- a/src/components/styledComponents.js
+++ b/src/components/styledComponents.js
@@ -33,8 +33,8 @@ const ScrollView = styled( UnstyledScrollView );
 const Text = styled(
   UnstyledText,
   Platform.OS === "ios"
-    ? "font-Whitney-Semibold"
-    : "font-Whitney-Semibold-Pro"
+    ? "font-Whitney-Book"
+    : "font-Whitney-Book-Pro"
 );
 // $FlowIgnore
 const MediumText = styled(

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.dark.test.js.snap
@@ -69,7 +69,7 @@ exports[`Button focus in dark mode should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -177,7 +177,7 @@ exports[`Button focus in dark mode when disabled should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -303,7 +303,7 @@ exports[`Button neutral in dark mode should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -429,7 +429,7 @@ exports[`Button neutral in dark mode when disabled should render correctly 1`] =
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -540,7 +540,7 @@ exports[`Button primary in dark mode should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -651,7 +651,7 @@ exports[`Button primary in dark mode when disabled should render correctly 1`] =
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -762,7 +762,7 @@ exports[`Button warning in dark mode should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -870,7 +870,7 @@ exports[`Button warning in dark mode when disabled should render correctly 1`] =
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/Button.test.js.snap
@@ -69,7 +69,7 @@ exports[`Button focus should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -177,7 +177,7 @@ exports[`Button focus when disabled should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -303,7 +303,7 @@ exports[`Button neutral should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -429,7 +429,7 @@ exports[`Button neutral when disabled should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -540,7 +540,7 @@ exports[`Button primary should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -651,7 +651,7 @@ exports[`Button primary when disabled should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -762,7 +762,7 @@ exports[`Button warning should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [
@@ -870,7 +870,7 @@ exports[`Button warning when disabled should render correctly 1`] = `
     style={
       [
         {
-          "fontFamily": "Whitney-Semibold",
+          "fontFamily": "Whitney-Book",
         },
         [
           [

--- a/tests/unit/components/SharedComponents/Tabs/__snapshots__/Tabs.test.js.snap
+++ b/tests/unit/components/SharedComponents/Tabs/__snapshots__/Tabs.test.js.snap
@@ -72,7 +72,7 @@ exports[`Tabs should render correctly 1`] = `
           style={
             [
               {
-                "fontFamily": "Whitney-Semibold",
+                "fontFamily": "Whitney-Book",
               },
               [
                 [
@@ -185,7 +185,7 @@ exports[`Tabs should render correctly 1`] = `
           style={
             [
               {
-                "fontFamily": "Whitney-Semibold",
+                "fontFamily": "Whitney-Book",
               },
               [
                 [

--- a/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading1.test.js.snap
+++ b/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading1.test.js.snap
@@ -5,7 +5,7 @@ exports[`Heading1 renders correctly 1`] = `
   style={
     [
       {
-        "fontFamily": "Whitney-Semibold",
+        "fontFamily": "Whitney-Book",
       },
       [
         [

--- a/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading2.test.js.snap
+++ b/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading2.test.js.snap
@@ -5,7 +5,7 @@ exports[`Heading2 renders correctly 1`] = `
   style={
     [
       {
-        "fontFamily": "Whitney-Semibold",
+        "fontFamily": "Whitney-Book",
       },
       [
         [

--- a/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading3.test.js.snap
+++ b/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading3.test.js.snap
@@ -5,7 +5,7 @@ exports[`Heading3 renders correctly 1`] = `
   style={
     [
       {
-        "fontFamily": "Whitney-Semibold",
+        "fontFamily": "Whitney-Book",
       },
       [
         [

--- a/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading4.test.js.snap
+++ b/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading4.test.js.snap
@@ -5,7 +5,7 @@ exports[`Heading4 renders correctly 1`] = `
   style={
     [
       {
-        "fontFamily": "Whitney-Semibold",
+        "fontFamily": "Whitney-Book",
       },
       [
         [

--- a/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading5.test.js.snap
+++ b/tests/unit/components/SharedComponents/Typography/__snapshots__/Heading5.test.js.snap
@@ -5,7 +5,7 @@ exports[`Heading5 renders correctly 1`] = `
   style={
     [
       {
-        "fontFamily": "Whitney-Semibold",
+        "fontFamily": "Whitney-Book",
       },
       [
         [

--- a/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
+++ b/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
@@ -386,6 +386,17 @@ exports[`TaxonResult should render correctly 1`] = `
                     {
                       "color": "#454545",
                     },
+                    [
+                      {
+                        "fontWeight": "400",
+                      },
+                      {
+                        "color": "#454545",
+                      },
+                      {
+                        "fontWeight": "300",
+                      },
+                    ],
                   ],
                 ],
               ]


### PR DESCRIPTION
Most of these are adjustments to work on #1209

* Restore Whitney Book as default font so <Text> isn't bold by default
* Refactor a function that fetches a class name to simply be a memoized string
* Simplified some italicization logic in <ScientificName>
* Fixed bug where higher rank species names were rendered as an illegible gray in ObsGridItem

Note that despite the changes to the snapshots, the actual rendered text looks identical to what's currently in main:

|Main (iPhone 14)|Branch (iPhone 15)|
|-|-|
|![main-headings](https://github.com/inaturalist/iNaturalistReactNative/assets/22691/178fcb01-1fde-4723-9bd3-e656bc6b9413)|![branch-headings](https://github.com/inaturalist/iNaturalistReactNative/assets/22691/ad90d25c-3def-4a72-bd82-a0a6d75ed571)|
|![main-buttons](https://github.com/inaturalist/iNaturalistReactNative/assets/22691/a1074923-2a97-4a94-9469-e0a1ab14ce67)|![branch-buttons](https://github.com/inaturalist/iNaturalistReactNative/assets/22691/6a97d3da-2309-4baa-8726-099a778e7189)|
