### PR TITLE
Downgrade: new patch version causes build failure in Xcode 15

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -417,7 +417,7 @@ PODS:
     - React-Core
   - RNCPicker (2.5.0):
     - React-Core
-  - RNDateTimePicker (7.6.3):
+  - RNDateTimePicker (7.6.2):
     - React-Core
   - RNDeviceInfo (10.12.0):
     - React-Core
@@ -766,7 +766,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: f2974eca860c16a3e56eea5771fda8d12e2d2057
   RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNCPicker: 32ca102146bc7d34a8b93a998d9938d9f9ec7898
-  RNDateTimePicker: 7b38b71bcd7c4cfa1cb95f2dff9a4f1faed2dced
+  RNDateTimePicker: fc2e4f2795877d45e84d85659bebe627eba5c931
   RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@react-native-async-storage/async-storage": "^1.19.5",
         "@react-native-camera-roll/camera-roll": "^5.9.0",
         "@react-native-clipboard/clipboard": "^1.11.2",
-        "@react-native-community/datetimepicker": "^7.6.3",
+        "@react-native-community/datetimepicker": "^7.6.2",
         "@react-native-community/geolocation": "^3.1.0",
         "@react-native-community/netinfo": "^9.4.1",
         "@react-native-community/slider": "^4.5.0",
@@ -6202,9 +6202,9 @@
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.6.3.tgz",
-      "integrity": "sha512-Ceb+zWwX67tJKK8gTk6JRRIlU1DqIuwe2kaFwz28s6SKrU8bn/nSSB8/y9B4vic3hb8Z0WTo22807GA1Kg4W7A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.6.2.tgz",
+      "integrity": "sha512-ogZnvCmNG/lGHhEQypqz/mPymiIWD5jv6uKczg/l/aWgiKs1RDPQH1abh+R0I26aKoXmgamJJPuXKeC5eRWtZg==",
       "dependencies": {
         "invariant": "^2.2.4"
       }
@@ -30709,9 +30709,9 @@
       }
     },
     "@react-native-community/datetimepicker": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.6.3.tgz",
-      "integrity": "sha512-Ceb+zWwX67tJKK8gTk6JRRIlU1DqIuwe2kaFwz28s6SKrU8bn/nSSB8/y9B4vic3hb8Z0WTo22807GA1Kg4W7A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-7.6.2.tgz",
+      "integrity": "sha512-ogZnvCmNG/lGHhEQypqz/mPymiIWD5jv6uKczg/l/aWgiKs1RDPQH1abh+R0I26aKoXmgamJJPuXKeC5eRWtZg==",
       "requires": {
         "invariant": "^2.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@react-native-async-storage/async-storage": "^1.19.5",
     "@react-native-camera-roll/camera-roll": "^5.9.0",
     "@react-native-clipboard/clipboard": "^1.11.2",
-    "@react-native-community/datetimepicker": "^7.6.3",
+    "@react-native-community/datetimepicker": "^7.6.2",
     "@react-native-community/geolocation": "^3.1.0",
     "@react-native-community/netinfo": "^9.4.1",
     "@react-native-community/slider": "^4.5.0",


### PR DESCRIPTION
Use datetimepicker version 7.6.2, not 7.6.3, due to [this issue](https://github.com/react-native-datetimepicker/datetimepicker/issues/874)