### PR TITLE
Track number of failed uploads

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,7 @@ module.exports = {
     "prefer-destructuring": [2, { object: true, array: false }],
     quotes: [2, "double"],
     "space-in-parens": [2, "always"],
+    "max-classes-per-file": 0,
     "module-resolver/use-alias": 2,
     "multiline-ternary": ["error", "always"],
     // At least before we start making production builds

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1105,6 +1105,11 @@ X-Species =
         [one] { $count } Species
        *[other] { $count } Species
     }
+x-uploads-failed =
+    { $count ->
+        [one] { $count } upload failed
+       *[other] { $count } uploads failed
+    }
 Yes-license-my-photos = Yes, license my photos, sounds, and observations so scientists can use my data (recommended)
 You-are-offline-Tap-to-try-again = You are offline. Tap to try again.
 You-can-add-up-to-20-media = You can add up to 20 photos and 20 sounds per observation.

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1394,6 +1394,7 @@
     "val": "{ $count ->\n  [one] 1 SOUND\n *[other] { $count } SOUNDS\n}"
   },
   "X-Species": "{ $count ->\n  [one] { $count } Species\n *[other] { $count } Species\n}",
+  "x-uploads-failed": "{ $count ->\n  [one] { $count } upload failed\n *[other] { $count } uploads failed\n}",
   "Yes-license-my-photos": "Yes, license my photos, sounds, and observations so scientists can use my data (recommended)",
   "You-are-offline-Tap-to-try-again": "You are offline. Tap to try again.",
   "You-can-add-up-to-20-media": "You can add up to 20 photos and 20 sounds per observation.",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1105,6 +1105,11 @@ X-Species =
         [one] { $count } Species
        *[other] { $count } Species
     }
+x-uploads-failed =
+    { $count ->
+        [one] { $count } upload failed
+       *[other] { $count } uploads failed
+    }
 Yes-license-my-photos = Yes, license my photos, sounds, and observations so scientists can use my data (recommended)
 You-are-offline-Tap-to-try-again = You are offline. Tap to try again.
 You-can-add-up-to-20-media = You can add up to 20 photos and 20 sounds per observation.

--- a/tests/unit/components/MyObservations/MyObservations.test.js
+++ b/tests/unit/components/MyObservations/MyObservations.test.js
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react-native";
 import MyObservations from "components/MyObservations/MyObservations";
+import { INITIAL_STATE } from "components/MyObservations/MyObservationsContainer";
 import React from "react";
 import DeviceInfo from "react-native-device-info";
 import useDeviceOrientation from "sharedHooks/useDeviceOrientation";
@@ -71,12 +72,7 @@ describe( "MyObservations", () => {
         toggleLayout={jest.fn( )}
         uploadStatus={{}}
         setShowLoginSheet={jest.fn( )}
-        uploadState={{
-          uploads: [],
-          error: null,
-          numToUpload: 0,
-          uploadInProgress: false
-        }}
+        uploadState={INITIAL_STATE}
       />
     );
     const obs = mockObservations[0];
@@ -98,12 +94,7 @@ describe( "MyObservations", () => {
         toggleLayout={jest.fn( )}
         uploadStatus={{}}
         setShowLoginSheet={jest.fn( )}
-        uploadState={{
-          uploads: [],
-          error: null,
-          numToUpload: 0,
-          uploadInProgress: false
-        }}
+        uploadState={INITIAL_STATE}
       />
     );
     // Awaiting the first observation because using await in the forEach errors out
@@ -128,12 +119,7 @@ describe( "MyObservations", () => {
         toggleLayout={jest.fn( )}
         uploadStatus={{}}
         setShowLoginSheet={jest.fn( )}
-        uploadState={{
-          uploads: [],
-          error: null,
-          numToUpload: 0,
-          uploadInProgress: false
-        }}
+        uploadState={INITIAL_STATE}
       />
     );
     mockObservations.forEach( obs => {
@@ -150,12 +136,7 @@ describe( "MyObservations", () => {
         toggleLayout={jest.fn( )}
         uploadStatus={{}}
         setShowLoginSheet={jest.fn( )}
-        uploadState={{
-          uploads: [],
-          error: null,
-          numToUpload: 0,
-          uploadInProgress: false
-        }}
+        uploadState={INITIAL_STATE}
       />
     );
     describe( "portrait orientation", ( ) => {

--- a/tests/unit/components/MyObservations/ToolbarContainer.test.js
+++ b/tests/unit/components/MyObservations/ToolbarContainer.test.js
@@ -1,5 +1,8 @@
 import { screen } from "@testing-library/react-native";
 import * as useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations";
+import {
+  INITIAL_STATE as MYOBS_INITIAL_STATE
+} from "components/MyObservations/MyObservationsContainer";
 import ToolbarContainer from "components/MyObservations/ToolbarContainer";
 import i18next from "i18next";
 import React from "react";
@@ -25,13 +28,10 @@ const deletionState = {
 };
 
 const uploadState = {
+  ...MYOBS_INITIAL_STATE,
   uploads: [{}],
   numUnuploadedObs: 1,
-  numToUpload: 1,
-  numFinishedUploads: 0,
-  uploadInProgress: false,
-  uploadsComplete: false,
-  error: null
+  numToUpload: 1
 };
 
 describe( "Toolbar", () => {
@@ -69,7 +69,8 @@ describe( "Toolbar", () => {
       uploadState={{
         ...uploadState,
         uploadsComplete: true,
-        numFinishedUploads
+        numFinishedUploads,
+        uploaded: [...Array( numFinishedUploads ).keys( )].map( i => `fake-uuid-${i}` )
       }}
     /> );
 
@@ -80,15 +81,15 @@ describe( "Toolbar", () => {
   } );
 
   it( "displays an upload error", async () => {
-    const error = "Couldn't complete upload";
+    const multiError = "Couldn't complete upload";
     renderComponent( <ToolbarContainer
       uploadState={{
         ...uploadState,
-        error
+        multiError
       }}
       numUnuploadedObs={1}
     /> );
-    expect( screen.getByText( error ) ).toBeVisible( );
+    expect( screen.getByText( multiError ) ).toBeVisible( );
   } );
 
   it( "displays multiple pending uploads", async () => {
@@ -130,7 +131,8 @@ describe( "Toolbar", () => {
         ...uploadState,
         uploads: [{}, {}, {}, {}, {}, {}, {}],
         uploadsComplete: true,
-        numToUpload: 7
+        numToUpload: 7,
+        uploaded: ["1", "2", "3", "4", "5", "6", "7"]
       }}
     /> );
 


### PR DESCRIPTION
This is a pretty narrow solution to the problem that adds a few more things to state, including an object that stores all the errors associated with each observation, and an array that holds all the *successfully* uploaded observation UUIDs, b/c before we were only tracking how many observations were finished, i.e. observations that we tried to upload.

Closes #1544