### PR TITLE
Stick the MyObs toolbar until user scrolls to the very top

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1570,7 +1570,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   VisionCamera: b633f90960feab2669b7a1c51f8a201dd0a5bfc3
   VisionCameraPluginInatVision: 2f2aa58b49c50b1b09bb552cab85c605fbb80053
-  Yoga: 47d399a73c0c0caa9ff824e5c657eae31215bfee
+  Yoga: c716aea2ee01df6258550c7505fa61b248145ced
 
 PODFILE CHECKSUM: eebd76aa39f99b44754431ed68ce0cfbfc5ec2f7
 

--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -66,11 +66,11 @@ const MyObservations = ( {
             logInButtonNeutral={observations.length === 0}
           />
         )}
-        renderScrollable={onSroll => (
+        renderScrollable={onScroll => (
           <ObservationsFlashList
             dataCanBeFetched={!!currentUser}
             data={observations.filter( o => o.isValid() )}
-            handleScroll={onSroll}
+            handleScroll={onScroll}
             hideLoadingWheel={!isFetchingNextPage || !currentUser}
             isFetchingNextPage={isFetchingNextPage}
             isOnline={isOnline}


### PR DESCRIPTION
This also has the welcome effect of not showing jitter while the user is uploading and the hidable part of the header is partially visible (#1426).