### PR TITLE
Photos lost from StandardCamera when confirming before processed

### DIFF
--- a/src/components/Camera/Buttons/GreenCheckmark.js
+++ b/src/components/Camera/Buttons/GreenCheckmark.js
@@ -9,10 +9,12 @@ import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
 type Props = {
+  disabled?: boolean,
   handleCheckmarkPress: Function
 }
 
 const GreenCheckmark = ( {
+  disabled,
   handleCheckmarkPress
 }: Props ): Node => {
   const { t } = useTranslation( );
@@ -22,7 +24,7 @@ const GreenCheckmark = ( {
       onPress={handleCheckmarkPress}
       accessibilityLabel={t( "View-suggestions" )}
       accessibilityHint={t( "Shows-identification-suggestions" )}
-      disabled={false}
+      disabled={disabled}
       icon="checkmark-circle"
       color={colors.inatGreen}
       size={40}

--- a/src/components/Camera/StandardCamera/CameraNavButtons.js
+++ b/src/components/Camera/StandardCamera/CameraNavButtons.js
@@ -39,6 +39,7 @@ const CameraNavButtons = ( {
     <View testID="CameraNavButtons">
       <MediaNavButtons
         captureButton={takePhotoButton}
+        disabled={disabled}
         mediaCaptured={photosTaken}
         onClose={handleClose}
         onConfirm={handleCheckmarkPress}

--- a/src/components/Camera/StandardCamera/PhotoPreview.tsx
+++ b/src/components/Camera/StandardCamera/PhotoPreview.tsx
@@ -12,15 +12,13 @@ import PhotoCarousel, {
 } from "./PhotoCarousel";
 
 interface Props {
-  rotation?: {
-    value: number
-  };
   isLandscapeMode?: boolean;
   isLargeScreen?: boolean;
   isTablet?: boolean;
-  takingPhoto: boolean;
-  rotatedOriginalCameraPhotos: string[];
   onDelete: ( _uri: string ) => void;
+  photoUris: string[];
+  rotation?: { value: number };
+  takingPhoto: boolean;
 }
 
 const STYLE = {
@@ -33,10 +31,10 @@ const PhotoPreview = ( {
   isLandscapeMode,
   isLargeScreen,
   isTablet,
+  onDelete,
+  photoUris,
   rotation,
-  takingPhoto,
-  rotatedOriginalCameraPhotos,
-  onDelete
+  takingPhoto
 }: Props ) => {
   const { t } = useTranslation( );
   const wrapperDim = isLargeScreen
@@ -90,11 +88,11 @@ const PhotoPreview = ( {
       style={[STYLE, dynamicStyle]}
     >
       {
-        rotatedOriginalCameraPhotos.length === 0 && !takingPhoto
+        photoUris.length === 0 && !takingPhoto
           ? noPhotosNotice
           : (
             <PhotoCarousel
-              photoUris={rotatedOriginalCameraPhotos.slice().reverse()}
+              photoUris={photoUris.slice().reverse()}
               rotation={rotation}
               takingPhoto={takingPhoto}
               isLargeScreen={isLargeScreen}

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -166,7 +166,7 @@ const StandardCamera = ( {
         isLandscapeMode={isLandscapeMode}
         isLargeScreen={screenWidth > BREAKPOINTS.md}
         isTablet={isTablet}
-        rotatedOriginalCameraPhotos={rotatedOriginalCameraPhotos}
+        photoUris={rotatedOriginalCameraPhotos}
         onDelete={deletePhotoByUri}
       />
       <View className="relative flex-1">

--- a/src/components/SharedComponents/MediaNavButtons.js
+++ b/src/components/SharedComponents/MediaNavButtons.js
@@ -41,6 +41,7 @@ type Props = {
   captureButton: Function,
   closeHidden?: boolean,
   confirmHidden?: boolean,
+  disabled?: boolean,
   mediaCaptured?: boolean,
   onClose: Function,
   onConfirm: Function,
@@ -51,6 +52,7 @@ const MediaNavButtons = ( {
   captureButton,
   closeHidden,
   confirmHidden,
+  disabled,
   mediaCaptured,
   onClose,
   onConfirm,
@@ -80,7 +82,10 @@ const MediaNavButtons = ( {
           style={!isTablet && rotatableAnimatedStyle}
           className={classnames( CHECKMARK_CLASSES, SIDE_BUTTON_CLASSES )}
         >
-          <GreenCheckmark handleCheckmarkPress={onConfirm} />
+          <GreenCheckmark
+            disabled={disabled}
+            handleCheckmarkPress={onConfirm}
+          />
         </Animated.View>
       )
       : (


### PR DESCRIPTION
Narrow solution that disables the confirmation button while a new photo is being processed.

Closes #1690