### PR TITLE
GitGuardian pre-commit hook

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,8 @@
+version: 2
+secret:
+  # Exclude files and paths by globbing
+  ignored-paths:
+    - '**/README.md'
+    - 'node_modules/*'
+    - 'package-lock.json'
+    - '**/package-lock.json'

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ artifacts/
 
 # Reassure performance testing #
 .reassure
+
+# GitGuardian cache file
+.cache_ggshield

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,15 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Run lint and flow
-npm run lint
-
-# Generate translations from strings.ftl
-npm run translate
-# ...and add them to the commit; this assumes src/i18n/l10n/ *only* contains
-#    files you want to add
-git status --porcelain --untracked-files src/i18n/l10n/ | cut -c 4- | xargs git add
-
 # If ggshield is installed, run it
 if command -v ggshield &> /dev/null; then
   ggshield secret scan pre-commit
@@ -24,3 +15,12 @@ else
   echo "If you are iNat staff, you should install ggshield: https://docs.gitguardian.com/ggshield-docs/getting-started"
   echo
 fi
+
+# Run lint and flow
+npm run lint
+
+# Generate translations from strings.ftl
+npm run translate
+# ...and add them to the commit; this assumes src/i18n/l10n/ *only* contains
+#    files you want to add
+git status --porcelain --untracked-files src/i18n/l10n/ | cut -c 4- | xargs git add

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,8 +10,17 @@ npm run translate
 #    files you want to add
 git status --porcelain --untracked-files src/i18n/l10n/ | cut -c 4- | xargs git add
 
-# TODO check to see if ggshielf is installed
-# TODO check to see if GITGUARDIAN_API_KEY is in env
-# TODO only do these things if the git user is in the iNaturalist Github org
-# Ensure we're not committing secrets w/ GitGuardian
-ggshield secret scan pre-commit
+# If ggshield is installed, run it
+if command -v ggshield &> /dev/null; then
+  ggshield secret scan pre-commit
+# Otherwise require that inaturalist.org git users install it
+elif git config --list | grep -q "user.email.*inaturalist.org"; then
+  echo
+  echo "Git users w/ inaturalist.org emails must install ggshield: https://docs.gitguardian.com/ggshield-docs/getting-started"
+  echo
+  exit 1
+else
+  echo
+  echo "If you are iNat staff, you should install ggshield: https://docs.gitguardian.com/ggshield-docs/getting-started"
+  echo
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,3 +9,9 @@ npm run translate
 # ...and add them to the commit; this assumes src/i18n/l10n/ *only* contains
 #    files you want to add
 git status --porcelain --untracked-files src/i18n/l10n/ | cut -c 4- | xargs git add
+
+# TODO check to see if ggshielf is installed
+# TODO check to see if GITGUARDIAN_API_KEY is in env
+# TODO only do these things if the git user is in the iNaturalist Github org
+# Ensure we're not committing secrets w/ GitGuardian
+ggshield secret scan pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-repos:
-  - repo: https://github.com/gitguardian/ggshield
-    rev: v1.10.7
-    hooks:
-      - id: ggshield
-        language_version: python3
-        stages: [commit]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ See [CONTRIBUTING](CONTRIBUTING.md) for guidelines on contributing to this proje
 ### Set up pre-commit hooks
 
 1. We're using [Husky](https://typicode.github.io/husky/#/) to automatically run `eslint` before each commit. Run `npm run postinstall` to install Husky locally.
+1. (Staff only) Set up GitGuardian to prevent yourself from committing secrets
+    1. [Install `ggshield`](https://docs.gitguardian.com/ggshield-docs/getting-started)
+    1. Get a GitGuardian API token from another staff developer and put it in the `GITGUARDIAN_API_KEY` env variable.
 
 ### Run build
 


### PR DESCRIPTION
Adds a pre-commit hook to run GitGuardian's `ggshield` command to check new code for secrets, passwords, API keys, etc.

I tested this by

1. Hard-coding an OAuth client secret
2. Hard-coding the Android Google Maps API key
3. Hard-coding the anonymous JWT secret

It catches 1 and 2, but 3 fails because GitGuardian's [generic high entropy secret detector](https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/generics/generic_high_entropy_secret) relies on assignment, and statements like `jwt.encode( claims, "bsaruceobkoraebisroaecbu89", "HS512" );` won't trigger it because there's no assignment happening (that's one of their example secrets). Since GitGuardian doesn't seem to provide a mechanism for custom detectors, the only way I can think of to prevent that kind of secret leakage would be a custom eslint rule. I spent an hour trying to write one but I couldn't figure out how to detect a function call and check if its second argument is a string literal or not in that time span.

Another concern is that I didn't want to require the GitGuardian check for volunteer contributors who might not have it installed, since setup is already a pain and volunteers shouldn't have access to or be using critical secrets. Instead, I'm running the check if `ggshield` is installed OR if the git user has an inaturalist.org email address. That means team members who don't use inaturalist.org email addresses w/ git will need to install GitGuardian.

Questions for review:

1. Do we want to live with the vulnerability of secrets leaking in ways GitGuardian can't detect? We're living with that now.
2. Is it ok to only require the `ggshield` check if it's installed OR if the git user has an inaturalist.org email address?

Closes #25 
