### PR TITLE
Restore removal of synced photos

### DIFF
--- a/src/components/MyObservations/hooks/useClearSyncedPhotosForUpload.ts
+++ b/src/components/MyObservations/hooks/useClearSyncedPhotosForUpload.ts
@@ -25,7 +25,11 @@ const useClearSyncedPhotosForUpload = ( ) => {
     .filter( Boolean );
 
   useEffect( ( ) => {
-    if ( !currentObservations ) {
+    // Ensure we don't clear out photos while we're creating observations.
+    // When imported/share a photo, it may exist on disk before we create an
+    // observation to with it. In that case, that photo will not appear in
+    // unsyncedPhotoFileNames
+    if ( !currentObservations || currentObservations.length === 0 ) {
       removeSyncedFilesFromDirectory( photoUploadPath, unsyncedPhotoFileNames );
     }
   }, [currentObservations, unsyncedPhotoFileNames] );

--- a/src/sharedHelpers/removeSyncedFilesFromDirectory.ts
+++ b/src/sharedHelpers/removeSyncedFilesFromDirectory.ts
@@ -1,7 +1,10 @@
 import RNFS from "react-native-fs";
 import { unlink } from "sharedHelpers/util";
 
-const removeSyncedFilesFromDirectory = async ( directoryPath, filesToKeep = [] ) => {
+const removeSyncedFilesFromDirectory = async (
+  directoryPath: string,
+  filesToKeep: string[] = []
+) => {
   const directoryExists = await RNFS.exists( directoryPath );
   if ( !directoryExists ) { return null; }
 


### PR DESCRIPTION
Closes #1741. That hook is a little hair-raising (deletes all photos *except* the ones you want to keep, runs pretty much every single time MyObs renders), so I might spend a bit of time trying to refactor and at least get it to run less frequently.