### PR TITLE
Add X-Installation-ID logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { startNetworkLogging } from "react-native-network-logger";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { reactQueryRetry } from "sharedHelpers/logging";
+import { installID } from "sharedHelpers/userData";
 
 import { name as appName } from "./app.json";
 import { log } from "./react-native-logs.config";
@@ -92,7 +93,10 @@ initI18next();
 inatjs.setConfig( {
   apiURL: Config.API_URL,
   writeApiURL: Config.API_URL,
-  userAgent: getUserAgent()
+  userAgent: getUserAgent(),
+  headers: {
+    "X-Installation-ID": installID( )
+  }
 } );
 
 const queryClient = new QueryClient( {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12041,8 +12041,8 @@
       }
     },
     "node_modules/inaturalistjs": {
-      "version": "2.9.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/inaturalistjs.git#9cbfcb1a004c90b26e812b7bf70da7fc8044a578",
+      "version": "2.11.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/inaturalistjs.git#65bf1b60eff311fcfc5a3213137ca619b6c6a433",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/src/api/log.ts
+++ b/src/api/log.ts
@@ -66,7 +66,7 @@ const iNatLogstashTransport: transportFunctionType = async props => {
       Authorization: [
         userToken,
         anonymousToken
-      ].flat( ).join( ", " ),
+      ].flat( ).join( ", " )
     }
   } );
 };

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -60,10 +60,14 @@ const App = ( { children }: Props ): Node => {
 
   useEffect( ( ) => {
     if ( realm?.path ) {
-      logger.debug( "[App.js] Need to open Realm in another app?" );
-      logger.debug( "[App.js] realm.path: ", realm.path );
+      console.debug( "Need to open Realm in another app?" );
+      console.debug( "realm.path: ", realm.path );
     }
   }, [realm?.path] );
+
+  useEffect( ( ) => {
+    logger.info( "pickup" );
+  }, [] );
 
   // this children prop is here for the sake of testing with jest
   // normally we would never do this in code

--- a/src/components/LoginSignUp/AuthenticationService.js
+++ b/src/components/LoginSignUp/AuthenticationService.js
@@ -14,6 +14,7 @@ import Realm from "realm";
 import realmConfig from "realmModels/index";
 import User from "realmModels/User";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { installID } from "sharedHelpers/userData";
 import { sleep } from "sharedHelpers/util";
 
 import { log, logFilePath } from "../../../react-native-logs.config";
@@ -78,7 +79,11 @@ async function deleteSensitiveItem( key, options = {} ) {
  */
 const createAPI = additionalHeaders => create( {
   axiosInstance,
-  headers: { "User-Agent": getUserAgent(), ...additionalHeaders }
+  headers: {
+    "User-Agent": getUserAgent(),
+    "X-Installation-ID": installID( ),
+    ...additionalHeaders
+  }
 } );
 
 /**

--- a/src/components/SharedComponents/Buttons/AddObsButton.js
+++ b/src/components/SharedComponents/Buttons/AddObsButton.js
@@ -7,7 +7,10 @@ import GradientButton from "components/SharedComponents/Buttons/GradientButton";
 import { t } from "i18next";
 import { getCurrentRoute } from "navigation/navigationUtils";
 import * as React from "react";
+import { log } from "sharedHelpers/logger";
 import useStore from "stores/useStore";
+
+const logger = log.extend( "AddObsButton" );
 
 const AddObsButton = (): React.Node => {
   const [showModal, setModal] = React.useState( false );
@@ -18,6 +21,9 @@ const AddObsButton = (): React.Node => {
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const isAdvancedUser = useStore( state => state.isAdvancedUser );
   const navigation = useNavigation( );
+  React.useEffect( ( ) => {
+    logger.info( `isAdvancedUser: ${isAdvancedUser}` );
+  }, [isAdvancedUser] );
 
   const navAndCloseModal = ( screen, params ) => {
     const currentRoute = getCurrentRoute();

--- a/src/sharedHelpers/userData.js
+++ b/src/sharedHelpers/userData.js
@@ -1,0 +1,17 @@
+import { MMKV } from "react-native-mmkv";
+import uuid from "react-native-uuid";
+
+const INSTALL_ID = "installID";
+
+const userData = new MMKV( {
+  id: "user-data"
+} );
+export default userData;
+
+export function installID( ) {
+  const id = userData.getString( INSTALL_ID );
+  if ( id ) return id;
+  const newID = uuid.v4( );
+  userData.set( INSTALL_ID, newID );
+  return newID;
+}


### PR DESCRIPTION
* include X-Installation-ID with most requests
* allow logged out logging
* log whether user has enabled advanced add obs btn

Note that at present, installation ID should be just that: an identifier that is unique per installation. So if two users sign in to the same installation on the same device, that's two users, one installation. If one user signs into to two separated devices, that's one user, two installations. The intent is to be able to count signed out users assuming generally only one user is using one account per installation.