### PR TITLE
Separate store for RootExplore

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -19,11 +19,11 @@ import {
   useStoredLayout,
   useTranslation
 } from "sharedHooks";
-import useStore from "stores/useStore";
 import { getShadowForColor } from "styles/global";
 import colors from "styles/tailwindColors";
 
 import Header from "./Header/Header";
+import useCurrentExploreView from "./hooks/useCurrentExploreView";
 import IdentifiersView from "./IdentifiersView";
 import ObservationsView from "./ObservationsView";
 import ObservationsViewBar from "./ObservationsViewBar";
@@ -78,21 +78,24 @@ const Explore = ( {
   const [showExploreBottomSheet, setShowExploreBottomSheet] = useState( false );
   const { layout, writeLayoutToStorage } = useStoredLayout( "exploreObservationsLayout" );
   const { isDebug } = useDebugMode( );
-  const exploreView = useStore( state => state.exploreView );
-  const setExploreView = useStore( state => state.setExploreView );
+  const { currentExploreView, setCurrentExploreView } = useCurrentExploreView( );
 
-  const exploreViewAccessibilityLabel = {
+  const exploreViewA11yLabel = {
     observations: t( "Observations-View" ),
     species: t( "Species-View" ),
     observers: t( "Observers-View" ),
     identifiers: t( "Identifiers-View" )
   };
 
+  const icon = exploreViewIcon[currentExploreView];
+  const a11yLabel = exploreViewA11yLabel[currentExploreView];
+  const headerCount = count[currentExploreView];
+
   const renderHeader = ( ) => (
     <Header
-      count={count[exploreView]}
-      exploreView={exploreView}
-      exploreViewIcon={exploreViewIcon[exploreView]}
+      count={headerCount}
+      exploreView={currentExploreView}
+      exploreViewIcon={icon}
       hideBackButton={hideBackButton}
       loadingStatus={loadingStatus}
       openFiltersModal={openFiltersModal}
@@ -143,11 +146,11 @@ const Explore = ( {
         headerText={t( "EXPLORE" )}
         hidden={!showExploreBottomSheet}
         confirm={newView => {
-          setExploreView( newView );
+          setCurrentExploreView( newView );
           setShowExploreBottomSheet( false );
         }}
         radioValues={values}
-        selectedValue={exploreView}
+        selectedValue={currentExploreView}
       />
     );
   };
@@ -159,7 +162,7 @@ const Explore = ( {
       <ViewWrapper testID="Explore" wrapperClassName="overflow-hidden">
         <View className="flex-1 overflow-hidden">
           {renderHeader()}
-          {exploreView === "observations" && (
+          {currentExploreView === "observations" && (
             <ObservationsViewBar
               layout={layout}
               updateObservationsView={writeLayoutToStorage}
@@ -168,7 +171,7 @@ const Explore = ( {
           { isOnline
             ? (
               <View className="flex-1">
-                {exploreView === "observations" && (
+                {currentExploreView === "observations" && (
                   <ObservationsView
                     count={count}
                     layout={layout}
@@ -176,7 +179,7 @@ const Explore = ( {
                     updateCount={updateCount}
                   />
                 )}
-                {exploreView === "species" && (
+                {currentExploreView === "species" && (
                   <SpeciesView
                     count={count}
                     isOnline={isOnline}
@@ -184,7 +187,7 @@ const Explore = ( {
                     updateCount={updateCount}
                   />
                 )}
-                {exploreView === "observers" && (
+                {currentExploreView === "observers" && (
                   <ObserversView
                     count={count}
                     isOnline={isOnline}
@@ -192,7 +195,7 @@ const Explore = ( {
                     updateCount={updateCount}
                   />
                 )}
-                {exploreView === "identifiers" && (
+                {currentExploreView === "identifiers" && (
                   <IdentifiersView
                     count={count}
                     isOnline={isOnline}
@@ -237,14 +240,14 @@ const Explore = ( {
             />
           )}
           <INatIconButton
-            icon={exploreViewIcon[exploreView]}
+            icon={icon}
             color={theme.colors.onPrimary}
             size={27}
             className={classnames(
               grayCircleClass,
               "absolute bottom-5 z-10 right-5"
             )}
-            accessibilityLabel={exploreViewAccessibilityLabel[exploreView]}
+            accessibilityLabel={a11yLabel}
             onPress={() => setShowExploreBottomSheet( true )}
             style={DROP_SHADOW}
           />

--- a/src/components/Explore/RootExploreContainer.js
+++ b/src/components/Explore/RootExploreContainer.js
@@ -25,8 +25,8 @@ const RootExploreContainerWithContext = ( ): Node => {
   const { t } = useTranslation( );
   const isOnline = useIsConnected( );
   const currentUser = useCurrentUser( );
-  const storedParams = useStore( state => state.storedParams );
-  const setStoredParams = useStore( state => state.setStoredParams );
+  const rootStoredParams = useStore( state => state.rootStoredParams );
+  const setRootStoredParams = useStore( state => state.setRootStoredParams );
 
   const worldwidePlaceText = t( "Worldwide" );
 
@@ -126,17 +126,17 @@ const RootExploreContainerWithContext = ( ): Node => {
 
   useEffect( ( ) => {
     navigation.addListener( "focus", ( ) => {
-      const storedState = Object.keys( storedParams ).length > 0 || false;
+      const storedState = Object.keys( rootStoredParams ).length > 0 || false;
 
       if ( storedState ) {
-        dispatch( { type: EXPLORE_ACTION.USE_STORED_STATE, storedState: storedParams } );
+        dispatch( { type: EXPLORE_ACTION.USE_STORED_STATE, storedState: rootStoredParams } );
       }
     } );
 
     navigation.addListener( "blur", ( ) => {
-      setStoredParams( state );
+      setRootStoredParams( state );
     } );
-  }, [navigation, setStoredParams, state, dispatch, storedParams] );
+  }, [navigation, setRootStoredParams, state, dispatch, rootStoredParams] );
 
   return (
     <>

--- a/src/components/Explore/TaxonGridItem.tsx
+++ b/src/components/Explore/TaxonGridItem.tsx
@@ -12,7 +12,8 @@ import React from "react";
 import Photo from "realmModels/Photo";
 import { accessibleTaxonName } from "sharedHelpers/taxon";
 import { useCurrentUser, useTranslation } from "sharedHooks";
-import useStore from "stores/useStore";
+
+import useCurrentExploreView from "./hooks/useCurrentExploreView";
 
 interface Props {
   count: number,
@@ -28,7 +29,7 @@ const TaxonGridItem = ( {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const currentUser = useCurrentUser( );
-  const setExploreView = useStore( state => state.setExploreView );
+  const { setCurrentExploreView } = useCurrentExploreView( );
   const {
     dispatch
   } = useExplore( );
@@ -74,7 +75,7 @@ const TaxonGridItem = ( {
                   taxonId: taxon?.id,
                   taxonName: taxon?.preferred_common_name || taxon?.name
                 } );
-                setExploreView( "observations" );
+                setCurrentExploreView( "observations" );
               }}
               accessibilityRole="link"
             >

--- a/src/components/Explore/hooks/useCurrentExploreView.ts
+++ b/src/components/Explore/hooks/useCurrentExploreView.ts
@@ -9,7 +9,7 @@ const useCurrentExploreView = ( ): Object => {
   const rootExploreView = useStore( state => state.rootExploreView );
   const setRootExploreView = useStore( state => state.setRootExploreView );
   const navState = useNavigationState( nav => nav );
-  const currentScreen = _.last( navState?.routes ).name;
+  const currentScreen = _.last( navState?.routes )?.name;
 
   const currentExploreView = currentScreen === "RootExplore"
     ? rootExploreView

--- a/src/components/Explore/hooks/useCurrentExploreView.ts
+++ b/src/components/Explore/hooks/useCurrentExploreView.ts
@@ -1,0 +1,32 @@
+import { useNavigationState } from "@react-navigation/native";
+import _ from "lodash";
+import { useCallback } from "react";
+import useStore from "stores/useStore";
+
+const useCurrentExploreView = ( ): Object => {
+  const exploreView = useStore( state => state.exploreView );
+  const setExploreView = useStore( state => state.setExploreView );
+  const rootExploreView = useStore( state => state.rootExploreView );
+  const setRootExploreView = useStore( state => state.setRootExploreView );
+  const navState = useNavigationState( nav => nav );
+  const currentScreen = _.last( navState?.routes ).name;
+
+  const currentExploreView = currentScreen === "RootExplore"
+    ? rootExploreView
+    : exploreView;
+
+  const setCurrentExploreView = useCallback( newView => {
+    if ( currentScreen === "RootExplore" ) {
+      setRootExploreView( newView );
+    } else {
+      setExploreView( newView );
+    }
+  }, [currentScreen, setRootExploreView, setExploreView] );
+
+  return {
+    currentExploreView,
+    setCurrentExploreView
+  };
+};
+
+export default useCurrentExploreView;

--- a/src/components/Explore/hooks/useCurrentMapRegion.ts
+++ b/src/components/Explore/hooks/useCurrentMapRegion.ts
@@ -9,7 +9,7 @@ const useCurrentMapRegion = ( ): Object => {
   const rootMapRegion = useStore( s => s.rootMapRegion );
   const setRootMapRegion = useStore( s => s.setRootMapRegion );
   const navState = useNavigationState( nav => nav );
-  const currentScreen = _.last( navState?.routes ).name;
+  const currentScreen = _.last( navState?.routes )?.name;
 
   const currentMapRegion = currentScreen === "RootExplore"
     ? rootMapRegion

--- a/src/components/Explore/hooks/useCurrentMapRegion.ts
+++ b/src/components/Explore/hooks/useCurrentMapRegion.ts
@@ -1,0 +1,32 @@
+import { useNavigationState } from "@react-navigation/native";
+import _ from "lodash";
+import { useCallback } from "react";
+import useStore from "stores/useStore";
+
+const useCurrentMapRegion = ( ): Object => {
+  const mapRegion = useStore( s => s.mapRegion );
+  const setMapRegion = useStore( s => s.setMapRegion );
+  const rootMapRegion = useStore( s => s.rootMapRegion );
+  const setRootMapRegion = useStore( s => s.setRootMapRegion );
+  const navState = useNavigationState( nav => nav );
+  const currentScreen = _.last( navState?.routes ).name;
+
+  const currentMapRegion = currentScreen === "RootExplore"
+    ? rootMapRegion
+    : mapRegion;
+
+  const setCurrentMapRegion = useCallback( newView => {
+    if ( currentScreen === "RootExplore" ) {
+      setRootMapRegion( newView );
+    } else {
+      setMapRegion( newView );
+    }
+  }, [currentScreen, setRootMapRegion, setMapRegion] );
+
+  return {
+    currentMapRegion,
+    setCurrentMapRegion
+  };
+};
+
+export default useCurrentMapRegion;

--- a/src/components/Explore/hooks/useMapLocation.js
+++ b/src/components/Explore/hooks/useMapLocation.js
@@ -7,13 +7,14 @@ import {
   useExplore
 } from "providers/ExploreContext.tsx";
 import { useCallback, useEffect, useState } from "react";
-import { log } from "sharedHelpers/logger";
+// import { log } from "sharedHelpers/logger";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { useTranslation } from "sharedHooks";
 import { initialMapRegion } from "stores/createExploreSlice.ts";
-import useStore from "stores/useStore";
 
-const logger = log.extend( "useMapLocation" );
+import useCurrentMapRegion from "./useCurrentMapRegion";
+
+// const logger = log.extend( "useMapLocation" );
 
 const { useRealm } = RealmContext;
 
@@ -25,8 +26,7 @@ const useMapLocation = ( ): Object => {
   const [mapBoundaries, setMapBoundaries] = useState( null );
   const [showMapBoundaryButton, setShowMapBoundaryButton] = useState( false );
   const [permissionRequested, setPermissionRequested] = useState( null );
-  const mapRegion = useStore( s => s.mapRegion );
-  const setMapRegion = useStore( s => s.setMapRegion );
+  const { currentMapRegion, setCurrentMapRegion } = useCurrentMapRegion( );
 
   const place = state?.place;
 
@@ -38,7 +38,7 @@ const useMapLocation = ( ): Object => {
 
   const mapWasReset = state.place_guess === t( "Nearby" ) || state.place_guess === t( "Worldwide" );
   const placeIdWasSet = state.place_id;
-  const mapWasPanned = state?.lat !== mapRegion.lat;
+  const mapWasPanned = state?.lat !== currentMapRegion.lat;
 
   const updateMapBoundaries = useCallback( async ( newRegion, boundaries ) => {
     const boundaryAPIParams = {
@@ -50,9 +50,9 @@ const useMapLocation = ( ): Object => {
     };
 
     setMapBoundaries( boundaryAPIParams );
-    setMapRegion( newRegion );
+    setCurrentMapRegion( newRegion );
     return boundaryAPIParams;
-  }, [t, setMapBoundaries, setMapRegion] );
+  }, [t, setMapBoundaries, setCurrentMapRegion] );
 
   const redoSearchInMapArea = ( ) => {
     setShowMapBoundaryButton( false );
@@ -69,7 +69,7 @@ const useMapLocation = ( ): Object => {
     // ensure LocationPermissionGate only pops up on fresh install of the app
     const localPrefs = realm.objects( "LocalPreferences" )[0];
     if ( !localPrefs || localPrefs?.explore_location_permission_shown === false ) {
-      logger.info( "showing LocationPermissionGate in Explore, first install only" );
+      // logger.debug( "showing LocationPermissionGate in Explore, first install only" );
       setPermissionRequested( true );
       safeRealmWrite( realm, ( ) => {
         if ( !localPrefs ) {
@@ -98,34 +98,34 @@ const useMapLocation = ( ): Object => {
   // PermissionGate callbacks need to use useCallback, otherwise they'll
   // trigger re-renders if/when they change
   const onPermissionGranted = useCallback( ( ) => {
-    logger.info( "onPermissionGranted" );
+    // logger.debug( "onPermissionGranted" );
     setPermissionRequested( false );
   }, [setPermissionRequested] );
 
   const onPermissionBlocked = useCallback( ( ) => {
-    logger.info( "onPermissionBlocked" );
+    // logger.debug( "onPermissionBlocked" );
     setPermissionRequested( false );
   }, [setPermissionRequested] );
 
   const onPermissionDenied = useCallback( ( ) => {
-    logger.info( "onPermissionDenied" );
+    // logger.debug( "onPermissionDenied" );
     setPermissionRequested( false );
   }, [setPermissionRequested] );
 
   useEffect( ( ) => {
     // region gets set when a user is navigating from ExploreLocationSearch
     if ( placeIdWasSet ) {
-      logger.info( "setting map region based on location search" );
+      // logger.debug( "setting map region based on location search" );
       const { coordinates } = place.point_geojson;
-      setMapRegion( {
+      setCurrentMapRegion( {
         ...initialMapRegion,
         latitude: coordinates[1],
         longitude: coordinates[0]
       } );
     } else if ( mapWasReset ) {
     // map gets set or reset back to nearby/worldwide
-      logger.info( "setting initial nearby or worldwide map region" );
-      setMapRegion( {
+      // logger.debug( "setting initial nearby or worldwide map region" );
+      setCurrentMapRegion( {
         ...initialMapRegion,
         latitude: state?.lat,
         longitude: state?.lng
@@ -136,7 +136,7 @@ const useMapLocation = ( ): Object => {
     mapWasPanned,
     place,
     placeIdWasSet,
-    setMapRegion,
+    setCurrentMapRegion,
     state
   ] );
 
@@ -148,7 +148,7 @@ const useMapLocation = ( ): Object => {
     onZoomToNearby,
     permissionRequested,
     redoSearchInMapArea,
-    region: mapRegion,
+    region: currentMapRegion,
     showMapBoundaryButton,
     startAtNearby,
     updateMapBoundaries

--- a/src/stores/createExploreSlice.ts
+++ b/src/stores/createExploreSlice.ts
@@ -33,9 +33,9 @@ interface ExploreSlice {
 
 const createExploreSlice: StateCreator<ExploreSlice> = set => ( {
   ...DEFAULT_STATE,
-  setStoredParams: params => set( ( ) => ( { storedParams: params } ) ),
+  setStoredParams: storedParams => set( ( ) => ( { storedParams } ) ),
   setExploreView: exploreView => set( ( ) => ( { exploreView } ) ),
-  setMapRegion: region => set( ( ) => ( { mapRegion: region } ) )
+  setMapRegion: mapRegion => set( ( ) => ( { mapRegion } ) )
 } );
 
 export default createExploreSlice;

--- a/src/stores/createRootExploreSlice.ts
+++ b/src/stores/createRootExploreSlice.ts
@@ -1,0 +1,41 @@
+import { StateCreator } from "zustand";
+
+const DELTA = 0.2;
+
+export const initialMapRegion = {
+  latitude: 0.0,
+  longitude: 0.0,
+  latitudeDelta: DELTA,
+  longitudeDelta: DELTA
+};
+
+const DEFAULT_STATE = {
+  rootStoredParams: {},
+  rootExploreView: "species",
+  rootMapRegion: initialMapRegion
+};
+
+interface MapRegion {
+  latitude: number,
+  longitude: number,
+  latitudeDelta: number,
+  longitudeDelta: number
+}
+
+interface RootExploreSlice {
+  rootStoredParams: Object,
+  setRootStoredParams: ( _params: Object ) => void,
+  rootExploreView: string,
+  setRootExploreView: ( _view: string ) => void,
+  rootMapRegion: MapRegion,
+  setRootMapRegion: ( _region: MapRegion ) => void
+}
+
+const createRootExploreSlice: StateCreator<RootExploreSlice> = set => ( {
+  ...DEFAULT_STATE,
+  setRootStoredParams: rootStoredParams => set( ( ) => ( { rootStoredParams } ) ),
+  setRootExploreView: rootExploreView => set( ( ) => ( { rootExploreView } ) ),
+  setRootMapRegion: rootMapRegion => set( ( ) => ( { rootMapRegion } ) )
+} );
+
+export default createRootExploreSlice;

--- a/src/stores/useStore.js
+++ b/src/stores/useStore.js
@@ -5,6 +5,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import createExploreSlice from "./createExploreSlice";
 import createLayoutSlice from "./createLayoutSlice";
 import createObservationFlowSlice from "./createObservationFlowSlice";
+import createRootExploreSlice from "./createRootExploreSlice";
 import createSyncObservationsSlice from "./createSyncObservationsSlice";
 import createUploadObservationsSlice from "./createUploadObservationsSlice";
 
@@ -27,6 +28,7 @@ const useStore = create( persist(
     const slices = [
       createSyncObservationsSlice( ...args ),
       createExploreSlice( ...args ),
+      createRootExploreSlice( ...args ),
       createObservationFlowSlice( ...args ),
       createLayoutSlice( ...args ),
       createUploadObservationsSlice( ...args )

--- a/tests/unit/components/Explore/TaxonGridItem.test.js
+++ b/tests/unit/components/Explore/TaxonGridItem.test.js
@@ -18,7 +18,8 @@ jest.mock( "@react-navigation/native", () => {
     ...actualNav,
     useNavigation: () => ( {
       navigate: mockedNavigate
-    } )
+    } ),
+    useNavigationState: jest.fn( )
   };
 } );
 


### PR DESCRIPTION
Closes #1686

As long as we have a separate RootExplore and Explore screen, we need each of these screens to maintain their own stores. Otherwise, when a user moves from RootExplore -> Explore -> any screen and then backs out to Explore -> RootExplore, they will not see a correct history of the screens with their previous states.

Before this change, when a user backed all the way out to RootExplore, they would see the RootExplore screen displaying the explore view and the relevant filters they had set on Explore, rather than on RootExplore. (So for example, if a user tapped a species, landed on TaxonDetails, then visited Explore for that species, they would back out of navigation all the way to RootExplore and see that screen filtered by the species they selected, even though their original RootExplore screen had no filters.)