### PR TITLE
Fetch remotely deleted observations automatically

### DIFF
--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -41,6 +41,7 @@ import MyObservations from "./MyObservations";
 const logger = log.extend( "MyObservationsContainer" );
 
 export const INITIAL_STATE = {
+  canBeginDeletions: true,
   error: null,
   singleUpload: true,
   totalProgressIncrements: 0,
@@ -127,6 +128,11 @@ const uploadReducer = ( state: Object, action: Function ): Object => {
         ...state,
         syncInProgress: true
       };
+    case "SET_START_DELETIONS":
+      return {
+        ...state,
+        canBeginDeletions: false
+      };
     default:
       return state;
   }
@@ -148,7 +154,7 @@ const MyObservationsContainer = ( ): Node => {
   const [state, dispatch] = useReducer( uploadReducer, INITIAL_STATE );
   const { observationList: observations } = useLocalObservations( );
   const { layout, writeLayoutToStorage } = useStoredLayout( "myObservationsLayout" );
-  const { deletionsCompletedAt } = useDeleteObservations( );
+  const { deletionsCompletedAt } = useDeleteObservations( state.canBeginDeletions, dispatch );
   const numUnuploadedObservations = useNumUnuploadedObservations( );
 
   const isOnline = useIsConnected( );

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -30,6 +30,7 @@ import {
   useStoredLayout,
   useTranslation
 } from "sharedHooks";
+import useStore from "stores/useStore";
 
 import useClearGalleryPhotos from "./hooks/useClearGalleryPhotos";
 import useClearRotatedOriginalPhotos from "./hooks/useClearRotatedOriginalPhotos";
@@ -183,8 +184,9 @@ const MyObservationsContainer = ( ): Node => {
   const [state, dispatch] = useReducer( uploadReducer, INITIAL_STATE );
   const { observationList: observations } = useLocalObservations( );
   const { layout, writeLayoutToStorage } = useStoredLayout( "myObservationsLayout" );
-  const { deletionsCompletedAt } = useDeleteObservations( state.canBeginDeletions, dispatch );
+  useDeleteObservations( state.canBeginDeletions, dispatch );
   const numUnuploadedObservations = useNumUnuploadedObservations( );
+  const deletionsCompletedAt = useStore( s => s.deletionsCompletedAt );
 
   const isOnline = useIsConnected( );
 

--- a/src/components/MyObservations/ToolbarContainer.js
+++ b/src/components/MyObservations/ToolbarContainer.js
@@ -42,11 +42,12 @@ const ToolbarContainer = ( {
 
   const {
     currentDeleteCount,
+    deletions,
     deletionsInProgress,
     deletionsComplete,
-    error: deleteError,
-    totalDeletions
+    error: deleteError
   } = deletionState;
+  const totalDeletions = deletions.length;
   const deletionsProgress = totalDeletions > 0
     ? currentDeleteCount / totalDeletions
     : 0;

--- a/src/components/MyObservations/ToolbarContainer.js
+++ b/src/components/MyObservations/ToolbarContainer.js
@@ -42,12 +42,11 @@ const ToolbarContainer = ( {
 
   const {
     currentDeleteCount,
-    deletions,
     deletionsInProgress,
     deletionsComplete,
-    error: deleteError
+    error: deleteError,
+    totalDeletions
   } = deletionState;
-  const totalDeletions = deletions.length;
   const deletionsProgress = totalDeletions > 0
     ? currentDeleteCount / totalDeletions
     : 0;

--- a/src/components/MyObservations/ToolbarContainer.js
+++ b/src/components/MyObservations/ToolbarContainer.js
@@ -9,8 +9,8 @@ import {
   useCurrentUser,
   useTranslation
 } from "sharedHooks";
+import useStore from "stores/useStore";
 
-import useDeleteObservations from "./hooks/useDeleteObservations";
 import Toolbar from "./Toolbar";
 
 const screenWidth = Dimensions.get( "window" ).width * PixelRatio.get( );
@@ -36,17 +36,14 @@ const ToolbarContainer = ( {
   uploadMultipleObservations,
   uploadState
 }: Props ): Node => {
-  const deletionState = useDeleteObservations( );
   const currentUser = useCurrentUser( );
   const navigation = useNavigation( );
+  const deletions = useStore( state => state.deletions );
+  const deletionsComplete = useStore( state => state.deletionsComplete );
+  const currentDeleteCount = useStore( state => state.currentDeleteCount );
+  const deleteError = useStore( state => state.error );
+  const deletionsInProgress = useStore( state => state.deletionsInProgress );
 
-  const {
-    currentDeleteCount,
-    deletions,
-    deletionsInProgress,
-    deletionsComplete,
-    error: deleteError
-  } = deletionState;
   const totalDeletions = deletions.length;
   const deletionsProgress = totalDeletions > 0
     ? currentDeleteCount / totalDeletions

--- a/src/components/MyObservations/helpers/filterLocalObservationsToDelete.ts
+++ b/src/components/MyObservations/helpers/filterLocalObservationsToDelete.ts
@@ -1,0 +1,9 @@
+export default filterLocalObservationsToDelete = realm => {
+  const deletions = [];
+  // currently sorting so oldest observations to delete are first
+  const observationsFlaggedForDeletion = realm
+    .objects( "Observation" ).filtered( "_deleted_at != nil" ).sorted( "_deleted_at", false );
+
+  deletions.concat( observationsFlaggedForDeletion.map( obs => obs.toJSON( ) ) );
+  return deletions;
+};

--- a/src/components/MyObservations/helpers/filterLocalObservationsToDelete.ts
+++ b/src/components/MyObservations/helpers/filterLocalObservationsToDelete.ts
@@ -1,9 +1,7 @@
 export default filterLocalObservationsToDelete = realm => {
-  const deletions = [];
   // currently sorting so oldest observations to delete are first
   const observationsFlaggedForDeletion = realm
     .objects( "Observation" ).filtered( "_deleted_at != nil" ).sorted( "_deleted_at", false );
 
-  deletions.concat( observationsFlaggedForDeletion.map( obs => obs.toJSON( ) ) );
-  return deletions;
+  return observationsFlaggedForDeletion.map( obs => obs.toJSON( ) );
 };

--- a/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
@@ -1,0 +1,56 @@
+import {
+  checkForDeletedObservations
+} from "api/observations";
+import { getJWT } from "components/LoginSignUp/AuthenticationService";
+import { format } from "date-fns";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+
+const setParamsWithLastSyncTime = realm => {
+  const lastSyncTime = realm.objects( "LocalPreferences" )?.[0]?.last_deleted_sync_time;
+  const deletedParams = { since: format( new Date( ), "yyyy-MM-dd" ) };
+  if ( lastSyncTime ) {
+    try {
+      deletedParams.since = format( lastSyncTime, "yyyy-MM-dd" );
+    } catch ( lastSyncTimeFormatError ) {
+      if ( lastSyncTimeFormatError instanceof RangeError ) {
+        // If we can't parse that date, assume we've never synced and use the default
+      } else {
+        throw lastSyncTimeFormatError;
+      }
+    }
+  }
+  return deletedParams;
+};
+
+const deleteRemotelyDeletedObservations = ( deletedObservations, realm ) => {
+  if ( !deletedObservations ) { return; }
+  if ( deletedObservations?.length > 0 ) {
+    safeRealmWrite( realm, ( ) => {
+      const localObservationsToDelete = realm.objects( "Observation" )
+        .filtered( `id IN { ${deletedObservations} }` );
+      localObservationsToDelete.forEach( observation => {
+        realm.delete( observation );
+      } );
+    }, "removing remotely deleted observations from realm" );
+  }
+};
+
+const updateDeletedSyncTime = realm => {
+  const localPrefs = realm.objects( "LocalPreferences" )[0];
+  const updatedPrefs = {
+    ...localPrefs,
+    last_deleted_sync_time: new Date( )
+  };
+  safeRealmWrite( realm, ( ) => {
+    realm.create( "LocalPreferences", updatedPrefs, "modified" );
+  }, "updating last deleted sync time" );
+};
+
+export default syncRemoteDeletedObservations = async realm => {
+  const apiToken = await getJWT( );
+  const deletedParams = setParamsWithLastSyncTime( realm );
+  const response = await checkForDeletedObservations( deletedParams, { api_token: apiToken } );
+  updateDeletedSyncTime( realm );
+  const deletedObservations = response?.results;
+  deleteRemotelyDeletedObservations( deletedObservations, realm );
+};

--- a/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
@@ -43,7 +43,7 @@ const updateDeletedSyncTime = realm => {
   };
   safeRealmWrite( realm, ( ) => {
     realm.create( "LocalPreferences", updatedPrefs, "modified" );
-  }, "updating last deleted sync time" );
+  }, "updating last remotely deleted sync time" );
 };
 
 export default syncRemoteDeletedObservations = async realm => {

--- a/src/components/MyObservations/hooks/useDeleteObservations.ts
+++ b/src/components/MyObservations/hooks/useDeleteObservations.ts
@@ -55,7 +55,7 @@ const deletionReducer = ( state: Object, action: Function ): Object => {
   }
 };
 
-const useDeleteObservations = ( ): Object => {
+const useDeleteObservations = ( canBeginDeletions, myObservationsDispatch ): Object => {
   const realm = useRealm( );
   const [state, dispatch] = useReducer( deletionReducer, INITIAL_DELETION_STATE );
   const navigation = useNavigation( );
@@ -151,8 +151,16 @@ const useDeleteObservations = ( ): Object => {
         } );
       }
     };
-    beginDeletions( );
-  }, [deletions, realm] );
+    if ( canBeginDeletions ) {
+      myObservationsDispatch( { type: "SET_START_DELETIONS" } );
+      beginDeletions( );
+    }
+  }, [
+    canBeginDeletions,
+    deletions,
+    myObservationsDispatch,
+    realm
+  ] );
 
   useEffect( ( ) => {
     if ( canStartDeletingLocalObservations ) {

--- a/src/components/ObsDetails/ActivityTab/ActivityHeaderContainer.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityHeaderContainer.js
@@ -1,13 +1,11 @@
 // @flow
 
-import { useQueryClient } from "@tanstack/react-query";
 import { deleteComments, updateComment } from "api/comments";
 import { updateIdentification as apiUpdateIdentification } from "api/identifications";
 import { isCurrentUser } from "components/LoginSignUp/AuthenticationService";
 import type { Node } from "react";
 import React, { useEffect, useState } from "react";
 import useAuthenticatedMutation from "sharedHooks/useAuthenticatedMutation";
-import { fetchRemoteObservationKey } from "sharedHooks/useRemoteObservation";
 
 import ActivityHeader from "./ActivityHeader";
 
@@ -29,7 +27,6 @@ const ActivityHeaderContainer = ( {
   const [currentUser, setCurrentUser] = useState( false );
   const [flagged, setFlagged] = useState( false );
   const [loading, setLoading] = useState( false );
-  const queryClient = useQueryClient( );
   const { user } = item;
 
   const numFlags = item.flags?.length || 0;
@@ -51,7 +48,6 @@ const ActivityHeaderContainer = ( {
     {
       onSuccess: ( ) => {
         setLoading( false );
-        queryClient.invalidateQueries( { queryKey: [fetchRemoteObservationKey, item.uuid] } );
         if ( refetchRemoteObservation ) {
           refetchRemoteObservation( );
         }
@@ -72,7 +68,6 @@ const ActivityHeaderContainer = ( {
     {
       onSuccess: () => {
         setLoading( false );
-        queryClient.invalidateQueries( { queryKey: [fetchRemoteObservationKey, item.uuid] } );
         if ( refetchRemoteObservation ) {
           refetchRemoteObservation( );
         }
@@ -99,7 +94,6 @@ const ActivityHeaderContainer = ( {
     {
       onSuccess: () => {
         setLoading( false );
-        queryClient.invalidateQueries( { queryKey: [fetchRemoteObservationKey, item.uuid] } );
         if ( refetchRemoteObservation ) {
           refetchRemoteObservation( );
         }

--- a/src/components/ObsDetails/DQAContainer.js
+++ b/src/components/ObsDetails/DQAContainer.js
@@ -4,7 +4,6 @@ import {
   useNetInfo
 } from "@react-native-community/netinfo";
 import { useRoute } from "@react-navigation/native";
-import { useQueryClient } from "@tanstack/react-query";
 import { faveObservation, unfaveObservation } from "api/observations";
 import { deleteQualityMetric, fetchQualityMetrics, setQualityMetric } from "api/qualityMetrics";
 import DataQualityAssessment from "components/ObsDetails/DataQualityAssessment";
@@ -23,12 +22,9 @@ import {
   useAuthenticatedMutation,
   useLocalObservation
 } from "sharedHooks";
-import useRemoteObservation, {
-  fetchRemoteObservationKey
-} from "sharedHooks/useRemoteObservation";
+import useRemoteObservation from "sharedHooks/useRemoteObservation";
 
 const DQAContainer = ( ): React.Node => {
-  const queryClient = useQueryClient( );
   const { isInternetReachable: isOnline } = useNetInfo( );
   const { params } = useRoute( );
   const { observationUUID } = params;
@@ -120,12 +116,6 @@ const DQAContainer = ( ): React.Node => {
     ( faveParams, optsWithAuth ) => faveObservation( faveParams, optsWithAuth ),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries( {
-          queryKey: [
-            fetchRemoteObservationKey,
-            observationUUID
-          ]
-        } );
         refetchRemoteObservation();
       },
       onError: () => {
@@ -138,12 +128,6 @@ const DQAContainer = ( ): React.Node => {
     ( faveParams, optsWithAuth ) => unfaveObservation( faveParams, optsWithAuth ),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries( {
-          queryKey: [
-            fetchRemoteObservationKey,
-            observationUUID
-          ]
-        } );
         refetchRemoteObservation();
       },
       onError: () => {

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -175,12 +175,16 @@ const ObsDetailsContainer = ( ): Node => {
     || ( !observation?.user && !observation?.id )
   );
 
+  const invalidateRemoteObservation = useCallback( ( ) => {
+    queryClient.invalidateQueries( { queryKey: [fetchRemoteObservationKey, observation.uuid] } );
+  }, [queryClient, observation.uuid] );
+
   useFocusEffect(
     // this ensures activity items load after a user taps suggest id
     // and adds a remote id on the Suggestions screen
     useCallback( ( ) => {
-      queryClient.invalidateQueries( { queryKey: fetchRemoteObservationKey } );
-    }, [queryClient] )
+      invalidateRemoteObservation( );
+    }, [invalidateRemoteObservation] )
   );
 
   useEffect( ( ) => {
@@ -341,8 +345,8 @@ const ObsDetailsContainer = ( ): Node => {
 
   const showActivityTab = currentTabId === ACTIVITY_TAB_ID;
 
-  const refetchObservation = ( ) => {
-    queryClient.invalidateQueries( { queryKey: [fetchRemoteObservationKey] } );
+  const invalidateQueryAndRefetch = ( ) => {
+    invalidateRemoteObservation( );
     refetchRemoteObservation( );
     refetchObservationUpdates( );
   };
@@ -387,7 +391,7 @@ const ObsDetailsContainer = ( ): Node => {
       onCommentAdded={onCommentAdded}
       onIDAgreePressed={onIDAgreePressed}
       openCommentBox={openCommentBox}
-      refetchRemoteObservation={refetchObservation}
+      refetchRemoteObservation={invalidateQueryAndRefetch}
       remoteObsWasDeleted={remoteObsWasDeleted}
       showActivityTab={showActivityTab}
       showAgreeWithIdSheet={showAgreeWithIdSheet}

--- a/src/realmModels/LocalPreferences.js
+++ b/src/realmModels/LocalPreferences.js
@@ -4,6 +4,7 @@ class LocalPreferences extends Realm.Object {
   static schema = {
     name: "LocalPreferences",
     properties: {
+      last_deleted_sync_time: "date?",
       last_sync_time: "date?",
       explore_location_permission_shown: { type: "bool", default: false }
     }

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -1,7 +1,7 @@
 import { Realm } from "@realm/react";
 import uuid from "react-native-uuid";
 import { createObservedOnStringForUpload } from "sharedHelpers/dateAndTime";
-import { log } from "sharedHelpers/logger";
+// import { log } from "sharedHelpers/logger";
 import { readExifFromMultiplePhotos } from "sharedHelpers/parseExif";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 
@@ -15,7 +15,7 @@ import Taxon from "./Taxon";
 import User from "./User";
 import Vote from "./Vote";
 
-const logger = log.extend( "Observation" );
+// const logger = log.extend( "Observation" );
 
 // noting that methods like .toJSON( ) are only accessible when the model
 // class is extended with Realm.Object per this issue:
@@ -132,16 +132,16 @@ class Observation extends Realm.Object {
     const obsToUpsert = options.force
       ? remoteObservations
       : remoteObservations.filter( obs => !Observation.isUnsyncedObservation( realm, obs ) );
-    const msg = obsToUpsert.map( remoteObservation => {
-      const obsPhotoUUIDs = remoteObservation.observation_photos?.map( op => op.uuid );
-      return `obs ${remoteObservation.uuid}, ops: ${obsPhotoUUIDs}`;
-    } );
+    // const msg = obsToUpsert.map( remoteObservation => {
+    //   const obsPhotoUUIDs = remoteObservation.observation_photos?.map( op => op.uuid );
+    //   return `obs ${remoteObservation.uuid}, ops: ${obsPhotoUUIDs}`;
+    // } );
     // Trying to debug disappearing photos
-    logger.info( "upsertRemoteObservations, upserting: ", msg );
+    // logger.info( "upsertRemoteObservations, upserting: ", msg );
     safeRealmWrite( realm, ( ) => {
       obsToUpsert.forEach( remoteObservation => {
         const obsMappedForRealm = Observation.mapApiToRealm( remoteObservation, realm );
-        logger.info( "upsertRemoteObservations, obsMappedForRealm: ", obsMappedForRealm );
+        // logger.info( "upsertRemoteObservations, obsMappedForRealm: ", obsMappedForRealm );
         realm.create(
           "Observation",
           obsMappedForRealm,

--- a/src/realmModels/index.js
+++ b/src/realmModels/index.js
@@ -30,7 +30,7 @@ export default {
     User,
     Vote
   ],
-  schemaVersion: 49,
+  schemaVersion: 50,
   path: `${RNFS.DocumentDirectoryPath}/db.realm`,
   // https://github.com/realm/realm-js/pull/6076 embedded constraints
   migrationOptions: {

--- a/src/sharedHooks/useRemoteObservation.js
+++ b/src/sharedHooks/useRemoteObservation.js
@@ -37,6 +37,8 @@ const useRemoteObservation = ( uuid: string, enabled: boolean ): Object => {
     }
   );
 
+  console.log( remoteObservation, "remote observation" );
+
   const needsLocalUpdate = remoteObservation
     && currentUser
     && remoteObservation?.user?.id === currentUser.id;

--- a/src/sharedHooks/useRemoteObservation.js
+++ b/src/sharedHooks/useRemoteObservation.js
@@ -37,8 +37,6 @@ const useRemoteObservation = ( uuid: string, enabled: boolean ): Object => {
     }
   );
 
-  console.log( remoteObservation, "remote observation" );
-
   const needsLocalUpdate = remoteObservation
     && currentUser
     && remoteObservation?.user?.id === currentUser.id;

--- a/src/stores/createDeleteObservationsSlice.ts
+++ b/src/stores/createDeleteObservationsSlice.ts
@@ -1,0 +1,37 @@
+const DEFAULT_STATE = {
+  currentDeleteCount: 1,
+  deletions: [],
+  deletionsComplete: false,
+  deletionsCompletedAt: null,
+  deletionsInProgress: false,
+  error: null
+};
+
+interface DeleteObservationsSlice {
+  currentDeleteCount: number,
+  deletions: Array<Object>,
+  deletionsComplete: boolean,
+  deletionsCompletedAt: Date,
+  deletionsInProgress: boolean,
+  error: string | null
+}
+
+const createDeleteObservationsSlice: StateCreator<DeleteObservationsSlice> = set => ( {
+  ...DEFAULT_STATE,
+  setDeletions: deletions => set( ( ) => ( { deletions } ) ),
+  startNextDeletion: ( ) => set( state => ( {
+    currentDeleteCount: state.currentDeleteCount + 1,
+    deletionsInProgress: true
+  } ) ),
+  finishDeletions: ( ) => set( ( ) => ( {
+    deletionsInProgress: false,
+    deletionsComplete: true,
+    deletionsCompletedAt: new Date( )
+  } ) ),
+  resetDeleteObservationsSlice: ( ) => set( DEFAULT_STATE ),
+  setDeletionError: message => set( ( ) => ( {
+    error: message
+  } ) )
+} );
+
+export default createDeleteObservationsSlice;

--- a/src/stores/useStore.js
+++ b/src/stores/useStore.js
@@ -2,6 +2,7 @@ import { MMKV } from "react-native-mmkv";
 import { create } from "zustand";
 import { createJSONStorage, persist, StateStorage } from "zustand/middleware";
 
+import createDeleteObservationsSlice from "./createDeleteObservationsSlice";
 import createExploreSlice from "./createExploreSlice";
 import createLayoutSlice from "./createLayoutSlice";
 import createObservationFlowSlice from "./createObservationFlowSlice";
@@ -23,6 +24,7 @@ const useStore = create( persist(
   ( ...args ) => {
     // Let's make our slices
     const slices = [
+      createDeleteObservationsSlice( ...args ),
       createExploreSlice( ...args ),
       createObservationFlowSlice( ...args ),
       createLayoutSlice( ...args )

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -311,25 +311,21 @@ describe( "MyObservations", ( ) => {
         } );
       } );
 
-      describe( "after initial sync", ( ) => {
+      describe( "on screen focus", ( ) => {
         beforeEach( ( ) => {
           safeRealmWrite( global.mockRealms[__filename], ( ) => {
             global.mockRealms[__filename].create( "LocalPreferences", {
-              last_sync_time: new Date( "2023-11-01" )
+              last_sync_time: new Date( "2023-11-01" ),
+              last_deleted_sync_time: new Date( "2024-05-01" )
             } );
           }, "add last_sync_time to LocalPreferences, MyObservations integration test" );
         } );
 
-        it( "downloads deleted observations from server when sync button tapped", async ( ) => {
+        it( "downloads deleted observations from server when screen focused", async ( ) => {
           const realm = global.mockRealms[__filename];
           expect( realm.objects( "Observation" ).length ).toBeGreaterThan( 0 );
           renderAppWithComponent( <MyObservationsContainer /> );
-          const syncIcon = await screen.findByTestId( "SyncButton" );
-          await waitFor( ( ) => {
-            expect( syncIcon ).toBeVisible( );
-          } );
-          fireEvent.press( syncIcon );
-          const lastSyncTime = realm.objects( "LocalPreferences" )[0].last_sync_time;
+          const lastSyncTime = realm.objects( "LocalPreferences" )[0].last_deleted_sync_time;
           await waitFor( ( ) => {
             expect( inatjs.observations.deleted ).toHaveBeenCalledWith(
               {
@@ -343,11 +339,6 @@ describe( "MyObservations", ( ) => {
         it( "deletes local observations if they have been deleted on server", async ( ) => {
           inatjs.observations.deleted.mockResolvedValue( makeResponse( mockDeletedIds ) );
           renderAppWithComponent( <MyObservationsContainer /> );
-          const syncIcon = await screen.findByTestId( "SyncButton" );
-          await waitFor( ( ) => {
-            expect( syncIcon ).toBeVisible( );
-          } );
-          fireEvent.press( syncIcon );
           const deleteSpy = jest.spyOn( global.mockRealms[__filename], "delete" );
           await waitFor( ( ) => {
             expect( deleteSpy ).toHaveBeenCalledTimes( 1 );

--- a/tests/unit/components/MyObservations/ToolbarContainer.test.js
+++ b/tests/unit/components/MyObservations/ToolbarContainer.test.js
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react-native";
-import * as useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations";
+import * as useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations.ts";
 import ToolbarContainer from "components/MyObservations/ToolbarContainer";
 import i18next from "i18next";
 import React from "react";

--- a/tests/unit/components/MyObservations/ToolbarContainer.test.js
+++ b/tests/unit/components/MyObservations/ToolbarContainer.test.js
@@ -1,25 +1,16 @@
 import { screen } from "@testing-library/react-native";
-import * as useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations.ts";
 import {
   INITIAL_STATE as MYOBS_INITIAL_STATE
 } from "components/MyObservations/MyObservationsContainer";
 import ToolbarContainer from "components/MyObservations/ToolbarContainer";
 import i18next from "i18next";
 import React from "react";
+import useStore from "stores/useStore";
 import { renderComponent } from "tests/helpers/render";
 
-jest.mock( "components/MyObservations/hooks/useDeleteObservations", () => ( {
-  __esModule: true,
-  default: ( ) => ( {
-    currentDeleteCount: 1,
-    deletions: [],
-    deletionsComplete: false,
-    deletionsInProgress: false,
-    error: null
-  } )
-} ) );
+const initialStoreState = useStore.getState( );
 
-const deletionState = {
+const deletionStore = {
   currentDeleteCount: 3,
   deletions: [{}, {}, {}],
   deletionsComplete: false,
@@ -35,6 +26,10 @@ const uploadState = {
 };
 
 describe( "Toolbar", () => {
+  beforeAll( async () => {
+    useStore.setState( initialStoreState, true );
+  } );
+
   it( "displays a pending upload", async () => {
     renderComponent( <ToolbarContainer
       numUnuploadedObs={1}
@@ -143,11 +138,11 @@ describe( "Toolbar", () => {
   } );
 
   it( "displays deletions in progress", async () => {
-    jest.spyOn( useDeleteObservations, "default" ).mockImplementation( ( ) => ( {
-      ...deletionState,
+    useStore.setState( {
+      ...deletionStore,
       deletionsInProgress: true,
       currentDeleteCount: 2
-    } ) );
+    } );
     renderComponent( <ToolbarContainer uploadState={uploadState} /> );
 
     const statusText = screen.getByText( i18next.t( "Deleting-x-of-y-observations", {
@@ -158,10 +153,10 @@ describe( "Toolbar", () => {
   } );
 
   it( "displays deletions completed", async () => {
-    jest.spyOn( useDeleteObservations, "default" ).mockImplementation( ( ) => ( {
-      ...deletionState,
+    useStore.setState( {
+      ...deletionStore,
       deletionsComplete: true
-    } ) );
+    } );
     renderComponent( <ToolbarContainer uploadState={uploadState} /> );
 
     const statusText = screen.getByText( i18next.t( "X-observations-deleted", {
@@ -172,10 +167,10 @@ describe( "Toolbar", () => {
 
   it( "displays deletion error", async () => {
     const error = "Unknown problem deleting observations";
-    jest.spyOn( useDeleteObservations, "default" ).mockImplementation( ( ) => ( {
-      ...deletionState,
+    useStore.setState( {
+      ...deletionStore,
       error
-    } ) );
+    } );
     renderComponent( <ToolbarContainer uploadState={uploadState} /> );
 
     const statusText = screen.getByText( error );

--- a/tests/unit/components/MyObservations/useDeleteObservations.test.js
+++ b/tests/unit/components/MyObservations/useDeleteObservations.test.js
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
-import useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations";
+import useDeleteObservations from "components/MyObservations/hooks/useDeleteObservations.ts";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";


### PR DESCRIPTION
Closes #1485 

- When a user lands on MyObs, their remotely deleted observations will sync automatically
- This happens before their locally deleted observations are deleted remotely
- It also happens without a user needing to press the sync button

This should eliminate errors related to a user landing on a previously deleted ObsDetails observation, since this will minimize the number of observations they can see in their observations list which have been deleted remotely.

It's still possible that a user could delete an observation remotely, have the mobile app open, and tap an observation before they navigate away from the MyObs screen, in which case they'll see the "Observation Has Been Deleted" bottom sheet on ObsDetails. However, this update means that when they close this bottom sheet, they'll be navigated back to MyObs where their remotely deleted observations will sync -- so this should only be able to happen for a single observation instead of a whole set of stale data.