### PR TITLE
Suggestions screen UI fixes, location toggle, and offline reloading state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,6 +129,10 @@ module.exports = {
     "react-native-a11y/has-valid-important-for-accessibility": 1,
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": "error",
+    // it's supposedly safe to remove no-undef because TS's compiler handles
+    // this, but I'm bumping into this error a lot in VSCode - 20240624 amanda
+    // https://eslint.org/docs/latest/rules/no-undef#handled_by_typescript
+    "no-undef": "error",
 
     // TODO: we should actually type these at some point ~amanda 041824
     "@typescript-eslint/ban-types": 0,

--- a/src/api/computerVision.js
+++ b/src/api/computerVision.js
@@ -7,7 +7,9 @@ import handleError from "./error";
 
 const PARAMS = {
   fields: {
-    taxon: Taxon.TAXON_FIELDS
+    combined_score: true,
+    taxon: Taxon.TAXON_FIELDS,
+    vision_score: true
   }
 };
 

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -22,7 +22,6 @@ Object.defineProperty( INatApiError.prototype, "name", {
 } );
 
 async function handleError( e: Object, options: Object = {} ): Object {
-  console.log( e, "e in handleError" );
   if ( !e.response ) { throw e; }
 
   // Try to parse JSON in the response if this was an HTTP error. If we can't

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -22,6 +22,7 @@ Object.defineProperty( INatApiError.prototype, "name", {
 } );
 
 async function handleError( e: Object, options: Object = {} ): Object {
+  console.log( e, "e in handleError" );
   if ( !e.response ) { throw e; }
 
   // Try to parse JSON in the response if this was an HTTP error. If we can't

--- a/src/components/Camera/CameraWithDevice.tsx
+++ b/src/components/Camera/CameraWithDevice.tsx
@@ -19,7 +19,7 @@ import {
   RESULTS
 } from "react-native-permissions";
 import { Camera, CameraDevice } from "react-native-vision-camera";
-import { log } from "sharedHelpers/logger";
+// import { log } from "sharedHelpers/logger";
 import { useTranslation } from "sharedHooks";
 import useDeviceOrientation, {
   LANDSCAPE_LEFT,
@@ -30,7 +30,7 @@ import AICamera from "./AICamera/AICamera";
 import usePrepareStoreAndNavigate from "./hooks/usePrepareStoreAndNavigate";
 import StandardCamera from "./StandardCamera/StandardCamera";
 
-const logger = log.extend( "CameraWithDevice" );
+// const logger = log.extend( "CameraWithDevice" );
 
 const isTablet = DeviceInfo.isTablet( );
 
@@ -71,7 +71,7 @@ const CameraWithDevice = ( {
   const isFocused = useIsFocused( );
   const [locationPermissionGranted, setLocationPermissionGranted] = useState( false );
 
-  logger.debug( `isFocused: ${isFocused}` );
+  // logger.debug( `isFocused: ${isFocused}` );
   const prepareStoreAndNavigate = usePrepareStoreAndNavigate( {
     addPhotoPermissionResult,
     addEvidence,

--- a/src/components/Camera/hooks/useFocusTap.ts
+++ b/src/components/Camera/hooks/useFocusTap.ts
@@ -1,4 +1,4 @@
-import {
+import React, {
   useCallback, useMemo, useRef, useState
 } from "react";
 import { Animated } from "react-native";

--- a/src/components/Camera/hooks/useTakePhoto.ts
+++ b/src/components/Camera/hooks/useTakePhoto.ts
@@ -1,5 +1,5 @@
 import { RealmContext } from "providers/contexts";
-import {
+import React, {
   useState
 } from "react";
 import {

--- a/src/components/LoginSignUp/LoginSignUpInputField.js
+++ b/src/components/LoginSignUp/LoginSignUpInputField.js
@@ -30,7 +30,8 @@ const LoginSignUpInputField: Function = forwardRef( ( {
   secureTextEntry = false,
   testID,
   textContentType
-}: Props, ref: any ): Node => {
+  // $FlowIgnore
+}: Props, ref: unknown ): Node => {
   const theme = useTheme( );
 
   return (

--- a/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
@@ -46,6 +46,7 @@ const updateDeletedSyncTime = realm => {
   }, "updating last remotely deleted sync time" );
 };
 
+// eslint-disable-next-line no-undef
 export default syncRemoteDeletedObservations = async realm => {
   const apiToken = await getJWT( );
   const deletedParams = setParamsWithLastSyncTime( realm );

--- a/src/components/MyObservations/helpers/syncRemoteObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteObservations.ts
@@ -18,6 +18,7 @@ const updateSyncTime = realm => {
   }, "updating sync time in syncRemoteObservations" );
 };
 
+// eslint-disable-next-line no-undef
 export default syncRemoteObservations = async ( realm, currentUserId, deletionsCompletedAt ) => {
   const apiToken = await getJWT( );
   const searchParams = {

--- a/src/components/MyObservations/hooks/useUploadObservations.ts
+++ b/src/components/MyObservations/hooks/useUploadObservations.ts
@@ -30,6 +30,7 @@ const MS_BEFORE_UPLOAD_TIMES_OUT = 60_000 * 5;
 
 const { useRealm } = RealmContext;
 
+// eslint-disable-next-line no-undef
 export default useUploadObservations = canUpload => {
   const realm = useRealm( );
 
@@ -64,6 +65,7 @@ export default useUploadObservations = canUpload => {
   const { t } = useTranslation( );
 
   useEffect( () => {
+    // eslint-disable-next-line no-undef
     let timer: number | NodeJS.Timeout;
     if ( [UPLOAD_COMPLETE, UPLOAD_CANCELLED].indexOf( uploadStatus ) >= 0 ) {
       timer = setTimeout( () => {

--- a/src/components/SharedComponents/TaxonResult.js
+++ b/src/components/SharedComponents/TaxonResult.js
@@ -163,16 +163,12 @@ const TaxonResult = ( {
           && (
             <INatIconButton
               className="ml-2"
-              icon={
-                clearBackground
-                  ? "checkmark-circle-outline"
-                  : "checkmark-circle"
-              }
+              icon="checkmark-circle-outline"
               size={40}
               color={
                 clearBackground
                   ? theme.colors.onSecondary
-                  : theme.colors.secondary
+                  : theme.colors.primary
               }
               onPress={() => handleCheckmarkPress( usableTaxon )}
               accessibilityLabel={accessibilityLabel}

--- a/src/components/Suggestions/Attribution.js
+++ b/src/components/Suggestions/Attribution.js
@@ -24,7 +24,7 @@ const Attribution = ( {
   }
 
   return (
-    <Body3 className="mt-6 mb-4 mx-4">
+    <Body3 className="mx-4">
       {t( "iNaturalist-identification-suggestions-are-based-on", {
         user1: observers[0],
         user2: observers[1],

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -1,83 +1,63 @@
 // @flow
 
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import {
   Body1,
-  Body2,
   Body3,
   Button,
   Heading4,
-  INatIcon,
-  INatIconButton,
   ViewWrapper
 } from "components/SharedComponents";
-import { Pressable, View } from "components/styledComponents";
+import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { FlatList } from "react-native";
-import { useTheme } from "react-native-paper";
 import { formatISONoTimezone } from "sharedHelpers/dateAndTime";
 import { useDebugMode, useTranslation } from "sharedHooks";
 
-import AddCommentPrompt from "./AddCommentPrompt";
 import Attribution from "./Attribution";
-import CommentBox from "./CommentBox";
 import useObservers from "./hooks/useObservers";
-import ObsPhotoSelectionList from "./ObsPhotoSelectionList";
 import Suggestion from "./Suggestion";
 import SuggestionsEmpty from "./SuggestionsEmpty";
+import SuggestionsHeader from "./SuggestionsHeader";
 
 type Props = {
   debugData: Object,
-  showSuggestionsWithLocation: boolean,
   loading: boolean,
   onPressPhoto: Function,
   onTaxonChosen: Function,
+  otherSuggestions: Array<Object>,
   photoUris: Array<string>,
   reloadSuggestions: Function,
   selectedPhotoUri: string,
-  otherSuggestions: Array<Object>,
+  setLocationPermissionNeeded: Function,
+  showImproveWithLocationButton: boolean,
+  showSuggestionsWithLocation: boolean,
   topSuggestion: Object,
   usingOfflineSuggestions: boolean,
 };
 
 const Suggestions = ( {
   debugData,
-  showSuggestionsWithLocation,
   loading,
   onPressPhoto,
   onTaxonChosen,
+  otherSuggestions,
   photoUris,
   reloadSuggestions,
   selectedPhotoUri,
-  otherSuggestions,
+  setLocationPermissionNeeded,
+  showImproveWithLocationButton,
+  showSuggestionsWithLocation,
   topSuggestion,
   usingOfflineSuggestions
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
-  const { params } = useRoute( );
-  const { lastScreen } = params;
   const { isDebug } = useDebugMode( );
-  const theme = useTheme( );
 
   const taxonIds = otherSuggestions?.map( s => s.taxon.id );
-
   const observers = useObservers( taxonIds );
-
-  const hasOtherSuggestions = otherSuggestions?.length > 0;
-
-  const headerRight = useCallback( ( ) => (
-    <INatIconButton
-      icon="magnifying-glass"
-      onPress={( ) => navigation.navigate( "TaxonSearch", { lastScreen } )}
-      accessibilityLabel={t( "Search" )}
-    />
-  ), [navigation, lastScreen, t] );
-
-  useEffect( ( ) => {
-    navigation.setOptions( { headerRight } );
-  }, [headerRight, navigation] );
 
   const navToObsEdit = useCallback( ( ) => navigation.navigate( "ObsEdit", {
     lastScreen: "Suggestions"
@@ -156,61 +136,31 @@ const Suggestions = ( {
   /* eslint-enable max-len */
 
   const renderHeader = useCallback( ( ) => (
-    <>
-      <AddCommentPrompt />
-      <View className="mx-5">
-        <ObsPhotoSelectionList
-          photoUris={photoUris}
-          selectedPhotoUri={selectedPhotoUri}
-          onPressPhoto={onPressPhoto}
-        />
-      </View>
-      {!loading && (
-        <>
-          { usingOfflineSuggestions && (
-            <Pressable
-              accessibilityRole="button"
-              className="border border-warningYellow border-[3px] m-5 rounded-2xl"
-              onPress={reloadSuggestions}
-            >
-              <View className="p-5">
-                <View className="flex-row mb-2">
-                  <INatIcon
-                    name="offline"
-                    size={22}
-                    color={theme.colors.warningYellow}
-                  />
-                  <Body2 className="mx-2">{t( "You-are-offline-Tap-to-reload" )}</Body2>
-                </View>
-                <Body3>{ t( "Offline-suggestions-do-not-use-your-location" ) }</Body3>
-              </View>
-            </Pressable>
-          ) }
-          { topSuggestion && (
-            <>
-              <Heading4 className="mt-6 mb-4 ml-4">{t( "TOP-ID-SUGGESTION" )}</Heading4>
-              <View className="bg-inatGreen/[.13]">
-                {renderSuggestion( { item: topSuggestion } )}
-              </View>
-            </>
-          ) }
-          { hasOtherSuggestions && (
-            <Heading4 className="mt-6 mb-4 ml-4">{t( "OTHER-SUGGESTIONS" )}</Heading4>
-          ) }
-        </>
-      )}
-      <CommentBox />
-    </>
+    <SuggestionsHeader
+      loading={loading}
+      onPressPhoto={onPressPhoto}
+      otherSuggestions={otherSuggestions}
+      photoUris={photoUris}
+      reloadSuggestions={reloadSuggestions}
+      renderSuggestion={renderSuggestion}
+      selectedPhotoUri={selectedPhotoUri}
+      setLocationPermissionNeeded={setLocationPermissionNeeded}
+      showImproveWithLocationButton={showImproveWithLocationButton}
+      showSuggestionsWithLocation={showSuggestionsWithLocation}
+      topSuggestion={topSuggestion}
+      usingOfflineSuggestions={usingOfflineSuggestions}
+    />
   ), [
-    hasOtherSuggestions,
     loading,
     onPressPhoto,
+    otherSuggestions,
     photoUris,
     reloadSuggestions,
     renderSuggestion,
     selectedPhotoUri,
-    t,
-    theme,
+    setLocationPermissionNeeded,
+    showImproveWithLocationButton,
+    showSuggestionsWithLocation,
     topSuggestion,
     usingOfflineSuggestions
   ] );

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -3,15 +3,18 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import {
   Body1,
+  Body2,
   Body3,
   Heading4,
+  INatIcon,
   INatIconButton,
   ViewWrapper
 } from "components/SharedComponents";
-import { View } from "components/styledComponents";
+import { Pressable, View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback, useEffect } from "react";
 import { FlatList } from "react-native";
+import { useTheme } from "react-native-paper";
 import { formatISONoTimezone } from "sharedHelpers/dateAndTime";
 import { useDebugMode, useTranslation } from "sharedHooks";
 
@@ -29,6 +32,7 @@ type Props = {
   onPressPhoto: Function,
   onTaxonChosen: Function,
   photoUris: Array<string>,
+  reloadSuggestions: Function,
   selectedPhotoUri: string,
   otherSuggestions: Array<Object>,
   topSuggestion: Object,
@@ -41,6 +45,7 @@ const Suggestions = ( {
   onPressPhoto,
   onTaxonChosen,
   photoUris,
+  reloadSuggestions,
   selectedPhotoUri,
   otherSuggestions,
   topSuggestion,
@@ -51,6 +56,7 @@ const Suggestions = ( {
   const { params } = useRoute( );
   const { lastScreen } = params;
   const { isDebug } = useDebugMode( );
+  const theme = useTheme( );
 
   const taxonIds = otherSuggestions?.map( s => s.taxon.id );
 
@@ -131,10 +137,23 @@ const Suggestions = ( {
       {!loading && (
         <>
           { usingOfflineSuggestions && (
-            <View className="bg-warningYellow px-8 py-5 mt-5">
-              <Heading4>{ t( "Viewing-Offline-Suggestions" ) }</Heading4>
-              <Body3>{ t( "Viewing-Offline-Suggestions-results-may-differ" ) }</Body3>
-            </View>
+            <Pressable
+              accessibilityRole="button"
+              className="border border-warningYellow border-[3px] m-5 rounded-2xl"
+              onPress={reloadSuggestions}
+            >
+              <View className="p-5">
+                <View className="flex-row mb-2">
+                  <INatIcon
+                    name="offline"
+                    size={22}
+                    color={theme.colors.warningYellow}
+                  />
+                  <Body2 className="mx-2">{t( "You-are-offline-Tap-to-reload" )}</Body2>
+                </View>
+                <Body3>{ t( "Offline-suggestions-do-not-use-your-location" ) }</Body3>
+              </View>
+            </Pressable>
           ) }
           { topSuggestion && (
             <>
@@ -156,9 +175,11 @@ const Suggestions = ( {
     loading,
     onPressPhoto,
     photoUris,
+    reloadSuggestions,
     renderSuggestion,
     selectedPhotoUri,
     t,
+    theme,
     topSuggestion,
     usingOfflineSuggestions
   ] );

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -1,24 +1,15 @@
 // @flow
 
-import { useNavigation } from "@react-navigation/native";
-import {
-  Body1,
-  Body3,
-  Button,
-  Heading4,
-  ViewWrapper
-} from "components/SharedComponents";
-import { View } from "components/styledComponents";
+import { ViewWrapper } from "components/SharedComponents";
 import type { Node } from "react";
 import React, { useCallback } from "react";
 import { FlatList } from "react-native";
-import { formatISONoTimezone } from "sharedHelpers/dateAndTime";
-import { useDebugMode, useTranslation } from "sharedHooks";
+import { useTranslation } from "sharedHooks";
 
-import Attribution from "./Attribution";
 import useObservers from "./hooks/useObservers";
 import Suggestion from "./Suggestion";
 import SuggestionsEmpty from "./SuggestionsEmpty";
+import SuggestionsFooter from "./SuggestionsFooter";
 import SuggestionsHeader from "./SuggestionsHeader";
 
 type Props = {
@@ -53,15 +44,10 @@ const Suggestions = ( {
   usingOfflineSuggestions
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const navigation = useNavigation( );
-  const { isDebug } = useDebugMode( );
 
   const taxonIds = otherSuggestions?.map( s => s.taxon.id );
   const observers = useObservers( taxonIds );
-
-  const navToObsEdit = useCallback( ( ) => navigation.navigate( "ObsEdit", {
-    lastScreen: "Suggestions"
-  } ), [navigation] );
+  const showLocationButton = !usingOfflineSuggestions && !loading;
 
   const renderSuggestion = useCallback( ( { item: suggestion } ) => (
     <Suggestion
@@ -76,64 +62,21 @@ const Suggestions = ( {
     <SuggestionsEmpty loading={loading} hasTopSuggestion={!!topSuggestion} />
   ), [loading, topSuggestion] );
 
-  /* eslint-disable i18next/no-literal-string */
-  /* eslint-disable react/jsx-one-expression-per-line */
-  /* eslint-disable max-len */
   const renderFooter = useCallback( ( ) => (
-    <>
-      {showSuggestionsWithLocation
-        ? (
-          <View className="px-4 py-6">
-            <Button
-              text={t( "IGNORE-LOCATION" )}
-              onPress={( ) => reloadSuggestions( { showLocation: false } )}
-              accessibilityLabel={t( "Search-suggestions-without-location" )}
-            />
-          </View>
-        )
-        : (
-          <View className="px-4 py-6">
-            <Button
-              text={t( "USE-LOCATION" )}
-              onPress={( ) => reloadSuggestions( { showLocation: true } )}
-              accessibilityLabel={t( "Search-suggestions-with-location" )}
-            />
-          </View>
-        )}
-      <Attribution observers={observers} />
-      <Body1
-        className="underline text-center py-6"
-        onPress={navToObsEdit}
-        accessibilityRole="link"
-        accessibilityHint={t( "Navigates-to-observation-edit-screen" )}
-      >
-        {t( "Add-an-ID-Later" )}
-      </Body1>
-      { isDebug && (
-        <View className="bg-deeppink text-white p-3">
-          <Heading4 className="text-white">Diagnostics</Heading4>
-          <Body3 className="text-white">Online suggestions URI: {JSON.stringify( debugData?.selectedPhotoUri )}</Body3>
-          <Body3 className="text-white">Online suggestions updated at: {formatISONoTimezone( debugData?.onlineSuggestionsUpdatedAt )}</Body3>
-          <Body3 className="text-white">Online suggestions timed out: {JSON.stringify( debugData?.timedOut )}</Body3>
-          <Body3 className="text-white">Online suggestions using location: {JSON.stringify( debugData?.showSuggestionsWithLocation )}</Body3>
-          <Body3 className="text-white">Num online suggestions: {JSON.stringify( debugData?.onlineSuggestions?.results.length )}</Body3>
-          <Body3 className="text-white">Num offline suggestions: {JSON.stringify( debugData?.offlineSuggestions?.length )}</Body3>
-          <Body3 className="text-white">Error loading online: {JSON.stringify( debugData?.onlineSuggestionsError )}</Body3>
-        </View>
-      )}
-    </>
+    <SuggestionsFooter
+      debugData={debugData}
+      observers={observers}
+      reloadSuggestions={reloadSuggestions}
+      showLocationButton={showLocationButton}
+      showSuggestionsWithLocation={showSuggestionsWithLocation}
+    />
   ), [
     debugData,
-    isDebug,
-    showSuggestionsWithLocation,
-    navToObsEdit,
     observers,
     reloadSuggestions,
-    t
+    showLocationButton,
+    showSuggestionsWithLocation
   ] );
-  /* eslint-enable i18next/no-literal-string */
-  /* eslint-enable react/jsx-one-expression-per-line */
-  /* eslint-enable max-len */
 
   const renderHeader = useCallback( ( ) => (
     <SuggestionsHeader

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -21,8 +21,8 @@ type Props = {
   photoUris: Array<string>,
   reloadSuggestions: Function,
   selectedPhotoUri: string,
-  setLocationPermissionNeeded: Function,
-  showImproveWithLocationButton: boolean,
+  // setLocationPermissionNeeded: Function,
+  // showImproveWithLocationButton: boolean,
   showSuggestionsWithLocation: boolean,
   topSuggestion: Object,
   usingOfflineSuggestions: boolean,
@@ -37,8 +37,8 @@ const Suggestions = ( {
   photoUris,
   reloadSuggestions,
   selectedPhotoUri,
-  setLocationPermissionNeeded,
-  showImproveWithLocationButton,
+  // setLocationPermissionNeeded,
+  // showImproveWithLocationButton,
   showSuggestionsWithLocation,
   topSuggestion,
   usingOfflineSuggestions
@@ -87,8 +87,8 @@ const Suggestions = ( {
       reloadSuggestions={reloadSuggestions}
       renderSuggestion={renderSuggestion}
       selectedPhotoUri={selectedPhotoUri}
-      setLocationPermissionNeeded={setLocationPermissionNeeded}
-      showImproveWithLocationButton={showImproveWithLocationButton}
+      // setLocationPermissionNeeded={setLocationPermissionNeeded}
+      // showImproveWithLocationButton={showImproveWithLocationButton}
       showSuggestionsWithLocation={showSuggestionsWithLocation}
       topSuggestion={topSuggestion}
       usingOfflineSuggestions={usingOfflineSuggestions}
@@ -101,8 +101,8 @@ const Suggestions = ( {
     reloadSuggestions,
     renderSuggestion,
     selectedPhotoUri,
-    setLocationPermissionNeeded,
-    showImproveWithLocationButton,
+    // setLocationPermissionNeeded,
+    // showImproveWithLocationButton,
     showSuggestionsWithLocation,
     topSuggestion,
     usingOfflineSuggestions

--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -5,6 +5,7 @@ import {
   Body1,
   Body2,
   Body3,
+  Button,
   Heading4,
   INatIcon,
   INatIconButton,
@@ -28,6 +29,7 @@ import SuggestionsEmpty from "./SuggestionsEmpty";
 
 type Props = {
   debugData: Object,
+  showSuggestionsWithLocation: boolean,
   loading: boolean,
   onPressPhoto: Function,
   onTaxonChosen: Function,
@@ -41,6 +43,7 @@ type Props = {
 
 const Suggestions = ( {
   debugData,
+  showSuggestionsWithLocation,
   loading,
   onPressPhoto,
   onTaxonChosen,
@@ -98,6 +101,25 @@ const Suggestions = ( {
   /* eslint-disable max-len */
   const renderFooter = useCallback( ( ) => (
     <>
+      {showSuggestionsWithLocation
+        ? (
+          <View className="px-4 py-6">
+            <Button
+              text={t( "IGNORE-LOCATION" )}
+              onPress={( ) => reloadSuggestions( { showLocation: false } )}
+              accessibilityLabel={t( "Search-suggestions-without-location" )}
+            />
+          </View>
+        )
+        : (
+          <View className="px-4 py-6">
+            <Button
+              text={t( "USE-LOCATION" )}
+              onPress={( ) => reloadSuggestions( { showLocation: true } )}
+              accessibilityLabel={t( "Search-suggestions-with-location" )}
+            />
+          </View>
+        )}
       <Attribution observers={observers} />
       <Body1
         className="underline text-center py-6"
@@ -113,13 +135,22 @@ const Suggestions = ( {
           <Body3 className="text-white">Online suggestions URI: {JSON.stringify( debugData?.selectedPhotoUri )}</Body3>
           <Body3 className="text-white">Online suggestions updated at: {formatISONoTimezone( debugData?.onlineSuggestionsUpdatedAt )}</Body3>
           <Body3 className="text-white">Online suggestions timed out: {JSON.stringify( debugData?.timedOut )}</Body3>
+          <Body3 className="text-white">Online suggestions using location: {JSON.stringify( debugData?.showSuggestionsWithLocation )}</Body3>
           <Body3 className="text-white">Num online suggestions: {JSON.stringify( debugData?.onlineSuggestions?.results.length )}</Body3>
           <Body3 className="text-white">Num offline suggestions: {JSON.stringify( debugData?.offlineSuggestions?.length )}</Body3>
           <Body3 className="text-white">Error loading online: {JSON.stringify( debugData?.onlineSuggestionsError )}</Body3>
         </View>
       )}
     </>
-  ), [debugData, isDebug, navToObsEdit, observers, t] );
+  ), [
+    debugData,
+    isDebug,
+    showSuggestionsWithLocation,
+    navToObsEdit,
+    observers,
+    reloadSuggestions,
+    t
+  ] );
   /* eslint-enable i18next/no-literal-string */
   /* eslint-enable react/jsx-one-expression-per-line */
   /* eslint-enable max-len */

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -42,8 +42,12 @@ const SuggestionsContainer = ( ): Node => {
   const [mediaViewerVisible, setMediaViewerVisible] = useState( false );
   const [isLoading, setIsLoading] = useState( true );
   const [otherSuggestions, setOtherSuggestions] = useState( [] );
+  const [locationPermissionNeeded, setLocationPermissionNeeded] = useState( false );
 
   const evidenceHasLocation = !!( currentObservation?.latitude );
+  const showImproveWithLocationButton = !evidenceHasLocation
+    && params?.lastScreen === "CameraWithDevice";
+
   const [
     showSuggestionsWithLocation,
     setShowSuggestionsWithLocation
@@ -154,23 +158,27 @@ const SuggestionsContainer = ( ): Node => {
 
   logger.debug( `${loadingOnlineSuggestions} is pending` );
 
+  const reloadSuggestions = useCallback( ( { showLocation } ) => {
+    setOtherSuggestions( [] );
+    setIsLoading( true );
+    refetchSuggestions( );
+    setShowSuggestionsWithLocation( showLocation );
+  }, [refetchSuggestions] );
+
   return (
     <>
       <Suggestions
         debugData={debugData}
-        showSuggestionsWithLocation={showSuggestionsWithLocation}
         loading={isLoading}
         onPressPhoto={onPressPhoto}
         onTaxonChosen={setSelectedTaxon}
-        photoUris={photoUris}
-        reloadSuggestions={( { showLocation } ) => {
-          setOtherSuggestions( [] );
-          setIsLoading( true );
-          refetchSuggestions( );
-          setShowSuggestionsWithLocation( showLocation );
-        }}
-        selectedPhotoUri={selectedPhotoUri}
         otherSuggestions={otherSuggestions}
+        photoUris={photoUris}
+        reloadSuggestions={reloadSuggestions}
+        selectedPhotoUri={selectedPhotoUri}
+        setLocationPermissionNeeded={setLocationPermissionNeeded}
+        showImproveWithLocationButton={showImproveWithLocationButton}
+        showSuggestionsWithLocation={showSuggestionsWithLocation}
         topSuggestion={topSuggestion}
         usingOfflineSuggestions={usingOfflineSuggestions}
       />
@@ -181,7 +189,7 @@ const SuggestionsContainer = ( ): Node => {
         photos={innerPhotos}
       />
       <LocationPermissionGate
-        permissionNeeded={!evidenceHasLocation && params.lastScreen === "CameraWithDevice"}
+        permissionNeeded={locationPermissionNeeded}
         withoutNavigation
         onPermissionGranted={( ) => console.log( "permission granted" )}
         onPermissionDenied={( ) => console.log( "permission denied" )}

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -2,7 +2,7 @@
 
 import { useRoute } from "@react-navigation/native";
 import MediaViewerModal from "components/MediaViewer/MediaViewerModal";
-import LocationPermissionGate from "components/SharedComponents/LocationPermissionGate";
+// import LocationPermissionGate from "components/SharedComponents/LocationPermissionGate";
 import _ from "lodash";
 import type { Node } from "react";
 import React, {
@@ -42,12 +42,12 @@ const SuggestionsContainer = ( ): Node => {
   const [mediaViewerVisible, setMediaViewerVisible] = useState( false );
   const [isLoading, setIsLoading] = useState( true );
   const [otherSuggestions, setOtherSuggestions] = useState( [] );
-  const [locationPermissionNeeded, setLocationPermissionNeeded] = useState( false );
+  // const [locationPermissionNeeded, setLocationPermissionNeeded] = useState( false );
   const [usingOfflineSuggestions, setUsingOfflineSuggestions] = useState( false );
 
   const evidenceHasLocation = !!( currentObservation?.latitude );
-  const showImproveWithLocationButton = !evidenceHasLocation
-    && params?.lastScreen === "CameraWithDevice";
+  // const showImproveWithLocationButton = !evidenceHasLocation
+  //   && params?.lastScreen === "CameraWithDevice";
 
   const [
     showSuggestionsWithLocation,
@@ -64,8 +64,6 @@ const SuggestionsContainer = ( ): Node => {
   } = useOnlineSuggestions( selectedPhotoUri, {
     showSuggestionsWithLocation
   } );
-
-  console.log( fetchStatus, "fetch status" );
 
   const loadingOnlineSuggestions = fetchStatus === "fetching";
 
@@ -198,8 +196,6 @@ const SuggestionsContainer = ( ): Node => {
     setUsingOfflineSuggestions( false );
   }, [refetchSuggestions] );
 
-  console.log( isLoading, loadingOnlineSuggestions, "is loading, loading online" );
-
   return (
     <>
       <Suggestions
@@ -211,8 +207,8 @@ const SuggestionsContainer = ( ): Node => {
         photoUris={photoUris}
         reloadSuggestions={reloadSuggestions}
         selectedPhotoUri={selectedPhotoUri}
-        setLocationPermissionNeeded={setLocationPermissionNeeded}
-        showImproveWithLocationButton={showImproveWithLocationButton}
+        // setLocationPermissionNeeded={setLocationPermissionNeeded}
+        // showImproveWithLocationButton={showImproveWithLocationButton}
         showSuggestionsWithLocation={showSuggestionsWithLocation}
         topSuggestion={topSuggestion}
         usingOfflineSuggestions={usingOfflineSuggestions}
@@ -223,13 +219,13 @@ const SuggestionsContainer = ( ): Node => {
         uri={selectedPhotoUri}
         photos={innerPhotos}
       />
-      <LocationPermissionGate
+      {/* <LocationPermissionGate
         permissionNeeded={locationPermissionNeeded}
         withoutNavigation
         onPermissionGranted={( ) => console.log( "permission granted" )}
         onPermissionDenied={( ) => console.log( "permission denied" )}
         onPermissionBlocked={( ) => console.log( "permission blocked" )}
-      />
+      /> */}
     </>
   );
 };

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -41,7 +41,9 @@ const SuggestionsContainer = ( ): Node => {
     error: onlineSuggestionsError,
     onlineSuggestions,
     loadingOnlineSuggestions,
-    timedOut
+    timedOut,
+    refetch,
+    isRefetching
   } = useOnlineSuggestions( selectedPhotoUri );
 
   // skip to offline suggestions if internet connection is spotty
@@ -124,7 +126,7 @@ const SuggestionsContainer = ( ): Node => {
     if ( hasVisionSuggestion ) {
       return currentObservation;
     }
-    if ( onlineSuggestions?.length > 0 ) {
+    if ( onlineSuggestions?.results?.length > 0 ) {
       return onlineSuggestions?.common_ancestor;
     }
     // if ( otherSuggestions?.length > 0 ) {
@@ -140,10 +142,11 @@ const SuggestionsContainer = ( ): Node => {
     <>
       <Suggestions
         debugData={debugData}
-        loading={isLoading}
+        loading={isLoading || isRefetching}
         onPressPhoto={onPressPhoto}
         onTaxonChosen={setSelectedTaxon}
         photoUris={photoUris}
+        reloadSuggestions={refetch}
         selectedPhotoUri={selectedPhotoUri}
         otherSuggestions={otherSuggestions}
         topSuggestion={topSuggestion}

--- a/src/components/Suggestions/SuggestionsContainer.js
+++ b/src/components/Suggestions/SuggestionsContainer.js
@@ -26,8 +26,8 @@ const SuggestionsContainer = ( ): Node => {
   // and only have the latest resized image stored in computerVisionSuggestions
   useClearComputerVisionDirectory( );
   const { params } = useRoute( );
-  const hasVisionSuggestion = params?.hasVisionSuggestion;
   const currentObservation = useStore( state => state.currentObservation );
+  const hasVisionSuggestion = params?.hasVisionSuggestion && currentObservation?.taxon;
   const innerPhotos = ObservationPhoto.mapInnerPhotos( currentObservation );
   const photoUris = ObservationPhoto.mapObsPhotoUris( currentObservation );
 
@@ -114,6 +114,8 @@ const SuggestionsContainer = ( ): Node => {
     }
   }, [loadingOfflineSuggestions, hasSuggestions] );
 
+  const otherSuggestions = filterSuggestions( );
+
   const filterTopSuggestions = ( ) => {
     if ( isLoading ) { return []; }
     if ( humanSuggestion ) {
@@ -125,11 +127,14 @@ const SuggestionsContainer = ( ): Node => {
     if ( onlineSuggestions?.length > 0 ) {
       return onlineSuggestions?.common_ancestor;
     }
+    // if ( otherSuggestions?.length > 0 ) {
+    //   const firstSuggestion = otherSuggestions.shift( );
+    //   return firstSuggestion;
+    // }
     return [];
   };
 
   const topSuggestion = filterTopSuggestions( );
-  const suggestions = filterSuggestions( );
 
   return (
     <>
@@ -140,7 +145,7 @@ const SuggestionsContainer = ( ): Node => {
         onTaxonChosen={setSelectedTaxon}
         photoUris={photoUris}
         selectedPhotoUri={selectedPhotoUri}
-        suggestions={suggestions}
+        otherSuggestions={otherSuggestions}
         topSuggestion={topSuggestion}
         usingOfflineSuggestions={usingOfflineSuggestions}
       />

--- a/src/components/Suggestions/SuggestionsEmpty.tsx
+++ b/src/components/Suggestions/SuggestionsEmpty.tsx
@@ -1,10 +1,7 @@
-// @flow
-
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { useRoute } from "@react-navigation/native";
 import {
   ActivityIndicator,
-  Body1,
-  Button
+  Body1
 } from "components/SharedComponents";
 import {
   View
@@ -23,7 +20,6 @@ const SuggestionsEmpty = ( {
   loading
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const navigation = useNavigation( );
   const { params } = useRoute( );
   const { lastScreen } = params;
 
@@ -33,6 +29,7 @@ const SuggestionsEmpty = ( {
     return (
       <View className="justify-center items-center mt-5" testID="SuggestionsList.loading">
         <ActivityIndicator size={50} />
+        <Body1 className="pt-6">{t( "iNaturalist-is-loading-ID-suggestions" )}</Body1>
       </View>
     );
   }
@@ -43,17 +40,9 @@ const SuggestionsEmpty = ( {
           {t( "iNaturalist-has-no-ID-suggestions-for-this-photo" )}
         </Body1>
         {lastScreen === "CameraWithDevice" && (
-          <>
-            <Body1 className={textClass}>
-              {t( "You-can-upload-this-observation-to-our-community" )}
-            </Body1>
-            <Button
-              className="mx-5 mt-10"
-              text={t( "CONTINUE" )}
-              onPress={( ) => navigation.navigate( "ObsEdit", { lastScreen: "Suggestions" } )}
-              level="focus"
-            />
-          </>
+          <Body1 className={textClass}>
+            {t( "You-can-upload-this-observation-to-our-community" )}
+          </Body1>
         )}
       </>
     );

--- a/src/components/Suggestions/SuggestionsFooter.tsx
+++ b/src/components/Suggestions/SuggestionsFooter.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable i18next/no-literal-string */
+/* eslint-disable react/jsx-one-expression-per-line */
+/* eslint-disable max-len */
+import { useNavigation } from "@react-navigation/native";
+import {
+  Body1,
+  Body3,
+  Button,
+  Heading4
+} from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import type { Node } from "react";
+import React, { useCallback } from "react";
+import { formatISONoTimezone } from "sharedHelpers/dateAndTime";
+import { useDebugMode, useTranslation } from "sharedHooks";
+
+import Attribution from "./Attribution";
+
+type Props = {
+  debugData: Object,
+  observers: Array<string>,
+  reloadSuggestions: Function,
+  showLocationButton: boolean,
+  showSuggestionsWithLocation: boolean
+};
+
+const SuggestionsFooter = ( {
+  debugData,
+  observers,
+  reloadSuggestions,
+  showLocationButton = false,
+  showSuggestionsWithLocation
+}: Props ): Node => {
+  const { t } = useTranslation( );
+  const { isDebug } = useDebugMode( );
+  const navigation = useNavigation( );
+  const navToObsEdit = useCallback( ( ) => navigation.navigate( "ObsEdit", {
+    lastScreen: "Suggestions"
+  } ), [navigation] );
+
+  return (
+    <>
+      {showLocationButton && (
+        <>
+          <View className="px-4 py-6">
+            {showSuggestionsWithLocation
+              ? (
+                <Button
+                  text={t( "IGNORE-LOCATION" )}
+                  onPress={( ) => reloadSuggestions( { showLocation: false } )}
+                  accessibilityLabel={t( "Search-suggestions-without-location" )}
+                />
+              )
+              : (
+                <Button
+                  text={t( "USE-LOCATION" )}
+                  onPress={( ) => reloadSuggestions( { showLocation: true } )}
+                  accessibilityLabel={t( "Search-suggestions-with-location" )}
+                />
+
+              )}
+          </View>
+          <Attribution observers={observers} />
+        </>
+      )}
+      <Body1
+        className="underline text-center py-6"
+        onPress={navToObsEdit}
+        accessibilityRole="link"
+        accessibilityHint={t( "Navigates-to-observation-edit-screen" )}
+      >
+        {t( "Add-an-ID-Later" )}
+      </Body1>
+      { isDebug && (
+        <View className="bg-deeppink text-white p-3">
+          <Heading4 className="text-white">Diagnostics</Heading4>
+          <Body3 className="text-white">Online suggestions URI: {JSON.stringify( debugData?.selectedPhotoUri )}</Body3>
+          <Body3 className="text-white">Online suggestions updated at: {formatISONoTimezone( debugData?.onlineSuggestionsUpdatedAt )}</Body3>
+          <Body3 className="text-white">Online suggestions timed out: {JSON.stringify( debugData?.timedOut )}</Body3>
+          <Body3 className="text-white">Online suggestions using location: {JSON.stringify( debugData?.showSuggestionsWithLocation )}</Body3>
+          <Body3 className="text-white">Num online suggestions: {JSON.stringify( debugData?.onlineSuggestions?.results.length )}</Body3>
+          <Body3 className="text-white">Num offline suggestions: {JSON.stringify( debugData?.offlineSuggestions?.length )}</Body3>
+          <Body3 className="text-white">Error loading online: {JSON.stringify( debugData?.onlineSuggestionsError )}</Body3>
+        </View>
+      )}
+    </>
+  );
+};
+export default SuggestionsFooter;

--- a/src/components/Suggestions/SuggestionsHeader.tsx
+++ b/src/components/Suggestions/SuggestionsHeader.tsx
@@ -1,0 +1,126 @@
+import { useNavigation, useRoute } from "@react-navigation/native";
+import {
+  Body2,
+  Body3,
+  Button,
+  Heading4,
+  INatIcon,
+  INatIconButton
+} from "components/SharedComponents";
+import { Pressable, View } from "components/styledComponents";
+import type { Node } from "react";
+import React, { useCallback, useEffect } from "react";
+import { useTheme } from "react-native-paper";
+import { useTranslation } from "sharedHooks";
+
+import AddCommentPrompt from "./AddCommentPrompt";
+import CommentBox from "./CommentBox";
+import ObsPhotoSelectionList from "./ObsPhotoSelectionList";
+
+type Props = {
+  loading: boolean,
+  onPressPhoto: Function,
+  otherSuggestions: Array<Object>,
+  photoUris: Array<string>,
+  reloadSuggestions: Function,
+  renderSuggestion: Function,
+  selectedPhotoUri: string,
+  setLocationPermissionNeeded: Function,
+  showImproveWithLocationButton: boolean,
+  topSuggestion: Object,
+  usingOfflineSuggestions: boolean,
+};
+
+const SuggestionsHeader = ( {
+  loading,
+  onPressPhoto,
+  otherSuggestions,
+  photoUris,
+  reloadSuggestions,
+  renderSuggestion,
+  selectedPhotoUri,
+  setLocationPermissionNeeded,
+  showImproveWithLocationButton,
+  topSuggestion,
+  usingOfflineSuggestions
+}: Props ): Node => {
+  const { t } = useTranslation( );
+  const navigation = useNavigation( );
+  const { params } = useRoute( );
+  const { lastScreen } = params;
+  const theme = useTheme( );
+
+  const hasOtherSuggestions = otherSuggestions?.length > 0;
+
+  const headerRight = useCallback( ( ) => (
+    <INatIconButton
+      icon="magnifying-glass"
+      onPress={( ) => navigation.navigate( "TaxonSearch", { lastScreen } )}
+      accessibilityLabel={t( "Search" )}
+    />
+  ), [navigation, lastScreen, t] );
+
+  useEffect( ( ) => {
+    navigation.setOptions( { headerRight } );
+  }, [headerRight, navigation] );
+
+  return (
+    <>
+      <AddCommentPrompt />
+      <View className="mx-5">
+        <ObsPhotoSelectionList
+          photoUris={photoUris}
+          selectedPhotoUri={selectedPhotoUri}
+          onPressPhoto={onPressPhoto}
+        />
+      </View>
+      {showImproveWithLocationButton && (
+        <View className="mx-5 mt-5">
+          <Button
+            text={t( "IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION" )}
+            accessibilityHint={t( "Opens-location-permission-prompt" )}
+            level="focus"
+            onPress={( ) => setLocationPermissionNeeded( true )}
+          />
+        </View>
+      )}
+      {!loading && (
+        <>
+          { usingOfflineSuggestions && (
+            <Pressable
+              accessibilityRole="button"
+              className="border border-warningYellow border-[3px] m-5 rounded-2xl"
+              onPress={reloadSuggestions}
+            >
+              <View className="p-5">
+                <View className="flex-row mb-2">
+                  <INatIcon
+                    name="offline"
+                    size={22}
+                    color={theme.colors.warningYellow}
+                  />
+                  <Body2 className="mx-2">{t( "You-are-offline-Tap-to-reload" )}</Body2>
+                </View>
+                <Body3>{ t( "Offline-suggestions-do-not-use-your-location" ) }</Body3>
+              </View>
+            </Pressable>
+          ) }
+          { topSuggestion && (
+            <>
+              <Heading4 className="mt-6 mb-4 ml-4">{t( "TOP-ID-SUGGESTION" )}</Heading4>
+              <View className="bg-inatGreen/[.13]">
+                {renderSuggestion( { item: topSuggestion } )}
+              </View>
+            </>
+          ) }
+          { hasOtherSuggestions && (
+            <Heading4 className="mt-6 mb-4 ml-4">{t( "OTHER-SUGGESTIONS" )}</Heading4>
+          ) }
+        </>
+      )}
+      <CommentBox />
+    </>
+  );
+};
+
+export default SuggestionsHeader;

--- a/src/components/Suggestions/SuggestionsHeader.tsx
+++ b/src/components/Suggestions/SuggestionsHeader.tsx
@@ -28,7 +28,7 @@ type Props = {
   setLocationPermissionNeeded: Function,
   showImproveWithLocationButton: boolean,
   topSuggestion: Object,
-  usingOfflineSuggestions: boolean,
+  usingOfflineSuggestions: boolean
 };
 
 const SuggestionsHeader = ( {

--- a/src/components/Suggestions/SuggestionsHeader.tsx
+++ b/src/components/Suggestions/SuggestionsHeader.tsx
@@ -2,7 +2,7 @@ import { useNavigation, useRoute } from "@react-navigation/native";
 import {
   Body2,
   Body3,
-  Button,
+  // Button,
   Heading4,
   INatIcon,
   INatIconButton
@@ -25,8 +25,8 @@ type Props = {
   reloadSuggestions: Function,
   renderSuggestion: Function,
   selectedPhotoUri: string,
-  setLocationPermissionNeeded: Function,
-  showImproveWithLocationButton: boolean,
+  // setLocationPermissionNeeded: Function,
+  // showImproveWithLocationButton: boolean,
   topSuggestion: Object,
   usingOfflineSuggestions: boolean
 };
@@ -39,8 +39,8 @@ const SuggestionsHeader = ( {
   reloadSuggestions,
   renderSuggestion,
   selectedPhotoUri,
-  setLocationPermissionNeeded,
-  showImproveWithLocationButton,
+  // setLocationPermissionNeeded,
+  // showImproveWithLocationButton,
   topSuggestion,
   usingOfflineSuggestions
 }: Props ): Node => {
@@ -74,7 +74,7 @@ const SuggestionsHeader = ( {
           onPressPhoto={onPressPhoto}
         />
       </View>
-      {showImproveWithLocationButton && (
+      {/* {showImproveWithLocationButton && (
         <View className="mx-5 mt-5">
           <Button
             text={t( "IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION" )}
@@ -83,7 +83,7 @@ const SuggestionsHeader = ( {
             onPress={( ) => setLocationPermissionNeeded( true )}
           />
         </View>
-      )}
+      )} */}
       {!loading && (
         <>
           { usingOfflineSuggestions && (

--- a/src/components/Suggestions/hooks/useOnlineSuggestions.ts
+++ b/src/components/Suggestions/hooks/useOnlineSuggestions.ts
@@ -90,7 +90,7 @@ const useOnlineSuggestions = (
   const {
     data: onlineSuggestions,
     dataUpdatedAt,
-    isPending,
+    fetchStatus,
     error
   } = useAuthenticatedQuery(
     ["scoreImage", selectedPhotoUri],
@@ -108,8 +108,6 @@ const useOnlineSuggestions = (
     }
   );
 
-  console.log( isPending, "refetch in useOnlineSuggestions" );
-
   // Give up on suggestions request after a timeout
   useEffect( ( ) => {
     const timer = setTimeout( ( ) => {
@@ -125,7 +123,6 @@ const useOnlineSuggestions = (
   }, [onlineSuggestions, selectedPhotoUri, queryClient] );
 
   const refetchSuggestions = async ( ) => {
-    console.log( "refetching suggestions" );
     setTimedOut( false );
     await queryClient.refetchQueries( { queryKey: ["scoreImage", selectedPhotoUri] } );
   };
@@ -141,7 +138,7 @@ const useOnlineSuggestions = (
     error,
     timedOut,
     refetchSuggestions,
-    isPending
+    fetchStatus
   };
 
   return timedOut

--- a/src/components/Suggestions/hooks/useOnlineSuggestions.ts
+++ b/src/components/Suggestions/hooks/useOnlineSuggestions.ts
@@ -85,7 +85,9 @@ const useOnlineSuggestions = (
     dataUpdatedAt,
     isLoading: loadingOnlineSuggestions,
     isError,
-    error
+    error,
+    refetch,
+    isRefetching
   } = useAuthenticatedQuery(
     ["scoreImage", selectedPhotoUri],
     async optsWithAuth => {
@@ -122,20 +124,24 @@ const useOnlineSuggestions = (
     }
   }, [isOnline] );
 
+  const queryObject = {
+    dataUpdatedAt,
+    error,
+    timedOut,
+    refetch,
+    isRefetching
+  };
+
   return timedOut
     ? {
-      dataUpdatedAt,
-      error,
+      ...queryObject,
       onlineSuggestions: undefined,
-      loadingOnlineSuggestions: false,
-      timedOut
+      loadingOnlineSuggestions: false
     }
     : {
-      dataUpdatedAt,
-      error,
+      ...queryObject,
       onlineSuggestions,
-      loadingOnlineSuggestions: loadingOnlineSuggestions && !isError,
-      timedOut
+      loadingOnlineSuggestions: loadingOnlineSuggestions && !isError
     };
 };
 

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -426,6 +426,7 @@ Identify-an-organism-with-the-iNaturalist-AI-Camera = Identify an organism with 
 If-an-account-with-that-email-exists = If an account with that email exists, we've sent password reset instructions to your email.
 If-you-want-to-collate-compare-promote = If you want to collate, compare, or promote a set of existing projects, then an Umbrella project is what you should use. For example the 2018 City Nature Challenge, which collated over 60 projects, made for a great landing page where anyone could compare and contrast each city's observations. Both Collection and Traditional projects can be used in an Umbrella project, and up to 500 projects can be collated by an Umbrella project.
 If-youre-seeing-this-error = If you're seeing this and you're online, iNat staff have already been notified. Thanks for finding a bug! If you're offline, please take a screenshot and send us an email when you're back on the Internet.
+IGNORE-LOCATION = IGNORE LOCATION
 Import-Photos-From = Import Photos From
 # Shows the number of observations a user is about to import
 IMPORT-X-OBSERVATIONS =
@@ -816,6 +817,8 @@ SEARCH-FOR-A-TAXON = SEARCH FOR A TAXON
 Search-for-a-taxon = Search for a taxon
 SEARCH-LOCATION = SEARCH LOCATION
 SEARCH-PROJECTS = SEARCH PROJECTS
+Search-suggestions-with-location = Search suggestions with location
+Search-suggestions-without-location = Search suggestions without location
 SEARCH-TAXA = SEARCH TAXA
 SEARCH-USERS = SEARCH USERS
 # Accessibility label for Explore button on MyObservations toolbar

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -640,6 +640,7 @@ October = October
 Offensive-Inappropriate = Offensive/Inappropriate
 Offensive-Inappropriate-Examples = Misleading or illegal content, racial or ethnic slurs, etc. For more on our defintion of "appropriate," see the FAQ.
 Offline-DQA-description = The DQA may not be accurate. Check your internet connection and try again.
+Offline-suggestions-do-not-use-your-location = Offline suggestions do not use your location and may differ from online suggestions. Taxon images and common names may not load.
 # Generic confirmation, e.g. button on a warning alert
 OK = OK
 # Sort order, refers to newest or oldest date
@@ -990,10 +991,6 @@ VIEW-PROJECTS = VIEW PROJECTS
 # or photo
 View-suggestions = View suggestions
 VIEW-TEACHERS-GUIDE = VIEW TEACHERS' GUIDE
-# Title for a notice informing the user that they are viewing offline
-# identification suggestions
-Viewing-Offline-Suggestions = Viewing Offline Suggestions
-Viewing-Offline-Suggestions-results-may-differ = Results may differ from the online suggestions and images and common names may not display.
 We-sent-a-confirmation-email = We sent a confirmation email to the email you signed up with.
 We-store-personal-information = We store personal information like usernames and email addresses in order to manage accounts on this site, and to comply with privacy laws, we need you to check this box to indicate that you consent to this use of personal information. To learn more about what information we collect and how we use it, please see our Privacy Policy and our Terms of Use.
 Welcome-to-iNaturalist = Welcome to iNaturalist!
@@ -1110,6 +1107,7 @@ x-uploads-failed =
        *[other] { $count } uploads failed
     }
 Yes-license-my-photos = Yes, license my photos, sounds, and observations so scientists can use my data (recommended)
+You-are-offline-Tap-to-reload = You are offline. Tap to reload.
 You-are-offline-Tap-to-try-again = You are offline. Tap to try again.
 You-can-add-up-to-20-media = You can add up to 20 photos and 20 sounds per observation.
 You-can-also-check-out-merchandise = You can also check out merchandise for iNaturalist and Seek at our store below!

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -434,6 +434,7 @@ IMPORT-X-OBSERVATIONS =
         [one] 1 OBSERVATION
        *[other] { $count } OBSERVATIONS
     }
+IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION = IMPROVE THESE SUGGESTIONS BY USING YOUR LOCATION
 # Identification category
 improving--identification = Improving
 INATURALIST-ACCOUNT-SETTINGS = INATURALIST ACCOUNT SETTINGS
@@ -657,6 +658,7 @@ OPEN-SETTINGS = OPEN SETTINGS
 Opens-add-comment-modal = Opens add comment modal.
 Opens-add-observation-modal = Opens add observation modal.
 Opens-AI-camera = Opens AI camera.
+Opens-location-permission-prompt = Opens location permission prompt
 Opens-the-side-drawer-menu = Opens the side drawer menu.
 # Picker prompt on observation edit
 Organism-is-captive = Organism is captive

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -34,6 +34,7 @@ ACTIVITY = ACTIVITY
 # Label for a button that adds a vote of agreement
 Add-agreement = Add agreement
 ADD-AN-ID = ADD AN ID
+Add-an-ID-Later = Add an ID Later
 ADD-COMMENT = ADD COMMENT
 Add-comment = Add comment
 Add-Date-Time = Add Date/Time
@@ -72,7 +73,6 @@ All-organisms = All organisms
 # As in intellectual property rights over a photo or other creative work
 all-rights-reserved = all rights reserved
 # As in automated identification suggestions
-ALL-SUGGESTIONS = ALL SUGGESTIONS
 Almost-done = Almost done!
 Already-have-an-account = Already have an account? Log in
 An-Internet-connection-is-required = An Internet connection is required to load more observations.
@@ -186,7 +186,6 @@ CONFIRM = CONFIRM
 Connect-with-other-naturalists = Connect with other naturalists and engage in conversations.
 Connection-problem-Please-try-again-later = Connection problem. Please try again later.
 CONTACT-SUPPORT = CONTACT SUPPORT
-CONTINUE = CONTINUE
 Continue-to-iNaturalist = Continue to iNaturalist
 # Notification when coordinates have been copied
 Coordinates-copied-to-clipboard = Coordinates copied to clipboard
@@ -448,6 +447,7 @@ iNaturalist-helps-you-identify = iNaturalist helps you identify the plants and a
 iNaturalist-identification-suggestions-are-based-on = iNaturalist's identification suggestions are based on observations and identifications made by the iNaturalist community, including { $user1 }, { $user2 }, { $user3 }, and many others.
 iNaturalist-is-a-501 = iNaturalist is a 501(c)(3) non-profit in the United States of America (Tax ID/EIN 92-1296468).
 iNaturalist-is-a-community-of-naturalists = iNaturalist is a community of naturalists that works together to create and identify wild biodiversity observations.
+iNaturalist-is-loading-ID-suggestions = iNaturalist is loading ID suggestions...
 iNaturalist-is-supported-by = iNaturalist is supported by an independent, 501(c)(3) nonprofit organization based in the United States of America. The iNaturalist platform includes this app, Seek by iNaturalist, the iNaturalist website, and more.
 iNaturalist-is-supported-by-community = iNaturalist is supported by our amazing community. From everyday naturalists who add observations and identifications, to curators who assist in the curation of taxonomy and moderation, to the volunteer translators at who make iNaturalist more accessible to worldwide audiences, to our community-based donors, we are extraordinarily grateful for all the people of our community who make iNaturalist the platform it is.
 iNaturalist-mission-is-to-connect = iNaturalist's mission is to connect people to nature and advance biodiversity science and conservation.
@@ -572,7 +572,6 @@ Navigates-to-your-observations = Navigates to your observations
 # Header for nearby projects
 NEARBY = NEARBY
 Nearby = Nearby
-NEARBY-SUGGESTIONS = NEARBY SUGGESTIONS
 Needs-ID = Needs ID
 # Heading when creating a new observation
 New-Observation = New Observation
@@ -666,6 +665,7 @@ Organisms-that-are-identified-to-species = Organisms that are identified to spec
 # one of the existing options
 Other = Other
 OTHER-DATA = OTHER DATA
+OTHER-SUGGESTIONS = OTHER SUGGESTIONS
 PASSWORD = PASSWORD
 PERSONAL-INFO = PERSONAL INFO
 Photo-importer = Photo importer
@@ -832,7 +832,6 @@ Select-captive-or-cultivated-status = Select captive or cultivated status
 Select-geoprivacy-status = Select geoprivacy status
 Select-or-drag-media = Select or drag media
 Select-photo = Select photo
-Select-the-identification-you-want-to-add = Select the identification you want to add to this observation. You can add a filter to further refine your results or search for a taxon.
 # Label for an element that let's you select a user
 Select-user = Select user
 Selects-iconic-taxon-X-for-identification = Selects iconic taxon { $iconicTaxon } for identification.

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -861,6 +861,7 @@
   "Offensive-Inappropriate": "Offensive/Inappropriate",
   "Offensive-Inappropriate-Examples": "Misleading or illegal content, racial or ethnic slurs, etc. For more on our defintion of \"appropriate,\" see the FAQ.",
   "Offline-DQA-description": "The DQA may not be accurate. Check your internet connection and try again.",
+  "Offline-suggestions-do-not-use-your-location": "Offline suggestions do not use your location and may differ from online suggestions. Taxon images and common names may not load.",
   "OK": {
     "comment": "Generic confirmation, e.g. button on a warning alert",
     "val": "OK"
@@ -1330,11 +1331,6 @@
     "val": "View suggestions"
   },
   "VIEW-TEACHERS-GUIDE": "VIEW TEACHERS' GUIDE",
-  "Viewing-Offline-Suggestions": {
-    "comment": "Title for a notice informing the user that they are viewing offline\nidentification suggestions",
-    "val": "Viewing Offline Suggestions"
-  },
-  "Viewing-Offline-Suggestions-results-may-differ": "Results may differ from the online suggestions and images and common names may not display.",
   "We-sent-a-confirmation-email": "We sent a confirmation email to the email you signed up with.",
   "We-store-personal-information": "We store personal information like usernames and email addresses in order to manage accounts on this site, and to comply with privacy laws, we need you to check this box to indicate that you consent to this use of personal information. To learn more about what information we collect and how we use it, please see our Privacy Policy and our Terms of Use.",
   "Welcome-to-iNaturalist": "Welcome to iNaturalist!",
@@ -1393,6 +1389,7 @@
   "X-Species": "{ $count ->\n  [one] { $count } Species\n *[other] { $count } Species\n}",
   "x-uploads-failed": "{ $count ->\n  [one] { $count } upload failed\n *[other] { $count } uploads failed\n}",
   "Yes-license-my-photos": "Yes, license my photos, sounds, and observations so scientists can use my data (recommended)",
+  "You-are-offline-Tap-to-reload": "You are offline. Tap to reload.",
   "You-are-offline-Tap-to-try-again": "You are offline. Tap to try again.",
   "You-can-add-up-to-20-media": "You can add up to 20 photos and 20 sounds per observation.",
   "You-can-also-check-out-merchandise": "You can also check out merchandise for iNaturalist and Seek at our store below!",

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -26,6 +26,7 @@
     "val": "Add agreement"
   },
   "ADD-AN-ID": "ADD AN ID",
+  "Add-an-ID-Later": "Add an ID Later",
   "ADD-COMMENT": "ADD COMMENT",
   "Add-comment": "Add comment",
   "Add-Date-Time": "Add Date/Time",
@@ -78,11 +79,10 @@
     "comment": "As in intellectual property rights over a photo or other creative work",
     "val": "all rights reserved"
   },
-  "ALL-SUGGESTIONS": {
+  "Almost-done": {
     "comment": "As in automated identification suggestions",
-    "val": "ALL SUGGESTIONS"
+    "val": "Almost done!"
   },
-  "Almost-done": "Almost done!",
   "Already-have-an-account": "Already have an account? Log in",
   "An-Internet-connection-is-required": "An Internet connection is required to load more observations.",
   "Any": {
@@ -262,7 +262,6 @@
   "Connect-with-other-naturalists": "Connect with other naturalists and engage in conversations.",
   "Connection-problem-Please-try-again-later": "Connection problem. Please try again later.",
   "CONTACT-SUPPORT": "CONTACT SUPPORT",
-  "CONTINUE": "CONTINUE",
   "Continue-to-iNaturalist": "Continue to iNaturalist",
   "Coordinates-copied-to-clipboard": {
     "comment": "Notification when coordinates have been copied",
@@ -607,6 +606,7 @@
   "iNaturalist-identification-suggestions-are-based-on": "iNaturalist's identification suggestions are based on observations and identifications made by the iNaturalist community, including { $user1 }, { $user2 }, { $user3 }, and many others.",
   "iNaturalist-is-a-501": "iNaturalist is a 501(c)(3) non-profit in the United States of America (Tax ID/EIN 92-1296468).",
   "iNaturalist-is-a-community-of-naturalists": "iNaturalist is a community of naturalists that works together to create and identify wild biodiversity observations.",
+  "iNaturalist-is-loading-ID-suggestions": "iNaturalist is loading ID suggestions...",
   "iNaturalist-is-supported-by": "iNaturalist is supported by an independent, 501(c)(3) nonprofit organization based in the United States of America. The iNaturalist platform includes this app, Seek by iNaturalist, the iNaturalist website, and more.",
   "iNaturalist-is-supported-by-community": "iNaturalist is supported by our amazing community. From everyday naturalists who add observations and identifications, to curators who assist in the curation of taxonomy and moderation, to the volunteer translators at who make iNaturalist more accessible to worldwide audiences, to our community-based donors, we are extraordinarily grateful for all the people of our community who make iNaturalist the platform it is.",
   "iNaturalist-mission-is-to-connect": "iNaturalist's mission is to connect people to nature and advance biodiversity science and conservation.",
@@ -760,7 +760,6 @@
     "val": "NEARBY"
   },
   "Nearby": "Nearby",
-  "NEARBY-SUGGESTIONS": "NEARBY SUGGESTIONS",
   "Needs-ID": "Needs ID",
   "New-Observation": {
     "comment": "Heading when creating a new observation",
@@ -897,6 +896,7 @@
     "val": "Other"
   },
   "OTHER-DATA": "OTHER DATA",
+  "OTHER-SUGGESTIONS": "OTHER SUGGESTIONS",
   "PASSWORD": "PASSWORD",
   "PERSONAL-INFO": "PERSONAL INFO",
   "Photo-importer": "Photo importer",
@@ -1138,7 +1138,6 @@
   "Select-geoprivacy-status": "Select geoprivacy status",
   "Select-or-drag-media": "Select or drag media",
   "Select-photo": "Select photo",
-  "Select-the-identification-you-want-to-add": "Select the identification you want to add to this observation. You can add a filter to further refine your results or search for a taxon.",
   "Select-user": {
     "comment": "Label for an element that let's you select a user",
     "val": "Select user"

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -585,6 +585,7 @@
   "If-an-account-with-that-email-exists": "If an account with that email exists, we've sent password reset instructions to your email.",
   "If-you-want-to-collate-compare-promote": "If you want to collate, compare, or promote a set of existing projects, then an Umbrella project is what you should use. For example the 2018 City Nature Challenge, which collated over 60 projects, made for a great landing page where anyone could compare and contrast each city's observations. Both Collection and Traditional projects can be used in an Umbrella project, and up to 500 projects can be collated by an Umbrella project.",
   "If-youre-seeing-this-error": "If you're seeing this and you're online, iNat staff have already been notified. Thanks for finding a bug! If you're offline, please take a screenshot and send us an email when you're back on the Internet.",
+  "IGNORE-LOCATION": "IGNORE LOCATION",
   "Import-Photos-From": "Import Photos From",
   "IMPORT-X-OBSERVATIONS": {
     "comment": "Shows the number of observations a user is about to import",
@@ -1112,6 +1113,8 @@
   "Search-for-a-taxon": "Search for a taxon",
   "SEARCH-LOCATION": "SEARCH LOCATION",
   "SEARCH-PROJECTS": "SEARCH PROJECTS",
+  "Search-suggestions-with-location": "Search suggestions with location",
+  "Search-suggestions-without-location": "Search suggestions without location",
   "SEARCH-TAXA": "SEARCH TAXA",
   "SEARCH-USERS": "SEARCH USERS",
   "See-all-your-observations-in-explore": {

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -591,6 +591,7 @@
     "comment": "Shows the number of observations a user is about to import",
     "val": "IMPORT { $count ->\n  [one] 1 OBSERVATION\n *[other] { $count } OBSERVATIONS\n}"
   },
+  "IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION": "IMPROVE THESE SUGGESTIONS BY USING YOUR LOCATION",
   "improving--identification": {
     "comment": "Identification category",
     "val": "Improving"
@@ -886,6 +887,7 @@
   "Opens-add-comment-modal": "Opens add comment modal.",
   "Opens-add-observation-modal": "Opens add observation modal.",
   "Opens-AI-camera": "Opens AI camera.",
+  "Opens-location-permission-prompt": "Opens location permission prompt",
   "Opens-the-side-drawer-menu": "Opens the side drawer menu.",
   "Organism-is-captive": {
     "comment": "Picker prompt on observation edit",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -426,6 +426,7 @@ Identify-an-organism-with-the-iNaturalist-AI-Camera = Identify an organism with 
 If-an-account-with-that-email-exists = If an account with that email exists, we've sent password reset instructions to your email.
 If-you-want-to-collate-compare-promote = If you want to collate, compare, or promote a set of existing projects, then an Umbrella project is what you should use. For example the 2018 City Nature Challenge, which collated over 60 projects, made for a great landing page where anyone could compare and contrast each city's observations. Both Collection and Traditional projects can be used in an Umbrella project, and up to 500 projects can be collated by an Umbrella project.
 If-youre-seeing-this-error = If you're seeing this and you're online, iNat staff have already been notified. Thanks for finding a bug! If you're offline, please take a screenshot and send us an email when you're back on the Internet.
+IGNORE-LOCATION = IGNORE LOCATION
 Import-Photos-From = Import Photos From
 # Shows the number of observations a user is about to import
 IMPORT-X-OBSERVATIONS =
@@ -816,6 +817,8 @@ SEARCH-FOR-A-TAXON = SEARCH FOR A TAXON
 Search-for-a-taxon = Search for a taxon
 SEARCH-LOCATION = SEARCH LOCATION
 SEARCH-PROJECTS = SEARCH PROJECTS
+Search-suggestions-with-location = Search suggestions with location
+Search-suggestions-without-location = Search suggestions without location
 SEARCH-TAXA = SEARCH TAXA
 SEARCH-USERS = SEARCH USERS
 # Accessibility label for Explore button on MyObservations toolbar

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -640,6 +640,7 @@ October = October
 Offensive-Inappropriate = Offensive/Inappropriate
 Offensive-Inappropriate-Examples = Misleading or illegal content, racial or ethnic slurs, etc. For more on our defintion of "appropriate," see the FAQ.
 Offline-DQA-description = The DQA may not be accurate. Check your internet connection and try again.
+Offline-suggestions-do-not-use-your-location = Offline suggestions do not use your location and may differ from online suggestions. Taxon images and common names may not load.
 # Generic confirmation, e.g. button on a warning alert
 OK = OK
 # Sort order, refers to newest or oldest date
@@ -990,10 +991,6 @@ VIEW-PROJECTS = VIEW PROJECTS
 # or photo
 View-suggestions = View suggestions
 VIEW-TEACHERS-GUIDE = VIEW TEACHERS' GUIDE
-# Title for a notice informing the user that they are viewing offline
-# identification suggestions
-Viewing-Offline-Suggestions = Viewing Offline Suggestions
-Viewing-Offline-Suggestions-results-may-differ = Results may differ from the online suggestions and images and common names may not display.
 We-sent-a-confirmation-email = We sent a confirmation email to the email you signed up with.
 We-store-personal-information = We store personal information like usernames and email addresses in order to manage accounts on this site, and to comply with privacy laws, we need you to check this box to indicate that you consent to this use of personal information. To learn more about what information we collect and how we use it, please see our Privacy Policy and our Terms of Use.
 Welcome-to-iNaturalist = Welcome to iNaturalist!
@@ -1110,6 +1107,7 @@ x-uploads-failed =
        *[other] { $count } uploads failed
     }
 Yes-license-my-photos = Yes, license my photos, sounds, and observations so scientists can use my data (recommended)
+You-are-offline-Tap-to-reload = You are offline. Tap to reload.
 You-are-offline-Tap-to-try-again = You are offline. Tap to try again.
 You-can-add-up-to-20-media = You can add up to 20 photos and 20 sounds per observation.
 You-can-also-check-out-merchandise = You can also check out merchandise for iNaturalist and Seek at our store below!

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -434,6 +434,7 @@ IMPORT-X-OBSERVATIONS =
         [one] 1 OBSERVATION
        *[other] { $count } OBSERVATIONS
     }
+IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION = IMPROVE THESE SUGGESTIONS BY USING YOUR LOCATION
 # Identification category
 improving--identification = Improving
 INATURALIST-ACCOUNT-SETTINGS = INATURALIST ACCOUNT SETTINGS
@@ -657,6 +658,7 @@ OPEN-SETTINGS = OPEN SETTINGS
 Opens-add-comment-modal = Opens add comment modal.
 Opens-add-observation-modal = Opens add observation modal.
 Opens-AI-camera = Opens AI camera.
+Opens-location-permission-prompt = Opens location permission prompt
 Opens-the-side-drawer-menu = Opens the side drawer menu.
 # Picker prompt on observation edit
 Organism-is-captive = Organism is captive
@@ -1144,5 +1146,3 @@ Youve-previously-denied-location-permissions = You’ve previously denied locati
 Youve-previously-denied-microphone-permissions = You’ve previously denied microphone permissions, so please enable them in settings.
 Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve location accuracy and get better identifications.
 Zoom-to-current-location = Zoom to current location
-IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION = IMPROVE THESE SUGGESTIONS BY USING YOUR LOCATION
-Opens-location-permission-prompt = Opens location permission prompt

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -34,6 +34,7 @@ ACTIVITY = ACTIVITY
 # Label for a button that adds a vote of agreement
 Add-agreement = Add agreement
 ADD-AN-ID = ADD AN ID
+Add-an-ID-Later = Add an ID Later
 ADD-COMMENT = ADD COMMENT
 Add-comment = Add comment
 Add-Date-Time = Add Date/Time
@@ -72,7 +73,6 @@ All-organisms = All organisms
 # As in intellectual property rights over a photo or other creative work
 all-rights-reserved = all rights reserved
 # As in automated identification suggestions
-ALL-SUGGESTIONS = ALL SUGGESTIONS
 Almost-done = Almost done!
 Already-have-an-account = Already have an account? Log in
 An-Internet-connection-is-required = An Internet connection is required to load more observations.
@@ -186,7 +186,6 @@ CONFIRM = CONFIRM
 Connect-with-other-naturalists = Connect with other naturalists and engage in conversations.
 Connection-problem-Please-try-again-later = Connection problem. Please try again later.
 CONTACT-SUPPORT = CONTACT SUPPORT
-CONTINUE = CONTINUE
 Continue-to-iNaturalist = Continue to iNaturalist
 # Notification when coordinates have been copied
 Coordinates-copied-to-clipboard = Coordinates copied to clipboard
@@ -448,6 +447,7 @@ iNaturalist-helps-you-identify = iNaturalist helps you identify the plants and a
 iNaturalist-identification-suggestions-are-based-on = iNaturalist's identification suggestions are based on observations and identifications made by the iNaturalist community, including { $user1 }, { $user2 }, { $user3 }, and many others.
 iNaturalist-is-a-501 = iNaturalist is a 501(c)(3) non-profit in the United States of America (Tax ID/EIN 92-1296468).
 iNaturalist-is-a-community-of-naturalists = iNaturalist is a community of naturalists that works together to create and identify wild biodiversity observations.
+iNaturalist-is-loading-ID-suggestions = iNaturalist is loading ID suggestions...
 iNaturalist-is-supported-by = iNaturalist is supported by an independent, 501(c)(3) nonprofit organization based in the United States of America. The iNaturalist platform includes this app, Seek by iNaturalist, the iNaturalist website, and more.
 iNaturalist-is-supported-by-community = iNaturalist is supported by our amazing community. From everyday naturalists who add observations and identifications, to curators who assist in the curation of taxonomy and moderation, to the volunteer translators at who make iNaturalist more accessible to worldwide audiences, to our community-based donors, we are extraordinarily grateful for all the people of our community who make iNaturalist the platform it is.
 iNaturalist-mission-is-to-connect = iNaturalist's mission is to connect people to nature and advance biodiversity science and conservation.
@@ -572,7 +572,6 @@ Navigates-to-your-observations = Navigates to your observations
 # Header for nearby projects
 NEARBY = NEARBY
 Nearby = Nearby
-NEARBY-SUGGESTIONS = NEARBY SUGGESTIONS
 Needs-ID = Needs ID
 # Heading when creating a new observation
 New-Observation = New Observation
@@ -666,6 +665,7 @@ Organisms-that-are-identified-to-species = Organisms that are identified to spec
 # one of the existing options
 Other = Other
 OTHER-DATA = OTHER DATA
+OTHER-SUGGESTIONS = OTHER SUGGESTIONS
 PASSWORD = PASSWORD
 PERSONAL-INFO = PERSONAL INFO
 Photo-importer = Photo importer
@@ -832,7 +832,6 @@ Select-captive-or-cultivated-status = Select captive or cultivated status
 Select-geoprivacy-status = Select geoprivacy status
 Select-or-drag-media = Select or drag media
 Select-photo = Select photo
-Select-the-identification-you-want-to-add = Select the identification you want to add to this observation. You can add a filter to further refine your results or search for a taxon.
 # Label for an element that let's you select a user
 Select-user = Select user
 Selects-iconic-taxon-X-for-identification = Selects iconic taxon { $iconicTaxon } for identification.

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1144,3 +1144,5 @@ Youve-previously-denied-location-permissions = You’ve previously denied locati
 Youve-previously-denied-microphone-permissions = You’ve previously denied microphone permissions, so please enable them in settings.
 Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve location accuracy and get better identifications.
 Zoom-to-current-location = Zoom to current location
+IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION = IMPROVE THESE SUGGESTIONS BY USING YOUR LOCATION
+Opens-location-permission-prompt = Opens location permission prompt

--- a/src/sharedHelpers/resizeImage.ts
+++ b/src/sharedHelpers/resizeImage.ts
@@ -1,7 +1,7 @@
 import ImageResizer from "@bam.tech/react-native-image-resizer";
-import { log } from "sharedHelpers/logger";
+// import { log } from "sharedHelpers/logger";
 
-const logger = log.extend( "resizeImage" );
+// const logger = log.extend( "resizeImage" );
 
 const resizeImage = async (
   pathOrUri: string,
@@ -40,7 +40,7 @@ const resizeImage = async (
 
   const { uri } = resizedPhoto;
 
-  logger.info( "resized image: ", resizedPhoto );
+  // logger.debug( "resized image: ", resizedPhoto );
   return uri;
 };
 

--- a/src/sharedHooks/useUserLocation.ts
+++ b/src/sharedHooks/useUserLocation.ts
@@ -13,9 +13,9 @@ import {
   RESULTS
 } from "react-native-permissions";
 import fetchPlaceName from "sharedHelpers/fetchPlaceName";
-import { log } from "sharedHelpers/logger";
+// import { log } from "sharedHelpers/logger";
 
-const logger = log.extend( "userUserLocation" );
+// const logger = log.extend( "userUserLocation" );
 
 // Max time to wait while fetching current location
 const CURRENT_LOCATION_TIMEOUT_MS = 30000;
@@ -48,7 +48,7 @@ function useUserLocation(
   } = options || {};
   const enabled = enabledOpt !== false;
   const [userLocation, setUserLocation] = useState<UserLocation | undefined>( undefined );
-  logger.debug( `userLocation?.latitude: ${userLocation?.latitude}` );
+  // logger.debug( `userLocation?.latitude: ${userLocation?.latitude}` );
   const [isLoading, setIsLoading] = useState( true );
   const [permissionsGranted, setPermissionsGranted] = useState( permissionsGrantedProp );
   const [permissionsChecked, setPermissionsChecked] = useState( false );
@@ -84,9 +84,9 @@ function useUserLocation(
       setIsLoading( true );
 
       const success = async ( position: GeolocationResponse ) => {
-        logger.debug(
-          `getCurrentPosition success, position?.coords?.latitude: ${position?.coords?.latitude}`
-        );
+        // logger.debug(
+        //   `getCurrentPosition success, position?.coords?.latitude: ${position?.coords?.latitude}`
+        // );
         const { coords } = position;
         let locationName;
         if ( !skipName ) {
@@ -152,9 +152,9 @@ function useUserLocation(
   // When the consumer tells us we no longer need to fetch location, reset the
   // user location so it's not stale the next time we need to fetch
   useEffect( ( ) => {
-    logger.debug( "enabled effect" );
+    // logger.debug( "enabled effect" );
     if ( enabled === false ) {
-      logger.debug( "enabled effect, disabled resetting" );
+      // logger.debug( "enabled effect, disabled resetting" );
       setUserLocation( undefined );
       setAccGoodEnough( false );
     }

--- a/src/stores/createExploreSlice.ts
+++ b/src/stores/createExploreSlice.ts
@@ -18,8 +18,8 @@ const DEFAULT_STATE = {
 interface MapRegion {
   latitude: number,
   longitude: number,
-  latitudeDelta: double,
-  longitudeDelta: double
+  latitudeDelta: number,
+  longitudeDelta: number
 }
 
 interface ExploreSlice {

--- a/src/stores/createSyncObservationsSlice.ts
+++ b/src/stores/createSyncObservationsSlice.ts
@@ -1,4 +1,5 @@
 import { activateKeepAwake, deactivateKeepAwake } from "@sayem314/react-native-keep-awake";
+import { StateCreator } from "zustand";
 
 export const SYNC_PENDING = "sync-pending";
 export const BEGIN_MANUAL_SYNC = "begin-manual-sync";

--- a/src/stores/createUploadObservationsSlice.ts
+++ b/src/stores/createUploadObservationsSlice.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { RealmObservation } from "realmModels/types.d.ts";
+import { StateCreator } from "zustand";
 
 export const UPLOAD_CANCELLED = "cancelled";
 export const UPLOAD_PENDING = "pending";

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -319,7 +319,7 @@ describe( "Suggestions", ( ) => {
       );
       const { observations } = await setupAppWithSignedInUser( );
       await navigateToSuggestionsForObservationViaObsEdit( observations[0] );
-      const offlineNotice = await screen.findByText( "Viewing Offline Suggestions" );
+      const offlineNotice = await screen.findByText( /You are offline. Tap to reload/ );
       expect( offlineNotice ).toBeTruthy( );
       const topOfflineTaxonResultButton = await screen.findByTestId(
         `SuggestionsList.taxa.${mockModelResult.predictions[0].taxon_id}.checkmark`

--- a/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
+++ b/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
@@ -569,7 +569,7 @@ exports[`TaxonResult should render correctly 1`] = `
           style={
             [
               {
-                "color": "rgba(98, 91, 113, 1)",
+                "color": "rgba(103, 80, 164, 1)",
                 "fontSize": 40,
               },
               undefined,
@@ -582,7 +582,7 @@ exports[`TaxonResult should render correctly 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>

--- a/tests/unit/components/Suggestions/Suggestions.test.js
+++ b/tests/unit/components/Suggestions/Suggestions.test.js
@@ -40,7 +40,7 @@ describe( "Suggestions", ( ) => {
   test( "should not have accessibility errors", async ( ) => {
     const suggestions = (
       <Suggestions
-        suggestions={mockSuggestionsList}
+        otherSuggestions={mockSuggestionsList}
       />
     );
     expect( suggestions ).toBeAccessible( );
@@ -48,7 +48,7 @@ describe( "Suggestions", ( ) => {
 
   it( "should fetch offline suggestions for current photo", async ( ) => {
     renderComponent( <Suggestions
-      suggestions={mockSuggestionsList}
+      otherSuggestions={mockSuggestionsList}
     /> );
     const taxonTopResult = screen.getByTestId(
       `SuggestionsList.taxa.${mockSuggestionsList[0].taxon.id}`
@@ -63,7 +63,7 @@ describe( "Suggestions", ( ) => {
       comment: "This is a test comment"
     } );
     renderComponent( <Suggestions
-      suggestions={mockSuggestionsList}
+      otherSuggestions={mockSuggestionsList}
     /> );
     const commentSection = screen.getByText(
       i18next.t( "Your-identification-will-be-posted-with-the-following-comment" )
@@ -73,26 +73,36 @@ describe( "Suggestions", ( ) => {
 
   it( "should display empty text if no suggestions are found", ( ) => {
     renderComponent( <Suggestions
-      suggestions={[]}
+      otherSuggestions={[]}
     /> );
     const emptyText = i18next
       .t( "iNaturalist-has-no-ID-suggestions-for-this-photo" );
     expect( screen.getByText( emptyText ) ).toBeVisible( );
   } );
 
-  it( "should display a loading wheel if suggestions are loading", ( ) => {
+  it( "should allow user to bypass suggestions screen", ( ) => {
     renderComponent( <Suggestions
-      suggestions={[]}
+      otherSuggestions={[]}
+    /> );
+    const bypassText = screen.getByText( /Add an ID Later/ );
+    expect( bypassText ).toBeVisible( );
+  } );
+
+  it( "should display loading wheel and text when suggestions are loading", ( ) => {
+    renderComponent( <Suggestions
+      otherSuggestions={[]}
       loading
       photoUris={["uri"]}
     /> );
     const loading = screen.getByTestId( "SuggestionsList.loading" );
     expect( loading ).toBeVisible( );
+    const loadingText = screen.getByText( /iNaturalist is loading ID suggestions.../ );
+    expect( loadingText ).toBeVisible( );
   } );
 
   it( "should create an id when checkmark is pressed", async ( ) => {
     renderComponent( <Suggestions
-      suggestions={mockSuggestionsList}
+      otherSuggestions={mockSuggestionsList}
       onTaxonChosen={mockCreateId}
     /> );
     const testID = `SuggestionsList.taxa.${mockSuggestionsList[0].taxon.id}`;


### PR DESCRIPTION
This PR makes most of the changes in the #1592 suggestions enhancement PR. Specifically, it:

1. Updates the UI across all states (checkmarks, search button, help text, skip button, etc.)
2. Adds an ignore/use location button to the online state. When a user toggles this, it also toggles the scoring used (vision_score for fetches with no location parameters, and combined_score for fetches with location parameters)
3. Allows user to reload the screen when they're offline, in case they have a better internet connection available

I didn't add the button for location permission in this PR, because that's currently blocked by https://github.com/inaturalist/iNaturalistReactNative/issues/1594