### PR TITLE
DQA voting status

### DIFF
--- a/src/components/ObsDetails/DQAContainer.js
+++ b/src/components/ObsDetails/DQAContainer.js
@@ -45,7 +45,9 @@ const DQAContainer = ( ): React.Node => {
     refetchRemoteObservation,
     isRefetching
   } = useRemoteObservation( observationUUID, fetchRemoteObservationEnabled );
-  const observation = localObservation || Observation.mapApiToRealm( remoteObservation );
+  const observation = remoteObservation
+    ? Observation.mapApiToRealm( remoteObservation )
+    : localObservation;
 
   const fetchMetricsParams = {
     id: observationUUID,
@@ -126,6 +128,7 @@ const DQAContainer = ( ): React.Node => {
     {
       onSuccess: async ( ) => {
         await refetchQualityMetrics( );
+        await refetchRemoteObservation( );
         setNotLoading( );
       },
       onError: error => {
@@ -167,6 +170,7 @@ const DQAContainer = ( ): React.Node => {
     {
       onSuccess: async ( ) => {
         await refetchQualityMetrics( );
+        await refetchRemoteObservation( );
         setNotLoading( );
       },
       onError: error => {

--- a/src/components/ObsDetails/DataQualityAssessment.js
+++ b/src/components/ObsDetails/DataQualityAssessment.js
@@ -121,6 +121,8 @@ const DataQualityAssessment = ( {
     );
   }
 
+  // console.log( "[DEBUG DataQualityAssessment.js] qualityMetrics?.date: ", qualityMetrics?.date );
+
   return (
     <ScrollViewWrapper testID="DataQualityAssessment">
       <View className="mx-[26px] my-[19px] space-y-[9px]">

--- a/tests/integration/DataQualityAssesment/DataQualityAssessment.test.js
+++ b/tests/integration/DataQualityAssesment/DataQualityAssessment.test.js
@@ -32,6 +32,13 @@ jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
   } ) )
 } ) );
 
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: () => ( {
+    data: []
+  } )
+} ) );
+
 const mockMutate = jest.fn();
 jest.mock( "sharedHooks/useAuthenticatedMutation", () => ( {
   __esModule: true,
@@ -51,31 +58,32 @@ useRoute.mockImplementation( ( ) => ( {
   }
 } ) );
 
+async function expectMutateToHaveBeenCalled() {
+  expect( await mockMutate ).toHaveBeenCalled();
+  // Since we mocked the mutate() method, we're expecting mutation not to
+  // succeed. We want to wait for this so there are no extra things happening
+  // outside of act()
+  await screen.findByText( "ERROR LOADING IN DQA" );
+}
+
 describe( "DQA Vote Buttons", ( ) => {
   test( "renders DQA vote buttons", async ( ) => {
     renderComponent( <DQAContainer /> );
-
     const emptyDisagreeButtons = await screen.findAllByTestId( "DQAVoteButton.EmptyDisagree" );
-    fireEvent.press( emptyDisagreeButtons[0] );
-
-    expect( await mockMutate ).toHaveBeenCalled();
+    expect( emptyDisagreeButtons ).toBeTruthy( );
   } );
 
   test( "calls api when DQA disagree button is pressed", async ( ) => {
     renderComponent( <DQAContainer /> );
-
     const emptyDisagreeButtons = await screen.findAllByTestId( "DQAVoteButton.EmptyDisagree" );
     fireEvent.press( emptyDisagreeButtons[0] );
-
-    expect( await mockMutate ).toHaveBeenCalled();
+    await expectMutateToHaveBeenCalled();
   } );
 
   test( "calls api when DQA agree button is pressed", async ( ) => {
     renderComponent( <DQAContainer /> );
-
     const emptyDisagreeButtons = await screen.findAllByTestId( "DQAVoteButton.EmptyAgree" );
     fireEvent.press( emptyDisagreeButtons[0] );
-
-    expect( await mockMutate ).toHaveBeenCalled();
+    await expectMutateToHaveBeenCalled();
   } );
 } );

--- a/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
+++ b/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
@@ -53,6 +53,15 @@ jest.mock( "sharedHooks/useLocalObservation", () => ( {
   default: jest.fn( ( ) => mockObservation )
 } ) );
 
+jest.mock( "sharedHooks/useRemoteObservation", ( ) => ( {
+  __esModule: true,
+  default: ( _uuid, _fetchRemoteEnabled ) => ( {
+    remoteObservation: mockObservation,
+    refetchRemoteObservation: jest.fn( ),
+    isRefetching: false
+  } )
+} ) );
+
 useRoute.mockImplementation( ( ) => ( {
   params: {
     observationUUID: mockObservation.uuid

--- a/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
+++ b/tests/unit/components/ObsDetails/DataQualityAssessment.test.js
@@ -33,6 +33,13 @@ jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
   } ) )
 } ) );
 
+jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
+  __esModule: true,
+  default: () => ( {
+    data: []
+  } )
+} ) );
+
 const mockMutate = jest.fn();
 jest.mock( "sharedHooks/useAuthenticatedMutation", () => ( {
   __esModule: true,


### PR DESCRIPTION
Mostly just cleanup, with the additional feature of updating the DQA header when quality grade changes. I suspect the original error reported in #1504 was happening only when downvoting the `date` or `location` metrics for observations without date or location attributes, which *should* have returned an error from the API but wasn't. That specific error will be resolved by https://github.com/inaturalist/inaturalist/pull/4150, which returns an error status when you do that.

Closes #1504