### PR TITLE
Remove temporary gallery photos

### DIFF
--- a/src/appConstants/paths.ts
+++ b/src/appConstants/paths.ts
@@ -2,6 +2,8 @@ import RNFS from "react-native-fs";
 
 export const computerVisionPath = `${RNFS.DocumentDirectoryPath}/computerVisionSuggestions`;
 
+export const galleryPhotosPath = `${RNFS.DocumentDirectoryPath}/galleryPhotos`;
+
 export const photoUploadPath = `${RNFS.DocumentDirectoryPath}/photoUploads`;
 
 export const rotatedOriginalPhotosPath = `${RNFS.DocumentDirectoryPath}/rotatedOriginalPhotos`;

--- a/src/components/Developer/hooks/useAppSize.ts
+++ b/src/components/Developer/hooks/useAppSize.ts
@@ -1,5 +1,6 @@
 import {
   computerVisionPath,
+  galleryPhotosPath,
   photoUploadPath,
   rotatedOriginalPhotosPath
 } from "appConstants/paths.ts";
@@ -42,6 +43,10 @@ const sharedDirectories = [
   {
     path: computerVisionPath,
     directoryName: "ComputerVisionSuggestions"
+  },
+  {
+    path: galleryPhotosPath,
+    directoryName: "GalleryPhotosPath"
   },
   {
     path: photoUploadPath,

--- a/src/components/Developer/hooks/useAppSize.ts
+++ b/src/components/Developer/hooks/useAppSize.ts
@@ -46,7 +46,7 @@ const sharedDirectories = [
   },
   {
     path: galleryPhotosPath,
-    directoryName: "GalleryPhotosPath"
+    directoryName: "GalleryPhotos"
   },
   {
     path: photoUploadPath,

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -34,6 +34,7 @@ import {
   useTranslation
 } from "sharedHooks";
 
+import useClearGalleryPhotos from "./hooks/useClearGalleryPhotos";
 import useClearRotatedOriginalPhotos from "./hooks/useClearRotatedOriginalPhotos";
 import useDeleteObservations from "./hooks/useDeleteObservations";
 import MyObservations from "./MyObservations";
@@ -137,6 +138,7 @@ const { useRealm } = RealmContext;
 const MyObservationsContainer = ( ): Node => {
   // clear original, large-sized photos before a user returns to any of the Camera or AICamera flows
   useClearRotatedOriginalPhotos( );
+  useClearGalleryPhotos( );
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const realm = useRealm( );

--- a/src/components/MyObservations/hooks/useClearGalleryPhotos.ts
+++ b/src/components/MyObservations/hooks/useClearGalleryPhotos.ts
@@ -1,0 +1,16 @@
+import { galleryPhotosPath } from "appConstants/paths.ts";
+import { useEffect } from "react";
+import removeAllFilesFromDirectory from "sharedHelpers/removeAllFilesFromDirectory.ts";
+
+const useClearGalleryPhotos = ( ) => {
+  useEffect( ( ) => {
+    const clearGalleryPhotos = async ( ) => {
+      await removeAllFilesFromDirectory( galleryPhotosPath );
+    };
+
+    clearGalleryPhotos( );
+  }, [] );
+  return null;
+};
+
+export default useClearGalleryPhotos;


### PR DESCRIPTION
Create a gallery photos directory; move gallery photos out of temporary directory and into this folder; clear photos when user leaves ObsEdit flow