### PR TITLE
Add Select Taxon button on TaxonDetails

### DIFF
--- a/src/components/SharedComponents/Buttons/Button.tsx
+++ b/src/components/SharedComponents/Buttons/Button.tsx
@@ -15,6 +15,7 @@ interface ButtonProps {
   disabled?: boolean;
   forceDark?: boolean;
   icon?: string;
+  iconPosition?: string,
   level?: string;
   loading?: boolean;
   onPress: ( _event?: GestureResponderEvent ) => void;
@@ -154,6 +155,7 @@ const Button = ( {
   disabled,
   forceDark,
   icon,
+  iconPosition = "left",
   level,
   loading,
   onPress,
@@ -210,7 +212,7 @@ const Button = ( {
             : undefined}
         />
       )}
-      {icon && (
+      {( icon && iconPosition === "left" ) && (
         <View className="mr-2">
           {icon}
         </View>
@@ -221,6 +223,11 @@ const Button = ( {
       >
         {text}
       </Heading4>
+      {( icon && iconPosition === "right" ) && (
+        <View className="ml-4">
+          {icon}
+        </View>
+      )}
       {dropdown && (
         <View className="ml-2 mb-1">
           <INatIcon

--- a/src/components/SharedComponents/TaxonResult.js
+++ b/src/components/SharedComponents/TaxonResult.js
@@ -29,12 +29,14 @@ type Props = {
   handleCheckmarkPress: Function,
   handlePress: Function,
   hideInfoButton?: boolean,
+  lastScreen?: ?string,
   onPressInfo?: Function,
   showCheckmark?: boolean,
   showEditButton?: boolean,
   taxon: Object,
   testID: string,
-  white?: boolean
+  white?: boolean,
+  vision?: boolean
 };
 
 const TaxonResult = ( {
@@ -51,15 +53,18 @@ const TaxonResult = ( {
   handlePress,
   hideInfoButton = false,
   hideNavButtons = false,
+  lastScreen = null,
   onPressInfo,
   showEditButton = false,
   showCheckmark = true,
   taxon: taxonProp,
   testID,
-  white = false
+  white = false,
+  vision = false
 }: Props ): Node => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
+
   const theme = useTheme( );
   const currentUser = useCurrentUser( );
   // thinking about future performance, it might make more sense to batch
@@ -76,10 +81,14 @@ const TaxonResult = ( {
   const taxonImage = { uri: usableTaxon?.default_photo?.url };
   const accessibleName = accessibleTaxonName( usableTaxon, currentUser, t );
 
-  const navToTaxonDetails = () => navigation.navigate( "TaxonDetails", {
-    id: usableTaxon?.id,
-    hideNavButtons
-  } );
+  const navToTaxonDetails = ( ) => {
+    navigation.navigate( "TaxonDetails", {
+      id: usableTaxon?.id,
+      hideNavButtons,
+      lastScreen,
+      vision
+    } );
+  };
 
   return (
     <View

--- a/src/components/Suggestions/Suggestion.js
+++ b/src/components/Suggestions/Suggestion.js
@@ -34,8 +34,10 @@ const Suggestion = ( {
     first
     handleCheckmarkPress={onTaxonChosen}
     hideNavButtons
+    lastScreen="Suggestions"
     taxon={suggestion?.taxon}
     testID={`SuggestionsList.taxa.${suggestion?.taxon?.id}`}
+    vision
   />
 );
 

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { useNavigation, useNavigationState, useRoute } from "@react-navigation/native";
 import { fetchTaxon } from "api/taxa";
 import classnames from "classnames";
 import MediaViewerModal from "components/MediaViewer/MediaViewerModal";
@@ -8,14 +8,17 @@ import {
   ActivityIndicator,
   BackButton,
   Body2,
+  Button,
+  INatIcon,
   INatIconButton,
   KebabMenu,
-  ScrollViewWrapper
+  ScrollViewWrapper,
+  StickyToolbar
 } from "components/SharedComponents";
 import {
   View
 } from "components/styledComponents";
-import { compact } from "lodash";
+import _, { compact } from "lodash";
 import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
 import React, { useCallback, useState } from "react";
@@ -49,6 +52,7 @@ const TAXON_URL = "https://www.inaturalist.org/taxa";
 const isTablet = DeviceInfo.isTablet();
 
 const TaxonDetails = ( ): Node => {
+  const updateObservationKeys = useStore( state => state.updateObservationKeys );
   const setExploreView = useStore( state => state.setExploreView );
   const theme = useTheme( );
   const navigation = useNavigation( );
@@ -59,6 +63,16 @@ const TaxonDetails = ( ): Node => {
   const { remoteUser } = useUserMe( );
   const [kebabMenuVisible, setKebabMenuVisible] = useState( false );
   const [mediaIndex, setMediaIndex] = useState( 0 );
+  const navState = useNavigationState( nav => nav );
+  const history = navState?.routes.map( r => r.name );
+  const fromObsDetails = _.includes( history, "ObsDetails" );
+
+  // previous ObsDetails observation uuid
+  const obsUuid = fromObsDetails
+    ? _.find( navState?.routes, r => r.name === "ObsDetails" ).params.uuid
+    : null;
+
+  const lastScreen = params?.lastScreen;
 
   const realm = useRealm( );
   const localTaxon = realm.objectForPrimaryKey( "Taxon", id );
@@ -134,141 +148,177 @@ const TaxonDetails = ( ): Node => {
   };
 
   return (
-    <ScrollViewWrapper
-      testID={`TaxonDetails.${taxon?.id}`}
-      className="bg-black"
-    >
-      {/*
+    <>
+      <ScrollViewWrapper
+        testID={`TaxonDetails.${taxon?.id}`}
+        className="bg-black"
+      >
+        {/*
         Making the bar dark here seems like the right thing, but I haven't
         figured a way to do that *and* not making the bg of the scrollview
         black, which reveals a dark area at the bottom of the screen on
         overscroll in iOS ~~~kueda20240228
       */}
-      <StatusBar barStyle="light-content" backgroundColor="#000000" />
-      <View className="flex-1 h-full bg-black">
-        <View className="w-full h-[420px] shrink-1">
-          <TaxonMedia
-            loading={isLoading}
-            photos={photos}
-            tablet={isTablet}
-            onChangeIndex={setMediaIndex}
-          />
-          <View className="absolute left-5 top-5">
-            <BackButton
-              color={theme.colors.onPrimary}
-              onPress={( ) => navigation.goBack( )}
+        <StatusBar barStyle="light-content" backgroundColor="#000000" />
+        <View className="flex-1 h-full bg-black">
+          <View className="w-full h-[420px] shrink-1">
+            <TaxonMedia
+              loading={isLoading}
+              photos={photos}
+              tablet={isTablet}
+              onChangeIndex={setMediaIndex}
             />
-          </View>
-          {!hideNavButtons && (
-            <View className="absolute right-5 top-5">
-              <KebabMenu
-                visible={kebabMenuVisible}
-                setVisible={setKebabMenuVisible}
-                large
-                white
-              >
-                <KebabMenu.Item
-                  testID="MenuItem.OpenInBrowser"
-                  onPress={( ) => {
-                    openURLInBrowser( taxonUrl );
-                    setKebabMenuVisible( false );
-                  }}
-                  title={t( "View-in-browser" )}
-                />
-                <KebabMenu.Item
-                  testID="MenuItem.Share"
-                  onPress={async ( ) => {
-                    const sharingOptions = {
-                      url: "",
-                      message: ""
-                    };
-
-                    if ( Platform.OS === "ios" ) {
-                      sharingOptions.url = taxonUrl;
-                    } else {
-                      sharingOptions.message = taxonUrl;
-                    }
-
-                    setKebabMenuVisible( false );
-
-                    try {
-                      return await Share.share( sharingOptions );
-                    } catch ( err ) {
-                      Alert.alert( err.message );
-                      return null;
-                    }
-                  }}
-                  title={t( "Share" )}
-                />
-              </KebabMenu>
+            <View className="absolute left-5 top-5">
+              <BackButton
+                color={theme.colors.onPrimary}
+                onPress={( ) => navigation.goBack( )}
+              />
             </View>
-          )}
-          <View
-            className="absolute bottom-0 p-0 w-full"
-            pointerEvents="box-none"
-          >
-            {!isTablet && photos.length > 1 && (
-              <View
-                className="flex flex-row w-full justify-center items-center mb-3"
-                pointerEvents="none"
-              >
-                { photos.map( ( item, idx ) => (
-                  <View
-                    key={`dot-${item.id}`}
-                    className={classnames(
-                      "rounded-full bg-white m-[2.5]",
-                      idx === mediaIndex
-                        ? "w-[4px] h-[4px]"
-                        : "w-[2px] h-[2px]"
-                    )}
+            {!hideNavButtons && (
+              <View className="absolute right-5 top-5">
+                <KebabMenu
+                  visible={kebabMenuVisible}
+                  setVisible={setKebabMenuVisible}
+                  large
+                  white
+                >
+                  <KebabMenu.Item
+                    testID="MenuItem.OpenInBrowser"
+                    onPress={( ) => {
+                      openURLInBrowser( taxonUrl );
+                      setKebabMenuVisible( false );
+                    }}
+                    title={t( "View-in-browser" )}
                   />
-                ) )}
+                  <KebabMenu.Item
+                    testID="MenuItem.Share"
+                    onPress={async ( ) => {
+                      const sharingOptions = {
+                        url: "",
+                        message: ""
+                      };
+
+                      if ( Platform.OS === "ios" ) {
+                        sharingOptions.url = taxonUrl;
+                      } else {
+                        sharingOptions.message = taxonUrl;
+                      }
+
+                      setKebabMenuVisible( false );
+
+                      try {
+                        return await Share.share( sharingOptions );
+                      } catch ( err ) {
+                        Alert.alert( err.message );
+                        return null;
+                      }
+                    }}
+                    title={t( "Share" )}
+                  />
+                </KebabMenu>
               </View>
             )}
-            <View className="w-full flex-row items-center pl-5 pr-5 pb-5" pointerEvents="box-none">
-              <TaxonDetailsTitle taxon={taxon} optionalClasses="text-white" />
-              {!hideNavButtons && (
-                <View className="ml-5">
-                  <INatIconButton
-                    icon="compass-rose-outline"
-                    onPress={( ) => {
-                      setExploreView( "observations" );
-                      navigation.navigate( "TabNavigator", {
-                        screen: "TabStackNavigator",
-                        params: {
-                          screen: "Explore",
-                          params: {
-                            taxon,
-                            worldwide: true,
-                            resetStoredParams: true
-                          }
-                        }
-                      } );
-                    }}
-                    accessibilityLabel={t( "See-observations-of-this-taxon-in-explore" )}
-                    accessibilityHint={t( "Navigates-to-explore" )}
-                    size={30}
-                    color={theme.colors.onPrimary}
-                    className="bg-inatGreen rounded-full"
-                    mode="contained"
-                    preventTransparency
-                  />
+            <View
+              className="absolute bottom-0 p-0 w-full"
+              pointerEvents="box-none"
+            >
+              {!isTablet && photos.length > 1 && (
+                <View
+                  className="flex flex-row w-full justify-center items-center mb-3"
+                  pointerEvents="none"
+                >
+                  { photos.map( ( item, idx ) => (
+                    <View
+                      key={`dot-${item.id}`}
+                      className={classnames(
+                        "rounded-full bg-white m-[2.5]",
+                        idx === mediaIndex
+                          ? "w-[4px] h-[4px]"
+                          : "w-[2px] h-[2px]"
+                      )}
+                    />
+                  ) )}
                 </View>
               )}
+              <View
+                className="w-full flex-row items-center pl-5 pr-5 pb-5"
+                pointerEvents="box-none"
+              >
+                <TaxonDetailsTitle taxon={taxon} optionalClasses="text-white" />
+                {!hideNavButtons && (
+                  <View className="ml-5">
+                    <INatIconButton
+                      icon="compass-rose-outline"
+                      onPress={( ) => {
+                        setExploreView( "observations" );
+                        navigation.navigate( "TabNavigator", {
+                          screen: "TabStackNavigator",
+                          params: {
+                            screen: "Explore",
+                            params: {
+                              taxon,
+                              worldwide: true,
+                              resetStoredParams: true
+                            }
+                          }
+                        } );
+                      }}
+                      accessibilityLabel={t( "See-observations-of-this-taxon-in-explore" )}
+                      accessibilityHint={t( "Navigates-to-explore" )}
+                      size={30}
+                      color={theme.colors.onPrimary}
+                      className="bg-inatGreen rounded-full"
+                      mode="contained"
+                      preventTransparency
+                    />
+                  </View>
+                )}
+              </View>
             </View>
           </View>
+          <View className="bg-white pt-5 h-full flex-1">
+            {displayTaxonDetails( )}
+          </View>
         </View>
-        <View className="bg-white pt-5 h-full flex-1">
-          {displayTaxonDetails( )}
-        </View>
-      </View>
-      <MediaViewerModal
-        showModal={mediaViewerVisible}
-        onClose={( ) => setMediaViewerVisible( false )}
-        photos={photos}
-        header={renderHeader}
-      />
-    </ScrollViewWrapper>
+        <MediaViewerModal
+          showModal={mediaViewerVisible}
+          onClose={( ) => setMediaViewerVisible( false )}
+          photos={photos}
+          header={renderHeader}
+        />
+      </ScrollViewWrapper>
+      {lastScreen === "Suggestions" && (
+        <StickyToolbar containerClass="items-center z-50">
+          <Button
+            className="max-w-[500px] w-full"
+            level="focus"
+            text={t( "SELECT-THIS-TAXON" )}
+            onPress={( ) => {
+              updateObservationKeys( {
+                taxon,
+                owners_identification_from_vision: params?.vision
+              } );
+              if ( fromObsDetails ) {
+                navigation.navigate( "ObsDetails", {
+                  uuid: obsUuid,
+                  suggestedTaxonId: id
+                } );
+              } else {
+                navigation.navigate( "ObsEdit" );
+              }
+            }}
+            icon={(
+              <INatIcon
+                name="checkmark"
+                size={19}
+                color={theme.colors.onPrimary}
+              />
+            )}
+            iconPosition="right"
+          />
+        </StickyToolbar>
+      )}
+    </>
   );
 };
 

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -840,6 +840,7 @@ Select-captive-or-cultivated-status = Select captive or cultivated status
 Select-geoprivacy-status = Select geoprivacy status
 Select-or-drag-media = Select or drag media
 Select-photo = Select photo
+SELECT-THIS-TAXON = SELECT THIS TAXON
 # Label for an element that let's you select a user
 Select-user = Select user
 Selects-iconic-taxon-X-for-identification = Selects iconic taxon { $iconicTaxon } for identification.

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1146,6 +1146,7 @@
   "Select-geoprivacy-status": "Select geoprivacy status",
   "Select-or-drag-media": "Select or drag media",
   "Select-photo": "Select photo",
+  "SELECT-THIS-TAXON": "SELECT THIS TAXON",
   "Select-user": {
     "comment": "Label for an element that let's you select a user",
     "val": "Select user"

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -840,6 +840,7 @@ Select-captive-or-cultivated-status = Select captive or cultivated status
 Select-geoprivacy-status = Select geoprivacy status
 Select-or-drag-media = Select or drag media
 Select-photo = Select photo
+SELECT-THIS-TAXON = SELECT THIS TAXON
 # Label for an element that let's you select a user
 Select-user = Select user
 Selects-iconic-taxon-X-for-identification = Selects iconic taxon { $iconicTaxon } for identification.

--- a/tests/integration/navigation/TaxonDetails.test.js
+++ b/tests/integration/navigation/TaxonDetails.test.js
@@ -1,0 +1,152 @@
+import {
+  act,
+  screen,
+  userEvent
+} from "@testing-library/react-native";
+import inatjs from "inaturalistjs";
+import factory, { makeResponse } from "tests/factory";
+import { renderAppWithObservations } from "tests/helpers/render";
+import setupUniqueRealm from "tests/helpers/uniqueRealm";
+
+// We're explicitly testing navigation here so we want react-navigation
+// working normally
+jest.unmock( "@react-navigation/native" );
+
+// UNIQUE REALM SETUP
+const mockRealmIdentifier = __filename;
+const { mockRealmModelsIndex, uniqueRealmBeforeAll, uniqueRealmAfterAll } = setupUniqueRealm(
+  mockRealmIdentifier
+);
+jest.mock( "realmModels/index", ( ) => mockRealmModelsIndex );
+jest.mock( "providers/contexts", ( ) => {
+  const originalModule = jest.requireActual( "providers/contexts" );
+  return {
+    __esModule: true,
+    ...originalModule,
+    RealmContext: {
+      ...originalModule.RealmContext,
+      useRealm: ( ) => global.mockRealms[mockRealmIdentifier],
+      useQuery: ( ) => []
+    }
+  };
+} );
+beforeAll( uniqueRealmBeforeAll );
+afterAll( uniqueRealmAfterAll );
+// /UNIQUE REALM SETUP
+
+const mockUser = factory( "LocalUser" );
+
+jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
+  __esModule: true,
+  default: ( ) => mockUser
+} ) );
+
+const topSuggestion = {
+  taxon: factory.states( "genus" )( "RemoteTaxon", { name: "Primum" } ),
+  combined_score: 90
+};
+
+const makeMockObservations = ( ) => ( [
+  factory( "RemoteObservation", {
+    // Suggestions won't load without a photo
+    observationPhotos: [
+      factory( "LocalObservationPhoto" )
+    ],
+    taxon: factory( "LocalTaxon" ),
+    user: mockUser
+  } )
+] );
+
+describe( "TaxonDetails", ( ) => {
+  beforeAll( async () => {
+    // userEvent recommends fake timers
+    jest.useFakeTimers( );
+  } );
+
+  const actor = userEvent.setup( );
+  beforeEach( ( ) => {
+    const mockScoreImageResponse = makeResponse( [topSuggestion] );
+    inatjs.computervision.score_image.mockResolvedValue( mockScoreImageResponse );
+    inatjs.taxa.fetch.mockResolvedValue( makeResponse( [topSuggestion.taxon] ) );
+  } );
+
+  afterEach( ( ) => {
+    inatjs.computervision.score_image.mockReset( );
+    inatjs.taxa.fetch.mockReset( );
+  } );
+
+  // navigate to ObsDetails -> Suggest ID -> Suggestions -> TaxonDetails
+  async function navigateToTaxonDetailsViaSuggestId( observation ) {
+    const { taxon } = topSuggestion;
+    const observationRow = await screen.findByTestId(
+      `MyObservations.obsListItem.${observation.uuid}`
+    );
+    await actor.press( observationRow );
+    const suggestIdButton = await screen.findByText( /SUGGEST ID/ );
+    await act( async ( ) => actor.press( suggestIdButton ) );
+    const suggestedTaxonName = await screen.findByText( taxon.name );
+    await actor.press( suggestedTaxonName );
+    const taxonDetailsScreen = await screen.findByTestId( `TaxonDetails.${taxon.id}` );
+    expect( taxonDetailsScreen ).toBeVisible( );
+  }
+
+  // navigate to ObsEdit -> Suggestions -> TaxonDetails
+  async function navigateToTaxonDetailsViaObsEdit( observation ) {
+    const { taxon } = topSuggestion;
+    const observationRow = await screen.findByTestId(
+      `MyObservations.obsListItem.${observation.uuid}`
+    );
+    await actor.press( observationRow );
+    const editButton = await screen.findByLabelText( /Edit/ );
+    expect( editButton ).toBeVisible( );
+    await act( async ( ) => actor.press( editButton ) );
+    const observationTaxonName = await screen.findByText( observation.taxon.name );
+    await actor.press( observationTaxonName );
+    const suggestedTaxonName = await screen.findByText( taxon.name );
+    await actor.press( suggestedTaxonName );
+    const taxonDetailsScreen = await screen.findByTestId( `TaxonDetails.${taxon.id}` );
+    expect( taxonDetailsScreen ).toBeVisible( );
+  }
+
+  it(
+    "should navigate from ObsDetails -> ObsDetails when taxon is selected",
+    async ( ) => {
+      const { taxon } = topSuggestion;
+      const observations = makeMockObservations( );
+      await renderAppWithObservations( observations, __filename );
+      await navigateToTaxonDetailsViaSuggestId( observations[0] );
+      // make sure we're on TaxonDetails
+      const selectTaxonButton = screen.getByText( /SELECT THIS TAXON/ );
+      expect( selectTaxonButton ).toBeVisible( );
+      await actor.press( selectTaxonButton );
+      // return to ObsDetails screen
+      expect( await screen.findByTestId( `ObsDetails.${observations[0].uuid}` ) ).toBeTruthy( );
+      // suggest ID should be popped open with the suggested taxon
+      const bottomSheetText = await screen.findByText(
+        /Would you like to suggest the following identification/
+      );
+      expect( bottomSheetText ).toBeVisible( );
+      const selectedTaxonName = await screen.findByText( taxon.name );
+      expect( selectedTaxonName ).toBeVisible( );
+    }
+  );
+
+  it(
+    "should navigate from obs create -> ObsEdit when taxon is selected",
+    async ( ) => {
+      const { taxon } = topSuggestion;
+      const observations = makeMockObservations( );
+      await renderAppWithObservations( observations, __filename );
+      await navigateToTaxonDetailsViaObsEdit( observations[0] );
+      // make sure we're on TaxonDetails
+      const selectTaxonButton = screen.getByText( /SELECT THIS TAXON/ );
+      expect( selectTaxonButton ).toBeVisible( );
+      await actor.press( selectTaxonButton );
+      // return to ObsEdit screen
+      const obsEditBackButton = screen.getByTestId( "ObsEdit.BackButton" );
+      expect( obsEditBackButton ).toBeVisible( );
+      const selectedTaxonName = await screen.findByText( taxon.name );
+      expect( selectedTaxonName ).toBeVisible( );
+    }
+  );
+} );

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -111,7 +111,8 @@ jest.mock( "@react-navigation/native", ( ) => {
       canGoBack: jest.fn( ( ) => true ),
       goBack: jest.fn( ),
       setOptions: jest.fn( )
-    } )
+    } ),
+    useNavigationState: jest.fn( )
   };
 } );
 

--- a/tests/unit/components/TaxonDetails/TaxonDetails.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetails.test.js
@@ -1,4 +1,4 @@
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, useRoute } from "@react-navigation/native";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import TaxonDetails from "components/TaxonDetails/TaxonDetails";
 import INatPaperProvider from "providers/INatPaperProvider";
@@ -35,11 +35,7 @@ jest.mock( "@react-navigation/native", ( ) => {
   const actualNav = jest.requireActual( "@react-navigation/native" );
   return {
     ...actualNav,
-    useRoute: ( ) => ( {
-      params: {
-        id: mockTaxon.id
-      }
-    } ),
+    useRoute: jest.fn( ),
     useNavigation: jest.fn( )
   };
 } );
@@ -74,6 +70,13 @@ jest.mock(
 );
 
 describe( "TaxonDetails", ( ) => {
+  beforeAll( ( ) => {
+    useRoute.mockImplementation( ( ) => ( {
+      params: { id: mockTaxon.id }
+    } ) );
+    jest.useFakeTimers( );
+  } );
+
   test( "renders taxon details from API call", async ( ) => {
     renderTaxonDetails( );
     expect( screen.getByTestId( `TaxonDetails.${mockTaxon.id}` ) ).toBeTruthy( );
@@ -95,5 +98,25 @@ describe( "TaxonDetails", ( ) => {
     fireEvent.press( screen.getByTestId( "TaxonDetails.wikipedia" ) );
     expect( Linking.openURL ).toHaveBeenCalledTimes( 1 );
     expect( Linking.openURL ).toHaveBeenCalledWith( mockTaxon.wikipedia_url );
+  } );
+
+  test( "does not show sticky select taxon button on default screen", ( ) => {
+    renderTaxonDetails( );
+    const selectTaxonButton = screen.queryByText( /SELECT THIS TAXON/ );
+    expect( selectTaxonButton ).toBeFalsy( );
+  } );
+} );
+
+describe( "TaxonDetails when coming from Suggestions screen", ( ) => {
+  beforeAll( ( ) => {
+    useRoute.mockImplementation( ( ) => ( {
+      params: { id: mockTaxon.id, lastScreen: "Suggestions" }
+    } ) );
+  } );
+
+  test( "shows sticky select taxon button when navigating from suggestions", ( ) => {
+    renderTaxonDetails( );
+    const selectTaxonButton = screen.getByText( /SELECT THIS TAXON/ );
+    expect( selectTaxonButton ).toBeTruthy( );
   } );
 } );


### PR DESCRIPTION
Closes #1742

- Adds a select a taxon button to TaxonDetails when coming from Suggestions
- Navigates user to ObsDetails with Suggest ID bottom sheet open to selected taxon when previous screen was ObsDetails
- Navigates user to ObsEdit with identification set to selected taxon when coming from any other screen
- Adds test coverage for these changes