### PR TITLE
Show up-to-date metadata for observations immediately after upload

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1472,12 +1472,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FasterImage: 60d0750ddbcefff0070c4c17309c2d1d6cc650f0
   FBLazyVector: 9f533d5a4c75ca77c8ed774aced1a91a0701781e
   FBReactNativeSpec: 40b791f4a1df779e7e4aa12c000319f4f216d40a
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 39589e9c297d024e90fe68f6830ff86c4e01498a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MMKV: ed58ad794b3f88c24d604a5b74f3fba17fcbaf74

--- a/src/components/Developer/Developer.js
+++ b/src/components/Developer/Developer.js
@@ -1,4 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
+import { getUserAgent } from "api/userAgent";
 import classnames from "classnames";
 import {
   Button,
@@ -126,6 +127,18 @@ const Developer = (): Node => {
         <H2>Caches</H2>
         <P>
           <CODE>{RNFS.CachesDirectoryPath}</CODE>
+        </P>
+        <H2>Config.API_URL</H2>
+        <P>
+          <CODE>{Config.API_URL}</CODE>
+        </P>
+        <H2>Config.API_URL</H2>
+        <P>
+          <CODE>{Config.API_URL}</CODE>
+        </P>
+        <H2>getUserAgent()</H2>
+        <P>
+          <CODE>{getUserAgent()}</CODE>
         </P>
         {displayFileSizes( )}
         <H1>Log file contents</H1>

--- a/src/components/Developer/UiLibrary/ObsListItemDemo.js
+++ b/src/components/Developer/UiLibrary/ObsListItemDemo.js
@@ -107,6 +107,14 @@ const ObsListItemDemo = ( ) => (
         observation={{ uuid: "the-uuid" }}
         uploadState={{ uploadProgress: { "the-uuid": 1 } }}
       />
+      <Heading2 className="my-2">Upload complete, w/ animation, w/ ID</Heading2>
+      <ObsListItem
+        observation={{
+          uuid: "the-uuid",
+          identifications: [{ uuid: "another-uuid", current: true }]
+        }}
+        uploadState={{ uploadProgress: { "the-uuid": 1 } }}
+      />
       <Heading2 className="my-2">Upload complete, before animation</Heading2>
       <ObsListItem
         observation={{ uuid: "the-uuid" }}

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -280,96 +280,6 @@ const MyObservationsContainer = ( ): Node => {
     }
   }, [currentUser] );
 
-  const uploadObservationAndCatchError = useCallback( async observation => {
-    try {
-      await uploadObservation( observation, realm );
-    } catch ( uploadError ) {
-      let { message } = uploadError;
-      if ( uploadError?.json?.errors ) {
-        // TODO localize comma join
-        message = uploadError.json.errors.map( e => {
-          if ( e.message?.errors ) {
-            return e.message.errors.flat( ).join( ", " );
-          }
-          return e.message;
-        } ).join( ", " );
-      } else if ( uploadError.message?.match( /Network request failed/ ) ) {
-        message = t( "Connection-problem-Please-try-again-later" );
-        logger.error(
-          `[MyObservationsContainer.js] upload failed due to network problem: ${uploadError}`
-        );
-      } else {
-        logger.error( `[MyObservationsContainer.js] upload failed: ${uploadError}` );
-        throw uploadError;
-      }
-      dispatch( { type: "SET_UPLOAD_ERROR", error: message } );
-    }
-  }, [
-    realm,
-    t
-  ] );
-
-  const uploadSingleObservation = useCallback( async ( observation, options ) => {
-    if ( !currentUser ) {
-      toggleLoginSheet( );
-      return;
-    }
-    if ( !isOnline ) {
-      showInternetErrorAlert( );
-      return;
-    }
-    if ( !options || options?.singleUpload !== false ) {
-      dispatch( { type: "START_UPLOAD", observation, singleUpload: true } );
-    }
-    await uploadObservationAndCatchError( observation );
-    dispatch( { type: "UPLOADS_COMPLETE" } );
-  }, [
-    currentUser,
-    isOnline,
-    showInternetErrorAlert,
-    toggleLoginSheet,
-    uploadObservationAndCatchError
-  ] );
-
-  const uploadMultipleObservations = useCallback( async ( ) => {
-    if ( !currentUser ) {
-      toggleLoginSheet( );
-      return;
-    }
-    if ( numUnuploadedObservations === 0 || uploadInProgress ) {
-      return;
-    }
-    if ( !isOnline ) {
-      showInternetErrorAlert( );
-      return;
-    }
-    dispatch( { type: "START_UPLOAD", singleUpload: uploads.length === 1 } );
-
-    try {
-      await Promise.all( uploads.map( async obsToUpload => {
-        await uploadObservationAndCatchError( obsToUpload );
-        dispatch( { type: "START_NEXT_UPLOAD" } );
-      } ) );
-      dispatch( { type: "UPLOADS_COMPLETE" } );
-    } catch ( uploadMultipleObservationsError ) {
-      logger.error( "Failed to uploadMultipleObservations: ", uploadMultipleObservationsError );
-      dispatch( {
-        type: "SET_UPLOAD_ERROR",
-        error: t( "Something-went-wrong" )
-      } );
-    }
-  }, [
-    currentUser,
-    isOnline,
-    numUnuploadedObservations,
-    showInternetErrorAlert,
-    t,
-    toggleLoginSheet,
-    uploadInProgress,
-    uploadObservationAndCatchError,
-    uploads
-  ] );
-
   const stopUploads = useCallback( ( ) => {
     dispatch( { type: "STOP_UPLOADS" } );
     deactivateKeepAwake( );
@@ -501,6 +411,96 @@ const MyObservationsContainer = ( ): Node => {
     updateSyncTime,
     uploadInProgress,
     uploadsComplete
+  ] );
+
+  const uploadObservationAndCatchError = useCallback( async observation => {
+    try {
+      await uploadObservation( observation, realm );
+    } catch ( uploadError ) {
+      let { message } = uploadError;
+      if ( uploadError?.json?.errors ) {
+        // TODO localize comma join
+        message = uploadError.json.errors.map( e => {
+          if ( e.message?.errors ) {
+            return e.message.errors.flat( ).join( ", " );
+          }
+          return e.message;
+        } ).join( ", " );
+      } else if ( uploadError.message?.match( /Network request failed/ ) ) {
+        message = t( "Connection-problem-Please-try-again-later" );
+        logger.error(
+          `[MyObservationsContainer.js] upload failed due to network problem: ${uploadError}`
+        );
+      } else {
+        logger.error( `[MyObservationsContainer.js] upload failed: ${uploadError}` );
+        throw uploadError;
+      }
+      dispatch( { type: "SET_UPLOAD_ERROR", error: message } );
+    }
+  }, [
+    realm,
+    t
+  ] );
+
+  const uploadSingleObservation = useCallback( async ( observation, options ) => {
+    if ( !currentUser ) {
+      toggleLoginSheet( );
+      return;
+    }
+    if ( !isOnline ) {
+      showInternetErrorAlert( );
+      return;
+    }
+    if ( !options || options?.singleUpload !== false ) {
+      dispatch( { type: "START_UPLOAD", observation, singleUpload: true } );
+    }
+    await uploadObservationAndCatchError( observation );
+    dispatch( { type: "UPLOADS_COMPLETE" } );
+  }, [
+    currentUser,
+    isOnline,
+    showInternetErrorAlert,
+    toggleLoginSheet,
+    uploadObservationAndCatchError
+  ] );
+
+  const uploadMultipleObservations = useCallback( async ( ) => {
+    if ( !currentUser ) {
+      toggleLoginSheet( );
+      return;
+    }
+    if ( numUnuploadedObservations === 0 || uploadInProgress ) {
+      return;
+    }
+    if ( !isOnline ) {
+      showInternetErrorAlert( );
+      return;
+    }
+    dispatch( { type: "START_UPLOAD", singleUpload: uploads.length === 1 } );
+
+    try {
+      await Promise.all( uploads.map( async obsToUpload => {
+        await uploadObservationAndCatchError( obsToUpload );
+        dispatch( { type: "START_NEXT_UPLOAD" } );
+      } ) );
+      dispatch( { type: "UPLOADS_COMPLETE" } );
+    } catch ( uploadMultipleObservationsError ) {
+      logger.error( "Failed to uploadMultipleObservations: ", uploadMultipleObservationsError );
+      dispatch( {
+        type: "SET_UPLOAD_ERROR",
+        error: t( "Something-went-wrong" )
+      } );
+    }
+  }, [
+    currentUser,
+    isOnline,
+    numUnuploadedObservations,
+    showInternetErrorAlert,
+    t,
+    toggleLoginSheet,
+    uploadInProgress,
+    uploadObservationAndCatchError,
+    uploads
   ] );
 
   useEffect( ( ) => {

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -280,6 +280,96 @@ const MyObservationsContainer = ( ): Node => {
     }
   }, [currentUser] );
 
+  const uploadObservationAndCatchError = useCallback( async observation => {
+    try {
+      await uploadObservation( observation, realm );
+    } catch ( uploadError ) {
+      let { message } = uploadError;
+      if ( uploadError?.json?.errors ) {
+        // TODO localize comma join
+        message = uploadError.json.errors.map( e => {
+          if ( e.message?.errors ) {
+            return e.message.errors.flat( ).join( ", " );
+          }
+          return e.message;
+        } ).join( ", " );
+      } else if ( uploadError.message?.match( /Network request failed/ ) ) {
+        message = t( "Connection-problem-Please-try-again-later" );
+        logger.error(
+          `[MyObservationsContainer.js] upload failed due to network problem: ${uploadError}`
+        );
+      } else {
+        logger.error( `[MyObservationsContainer.js] upload failed: ${uploadError}` );
+        throw uploadError;
+      }
+      dispatch( { type: "SET_UPLOAD_ERROR", error: message } );
+    }
+  }, [
+    realm,
+    t
+  ] );
+
+  const uploadSingleObservation = useCallback( async ( observation, options ) => {
+    if ( !currentUser ) {
+      toggleLoginSheet( );
+      return;
+    }
+    if ( !isOnline ) {
+      showInternetErrorAlert( );
+      return;
+    }
+    if ( !options || options?.singleUpload !== false ) {
+      dispatch( { type: "START_UPLOAD", observation, singleUpload: true } );
+    }
+    await uploadObservationAndCatchError( observation );
+    dispatch( { type: "UPLOADS_COMPLETE" } );
+  }, [
+    currentUser,
+    isOnline,
+    showInternetErrorAlert,
+    toggleLoginSheet,
+    uploadObservationAndCatchError
+  ] );
+
+  const uploadMultipleObservations = useCallback( async ( ) => {
+    if ( !currentUser ) {
+      toggleLoginSheet( );
+      return;
+    }
+    if ( numUnuploadedObservations === 0 || uploadInProgress ) {
+      return;
+    }
+    if ( !isOnline ) {
+      showInternetErrorAlert( );
+      return;
+    }
+    dispatch( { type: "START_UPLOAD", singleUpload: uploads.length === 1 } );
+
+    try {
+      await Promise.all( uploads.map( async obsToUpload => {
+        await uploadObservationAndCatchError( obsToUpload );
+        dispatch( { type: "START_NEXT_UPLOAD" } );
+      } ) );
+      dispatch( { type: "UPLOADS_COMPLETE" } );
+    } catch ( uploadMultipleObservationsError ) {
+      logger.error( "Failed to uploadMultipleObservations: ", uploadMultipleObservationsError );
+      dispatch( {
+        type: "SET_UPLOAD_ERROR",
+        error: t( "Something-went-wrong" )
+      } );
+    }
+  }, [
+    currentUser,
+    isOnline,
+    numUnuploadedObservations,
+    showInternetErrorAlert,
+    t,
+    toggleLoginSheet,
+    uploadInProgress,
+    uploadObservationAndCatchError,
+    uploads
+  ] );
+
   const stopUploads = useCallback( ( ) => {
     dispatch( { type: "STOP_UPLOADS" } );
     deactivateKeepAwake( );
@@ -411,96 +501,6 @@ const MyObservationsContainer = ( ): Node => {
     updateSyncTime,
     uploadInProgress,
     uploadsComplete
-  ] );
-
-  const uploadObservationAndCatchError = useCallback( async observation => {
-    try {
-      await uploadObservation( observation, realm );
-    } catch ( uploadError ) {
-      let { message } = uploadError;
-      if ( uploadError?.json?.errors ) {
-        // TODO localize comma join
-        message = uploadError.json.errors.map( e => {
-          if ( e.message?.errors ) {
-            return e.message.errors.flat( ).join( ", " );
-          }
-          return e.message;
-        } ).join( ", " );
-      } else if ( uploadError.message?.match( /Network request failed/ ) ) {
-        message = t( "Connection-problem-Please-try-again-later" );
-        logger.error(
-          `[MyObservationsContainer.js] upload failed due to network problem: ${uploadError}`
-        );
-      } else {
-        logger.error( `[MyObservationsContainer.js] upload failed: ${uploadError}` );
-        throw uploadError;
-      }
-      dispatch( { type: "SET_UPLOAD_ERROR", error: message } );
-    }
-  }, [
-    realm,
-    t
-  ] );
-
-  const uploadSingleObservation = useCallback( async ( observation, options ) => {
-    if ( !currentUser ) {
-      toggleLoginSheet( );
-      return;
-    }
-    if ( !isOnline ) {
-      showInternetErrorAlert( );
-      return;
-    }
-    if ( !options || options?.singleUpload !== false ) {
-      dispatch( { type: "START_UPLOAD", observation, singleUpload: true } );
-    }
-    await uploadObservationAndCatchError( observation );
-    dispatch( { type: "UPLOADS_COMPLETE" } );
-  }, [
-    currentUser,
-    isOnline,
-    showInternetErrorAlert,
-    toggleLoginSheet,
-    uploadObservationAndCatchError
-  ] );
-
-  const uploadMultipleObservations = useCallback( async ( ) => {
-    if ( !currentUser ) {
-      toggleLoginSheet( );
-      return;
-    }
-    if ( numUnuploadedObservations === 0 || uploadInProgress ) {
-      return;
-    }
-    if ( !isOnline ) {
-      showInternetErrorAlert( );
-      return;
-    }
-    dispatch( { type: "START_UPLOAD", singleUpload: uploads.length === 1 } );
-
-    try {
-      await Promise.all( uploads.map( async obsToUpload => {
-        await uploadObservationAndCatchError( obsToUpload );
-        dispatch( { type: "START_NEXT_UPLOAD" } );
-      } ) );
-      dispatch( { type: "UPLOADS_COMPLETE" } );
-    } catch ( uploadMultipleObservationsError ) {
-      logger.error( "Failed to uploadMultipleObservations: ", uploadMultipleObservationsError );
-      dispatch( {
-        type: "SET_UPLOAD_ERROR",
-        error: t( "Something-went-wrong" )
-      } );
-    }
-  }, [
-    currentUser,
-    isOnline,
-    numUnuploadedObservations,
-    showInternetErrorAlert,
-    t,
-    toggleLoginSheet,
-    uploadInProgress,
-    uploadObservationAndCatchError,
-    uploads
   ] );
 
   useEffect( ( ) => {

--- a/src/components/ObsDetails/DetailsTab/DetailsTab.js
+++ b/src/components/ObsDetails/DetailsTab/DetailsTab.js
@@ -159,6 +159,8 @@ const DetailsTab = ( { observation }: Props ): Node => {
         {application && (
           <Body4>{t( "Uploaded-via-application", { application } )}</Body4>
         )}
+        <Body4>{t( "Label-colon-value", { label: "ID", value: observation.id } )}</Body4>
+        <Body4>{t( "Label-colon-value", { label: "UUID", value: observation.uuid } )}</Body4>
         <ViewInBrowserButton id={observation.id} />
       </View>
     </>

--- a/src/components/ObsEdit/IdentificationSection.js
+++ b/src/components/ObsEdit/IdentificationSection.js
@@ -49,14 +49,9 @@ const IdentificationSection = ( {
     || identification.isIconic
     || identification.name === "Life";
 
-  const onTaxonChosen = taxonName => {
-    const selectedTaxon = realm?.objects( "Taxon" ).filtered( "name CONTAINS[c] $0", taxonName );
-    updateObservationKeys( {
-      taxon: selectedTaxon.length > 0
-        ? selectedTaxon[0]
-        : null
-    } );
-  };
+  const onTaxonChosen = taxonName => updateObservationKeys( {
+    taxon: realm?.objects( "Taxon" ).filtered( "name CONTAINS[c] $0", taxonName )[0]
+  } );
 
   const navToSuggestions = useCallback( ( ) => {
     if ( hasPhotos ) {

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -30,68 +30,67 @@ const ObsEdit = ( ): Node => {
   const [passesEvidenceTest, setPassesEvidenceTest] = useState( false );
   const [passesIdentificationTest, setPassesIdentificationTest] = useState( false );
   const [resetScreen, setResetScreen] = useState( false );
-
   const isFocused = useIsFocused( );
 
-  return isFocused
-    ? (
-      <>
-        <ViewWrapper testID="obs-edit">
-          <Header
-            currentObservation={currentObservation}
-            observations={observations}
-          />
-          <KeyboardAwareScrollView className="mb-[80px]">
-            {currentObservation && (
-              <View
-                className="bg-white rounded-t-3xl mt-1"
-                style={( observations.length > 1 )
-                  ? DROP_SHADOW
-                  : undefined}
-              >
-                <View className="pb-5">
-                  {observations.length > 1 && (
-                    <MultipleObservationsArrows
-                      currentObservationIndex={currentObservationIndex}
-                      observations={observations}
-                      setCurrentObservationIndex={setCurrentObservationIndex}
-                      setResetScreen={setResetScreen}
-                    />
-                  )}
-                  <EvidenceSectionContainer
-                    currentObservation={currentObservation}
-                    passesEvidenceTest={passesEvidenceTest}
-                    setPassesEvidenceTest={setPassesEvidenceTest}
-                    updateObservationKeys={updateObservationKeys}
-                  />
-                  <IdentificationSection
-                    currentObservation={currentObservation}
-                    passesIdentificationTest={passesIdentificationTest}
-                    resetScreen={resetScreen}
-                    setPassesIdentificationTest={setPassesIdentificationTest}
-                    setResetScreen={setResetScreen}
-                    updateObservationKeys={updateObservationKeys}
-                  />
-                  <OtherDataSection
-                    currentObservation={currentObservation}
-                    updateObservationKeys={updateObservationKeys}
-                  />
-                </View>
-              </View>
-            )}
-          </KeyboardAwareScrollView>
-        </ViewWrapper>
-        <BottomButtons
+  if ( !isFocused ) return null;
+
+  return (
+    <>
+      <ViewWrapper testID="obs-edit">
+        <Header
           currentObservation={currentObservation}
-          currentObservationIndex={currentObservationIndex}
           observations={observations}
-          passesEvidenceTest={passesEvidenceTest}
-          passesIdentificationTest={passesIdentificationTest}
-          setCurrentObservationIndex={setCurrentObservationIndex}
         />
-      </>
-    )
-    : null;
+        <KeyboardAwareScrollView className="mb-[80px]">
+          {currentObservation && (
+            <View
+              className="bg-white rounded-t-3xl mt-1"
+              style={( observations.length > 1 )
+                ? DROP_SHADOW
+                : undefined}
+            >
+              <View className="pb-5">
+                {observations.length > 1 && (
+                  <MultipleObservationsArrows
+                    currentObservationIndex={currentObservationIndex}
+                    observations={observations}
+                    setCurrentObservationIndex={setCurrentObservationIndex}
+                    setResetScreen={setResetScreen}
+                  />
+                )}
+                <EvidenceSectionContainer
+                  currentObservation={currentObservation}
+                  passesEvidenceTest={passesEvidenceTest}
+                  setPassesEvidenceTest={setPassesEvidenceTest}
+                  updateObservationKeys={updateObservationKeys}
+                />
+                <IdentificationSection
+                  currentObservation={currentObservation}
+                  passesIdentificationTest={passesIdentificationTest}
+                  resetScreen={resetScreen}
+                  setPassesIdentificationTest={setPassesIdentificationTest}
+                  setResetScreen={setResetScreen}
+                  updateObservationKeys={updateObservationKeys}
+                />
+                <OtherDataSection
+                  currentObservation={currentObservation}
+                  updateObservationKeys={updateObservationKeys}
+                />
+              </View>
+            </View>
+          )}
+        </KeyboardAwareScrollView>
+      </ViewWrapper>
+      <BottomButtons
+        currentObservation={currentObservation}
+        currentObservationIndex={currentObservationIndex}
+        observations={observations}
+        passesEvidenceTest={passesEvidenceTest}
+        passesIdentificationTest={passesIdentificationTest}
+        setCurrentObservationIndex={setCurrentObservationIndex}
+      />
+    </>
+  );
 };
 
 export default ObsEdit;

--- a/src/components/SharedComponents/ObsStatus.js
+++ b/src/components/SharedComponents/ObsStatus.js
@@ -34,9 +34,12 @@ const ObsStatus = ( {
     : "mr-2";
 
   const showCurrentIdCount = useCallback( ( ) => {
-    const numCurrentIdents = observation?.identifications?.filter(
+    let numCurrentIdents = observation?.identifications?.filter(
       id => id.current === true
     )?.length || 0;
+    if ( numCurrentIdents === 0 && observation?.taxon ) {
+      numCurrentIdents = 1;
+    }
     const identificationsFilled = observation?.identifications_viewed === false;
 
     return (

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -485,6 +485,7 @@ JOURNAL-POSTS-WITHOUT-NUMBER =
 July = July
 # Month of June
 June = June
+Label-colon-value = { $label }: { $value }
 # Shows date user last active on iNaturalist on user profile
 Last-Active-date = Last Active: { $date }
 # Latitude, longitude on a single line on a single line

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -649,6 +649,7 @@
     "comment": "Month of June",
     "val": "June"
   },
+  "Label-colon-value": "{ $label }: { $value }",
   "Last-Active-date": {
     "comment": "Shows date user last active on iNaturalist on user profile",
     "val": "Last Active: { $date }"

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -485,6 +485,7 @@ JOURNAL-POSTS-WITHOUT-NUMBER =
 July = July
 # Month of June
 June = June
+Label-colon-value = { $label }: { $value }
 # Shows date user last active on iNaturalist on user profile
 Last-Active-date = Last Active: { $date }
 # Latitude, longitude on a single line on a single line

--- a/src/sharedHelpers/uploadObservation.js
+++ b/src/sharedHelpers/uploadObservation.js
@@ -3,6 +3,7 @@ import { activateKeepAwake, deactivateKeepAwake } from "@sayem314/react-native-k
 import {
   createObservation,
   createOrUpdateEvidence,
+  fetchRemoteObservation,
   updateObservation
 } from "api/observations";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
@@ -195,6 +196,7 @@ const uploadObservation = async ( obs: Object, realm: Object ): Object => {
   const uploadParams = {
     observation: { ...newObs },
     fields: { id: true }
+    // fields: "all"
   };
 
   // we're emitting progress increments:
@@ -260,6 +262,9 @@ const uploadObservation = async ( obs: Object, realm: Object ): Object => {
       )
       : null
   ] );
+  // fetch observation and upsert it
+  const remoteObs = await fetchRemoteObservation( obsUUID, { fields: Observation.FIELDS } );
+  Observation.upsertRemoteObservations( [remoteObs], realm, { force: true } );
   deactivateKeepAwake( );
   return response;
 };

--- a/src/sharedHelpers/uploadObservation.js
+++ b/src/sharedHelpers/uploadObservation.js
@@ -196,7 +196,6 @@ const uploadObservation = async ( obs: Object, realm: Object ): Object => {
   const uploadParams = {
     observation: { ...newObs },
     fields: { id: true }
-    // fields: "all"
   };
 
   // we're emitting progress increments:

--- a/src/sharedHooks/useIconicTaxa.js
+++ b/src/sharedHooks/useIconicTaxa.js
@@ -12,12 +12,13 @@ const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ): Obje
   const realm = useRealm( );
   const isConnected = useIsConnected( );
   const [isUpdatingRealm, setIsUpdatingRealm] = useState( );
+  const enabled = !!isConnected && !!reload;
 
   const queryKey = ["searchTaxa", reload];
   const { data: iconicTaxa } = useAuthenticatedQuery(
     queryKey,
     ( ) => searchTaxa( { iconic: true } ),
-    { enabled: !!isConnected && !!reload }
+    { enabled }
   );
 
   useEffect( ( ) => {

--- a/tests/factories/LocalObservationPhoto.js
+++ b/tests/factories/LocalObservationPhoto.js
@@ -1,4 +1,5 @@
 import { define } from "factoria";
+import { toJSON } from "tests/helpers/factoria";
 
 import photoFactory from "./LocalPhoto";
 
@@ -7,7 +8,7 @@ export default define( "LocalObservationPhoto", faker => ( {
   photo: photoFactory( "LocalPhoto" ),
   wasSynced: jest.fn( ( ) => false ),
   needsSync: jest.fn( ( ) => true ),
-  toJSON: jest.fn( ( ) => ( { } ) )
+  toJSON
 } ), {
   uploaded: faker => ( {
     _synced_at: faker.date.past( ),

--- a/tests/factories/LocalObservationSound.js
+++ b/tests/factories/LocalObservationSound.js
@@ -1,4 +1,5 @@
 import { define } from "factoria";
+import { toJSON } from "tests/helpers/factoria";
 
 import soundFactory from "./LocalSound";
 
@@ -6,7 +7,7 @@ export default define( "LocalObservationSound", faker => ( {
   uuid: faker.string.uuid( ),
   sound: soundFactory( "LocalSound" ),
   wasSynced: jest.fn( ( ) => false ),
-  toJSON: jest.fn( ( ) => ( { } ) )
+  toJSON
 } ), {
   uploaded: faker => ( {
     _synced_at: faker.date.past( ),

--- a/tests/helpers/factoria.js
+++ b/tests/helpers/factoria.js
@@ -1,0 +1,15 @@
+// Helpers for making factoria modals
+
+// Trivial toJSON implementation. Note that it is import to use the
+// `function`` keyword here so that `this` refers to the actual factoria
+// object and not the global scope
+// eslint-disable-next-line import/prefer-default-export
+export function toJSON( ) {
+  const json = {};
+  Object.keys( this ).forEach( key => {
+    if ( typeof ( this[key] ) !== "function" ) {
+      json[key] = this[key];
+    }
+  } );
+  return json;
+}

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -129,6 +129,12 @@ describe( "MyObservations", ( ) => {
         const mockObs = mockObservations.find( o => o.uuid === params.observation.uuid );
         return Promise.resolve( makeResponse( [{ id: faker.number.int( ), uuid: mockObs.uuid }] ) );
       } );
+      inatjs.observations.fetch.mockImplementation( ( uuid, _params, _opts ) => {
+        const mockObs = mockObservations.find( o => o.uuid === uuid );
+        // It would be a lot better if this returned something that looks like
+        // a remote obs, but this works
+        return Promise.resolve( makeResponse( [mockObs] ) );
+      } );
       inatjs.observation_photos.create.mockImplementation( async ( params, _opts ) => {
         const mockObsPhotos = flatten( mockObservations.map( o => o.observationPhotos ) );
         const mockObsPhoto = mockObsPhotos.find(


### PR DESCRIPTION
This fetches a remote copy of each observation after upload to make sure the client has the freshest copy of the data immediately.

Closes #1259, but it should also address a number of related bugs, e.g. the quality grade being incorrect immediately after uploading a Casual obs.