### PR TITLE
Clean up Suggestions navigation state after navigating

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -948,7 +948,7 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - react-native-worklets-core (1.3.0):
+  - react-native-worklets-core (1.2.0):
     - React
     - React-callinvoker
     - React-Core
@@ -1147,7 +1147,7 @@ PODS:
     - React-Core
   - RNPermissions (4.1.5):
     - React-Core
-  - RNReanimated (3.11.0):
+  - RNReanimated (3.8.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1167,19 +1167,19 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - VisionCamera (4.0.3):
-    - VisionCamera/Core (= 4.0.3)
-    - VisionCamera/FrameProcessors (= 4.0.3)
-    - VisionCamera/React (= 4.0.3)
-  - VisionCamera/Core (4.0.3)
-  - VisionCamera/FrameProcessors (4.0.3):
+  - VisionCamera (4.0.1):
+    - VisionCamera/Core (= 4.0.1)
+    - VisionCamera/FrameProcessors (= 4.0.1)
+    - VisionCamera/React (= 4.0.1)
+  - VisionCamera/Core (4.0.1)
+  - VisionCamera/FrameProcessors (4.0.1):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.0.3):
+  - VisionCamera/React (4.0.1):
     - React-Core
     - VisionCamera/FrameProcessors
-  - VisionCameraPluginInatVision (4.0.2):
+  - VisionCameraPluginInatVision (4.0.1):
     - React-Core
   - Yoga (1.14.0)
 
@@ -1521,7 +1521,7 @@ SPEC CHECKSUMS:
   react-native-sensitive-info: d44e909d065f9c0e15734245e5dd6a24b82e3dcd
   react-native-slider: 09e5a8b7e766d3b5ae24ec15c5c4ec2679ca0f8c
   react-native-webview: 9395e82c917d81407deb9b1fe53158dd6c8880ff
-  react-native-worklets-core: 7a50c0c14005cc57df8583eabd99ea3f467fa277
+  react-native-worklets-core: a316975bba20b73d47aa4d41bffb0ca984ba592e
   React-nativeconfig: 754233aac2a769578f828093b672b399355582e6
   React-NativeModulesApple: a03b2da2b8e127d5f5ee29c683e0deba7a9e1575
   React-perflogger: 68ec84e2f858a3e35009aef8866b55893e5e0a1f
@@ -1555,17 +1555,17 @@ SPEC CHECKSUMS:
   RNGestureHandler: bc2cdb2dc42facdf34992ae364b8a728e19a3686
   RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
   RNPermissions: b3d6efca086546e29a2920cd649a0ab04ca77794
-  RNReanimated: 6cfa556540186ce7ae7a0b048f369236b1d86ebb
+  RNReanimated: 8a4d86eb951a4a99d8e86266dc71d7735c0c30a9
   RNScreens: b6b64d956af3715adbfe84808694ae82d3fec74f
   RNShareMenu: cb9dac548c8bf147d06f0bf07296ad51ea9f5fc3
   RNStoreReview: 31dbfd0dac2eea9675f0b84f1dd3261c2110c337
   RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
   RNVectorIcons: 73ab573085f65a572d3b6233e68996d4707fd505
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: b633f90960feab2669b7a1c51f8a201dd0a5bfc3
-  VisionCameraPluginInatVision: 2f2aa58b49c50b1b09bb552cab85c605fbb80053
+  VisionCamera: 8e00df84a76cf26ca70ecd3b6ed05dc0d3b60beb
+  VisionCameraPluginInatVision: b52d470949789abc1ad3c434d3fbaf366972f989
   Yoga: c716aea2ee01df6258550c7505fa61b248145ced
 
 PODFILE CHECKSUM: eebd76aa39f99b44754431ed68ce0cfbfc5ec2f7
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -948,7 +948,7 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - react-native-worklets-core (1.2.0):
+  - react-native-worklets-core (1.3.0):
     - React
     - React-callinvoker
     - React-Core
@@ -1147,7 +1147,7 @@ PODS:
     - React-Core
   - RNPermissions (4.1.5):
     - React-Core
-  - RNReanimated (3.8.1):
+  - RNReanimated (3.11.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1167,19 +1167,19 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - VisionCamera (4.0.1):
-    - VisionCamera/Core (= 4.0.1)
-    - VisionCamera/FrameProcessors (= 4.0.1)
-    - VisionCamera/React (= 4.0.1)
-  - VisionCamera/Core (4.0.1)
-  - VisionCamera/FrameProcessors (4.0.1):
+  - VisionCamera (4.0.3):
+    - VisionCamera/Core (= 4.0.3)
+    - VisionCamera/FrameProcessors (= 4.0.3)
+    - VisionCamera/React (= 4.0.3)
+  - VisionCamera/Core (4.0.3)
+  - VisionCamera/FrameProcessors (4.0.3):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.0.1):
+  - VisionCamera/React (4.0.3):
     - React-Core
     - VisionCamera/FrameProcessors
-  - VisionCameraPluginInatVision (4.0.1):
+  - VisionCameraPluginInatVision (4.0.2):
     - React-Core
   - Yoga (1.14.0)
 
@@ -1521,7 +1521,7 @@ SPEC CHECKSUMS:
   react-native-sensitive-info: d44e909d065f9c0e15734245e5dd6a24b82e3dcd
   react-native-slider: 09e5a8b7e766d3b5ae24ec15c5c4ec2679ca0f8c
   react-native-webview: 9395e82c917d81407deb9b1fe53158dd6c8880ff
-  react-native-worklets-core: a316975bba20b73d47aa4d41bffb0ca984ba592e
+  react-native-worklets-core: 7a50c0c14005cc57df8583eabd99ea3f467fa277
   React-nativeconfig: 754233aac2a769578f828093b672b399355582e6
   React-NativeModulesApple: a03b2da2b8e127d5f5ee29c683e0deba7a9e1575
   React-perflogger: 68ec84e2f858a3e35009aef8866b55893e5e0a1f
@@ -1555,15 +1555,15 @@ SPEC CHECKSUMS:
   RNGestureHandler: bc2cdb2dc42facdf34992ae364b8a728e19a3686
   RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
   RNPermissions: b3d6efca086546e29a2920cd649a0ab04ca77794
-  RNReanimated: 8a4d86eb951a4a99d8e86266dc71d7735c0c30a9
+  RNReanimated: 6cfa556540186ce7ae7a0b048f369236b1d86ebb
   RNScreens: b6b64d956af3715adbfe84808694ae82d3fec74f
   RNShareMenu: cb9dac548c8bf147d06f0bf07296ad51ea9f5fc3
   RNStoreReview: 31dbfd0dac2eea9675f0b84f1dd3261c2110c337
   RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
   RNVectorIcons: 73ab573085f65a572d3b6233e68996d4707fd505
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 8e00df84a76cf26ca70ecd3b6ed05dc0d3b60beb
-  VisionCameraPluginInatVision: b52d470949789abc1ad3c434d3fbaf366972f989
+  VisionCamera: b633f90960feab2669b7a1c51f8a201dd0a5bfc3
+  VisionCameraPluginInatVision: 2f2aa58b49c50b1b09bb552cab85c605fbb80053
   Yoga: c716aea2ee01df6258550c7505fa61b248145ced
 
 PODFILE CHECKSUM: eebd76aa39f99b44754431ed68ce0cfbfc5ec2f7

--- a/src/components/AddObsModal.js
+++ b/src/components/AddObsModal.js
@@ -26,11 +26,11 @@ const AddObsModal = ( { closeModal, navAndCloseModal }: Props ): React.Node => {
   const showARCamera = ( Platform.OS === "ios" && majorVersionIOS >= 11 )
     || ( Platform.OS === "android" && Platform.Version > 21 );
 
-  const resetStore = useStore( state => state.resetStore );
+  const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const setObservations = useStore( state => state.setObservations );
 
   const navToObsEdit = async ( ) => {
-    resetStore( );
+    resetObservationFlowSlice( );
     const newObservation = await Observation.new( );
     setObservations( [newObservation] );
     navAndCloseModal( "ObsEdit" );

--- a/src/components/MyObservations/MyObservationsEmpty.js
+++ b/src/components/MyObservations/MyObservationsEmpty.js
@@ -27,10 +27,10 @@ const MyObservationsEmpty = ( { isFetchingNextPage }: Props ): Node => {
   const currentUser = useCurrentUser( );
   const [showModal, setShowModal] = useState( false );
 
-  const resetStore = useStore( state => state.resetStore );
+  const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const navAndCloseModal = ( screen, params ) => {
     if ( screen !== "ObsEdit" ) {
-      resetStore( );
+      resetObservationFlowSlice( );
     }
     navigation.navigate( "NoBottomTabStackNavigator", {
       screen,

--- a/src/components/PhotoSharing.js
+++ b/src/components/PhotoSharing.js
@@ -17,7 +17,7 @@ const PhotoSharing = ( ): Node => {
   const { params } = useRoute( );
   const { item } = params;
   const sharedText = item.extraData?.userInput;
-  const resetStore = useStore( state => state.resetStore );
+  const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const setObservations = useStore( state => state.setObservations );
   const setPhotoImporterState = useStore( state => state.setPhotoImporterState );
   const [navigationHandled, setNavigationHandled] = useState( null );
@@ -49,8 +49,8 @@ const PhotoSharing = ( ): Node => {
     }
 
     // Move to ObsEdit screen (new observation, with shared photos).
-    logger.info( "calling resetStore" );
-    resetStore( );
+    logger.info( "calling resetObservationFlowSlice" );
+    resetObservationFlowSlice( );
 
     // Create a new observation with multiple shared photos (one or more)
     let photoUris;
@@ -94,7 +94,7 @@ const PhotoSharing = ( ): Node => {
     createObservationAndNavToObsEdit,
     item,
     navigation,
-    resetStore,
+    resetObservationFlowSlice,
     setObservations,
     setPhotoImporterState,
     sharedText

--- a/src/components/SharedComponents/Buttons/AddObsButton.js
+++ b/src/components/SharedComponents/Buttons/AddObsButton.js
@@ -15,14 +15,14 @@ const AddObsButton = (): React.Node => {
   const openModal = React.useCallback( () => setModal( true ), [] );
   const closeModal = React.useCallback( () => setModal( false ), [] );
 
-  const resetStore = useStore( state => state.resetStore );
+  const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const isAdvancedUser = useStore( state => state.isAdvancedUser );
   const navigation = useNavigation( );
 
   const navAndCloseModal = ( screen, params ) => {
     const currentRoute = getCurrentRoute();
     if ( screen !== "ObsEdit" ) {
-      resetStore( );
+      resetObservationFlowSlice( );
     }
     // access nested screen
     navigation.navigate( "NoBottomTabStackNavigator", {

--- a/src/components/SharedComponents/TaxonResult.js
+++ b/src/components/SharedComponents/TaxonResult.js
@@ -66,6 +66,9 @@ const TaxonResult = ( {
   const usableTaxon = fromLocal
     ? localTaxon
     : taxonProp;
+  // useTaxon could return null, and it's at least remotely possible taxonProp is null
+  if ( !usableTaxon ) return null;
+
   const taxonImage = { uri: usableTaxon?.default_photo?.url };
   const accessibleName = accessibleTaxonName( usableTaxon, currentUser, t );
 
@@ -110,7 +113,7 @@ const TaxonResult = ( {
                 />
               )
           }
-          {( confidence && confidencePosition === "photo" ) && (
+          {!!( confidence && confidencePosition === "photo" ) && (
             <View className="absolute -bottom-4 w-full items-center">
               <ConfidenceInterval
                 confidence={confidence}
@@ -124,7 +127,7 @@ const TaxonResult = ( {
             taxon={usableTaxon}
             color={clearBackground && "text-white"}
           />
-          {( confidence && confidencePosition === "text" ) && (
+          {!!( confidence && confidencePosition === "text" ) && (
             <View className="mt-1 w-[62px]">
               <ConfidenceInterval
                 confidence={confidence}
@@ -133,7 +136,6 @@ const TaxonResult = ( {
             </View>
           )}
         </View>
-
       </Pressable>
       <View className="flex-row items-center">
         { showInfoButton && (

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -26,7 +26,7 @@ import Suggestion from "./Suggestion";
 import SuggestionsEmpty from "./SuggestionsEmpty";
 
 type Props = {
-  commonAncestor: ?string,
+  commonAncestor: ?Object,
   debugData: Object,
   hasVisionSuggestion: boolean,
   loading: boolean,

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -51,7 +51,11 @@ const SuggestionsContainer = ( ): Node => {
     tryOfflineSuggestions
   } );
 
-  useNavigateWithTaxonSelected( selectedTaxon, { vision: true } );
+  useNavigateWithTaxonSelected(
+    selectedTaxon,
+    ( ) => setSelectedTaxon( null ),
+    { vision: true }
+  );
 
   const onPressPhoto = useCallback(
     uri => {

--- a/src/components/Suggestions/TaxonSearch.js
+++ b/src/components/Suggestions/TaxonSearch.js
@@ -30,7 +30,11 @@ const TaxonSearch = ( ): Node => {
   const taxonList = useTaxonSearch( taxonQuery );
   const { t } = useTranslation( );
 
-  useNavigateWithTaxonSelected( selectedTaxon, { vision: false } );
+  useNavigateWithTaxonSelected(
+    selectedTaxon,
+    ( ) => setSelectedTaxon( null ),
+    { vision: false }
+  );
 
   const renderFooter = useCallback( ( ) => <View className="pb-10" />, [] );
 

--- a/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.js
+++ b/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.js
@@ -4,10 +4,12 @@ import { useNavigation, useRoute } from "@react-navigation/native";
 import { useEffect } from "react";
 import useStore from "stores/useStore";
 
-// TODO rename this, should be something to indicate that it handles
-// navigation
 const useNavigateWithTaxonSelected = (
+  // Navgiation happens when a taxon was selected
   selectedTaxon: ?Object,
+  // After navigation we need to unselect the taxon so we don't have
+  // mysterious background nonsense happening after this screen loses focus
+  unselectTaxon: Function,
   options: Object
 ) => {
   const navigation = useNavigation( );
@@ -33,8 +35,6 @@ const useNavigateWithTaxonSelected = (
     if ( lastScreen === "ObsDetails" ) {
       navigation.navigate( "ObsDetails", {
         uuid: currentObservation?.uuid,
-        // TODO refactor so we're not passing complex objects as params; all
-        // obs details really needs to know is the ID of the taxon
         suggestedTaxonId: selectedTaxon.id,
         comment,
         vision
@@ -42,12 +42,15 @@ const useNavigateWithTaxonSelected = (
     } else {
       navigation.navigate( "ObsEdit" );
     }
+    // If we've navigated, there's no need to run this effect again
+    unselectTaxon( );
   }, [
     comment,
     currentObservation?.uuid,
     lastScreen,
     navigation,
     selectedTaxon,
+    unselectTaxon,
     updateObservationKeys,
     vision
   ] );

--- a/src/stores/createObservationFlowSlice.js
+++ b/src/stores/createObservationFlowSlice.js
@@ -2,6 +2,25 @@
 import { Realm } from "@realm/react";
 import _ from "lodash";
 
+const DEFAULT_STATE = {
+  cameraPreviewUris: [],
+  cameraRollUris: [],
+  comment: "",
+  currentObservation: {},
+  currentObservationIndex: 0,
+  evidenceToAdd: [],
+  galleryUris: [],
+  groupedPhotos: [],
+  observations: [],
+  // Track when any obs was last marked as viewed so we know when to update
+  // the notifications indicator
+  observationMarkedAsViewedAt: null,
+  originalCameraUrisMap: {},
+  photoEvidenceUris: [],
+  savingPhoto: false,
+  unsavedChanges: false
+};
+
 const removeObsPhotoFromObservation = ( currentObservation, uri ) => {
   if ( _.isEmpty( currentObservation ) ) { return []; }
   const updatedObservation = currentObservation;
@@ -54,22 +73,7 @@ const updateObservationKeysWithState = ( keysAndValues, state ) => {
 };
 
 const createObservationFlowSlice = set => ( {
-  cameraPreviewUris: [],
-  cameraRollUris: [],
-  comment: "",
-  currentObservation: {},
-  currentObservationIndex: 0,
-  evidenceToAdd: [],
-  galleryUris: [],
-  groupedPhotos: [],
-  observations: [],
-  // Track when any obs was last marked as viewed so we know when to update
-  // the notifications indicator
-  observationMarkedAsViewedAt: null,
-  originalCameraUrisMap: {},
-  photoEvidenceUris: [],
-  savingPhoto: false,
-  unsavedChanges: false,
+  ...DEFAULT_STATE,
   deletePhotoFromObservation: uri => set( state => ( {
     photoEvidenceUris: [..._.pull( state.photoEvidenceUris, uri )],
     cameraPreviewUris: [..._.pull( state.cameraPreviewUris, uri )],
@@ -92,21 +96,7 @@ const createObservationFlowSlice = set => ( {
       currentObservation: newObservation
     };
   } ),
-  resetStore: ( ) => set( {
-    cameraPreviewUris: [],
-    cameraRollUris: [],
-    comment: "",
-    currentObservation: {},
-    currentObservationIndex: 0,
-    evidenceToAdd: [],
-    galleryUris: [],
-    groupedPhotos: [],
-    observations: [],
-    originalCameraUrisMap: {},
-    photoEvidenceUris: [],
-    savingPhoto: false,
-    unsavedChanges: false
-  } ),
+  resetObservationFlowSlice: ( ) => set( DEFAULT_STATE ),
   addCameraRollUri: uri => set( state => {
     const savedUris = state.cameraRollUris;
     savedUris.push( uri );

--- a/src/stores/useStore.js
+++ b/src/stores/useStore.js
@@ -20,11 +20,45 @@ const zustandStorage: StateStorage = {
 // Using slices to separate store for Explore and Observation creation flow
 // https://docs.pmnd.rs/zustand/guides/slices-pattern
 const useStore = create( persist(
-  ( ...a ) => ( {
-    ...createExploreSlice( ...a ),
-    ...createObservationFlowSlice( ...a ),
-    ...createLayoutSlice( ...a )
-  } ),
+  ( ...args ) => {
+    // Let's make our slices
+    const slices = [
+      createExploreSlice( ...args ),
+      createObservationFlowSlice( ...args ),
+      createLayoutSlice( ...args )
+    ];
+
+    // Now let's make sure they're not clobbering each other because
+    // everything in Zustand state exists in a single namespace and
+    // clobbering can happen silently... which is bad.
+    const allKeys = slices.map( slice => Object.keys( slice ) ).flat( );
+    const keyCounts = allKeys.reduce(
+      ( memo, curr ) => {
+        memo[curr] ||= 0;
+        memo[curr] += 1;
+        return memo;
+      },
+      {}
+    );
+    const nonUniqueKeys = Object.keys( keyCounts ).reduce(
+      ( memo, curr ) => {
+        if ( keyCounts[curr] > 1 ) memo.push( curr );
+        return memo;
+      },
+      []
+    );
+    if ( nonUniqueKeys.length > 0 ) {
+      throw new Error(
+        `You have multiple Zustand slices with the following keys: ${nonUniqueKeys}`
+      );
+    }
+
+    // All good? Now let's combine them into one enormous hideous object
+    return slices.reduce(
+      ( memo, curr ) => ( { ...memo, ...curr } ),
+      {}
+    );
+  },
   {
     name: "persisted-zustand",
     partialize: state => ( {


### PR DESCRIPTION
The specific crash repro'd in #1477 was due to TaxonResult getting rendered in Suggestions while that screen was in the background and lost its taxon, so a null check addressed that. Then there was a crash related to `( confidence && confidencePosition === "photo" )` resolving to a number or string literal sometimes, I think when `confidence` was 0, which evaluates as false-y. My workaround works, but we should take some care when using this pattern in React, where just adding a `0` without wrapping it in a `<Text>` component is going to cause problems.

There was still a problem with stale state, which again had to do with Suggestions being mounted in the background and a navigation-related hook it uses getting triggered when `currentObservation` changed in the Zustand state. I made it so this `useState` variable gets cleared after navigating.

FWIW, I think all the buttons in the AddObsModal reset the Zustand state when pressed, which is probably the right approach since we *always* want to clear state in those cases, whereas there are number of situations where the user navigates away from ObsEdit and we want to hold on to state, e.g. navigating to Suggestions. It's just that Zustand isn't the only way we manage state in this app. This PR address the specific problem raised in the issue but it isn't a general solution to resetting *all* relevant state when starting a new observation creation flow. For that... I think we'd need to consolidate all our ephemeral state management in this flow into Zustand, which may not be a good idea and seems out of scope here.

Closes #1477