### PR TITLE
Explore current location zoom level

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1465,12 +1465,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FasterImage: 60d0750ddbcefff0070c4c17309c2d1d6cc650f0
   FBLazyVector: f64d1e2ea739b4d8f7e4740cde18089cd97fe864
   FBReactNativeSpec: 9f2b8b243131565335437dba74923a8d3015e780
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MMKV: ed58ad794b3f88c24d604a5b74f3fba17fcbaf74

--- a/src/components/Explore/MapView.js
+++ b/src/components/Explore/MapView.js
@@ -1,15 +1,17 @@
 // @flow
 
+import classnames from "classnames";
 import {
+  Body1,
   Button,
   Map
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React from "react";
+import React, { useState } from "react";
 import { Platform } from "react-native";
 import { useTheme } from "react-native-paper";
-import { useTranslation } from "sharedHooks";
+import { useDebugMode, useTranslation } from "sharedHooks";
 import { getShadowStyle } from "styles/global";
 
 import useMapLocation from "./hooks/useMapLocation";
@@ -34,6 +36,8 @@ const MapView = ( {
 }: Props ): Node => {
   const theme = useTheme( );
   const { t } = useTranslation( );
+  const { isDebug } = useDebugMode( );
+  const [zoom, setZoom] = useState( -1 );
 
   const {
     onPanDrag,
@@ -66,6 +70,22 @@ const MapView = ( {
           </View>
         )}
       </View>
+      { isDebug && (
+        <View
+          className={classnames(
+            "absolute",
+            "left-5",
+            "bottom-[140px]",
+            "bg-deeppink",
+            "p-1",
+            "z-10"
+          )}
+        >
+          <Body1 className="text-white">
+            {`Zoom: ${zoom}`}
+          </Body1>
+        </View>
+      ) }
       <Map
         currentLocationButtonClassName="left-5 bottom-20"
         observations={observations}
@@ -84,6 +104,7 @@ const MapView = ( {
           }
         }}
         onZoomToNearby={onZoomToNearby}
+        onZoomChange={newZoom => setZoom( newZoom )}
         region={region}
         showCurrentLocationButton
         showExplore

--- a/src/components/Explore/MapView.js
+++ b/src/components/Explore/MapView.js
@@ -118,6 +118,7 @@ const MapView = ( {
         onPermissionDenied={onPermissionDenied}
         onPermissionGranted={onPermissionGranted}
         permissionRequested={permissionRequested}
+        currentLocationZoomLevel={15}
       />
     </View>
   );

--- a/src/components/SharedComponents/Map.js
+++ b/src/components/SharedComponents/Map.js
@@ -29,9 +29,19 @@ import useTranslation from "sharedHooks/useTranslation";
 import { getShadowStyle } from "styles/global";
 import colors from "styles/tailwindColors";
 
-const calculateZoom = ( width, delta ) => Math.round(
-  Math.log2( 360 * ( width / 256 / delta ) ) + 1
-);
+function calculateZoom( width, delta ) {
+  return Math.round(
+    Math.log2( 360 * ( width / 256 / delta ) ) + 1
+  );
+}
+
+// Kind of the inverse of calculateZoom. Probably not actually accurate for
+// longitude, but works for our purposes
+function zoomToDeltas( zoom, screenWidth, screenHeight ) {
+  const longitudeDelta = screenWidth / 256 / ( 2 ** zoom / 360 );
+  const latitudeDelta = screenHeight / 256 / ( 2 ** zoom / 360 );
+  return [latitudeDelta, longitudeDelta];
+}
 
 const POINT_TILES_ENDPOINT = "https://tiles.inaturalist.org/v1/points";
 const API_ENDPOINT = "https://api.inaturalist.org/v2";
@@ -78,6 +88,7 @@ type Props = {
   children?: any,
   className?: string,
   currentLocationButtonClassName?: string,
+  currentLocationZoomLevel?: number,
   mapHeight?: number|string, // allows for height to be defined as px or percentage
   mapType?: string,
   mapViewClassName?: string,
@@ -93,6 +104,7 @@ type Props = {
   onPermissionGranted?: Function,
   onRegionChange?: Function,
   onRegionChangeComplete?: Function,
+  onZoomChange?: Function,
   onZoomToNearby?: Function,
   openMapScreen?: Function,
   permissionRequested?: boolean,
@@ -112,8 +124,7 @@ type Props = {
   withObsTiles?: boolean,
   withPressableObsTiles?: boolean,
   zoomEnabled?: boolean,
-  zoomTapEnabled?: boolean,
-  onZoomChange?: Function,
+  zoomTapEnabled?: boolean
 }
 
 const getShadow = shadowColor => getShadowStyle( {
@@ -131,6 +142,7 @@ const Map = ( {
   children,
   className = "flex-1",
   currentLocationButtonClassName,
+  currentLocationZoomLevel, // target zoom level when user hits current location btn
   mapHeight,
   mapType,
   mapViewClassName,
@@ -146,6 +158,7 @@ const Map = ( {
   onPermissionGranted: onPermissionGrantedProp,
   onRegionChange,
   onRegionChangeComplete,
+  onZoomChange,
   onZoomToNearby,
   openMapScreen,
   permissionRequested: permissionRequestedProp,
@@ -165,10 +178,9 @@ const Map = ( {
   withObsTiles,
   withPressableObsTiles,
   zoomEnabled = true,
-  zoomTapEnabled = true,
-  onZoomChange
+  zoomTapEnabled = true
 }: Props ): Node => {
-  const { screenWidth } = useDeviceOrientation( );
+  const { screenWidth, screenHeight } = useDeviceOrientation( );
   const [currentZoom, setCurrentZoom] = useState(
     region
       ? calculateZoom( screenWidth, region.longitudeDelta )
@@ -234,17 +246,38 @@ const Map = ( {
 
   useEffect( ( ) => {
     if ( userLocation && zoomToUserLocationRequested && mapViewRef?.current ) {
-      mapViewRef.current.animateToRegion( {
+      // Zoom level based on location accuracy.
+      let latitudeDelta = metersToLatitudeDelta( userLocation.accuracy, userLocation.latitude );
+      // Intentional use of latitudeDelta here because longitudeDelta is harder to calculate
+      let longitudeDelta = metersToLatitudeDelta( userLocation.accuracy, userLocation.latitude );
+      // If this map redefines the level we want to zoom into when the user
+      // wants to see their current location, choose which ever is more
+      // zoomed out, the configured zoom level or the zoom level based on the
+      // coordinate accuracy
+      if ( currentLocationZoomLevel ) {
+        const [configuredLatitudeDelta, configuredLongitudeDelta] = zoomToDeltas(
+          currentLocationZoomLevel,
+          screenWidth,
+          screenHeight
+        );
+        latitudeDelta = Math.max( latitudeDelta, configuredLatitudeDelta );
+        longitudeDelta = Math.max( longitudeDelta, configuredLongitudeDelta );
+      }
+      mapViewRef.current?.animateToRegion( {
         latitude: userLocation.latitude,
         longitude: userLocation.longitude,
-        // Zoom level based on location accuracy.
-        latitudeDelta: metersToLatitudeDelta( userLocation.accuracy, userLocation.latitude ),
-        // Intentional use of latitudeDelta here because longitudeDelta is harder to calculate
-        longitudeDelta: metersToLatitudeDelta( userLocation.accuracy, userLocation.latitude )
+        latitudeDelta,
+        longitudeDelta
       } );
       setZoomToUserLocationRequested( false );
     }
-  }, [userLocation, zoomToUserLocationRequested] );
+  }, [
+    currentLocationZoomLevel,
+    screenHeight,
+    screenWidth,
+    userLocation,
+    zoomToUserLocationRequested
+  ] );
 
   // Zoom to nearby region if requested. Note that if you want to do something
   // after the map zooms, you need to use onRegionChangeComplete

--- a/src/components/SharedComponents/Map.js
+++ b/src/components/SharedComponents/Map.js
@@ -112,7 +112,8 @@ type Props = {
   withObsTiles?: boolean,
   withPressableObsTiles?: boolean,
   zoomEnabled?: boolean,
-  zoomTapEnabled?: boolean
+  zoomTapEnabled?: boolean,
+  onZoomChange?: Function,
 }
 
 const getShadow = shadowColor => getShadowStyle( {
@@ -164,7 +165,8 @@ const Map = ( {
   withObsTiles,
   withPressableObsTiles,
   zoomEnabled = true,
-  zoomTapEnabled = true
+  zoomTapEnabled = true,
+  onZoomChange
 }: Props ): Node => {
   const { screenWidth } = useDeviceOrientation( );
   const [currentZoom, setCurrentZoom] = useState(
@@ -398,6 +400,12 @@ const Map = ( {
     withPressableObsTiles,
     withObsTiles
   ] );
+
+  useEffect( ( ) => {
+    if ( typeof ( onZoomChange ) === "function" ) {
+      onZoomChange( currentZoom );
+    }
+  }, [currentZoom, onZoomChange] );
 
   return (
     <View


### PR DESCRIPTION
Makes the current location button on Explore zoom in to a neighborhood level instead of a backyard level.

Closes #1192