### PR TITLE
Jest config updates; fixes for slower tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,29 @@
+import type {Config} from 'jest';
+
+const config: Config = {
+  moduleNameMapper: {
+    "\\.svg": "<rootDir>/tests/mocks/svgMock.js"
+  },
+  preset: "react-native",
+  setupFiles: [
+    "./node_modules/react-native-gesture-handler/jestSetup.js",
+    "<rootDir>/tests/jest.setup.js"
+  ],
+  globalSetup: "<rootDir>/tests/jest.globalSetup.js",
+  setupFilesAfterEnv: [
+    "react-native-accessibility-engine",
+    "<rootDir>/tests/jest.post-setup.js",
+    "<rootDir>/tests/realm.setup.js",
+    "<rootDir>/tests/initI18next.setup.js"
+  ],
+  transformIgnorePatterns: [
+    "node_modules/(?!(jest-)?@react-native|react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base||(?!react-native-redash))|jest-runner"
+  ],
+  verbose: true,
+  // uncomment reporters below to see which tests are running the slowest in jest
+  // reporters: [
+  //   ["jest-slow-test-reporter", {"numTests": 8, "warnOnSlowerThan": 300, "color": true}]
+  // ],
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,7 @@
         "react-native-config-node": "^0.0.3",
         "react-test-renderer": "18.2.0",
         "tailwindcss": "^3.3.2",
+        "ts-node": "^10.9.2",
         "typescript": "5.0.4",
         "yargs": "^17.7.2"
       },
@@ -2605,6 +2606,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -6591,6 +6614,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -7061,6 +7108,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -8765,6 +8821,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -9928,6 +9990,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -16071,6 +16142,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -21067,6 +21144,55 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/ts-object-utils": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
@@ -21447,6 +21573,12 @@
       "bin": {
         "uuid": "bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -21897,6 +22029,15 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -23623,6 +23764,27 @@
       "resolved": "https://registry.npmjs.org/@candlefinance/faster-image/-/faster-image-1.4.3.tgz",
       "integrity": "sha512-CmQuJhgM3+R8ZNlEB8tFt+0r3Ei0OnX5aLnT6rLCDM1KobHAfbIXF1W0WlanlGudfitsdLx+qrX9oolOf+9enA==",
       "requires": {}
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "devOptional": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@egjs/hammerjs": {
       "version": "2.0.17",
@@ -26479,6 +26641,30 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
     },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
+    },
     "@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -26831,6 +27017,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "devOptional": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -28122,6 +28314,12 @@
         }
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
+    },
     "cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -28952,6 +29150,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -33488,6 +33692,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -37180,6 +37390,35 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "devOptional": true
+        }
+      }
+    },
     "ts-object-utils": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
@@ -37454,6 +37693,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
     },
     "v8-to-istanbul": {
       "version": "9.2.0",
@@ -37787,6 +38032,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-fetch-mock": "github:jefflau/jest-fetch-mock",
+        "jest-slow-test-reporter": "^1.0.0",
         "nock": "^13.5.4",
         "node-downloader-helper": "^2.1.9",
         "patch-package": "^8.0.0",
@@ -14769,6 +14770,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jest-slow-test-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-slow-test-reporter/-/jest-slow-test-reporter-1.0.0.tgz",
+      "integrity": "sha512-5FG8hlaO7Wdgdo6oQxGiFAKwd1HW51+8/KmQJgUV3bsW3cCXx9TukaoGnHhBl+hwLkCYENynWL1PQnG8DwOV6w==",
+      "dev": true
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
@@ -32543,6 +32550,12 @@
           }
         }
       }
+    },
+    "jest-slow-test-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-slow-test-reporter/-/jest-slow-test-reporter-1.0.0.tgz",
+      "integrity": "sha512-5FG8hlaO7Wdgdo6oQxGiFAKwd1HW51+8/KmQJgUV3bsW3cCXx9TukaoGnHhBl+hwLkCYENynWL1PQnG8DwOV6w==",
+      "dev": true
     },
     "jest-snapshot": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "husky": "^9.0.11",
     "jest": "^29.7.0",
     "jest-fetch-mock": "github:jefflau/jest-fetch-mock",
+    "jest-slow-test-reporter": "^1.0.0",
     "nock": "^13.5.4",
     "node-downloader-helper": "^2.1.9",
     "patch-package": "^8.0.0",
@@ -205,6 +206,9 @@
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?@react-native|react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base||(?!react-native-redash))|jest-runner"
+    ],
+    "reporters": [
+      ["jest-slow-test-reporter", {"numTests": 8, "warnOnSlowerThan": 300, "color": true}]
     ],
     "verbose": true
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "./scripts/clean.sh",
     "clean-start": "npx react-native clean-project-auto && npx pod-install && npm start -- --reset-cache",
     "test": "jest",
+    "test:memory": "jest --runInBand --logHeapUsage",
     "lint": "npm run lint:eslint && npm run lint:flow",
     "lint:eslint": "eslint . --fix",
     "lint:flow": "flow check",

--- a/package.json
+++ b/package.json
@@ -182,34 +182,11 @@
     "react-native-config-node": "^0.0.3",
     "react-test-renderer": "18.2.0",
     "tailwindcss": "^3.3.2",
+    "ts-node": "^10.9.2",
     "typescript": "5.0.4",
     "yargs": "^17.7.2"
   },
   "engines": {
     "node": ">=18"
-  },
-  "jest": {
-    "moduleNameMapper": {
-      "\\.svg": "<rootDir>/tests/mocks/svgMock.js"
-    },
-    "preset": "react-native",
-    "setupFiles": [
-      "./node_modules/react-native-gesture-handler/jestSetup.js",
-      "<rootDir>/tests/jest.setup.js"
-    ],
-    "globalSetup": "<rootDir>/tests/jest.globalSetup.js",
-    "setupFilesAfterEnv": [
-      "react-native-accessibility-engine",
-      "<rootDir>/tests/jest.post-setup.js",
-      "<rootDir>/tests/realm.setup.js",
-      "<rootDir>/tests/initI18next.setup.js"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?@react-native|react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base||(?!react-native-redash))|jest-runner"
-    ],
-    "reporters": [
-      ["jest-slow-test-reporter", {"numTests": 8, "warnOnSlowerThan": 300, "color": true}]
-    ],
-    "verbose": true
   }
 }

--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -61,6 +61,7 @@ const EvidenceList = ( {
         <Pressable
           onLongPress={drag}
           accessibilityRole="button"
+          accessibilityLabel={t( "Select-or-drag-media" )}
           onPress={( ) => {
             setSelectedMediaUri( uri );
           }}
@@ -78,7 +79,7 @@ const EvidenceList = ( {
         </Pressable>
       </ScaleDecorator>
     );
-  }, [setSelectedMediaUri] );
+  }, [setSelectedMediaUri, t] );
 
   const renderFooter = useCallback( ( ) => (
     <View className="flex-1 flex-row">

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -823,6 +823,7 @@ See-species-observed-by-this-user-in-Explore = See species observed by this user
 Select-a-date-and-time-for-observation = Select a date and time for observation
 Select-captive-or-cultivated-status = Select captive or cultivated status
 Select-geoprivacy-status = Select geoprivacy status
+Select-or-drag-media = Select or drag media
 Select-photo = Select photo
 Select-the-identification-you-want-to-add = Select the identification you want to add to this observation. You can add a filter to further refine your results or search for a taxon.
 # Label for an element that let's you select a user

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1127,6 +1127,7 @@
   "Select-a-date-and-time-for-observation": "Select a date and time for observation",
   "Select-captive-or-cultivated-status": "Select captive or cultivated status",
   "Select-geoprivacy-status": "Select geoprivacy status",
+  "Select-or-drag-media": "Select or drag media",
   "Select-photo": "Select photo",
   "Select-the-identification-you-want-to-add": "Select the identification you want to add to this observation. You can add a filter to further refine your results or search for a taxon.",
   "Select-user": {

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -823,6 +823,7 @@ See-species-observed-by-this-user-in-Explore = See species observed by this user
 Select-a-date-and-time-for-observation = Select a date and time for observation
 Select-captive-or-cultivated-status = Select captive or cultivated status
 Select-geoprivacy-status = Select geoprivacy status
+Select-or-drag-media = Select or drag media
 Select-photo = Select photo
 Select-the-identification-you-want-to-add = Select the identification you want to add to this observation. You can add a filter to further refine your results or search for a taxon.
 # Label for an element that let's you select a user
@@ -1131,5 +1132,3 @@ Youve-previously-denied-location-permissions = You’ve previously denied locati
 Youve-previously-denied-microphone-permissions = You’ve previously denied microphone permissions, so please enable them in settings.
 Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve location accuracy and get better identifications.
 Zoom-to-current-location = Zoom to current location
-
-Select-or-drag-media = Select or drag media

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1131,3 +1131,5 @@ Youve-previously-denied-location-permissions = You’ve previously denied locati
 Youve-previously-denied-microphone-permissions = You’ve previously denied microphone permissions, so please enable them in settings.
 Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve location accuracy and get better identifications.
 Zoom-to-current-location = Zoom to current location
+
+Select-or-drag-media = Select or drag media

--- a/tests/unit/components/Camera/CameraContainer.test.js
+++ b/tests/unit/components/Camera/CameraContainer.test.js
@@ -64,11 +64,7 @@ describe( "CameraContainer", ( ) => {
   } );
 
   it( "should not have accessibility errors", () => {
-    const Camera = (
-      <INatPaperProvider>
-        <CameraContainer />
-      </INatPaperProvider>
-    );
+    const Camera = <CameraContainer />;
 
     expect( Camera ).toBeAccessible();
   } );

--- a/tests/unit/components/MediaViewer/MediaViewer.test.js
+++ b/tests/unit/components/MediaViewer/MediaViewer.test.js
@@ -7,8 +7,7 @@ import { renderComponent } from "tests/helpers/render";
 describe( "MediaViewer", ( ) => {
   describe( "without media", ( ) => {
     it( "should not have accessibility errors", async () => {
-      renderComponent( <MediaViewer /> );
-      const mediaViewer = await screen.findByTestId( "MediaViewer" );
+      const mediaViewer = <MediaViewer />;
       expect( mediaViewer ).toBeAccessible( );
     } );
 
@@ -24,8 +23,7 @@ describe( "MediaViewer", ( ) => {
       const photos = [factory( "LocalPhoto" )];
 
       it( "should not have accessibility errors", async () => {
-        renderComponent( <MediaViewer photos={photos} /> );
-        const mediaViewer = await screen.findByTestId( "MediaViewer" );
+        const mediaViewer = <MediaViewer photos={photos} />;
         expect( mediaViewer ).toBeAccessible( );
       } );
 

--- a/tests/unit/components/Messages/Messages.test.js
+++ b/tests/unit/components/Messages/Messages.test.js
@@ -54,11 +54,7 @@ jest.mock( "@tanstack/react-query", ( ) => ( {
 
 describe( "Messages", ( ) => {
   it( "should not have accessibility errors", () => {
-    const messages = (
-      <INatPaperProvider>
-        <Messages />
-      </INatPaperProvider>
-    );
+    const messages = <Messages />;
     expect( messages ).toBeAccessible();
   } );
 

--- a/tests/unit/components/ObsEdit/ObsEdit.test.js
+++ b/tests/unit/components/ObsEdit/ObsEdit.test.js
@@ -3,63 +3,50 @@ import ObsEdit from "components/ObsEdit/ObsEdit";
 import React from "react";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
-import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
 const initialStoreState = useStore.getState( );
 
-const mockLocationName = "San Francisco, CA";
-
-const mockCurrentUser = factory( "LocalUser" );
-
-const mockObservations = [
-  factory( "RemoteObservation", {
-    latitude: 37.99,
-    longitude: -142.88,
-    user: mockCurrentUser,
-    place_guess: mockLocationName
+jest.mock( "sharedHooks/useCurrentObservationLocation", () => ( {
+  __esModule: true,
+  default: ( ) => ( {
+    hasLocation: true,
+    isFetchingLocation: false,
+    permissionResult: "granted"
   } )
-];
+} ) );
+
+jest.mock( "components/ObsEdit/BottomButtons" );
+jest.mock( "components/SharedComponents/IconicTaxonChooser" );
+jest.mock( "components/ObsEdit/Sheets/AddEvidenceSheet" );
 
 const observationPhotos = [
   factory( "RemoteObservationPhoto", {
-    photo: {
-      url: faker.image.url( )
-    },
     position: 0
-  } ),
-  factory( "RemoteObservationPhoto", {
-    photo: {
-      url: `${faker.image.url( )}/100`
-    },
-    position: 1
   } )
 ];
 
-const mockObservation = factory( "RemoteObservation", {
-  speciesGuess: "Obsedit test",
-  observationPhotos
+const mockObservation = factory( "LocalObservation", {
+  observationPhotos,
+  time_observed_at: null
 } );
 
-const renderObsEdit = ( ) => renderComponent( <ObsEdit /> );
+beforeAll( async ( ) => {
+  useStore.setState( initialStoreState, true );
+  useStore.setState( {
+    currentObservation: mockObservation,
+    observations: [mockObservation]
+  } );
+} );
 
 describe( "ObsEdit", () => {
-  beforeAll( async ( ) => {
-    useStore.setState( initialStoreState, true );
-  } );
-
-  it( "should not have accessibility errors", async () => {
-    renderObsEdit( mockObservations );
-
+  it( "should not have accessibility errors", async ( ) => {
+    renderComponent( <ObsEdit /> );
     const obsEdit = await screen.findByTestId( "obs-edit" );
     expect( obsEdit ).toBeAccessible();
   } );
 
   it( "displays the number of photos in global state obsPhotos", async ( ) => {
-    useStore.setState( {
-      currentObservation: mockObservation,
-      observations: [mockObservation]
-    } );
     renderComponent( <ObsEdit /> );
 
     const evidenceList = screen.getByTestId( "EvidenceList.DraggableFlatList" );

--- a/tests/unit/components/ObsEdit/ObsEdit.test.js
+++ b/tests/unit/components/ObsEdit/ObsEdit.test.js
@@ -20,6 +20,14 @@ jest.mock( "components/ObsEdit/BottomButtons" );
 jest.mock( "components/SharedComponents/IconicTaxonChooser" );
 jest.mock( "components/ObsEdit/Sheets/AddEvidenceSheet" );
 
+const mockMutate = jest.fn();
+jest.mock( "sharedHooks/useAuthenticatedMutation", () => ( {
+  __esModule: true,
+  default: () => ( {
+    mutate: mockMutate
+  } )
+} ) );
+
 const observationPhotos = [
   factory( "RemoteObservationPhoto", {
     position: 0
@@ -41,8 +49,7 @@ beforeAll( async ( ) => {
 
 describe( "ObsEdit", () => {
   it( "should not have accessibility errors", async ( ) => {
-    renderComponent( <ObsEdit /> );
-    const obsEdit = await screen.findByTestId( "obs-edit" );
+    const obsEdit = <ObsEdit />;
     expect( obsEdit ).toBeAccessible();
   } );
 

--- a/tests/unit/components/ProjectDetails/ProjectDetails.test.js
+++ b/tests/unit/components/ProjectDetails/ProjectDetails.test.js
@@ -20,6 +20,14 @@ jest.mock( "sharedHooks/useAuthenticatedQuery", ( ) => ( {
   } )
 } ) );
 
+const mockMutate = jest.fn();
+jest.mock( "sharedHooks/useAuthenticatedMutation", () => ( {
+  __esModule: true,
+  default: ( ) => ( {
+    mutate: mockMutate
+  } )
+} ) );
+
 jest.mock( "@react-navigation/native", ( ) => {
   const actualNav = jest.requireActual( "@react-navigation/native" );
   return {
@@ -28,14 +36,18 @@ jest.mock( "@react-navigation/native", ( ) => {
       params: {
         id: mockProject.id
       }
-    } )
+    } ),
+    useNavigation: jest.fn( )
   };
+} );
+
+beforeAll( async () => {
+  jest.useFakeTimers( );
 } );
 
 describe( "ProjectDetails", ( ) => {
   test( "should not have accessibility errors", async ( ) => {
-    renderComponent( <ProjectDetailsContainer /> );
-    const projectDetails = await screen.findByTestId( "project-details" );
+    const projectDetails = <ProjectDetailsContainer />;
     expect( projectDetails ).toBeAccessible();
   } );
 

--- a/tests/unit/components/Suggestions/Suggestions.test.js
+++ b/tests/unit/components/Suggestions/Suggestions.test.js
@@ -16,6 +16,13 @@ const initialStoreState = useStore.getState( );
 
 const mockTaxon = factory( "RemoteTaxon" );
 
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: () => ( {
+    data: []
+  } )
+} ) );
+
 jest.mock( "sharedHooks/useTaxon", () => ( {
   __esModule: true,
   default: () => ( { taxon: mockTaxon } )
@@ -31,11 +38,11 @@ describe( "Suggestions", ( ) => {
   } );
 
   test( "should not have accessibility errors", async ( ) => {
-    renderComponent( <Suggestions
-      suggestions={mockSuggestionsList}
-    /> );
-
-    const suggestions = await screen.findByTestId( "suggestions" );
+    const suggestions = (
+      <Suggestions
+        suggestions={mockSuggestionsList}
+      />
+    );
     expect( suggestions ).toBeAccessible( );
   } );
 

--- a/tests/unit/components/TaxonDetails/TaxonDetails.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetails.test.js
@@ -39,7 +39,8 @@ jest.mock( "@react-navigation/native", ( ) => {
       params: {
         id: mockTaxon.id
       }
-    } )
+    } ),
+    useNavigation: jest.fn( )
   };
 } );
 
@@ -82,13 +83,7 @@ describe( "TaxonDetails", ( ) => {
   } );
 
   test( "should not have accessibility errors", ( ) => {
-    const taxonDetails = (
-      <INatPaperProvider>
-        <NavigationContainer>
-          <TaxonDetails />
-        </NavigationContainer>
-      </INatPaperProvider>
-    );
+    const taxonDetails = <TaxonDetails />;
     expect( taxonDetails ).toBeAccessible( );
   } );
 

--- a/tests/unit/components/TaxonDetails/Taxonomy.test.js
+++ b/tests/unit/components/TaxonDetails/Taxonomy.test.js
@@ -3,6 +3,21 @@ import Taxonomy from "components/TaxonDetails/Taxonomy";
 import React from "react";
 import factory from "tests/factory";
 
+const mockUser = factory( "LocalUser" );
+
+jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
+  __esModule: true,
+  default: ( ) => mockUser
+} ) );
+
+jest.mock( "@react-navigation/native", ( ) => {
+  const actualNav = jest.requireActual( "@react-navigation/native" );
+  return {
+    ...actualNav,
+    useNavigation: jest.fn( )
+  };
+} );
+
 const capitalizeFirstLetter = s => s.charAt( 0 ).toUpperCase( ) + s.slice( 1 );
 
 const ancestors = [
@@ -46,16 +61,6 @@ describe( "Taxonomy", ( ) => {
     const currentTaxonRow = screen.getByTestId( `TaxonomyRow.${currentTaxon.id}` );
 
     expect( currentTaxonRow ).toHaveTextContent( `${commonName}(${rankAndName})` );
-  } );
-
-  test( "renders current taxon", ( ) => {
-    render( <Taxonomy taxon={currentTaxon} /> );
-
-    const name = screen.getByText( currentTaxon.name );
-    const commonName = screen.getByText( currentTaxon.preferred_common_name );
-
-    expect( commonName ).toBeVisible( );
-    expect( name ).toBeVisible( );
   } );
 
   test( "renders all ancestors", ( ) => {

--- a/tests/unit/components/UserProfile/UserProfile.test.js
+++ b/tests/unit/components/UserProfile/UserProfile.test.js
@@ -14,6 +14,14 @@ jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
   } )
 } ) );
 
+const mockMutate = jest.fn();
+jest.mock( "sharedHooks/useAuthenticatedMutation", () => ( {
+  __esModule: true,
+  default: ( ) => ( {
+    mutate: mockMutate
+  } )
+} ) );
+
 jest.mock( "@react-navigation/native", () => {
   const actualNav = jest.requireActual( "@react-navigation/native" );
   return {
@@ -46,8 +54,7 @@ describe( "UserProfile", () => {
   } );
 
   test( "should not have accessibility errors", async () => {
-    renderComponent( <UserProfile /> );
-    const userProfile = await screen.findByTestId( "UserProfile" );
+    const userProfile = <UserProfile />;
     expect( userProfile ).toBeAccessible();
   } );
 


### PR DESCRIPTION
This PR:
- Moves Jest config out of package.json into its own file
- Adds `jest-slow-test-reporter`, which we can use to see which tests are running the slowest (and try to fix them accordingly)
- Adds `test:memory` to package.json, which lets us run a script to check for growing heap size / memory leaks in our Jest tests (we currently do seem to have a growing heap)
- Improves the test speed of a few slower tests
- Fixes accessibility issues in EvidenceList