### PR TITLE
Show bottom sheet before confirming suggested ID in ObsDetails -> Suggestions flow

### DIFF
--- a/e2e/signedIn.e2e.js
+++ b/e2e/signedIn.e2e.js
@@ -149,7 +149,7 @@ describe( "Signed in user", () => {
     await waitFor( commentButton ).toBeVisible().withTimeout( 10000 );
     await commentButton.tap();
     // Check that the comment modal is visible
-    const commentModalInput = element( by.id( "ObsEdit.notes" ) );
+    const commentModalInput = element( by.id( "TextInputSheet.notes" ) );
     await waitFor( commentModalInput ).toBeVisible().withTimeout( 10000 );
     // Add a comment
     await commentModalInput.tap();
@@ -158,7 +158,7 @@ describe( "Signed in user", () => {
     const bottomSheetHeader = element( by.id( "bottom-sheet-header" ) );
     await bottomSheetHeader.tap();
     // Tap the submit button
-    const commentModalSubmitButton = element( by.id( "ObsEdit.confirm" ) );
+    const commentModalSubmitButton = element( by.id( "TextInputSheet.confirm" ) );
     await commentModalSubmitButton.tap();
     // Check that the comment is visible
     await element( by.id( `ObsDetails.${uuid}` ) ).scrollTo( "bottom" );

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1477,12 +1477,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FasterImage: 60d0750ddbcefff0070c4c17309c2d1d6cc650f0
   FBLazyVector: 9f533d5a4c75ca77c8ed774aced1a91a0701781e
   FBReactNativeSpec: 40b791f4a1df779e7e4aa12c000319f4f216d40a
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 39589e9c297d024e90fe68f6830ff86c4e01498a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MMKV: 506311d0494023c2f7e0b62cc1f31b7370fa3cfb

--- a/src/components/ObsDetails/ActivityTab/ActivityItem.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityItem.js
@@ -20,7 +20,7 @@ type Props = {
   isFirstDisplay: boolean,
   isOnline: boolean,
   item: Object,
-  onIDAgreePressed: Function,
+  openAgreeWithIdSheet: Function,
   refetchRemoteObservation: Function,
   userAgreedId?: string
 }
@@ -30,7 +30,7 @@ const ActivityItem = ( {
   isFirstDisplay,
   isOnline,
   item,
-  onIDAgreePressed,
+  openAgreeWithIdSheet,
   refetchRemoteObservation,
   userAgreedId
 }: Props ): Node => {
@@ -69,7 +69,7 @@ const ActivityItem = ( {
             { showAgreeButton && (
               <INatIconButton
                 testID={`ActivityItem.AgreeIdButton.${item.taxon.id}`}
-                onPress={( ) => onIDAgreePressed( item.taxon )}
+                onPress={( ) => openAgreeWithIdSheet( item.taxon )}
                 icon="id-agree"
                 size={33}
                 accessibilityLabel={t( "Agree" )}

--- a/src/components/ObsDetails/ActivityTab/ActivityTab.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityTab.js
@@ -11,7 +11,7 @@ type Props = {
   observation:Object,
   refetchRemoteObservation: Function,
   activityItems: Array<Object>,
-  onIDAgreePressed: Function,
+  openAgreeWithIdSheet: Function,
   isOnline: boolean
 }
 
@@ -19,7 +19,7 @@ const ActivityTab = ( {
   observation,
   refetchRemoteObservation,
   activityItems,
-  onIDAgreePressed,
+  openAgreeWithIdSheet,
   isOnline
 }: Props ): Node => {
   const currentUser = useCurrentUser( );
@@ -60,7 +60,7 @@ const ActivityTab = ( {
             isOnline={isOnline}
             item={item}
             key={item.uuid}
-            onIDAgreePressed={onIDAgreePressed}
+            openAgreeWithIdSheet={openAgreeWithIdSheet}
             refetchRemoteObservation={refetchRemoteObservation}
             userAgreedId={userAgreedToId}
           />

--- a/src/components/ObsDetails/ActivityTab/FloatingButtons.js
+++ b/src/components/ObsDetails/ActivityTab/FloatingButtons.js
@@ -18,14 +18,14 @@ const DROP_SHADOW = getShadowForColor( colors.black, {
 
 type Props = {
   navToSuggestions: Function,
-  showCommentBox: Function,
-  openCommentBox: Function
+  showAddCommentSheet: Function,
+  openAddCommentSheet: Function
 }
 
 const FloatingButtons = ( {
   navToSuggestions,
-  openCommentBox,
-  showCommentBox
+  openAddCommentSheet,
+  showAddCommentSheet
 }: Props ): Node => {
   const { t } = useTranslation( );
 
@@ -36,10 +36,10 @@ const FloatingButtons = ( {
     >
       <Button
         text={t( "COMMENT" )}
-        onPress={openCommentBox}
+        onPress={openAddCommentSheet}
         className="w-1/2 mx-6"
         testID="ObsDetail.commentButton"
-        disabled={showCommentBox}
+        disabled={showAddCommentSheet}
         accessibilityHint={t( "Opens-add-comment-modal" )}
       />
       <Button

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -1,6 +1,5 @@
 // @flow
 import { useRoute } from "@react-navigation/native";
-import AgreeWithIDSheet from "components/ObsDetails/Sheets/AgreeWithIDSheet";
 import {
   ActivityIndicator,
   HideView,
@@ -23,6 +22,7 @@ import {
 import {
   useTranslation
 } from "sharedHooks";
+import useStore from "stores/useStore";
 
 import ActivityTab from "./ActivityTab/ActivityTab";
 import FloatingButtons from "./ActivityTab/FloatingButtons";
@@ -31,32 +31,38 @@ import FaveButton from "./FaveButton";
 import ObsDetailsHeader from "./ObsDetailsHeader";
 import ObsDetailsOverview from "./ObsDetailsOverview";
 import ObsMediaDisplayContainer from "./ObsMediaDisplayContainer";
+import AgreeWithIDSheet from "./Sheets/AgreeWithIDSheet";
+import SuggestIDSheet from "./Sheets/SuggestIDSheet";
 
 const isTablet = DeviceInfo.isTablet();
 
 type Props = {
   activityItems: Array<Object>,
   addingActivityItem: Function,
-  agreeIdSheetDiscardChanges: Function,
+  closeAgreeWithIdSheet: Function,
   belongsToCurrentUser: boolean,
+  comment: string,
+  commentIsOptional: ?boolean,
+  confirmCommentFromCommentSheet: Function,
   confirmRemoteObsWasDeleted?: Function,
   currentTabId: string,
   currentUser: Object,
-  hideCommentBox: Function,
+  hideAddCommentSheet: Function,
   isOnline: boolean,
   isRefetching: boolean,
   navToSuggestions: Function,
   observation: Object,
   onAgree: Function,
-  onCommentAdded: Function,
-  onIDAgreePressed: Function,
-  openCommentBox: Function,
-  openCommentBox: Function,
+  openAgreeWithIdSheet: Function,
+  onSuggestId: Function,
+  openAddCommentSheet: Function,
   refetchRemoteObservation: Function,
   remoteObsWasDeleted?: boolean,
   showActivityTab: boolean,
   showAgreeWithIdSheet: boolean,
-  showCommentBox: Function,
+  showAddCommentSheet: Function,
+  showSuggestIdSheet: boolean,
+  suggestIdSheetDiscardChanges: Function,
   tabs: Array<Object>,
   taxonForAgreement: ?Object
 }
@@ -64,25 +70,30 @@ type Props = {
 const ObsDetails = ( {
   activityItems,
   addingActivityItem,
-  agreeIdSheetDiscardChanges,
+  closeAgreeWithIdSheet,
   belongsToCurrentUser,
+  comment,
+  commentIsOptional,
+  confirmCommentFromCommentSheet,
   confirmRemoteObsWasDeleted,
   currentTabId,
   currentUser,
-  hideCommentBox,
+  hideAddCommentSheet,
   isOnline,
   isRefetching,
   navToSuggestions,
   observation,
   onAgree,
-  onCommentAdded,
-  onIDAgreePressed,
-  openCommentBox,
+  openAgreeWithIdSheet,
+  onSuggestId,
+  openAddCommentSheet,
   refetchRemoteObservation,
   remoteObsWasDeleted,
   showActivityTab,
   showAgreeWithIdSheet,
-  showCommentBox,
+  showAddCommentSheet,
+  showSuggestIdSheet,
+  suggestIdSheetDiscardChanges,
   tabs,
   taxonForAgreement
 }: Props ): Node => {
@@ -90,6 +101,7 @@ const ObsDetails = ( {
   const { params } = useRoute( );
   const { uuid } = params;
   const { t } = useTranslation( );
+  const currentObservation = useStore( state => state.currentObservation );
 
   const dynamicInsets = useMemo( () => ( {
     backgroundColor: "#ffffff",
@@ -109,7 +121,7 @@ const ObsDetails = ( {
         activityItems={activityItems}
         isOnline={isOnline}
         observation={observation}
-        onIDAgreePressed={onIDAgreePressed}
+        openAgreeWithIdSheet={openAgreeWithIdSheet}
         refetchRemoteObservation={refetchRemoteObservation}
       />
     </HideView>
@@ -168,8 +180,8 @@ const ObsDetails = ( {
         {showActivityTab && (
           <FloatingButtons
             navToSuggestions={navToSuggestions}
-            openCommentBox={openCommentBox}
-            showCommentBox={showCommentBox}
+            openAddCommentSheet={openAddCommentSheet}
+            showAddCommentSheet={showAddCommentSheet}
           />
         )}
       </View>
@@ -229,12 +241,23 @@ const ObsDetails = ( {
       {showActivityTab && currentUser && (
         <FloatingButtons
           navToSuggestions={navToSuggestions}
-          openCommentBox={openCommentBox}
-          showCommentBox={showCommentBox}
+          openAddCommentSheet={openAddCommentSheet}
+          showAddCommentSheet={showAddCommentSheet}
         />
       )}
     </>
   );
+
+  const hasComment = !!( comment || currentObservation?.description );
+
+  const showAddCommentHeader = ( ) => {
+    if ( hasComment ) {
+      return t( "EDIT-COMMENT" );
+    } if ( commentIsOptional ) {
+      return t( "ADD-OPTIONAL-COMMENT" );
+    }
+    return t( "ADD-COMMENT" );
+  };
 
   return (
     <SafeAreaView
@@ -246,18 +269,29 @@ const ObsDetails = ( {
         : renderTablet()}
       {showAgreeWithIdSheet && (
         <AgreeWithIDSheet
-          taxon={taxonForAgreement}
-          handleClose={agreeIdSheetDiscardChanges}
+          comment={comment}
+          handleClose={closeAgreeWithIdSheet}
           onAgree={onAgree}
+          openAddCommentSheet={openAddCommentSheet}
+          taxon={taxonForAgreement}
         />
       )}
       {/* AddCommentSheet */}
-      {showCommentBox && (
+      {showAddCommentSheet && (
         <TextInputSheet
-          handleClose={hideCommentBox}
-          headerText={t( "ADD-COMMENT" )}
+          buttonText={t( "CONFIRM" )}
+          handleClose={hideAddCommentSheet}
+          headerText={showAddCommentHeader( )}
           textInputStyle={textInputStyle}
-          confirm={textInput => onCommentAdded( textInput )}
+          initialInput={comment || currentObservation?.description}
+          confirm={confirmCommentFromCommentSheet}
+        />
+      )}
+      {showSuggestIdSheet && (
+        <SuggestIDSheet
+          openAddCommentSheet={openAddCommentSheet}
+          handleClose={suggestIdSheetDiscardChanges}
+          onSuggestId={onSuggestId}
         />
       )}
       {/*

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -45,12 +45,15 @@ const sortItems = ( ids, comments ) => ids.concat( [...comments] ).sort(
 );
 
 const initialState = {
-  currentTabId: ACTIVITY_TAB_ID,
-  addingActivityItem: false,
-  showAgreeWithIdSheet: false,
-  showCommentBox: false,
-  observationShown: null,
   activityItems: [],
+  addingActivityItem: false,
+  comment: "",
+  commentIsOptional: false,
+  currentTabId: ACTIVITY_TAB_ID,
+  observationShown: null,
+  showAgreeWithIdSheet: false,
+  showAddCommentSheet: false,
+  showSuggestIdSheet: false,
   taxonForAgreement: null
 };
 
@@ -84,12 +87,24 @@ const reducer = ( state, action ) => {
       return {
         ...state,
         showAgreeWithIdSheet: action.showAgreeWithIdSheet,
-        taxonForAgreement: action.taxonForAgreement
+        taxonForAgreement: action.taxonForAgreement || state.taxonForAgreement,
+        comment: action.comment || state.comment
       };
-    case "SHOW_COMMENT_BOX":
+    case "SHOW_ADD_COMMENT_SHEET":
       return {
         ...state,
-        showCommentBox: action.showCommentBox
+        commentIsOptional: action.commentIsOptional,
+        showAddCommentSheet: action.showAddCommentSheet
+      };
+    case "SHOW_SUGGEST_ID_SHEET":
+      return {
+        ...state,
+        showSuggestIdSheet: action.showSuggestIdSheet
+      };
+    case "SET_COMMENT":
+      return {
+        ...state,
+        comment: action.comment
       };
     default:
       throw new Error( );
@@ -100,18 +115,19 @@ const ObsDetailsContainer = ( ): Node => {
   const setObservations = useStore( state => state.setObservations );
   const currentTabId = useStore( state => state.currentTabId );
   const setCurrentTabId = useStore( state => state.setCurrentTabId );
+  const currentObservation = useStore( state => state.currentObservation );
+  const updateObservationKeys = useStore( state => state.updateObservationKeys );
   const currentUser = useCurrentUser( );
   const { params } = useRoute();
   const {
-    comment,
     suggestedTaxonId,
-    uuid,
-    vision
+    uuid
   } = params;
   const navigation = useNavigation( );
   const realm = useRealm( );
   const { t } = useTranslation( );
   const isOnline = useIsConnected( );
+  const vision = currentObservation?.owners_identification_from_vision;
 
   const [state, dispatch] = useReducer( reducer, initialState );
   const [remoteObsWasDeleted, setRemoteObsWasDeleted] = useState( false );
@@ -119,9 +135,12 @@ const ObsDetailsContainer = ( ): Node => {
   const {
     activityItems,
     addingActivityItem,
+    comment,
+    commentIsOptional,
     observationShown,
     showAgreeWithIdSheet,
-    showCommentBox,
+    showAddCommentSheet,
+    showSuggestIdSheet,
     taxonForAgreement
   } = state;
 
@@ -234,7 +253,19 @@ const ObsDetailsContainer = ( ): Node => {
     cancelable: true
   } );
 
-  const openCommentBox = ( ) => dispatch( { type: "SHOW_COMMENT_BOX", showCommentBox: true } );
+  const openAddCommentSheet = ( { isOptional = false } ) => {
+    dispatch( {
+      type: "SHOW_ADD_COMMENT_SHEET",
+      showAddCommentSheet: true,
+      commentIsOptional: isOptional || false
+    } );
+  };
+
+  const hideAddCommentSheet = ( ) => dispatch( {
+    type: "SHOW_ADD_COMMENT_SHEET",
+    showAddCommentSheet: false,
+    comment: null
+  } );
 
   const createCommentMutation = useAuthenticatedMutation(
     ( commentParams, optsWithAuth ) => createComment( commentParams, optsWithAuth ),
@@ -311,32 +342,14 @@ const ObsDetailsContainer = ( ): Node => {
     }
   );
 
-  const onIDAdded = useCallback( () => {
-    if ( !suggestedTaxonId ) return;
-
-    // New taxon identification added by user
-    const idParams = {
-      observation_id: uuid,
-      taxon_id: suggestedTaxonId,
-      vision
-    };
-
-    if ( comment ) {
-      // $FlowIgnore
-      idParams.body = comment;
-    }
-
-    dispatch( { type: "LOADING_ACTIVITY_ITEM" } );
-    createIdentificationMutation.mutate( { identification: idParams } );
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [suggestedTaxonId, uuid, vision] );
+  const openSuggestIdSheet = useCallback( () => {
+    dispatch( { type: "SHOW_SUGGEST_ID_SHEET", showSuggestIdSheet: true } );
+  }, [] );
 
   useEffect( () => {
     if ( !suggestedTaxonId ) return;
-
-    onIDAdded();
-  }, [onIDAdded, suggestedTaxonId] );
+    openSuggestIdSheet( );
+  }, [openSuggestIdSheet, suggestedTaxonId] );
 
   const navToSuggestions = ( ) => {
     setObservations( [observation] );
@@ -356,6 +369,15 @@ const ObsDetailsContainer = ( ): Node => {
     refetchObservationUpdates( );
   };
 
+  const closeAgreeWithIdSheet = ( ) => {
+    dispatch( {
+      type: "SHOW_AGREE_SHEET",
+      showAgreeWithIdSheet: false,
+      taxonForAgreement: null,
+      comment: null
+    } );
+  };
+
   const onAgree = newComment => {
     const agreeParams = {
       observation_id: observation?.uuid,
@@ -365,27 +387,64 @@ const ObsDetailsContainer = ( ): Node => {
 
     dispatch( { type: "LOADING_ACTIVITY_ITEM" } );
     createIdentificationMutation.mutate( { identification: agreeParams } );
-    dispatch( { type: "SHOW_AGREE_SHEET", showAgreeWithIdSheet: false } );
+    closeAgreeWithIdSheet( );
   };
 
-  const agreeIdSheetDiscardChanges = ( ) => {
-    dispatch( { type: "SHOW_AGREE_SHEET", showAgreeWithIdSheet: false } );
-  };
-
-  const onIDAgreePressed = taxon => {
+  const openAgreeWithIdSheet = taxon => {
     dispatch( { type: "SHOW_AGREE_SHEET", showAgreeWithIdSheet: true, taxonForAgreement: taxon } );
   };
+
+  const suggestIdSheetDiscardChanges = ( ) => {
+    dispatch( { type: "SHOW_SUGGEST_ID_SHEET", showSuggestIdSheet: false } );
+  };
+
+  const onSuggestId = ( ) => {
+    const remark = currentObservation?.description;
+    // New taxon identification added by user
+    const idParams = {
+      observation_id: uuid,
+      taxon_id: suggestedTaxonId,
+      vision
+    };
+
+    if ( remark ) {
+      // $FlowIgnore
+      idParams.body = remark;
+    }
+
+    dispatch( { type: "LOADING_ACTIVITY_ITEM" } );
+    createIdentificationMutation.mutate( { identification: idParams } );
+  };
+
+  const confirmCommentFromCommentSheet = newComment => {
+    if ( !commentIsOptional ) {
+      onCommentAdded( newComment );
+    } else if ( suggestedTaxonId ) {
+      updateObservationKeys( {
+        description: newComment
+      } );
+      openSuggestIdSheet( );
+    } else {
+      dispatch( { type: "SET_COMMENT", comment: newComment } );
+      openAgreeWithIdSheet( taxonForAgreement );
+    }
+  };
+
+  console.log( state.comment, state.taxonForAgreement, "state and taxon" );
 
   return observationShown && (
     <ObsDetails
       activityItems={activityItems}
       addingActivityItem={addingActivityItem}
-      agreeIdSheetDiscardChanges={agreeIdSheetDiscardChanges}
+      closeAgreeWithIdSheet={closeAgreeWithIdSheet}
       belongsToCurrentUser={belongsToCurrentUser}
+      comment={comment}
+      commentIsOptional={commentIsOptional}
+      confirmCommentFromCommentSheet={confirmCommentFromCommentSheet}
       confirmRemoteObsWasDeleted={confirmRemoteObsWasDeleted}
       currentTabId={currentTabId}
       currentUser={currentUser}
-      hideCommentBox={( ) => dispatch( { type: "SHOW_COMMENT_BOX", showCommentBox: false } )}
+      hideAddCommentSheet={hideAddCommentSheet}
       isOnline={isOnline}
       isRefetching={isRefetching}
       navToSuggestions={navToSuggestions}
@@ -393,14 +452,16 @@ const ObsDetailsContainer = ( ): Node => {
       // limits the number of rerenders to entire obs details tree
       observation={observationShown}
       onAgree={onAgree}
-      onCommentAdded={onCommentAdded}
-      onIDAgreePressed={onIDAgreePressed}
-      openCommentBox={openCommentBox}
+      openAgreeWithIdSheet={openAgreeWithIdSheet}
+      onSuggestId={onSuggestId}
+      openAddCommentSheet={openAddCommentSheet}
       refetchRemoteObservation={invalidateQueryAndRefetch}
       remoteObsWasDeleted={remoteObsWasDeleted}
       showActivityTab={showActivityTab}
       showAgreeWithIdSheet={showAgreeWithIdSheet}
-      showCommentBox={showCommentBox}
+      showAddCommentSheet={showAddCommentSheet}
+      showSuggestIdSheet={showSuggestIdSheet}
+      suggestIdSheetDiscardChanges={suggestIdSheetDiscardChanges}
       tabs={tabs}
       taxonForAgreement={taxonForAgreement}
     />

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -430,8 +430,6 @@ const ObsDetailsContainer = ( ): Node => {
     }
   };
 
-  console.log( state.comment, state.taxonForAgreement, "state and taxon" );
-
   return observationShown && (
     <ObsDetails
       activityItems={activityItems}

--- a/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
+++ b/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
@@ -4,17 +4,18 @@ import {
   Button,
   DisplayTaxon,
   INatIcon,
-  List2,
-  TextInputSheet
+  List2
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
-import React, { useState } from "react";
+import React from "react";
 import { Text } from "react-native";
 
 type Props = {
+  comment: string,
   onAgree:Function,
+  openAddCommentSheet: Function,
   handleClose: Function,
   taxon: Object
 }
@@ -31,82 +32,72 @@ const showTaxon = taxon => {
 };
 
 const AgreeWithIDSheet = ( {
+  comment,
   onAgree,
+  openAddCommentSheet,
   handleClose,
   taxon
-}: Props ): Node => {
-  const [comment, setComment] = useState( "" );
-  const [showCommentBox, setShowCommentBox] = useState( false );
-
-  return (
-    <BottomSheet
-      handleClose={handleClose}
-      headerText={t( "AGREE-WITH-ID" )}
-      text={t( "By-exiting-changes-not-saved" )}
-      buttonText={t( "DISCARD-CHANGES" )}
+}: Props ): Node => (
+  <BottomSheet
+    handleClose={handleClose}
+    headerText={t( "AGREE-WITH-ID" )}
+  >
+    <View
+      className="mx-[26px] space-y-[11px] my-[15px]"
     >
-      <View
-        className="mx-[26px] space-y-[11px] my-[15px]"
-      >
-        <List2 className="text-black">
-          {t( "Agree-with-ID-description" )}
-        </List2>
-        { comment && (
-          <View
-            className=" flex-row items-center bg-lightGray p-[15px] rounded"
-          >
-            <INatIcon name="add-comment-outline" size={22} />
-            <List2 className="ml-[7px] text-black">
-              {comment}
-            </List2>
-          </View>
-        )}
-        {showTaxon( taxon )}
-      </View>
-      <View className="flex-row justify-evenly mx-3 mb-3">
-        {comment
-          ? (
-            <Button
-              text={t( "EDIT-COMMENT" )}
-              onPress={( ) => setShowCommentBox( true )}
-              className="mx-2 grow"
-              testID="ObsDetail.AgreeId.EditCommentButton"
-              disabled={!comment}
-              accessibilityHint={t( "Opens-add-comment-modal" )}
-            />
-          )
-          : (
-            <Button
-              text={t( "ADD-COMMENT" )}
-              onPress={( ) => setShowCommentBox( true )}
-              className="mx-2 grow"
-              testID="ObsDetail.AgreeId.commentButton"
-              disabled={false}
-              accessibilityHint={t( "Opens-add-comment-modal" )}
-            />
-          )}
-
-        <Button
-          text={t( "AGREE" )}
-          onPress={( ) => {
-            onAgree( comment );
-          }}
-          className="mx-2 grow"
-          testID="ObsDetail.AgreeId.cvSuggestionsButton"
-          accessibilityRole="link"
-          accessibilityHint={t( "Navigates-to-suggest-identification" )}
-          level={comment && "primary"}
-        />
-      </View>
-      {showCommentBox && (
-        <TextInputSheet
-          handleClose={( ) => setShowCommentBox( false )}
-          headerText={t( "ADD-OPTIONAL-COMMENT" )}
-          confirm={textInput => setComment( textInput )}
-        />
+      <List2 className="text-black">
+        {t( "Agree-with-ID-description" )}
+      </List2>
+      { comment && (
+        <View
+          className=" flex-row items-center bg-lightGray p-[15px] rounded"
+        >
+          <INatIcon name="add-comment-outline" size={22} />
+          <List2 className="ml-[7px] text-black">
+            {comment}
+          </List2>
+        </View>
       )}
-    </BottomSheet>
-  );
-};
+      {showTaxon( taxon )}
+    </View>
+    <View className="flex-row justify-evenly mx-3 mb-3">
+      {comment
+        ? (
+          <Button
+            text={t( "EDIT-COMMENT" )}
+            onPress={( ) => {
+              openAddCommentSheet( { isOptional: true } );
+              handleClose( );
+            }}
+            className="mx-2 grow"
+            testID="ObsDetail.AgreeId.EditCommentButton"
+            accessibilityHint={t( "Opens-add-comment-modal" )}
+          />
+        )
+        : (
+          <Button
+            text={t( "ADD-COMMENT" )}
+            onPress={( ) => {
+              openAddCommentSheet( { isOptional: true } );
+              handleClose( );
+            }}
+            className="mx-2 grow"
+            testID="ObsDetail.AgreeId.commentButton"
+            accessibilityHint={t( "Opens-add-comment-modal" )}
+          />
+        )}
+
+      <Button
+        text={t( "AGREE" )}
+        onPress={( ) => onAgree( comment )}
+        className="mx-2 grow"
+        testID="ObsDetail.AgreeId.cvSuggestionsButton"
+        accessibilityRole="link"
+        accessibilityHint={t( "Navigates-to-suggest-identification" )}
+        level={comment && "primary"}
+      />
+    </View>
+  </BottomSheet>
+);
 
 export default AgreeWithIDSheet;

--- a/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
+++ b/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
@@ -1,0 +1,104 @@
+import {
+  BottomSheet,
+  Button,
+  DisplayTaxon,
+  INatIcon,
+  List2
+} from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import { t } from "i18next";
+import type { Node } from "react";
+import React from "react";
+import useStore from "stores/useStore";
+
+interface Props {
+  onSuggestId:Function,
+  openAddCommentSheet: Function,
+  handleClose: Function
+}
+
+const showTaxon = taxon => {
+  if ( !taxon ) {
+    return <List2>{t( "Unknown-organism" )}</List2>;
+  }
+  return (
+    <View className="flex-row mx-[15px]">
+      <DisplayTaxon taxon={taxon} />
+    </View>
+  );
+};
+
+const SuggestIDSheet = ( {
+  onSuggestId,
+  openAddCommentSheet,
+  handleClose
+}: Props ): Node => {
+  const currentObservation = useStore( state => state.currentObservation );
+  const comment = currentObservation?.description;
+  const taxon = currentObservation?.taxon;
+
+  return (
+    <BottomSheet
+      handleClose={handleClose}
+      headerText={t( "SUGGEST-ID" )}
+    >
+      <View className="mx-[26px] space-y-[11px] my-[15px]">
+        <List2>
+          {t( "Would-you-like-to-suggest-the-following-identification" )}
+        </List2>
+        { comment && (
+          <View
+            className=" flex-row items-center bg-lightGray p-[15px] rounded"
+          >
+            <INatIcon name="add-comment-outline" size={22} />
+            <List2 className="ml-[7px] text-black">
+              {comment}
+            </List2>
+          </View>
+        )}
+        {showTaxon( taxon )}
+      </View>
+      <View className="flex-row justify-evenly mx-3 mb-3">
+        {comment
+          ? (
+            <Button
+              text={t( "EDIT-COMMENT" )}
+              onPress={( ) => {
+                openAddCommentSheet( { isOptional: true } );
+                handleClose( );
+              }}
+              className="mx-2 grow"
+              testID="SuggestID.EditCommentButton"
+              accessibilityHint={t( "Opens-add-comment-modal" )}
+            />
+          )
+          : (
+            <Button
+              text={t( "ADD-COMMENT" )}
+              onPress={( ) => {
+                openAddCommentSheet( { isOptional: true } );
+                handleClose( );
+              }}
+              className="mx-2 grow"
+              testID="SuggestID.commentButton"
+              accessibilityHint={t( "Opens-add-comment-modal" )}
+            />
+          )}
+        <Button
+          text={t( "SUGGEST-ID" )}
+          onPress={( ) => {
+            onSuggestId( );
+            handleClose( );
+          }}
+          className="mx-2 grow"
+          testID="SuggestIDSheet.cvSuggestionsButton"
+          accessibilityRole="link"
+          accessibilityHint={t( "Add-suggestion-and-remarks-to-observation" )}
+          level="primary"
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default SuggestIDSheet;

--- a/src/components/SharedComponents/Sheets/TextInputSheet.js
+++ b/src/components/SharedComponents/Sheets/TextInputSheet.js
@@ -12,26 +12,32 @@ import { useTheme } from "react-native-paper";
 import useTranslation from "sharedHooks/useTranslation";
 
 type Props = {
-  handleClose: Function,
+  buttonText: string,
   confirm: Function,
+  handleClose: Function,
+  headerText: string,
   initialInput?: ?string,
   placeholder: string,
-  headerText: string,
   textInputStyle?: Object
 }
 
 const TextInputSheet = ( {
-  handleClose,
+  buttonText,
   confirm,
+  handleClose,
+  headerText,
   initialInput = null,
   placeholder,
-  headerText,
   textInputStyle
 }: Props ): Node => {
   const textInputRef = useRef( );
   const theme = useTheme( );
   const [input, setInput] = useState( initialInput );
+  const [hasChanged, setHasChanged] = useState( false );
   const { t } = useTranslation( );
+
+  // disable if user hasn't changed existing text
+  const confirmButtonDisabled = initialInput === input && !hasChanged;
 
   const inputStyle = useMemo( ( ) => ( {
     height: 223,
@@ -54,9 +60,14 @@ const TextInputSheet = ( {
             accessibilityLabel="Text input field"
             keyboardType="default"
             multiline
-            onChangeText={text => setInput( text )}
+            onChangeText={text => {
+              if ( !hasChanged ) {
+                setHasChanged( true );
+              }
+              setInput( text );
+            }}
             placeholder={placeholder}
-            testID="ObsEdit.notes"
+            testID="TextInputSheet.notes"
             style={[inputStyle, textInputStyle]}
             autoFocus
             defaultValue={input}
@@ -71,10 +82,11 @@ const TextInputSheet = ( {
           </Body3>
         </View>
         <Button
-          testID="ObsEdit.confirm"
+          testID="TextInputSheet.confirm"
           className="mt-5"
+          disabled={confirmButtonDisabled}
           level="primary"
-          text={t( "DONE" )}
+          text={buttonText || t( "DONE" )}
           onPress={() => {
             confirm( input );
             handleClose();

--- a/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.js
+++ b/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.js
@@ -25,7 +25,8 @@ const useNavigateWithTaxonSelected = (
 
     updateObservationKeys( {
       owners_identification_from_vision: vision,
-      taxon: selectedTaxon
+      taxon: selectedTaxon,
+      description: comment
     } );
 
     // checking for previous screen here rather than a synced/unsynced observation
@@ -35,9 +36,7 @@ const useNavigateWithTaxonSelected = (
     if ( lastScreen === "ObsDetails" ) {
       navigation.navigate( "ObsDetails", {
         uuid: currentObservation?.uuid,
-        suggestedTaxonId: selectedTaxon.id,
-        comment,
-        vision
+        suggestedTaxonId: selectedTaxon.id
       } );
     } else {
       navigation.navigate( "ObsEdit", { lastScreen: "Suggestions" } );

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -48,6 +48,7 @@ Add-Location = Add Location
 Add-observations = Add observations
 ADD-OPTIONAL-COMMENT = ADD OPTIONAL COMMENT
 Add-optional-notes = Add optional notes
+Add-suggestion-and-remarks-to-observation = Add suggestion and remarks to observation
 # Hint for a button that adds a vote of agreement
 Adds-your-vote-of-agreement = Adds your vote of agreement
 # Hint for a button that adds a vote of disagreement
@@ -1016,6 +1017,7 @@ Withdraws-identification = Withdraws identification
 Worldwide = Worldwide
 WORLDWIDE = WORLDWIDE
 Would-you-like-to-discard-your-current-recording-and-start-over = Would you like to discard your current recording and start over?
+Would-you-like-to-suggest-the-following-identification = Would you like to suggest the following identification?
 x-comments =
     { $count ->
         [one] { $count } comment

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -43,6 +43,7 @@
   },
   "ADD-OPTIONAL-COMMENT": "ADD OPTIONAL COMMENT",
   "Add-optional-notes": "Add optional notes",
+  "Add-suggestion-and-remarks-to-observation": "Add suggestion and remarks to observation",
   "Adds-your-vote-of-agreement": {
     "comment": "Hint for a button that adds a vote of agreement",
     "val": "Adds your vote of agreement"
@@ -1362,6 +1363,7 @@
   "Worldwide": "Worldwide",
   "WORLDWIDE": "WORLDWIDE",
   "Would-you-like-to-discard-your-current-recording-and-start-over": "Would you like to discard your current recording and start over?",
+  "Would-you-like-to-suggest-the-following-identification": "Would you like to suggest the following identification?",
   "x-comments": "{ $count ->\n  [one] { $count } comment\n *[other] { $count } comments\n}",
   "X-Identifications": "{ $count ->\n  [one] { $count } Identification\n *[other] { $count } Identifications\n}",
   "x-identifications": "{ $count ->\n  [one] { $count } identification\n *[other] { $count } identifications\n}",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -48,6 +48,7 @@ Add-Location = Add Location
 Add-observations = Add observations
 ADD-OPTIONAL-COMMENT = ADD OPTIONAL COMMENT
 Add-optional-notes = Add optional notes
+Add-suggestion-and-remarks-to-observation = Add suggestion and remarks to observation
 # Hint for a button that adds a vote of agreement
 Adds-your-vote-of-agreement = Adds your vote of agreement
 # Hint for a button that adds a vote of disagreement
@@ -1016,6 +1017,7 @@ Withdraws-identification = Withdraws identification
 Worldwide = Worldwide
 WORLDWIDE = WORLDWIDE
 Would-you-like-to-discard-your-current-recording-and-start-over = Would you like to discard your current recording and start over?
+Would-you-like-to-suggest-the-following-identification = Would you like to suggest the following identification?
 x-comments =
     { $count ->
         [one] { $count } comment

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -264,6 +264,14 @@ describe( "Suggestions", ( ) => {
     await actor.press( activityTabBtn );
     const activityTab = await screen.findByTestId( "ActivityTab" );
     expect( activityTab ).toBeVisible( );
+    // open bottom sheet
+    const bottomSheetText = await screen.findByText(
+      /Would you like to suggest the following identification/
+    );
+    expect( bottomSheetText ).toBeVisible( );
+    const confirmButton = await screen.findByTestId( "SuggestIDSheet.cvSuggestionsButton" );
+    expect( confirmButton ).toBeVisible( );
+    await actor.press( confirmButton );
     // Wait for the actual identification we created to appear
     const taxonNameInIdent = await within( activityTab ).findByText( topSuggestion.taxon.name );
     expect( taxonNameInIdent ).toBeVisible( );

--- a/tests/unit/components/ObsDetails/ActivityItem.test.js
+++ b/tests/unit/components/ObsDetails/ActivityItem.test.js
@@ -33,7 +33,7 @@ describe( "ActivityItem", () => {
         isFirstDisplay
         item={mockIdentification}
         key={mockIdentification.uuid}
-        onIDAgreePressed={jest.fn()}
+        openAgreeWithIdSheet={jest.fn()}
         userAgreedId=""
       />
     );
@@ -61,19 +61,19 @@ describe( "ActivityItem", () => {
   } );
 
   it( "shows agree sheet with correct taxon", async ( ) => {
-    const mockOnIDAgreePressed = jest.fn();
+    const mockopenAgreeWithIdSheet = jest.fn();
     renderComponent(
       <ActivityItem
         isFirstDisplay
         item={mockIdentification}
-        onIDAgreePressed={mockOnIDAgreePressed}
+        openAgreeWithIdSheet={mockopenAgreeWithIdSheet}
       />
     );
     const agreeButton = await screen.findByTestId(
       `ActivityItem.AgreeIdButton.${mockIdentification.taxon.id}`
     );
     fireEvent.press( agreeButton );
-    expect( mockOnIDAgreePressed ).toHaveBeenCalledWith( mockIdentification.taxon );
+    expect( mockopenAgreeWithIdSheet ).toHaveBeenCalledWith( mockIdentification.taxon );
   } );
 
   it( "renders withdrawn id label", async ( ) => {

--- a/tests/unit/components/ObsDetails/ActivityTab.test.js
+++ b/tests/unit/components/ObsDetails/ActivityTab.test.js
@@ -54,7 +54,7 @@ describe( "ActivityTab", () => {
         observation={mockObservation}
         activityItems={[]}
         refetchRemoteObservation={jest.fn()}
-        onIDAgreePressed={jest.fn()}
+        openAgreeWithIdSheet={jest.fn()}
       />
     );
     expect( await screen.findByTestId( "ActivityTab" ) ).toBeTruthy( );


### PR DESCRIPTION
This flow is mentioned in [#1592](https://github.com/inaturalist/iNaturalistReactNative/issues/1592). It does a couple things:

- Adds a Suggest ID bottom sheet when a user returns from ObsDetails -> Suggestions -> ObsDetails
- Allows a user to add remarks, confirm their suggestion, or cancel
- Fixes a bug where users could not confirm or close out of the "Add Optional Comment" bottom sheet when tapping agree and seeing the agreement bottom sheet