### PR TITLE
Change url for connectivity check

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 import "react-native-url-polyfill/auto";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import { NetInfo } from "@react-native-community/netinfo";
 import { NavigationContainer } from "@react-navigation/native";
 import {
   QueryClient,
@@ -109,6 +110,12 @@ const queryClient = new QueryClient( {
       retry: reactQueryRetry
     }
   }
+} );
+
+// better to ping our own website to check for site uptime
+// with no rendering required, per issue #1770
+NetInfo.configure( {
+  reachabilityUrl: "https://www.inaturalist.org/ping"
 } );
 
 const AppWithProviders = ( ) => (

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
 import "react-native-url-polyfill/auto";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
-import { NetInfo } from "@react-native-community/netinfo";
 import { NavigationContainer } from "@react-navigation/native";
 import {
   QueryClient,
@@ -110,12 +109,6 @@ const queryClient = new QueryClient( {
       retry: reactQueryRetry
     }
   }
-} );
-
-// better to ping our own website to check for site uptime
-// with no rendering required, per issue #1770
-NetInfo.configure( {
-  reachabilityUrl: "https://www.inaturalist.org/ping"
 } );
 
 const AppWithProviders = ( ) => (

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,7 @@
 // @flow
 
 import Geolocation from "@react-native-community/geolocation";
+import NetInfo from "@react-native-community/netinfo";
 import RootDrawerNavigator from "navigation/rootDrawerNavigator";
 import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
@@ -33,6 +34,12 @@ Realm.setLogLevel( "warn" );
 // from react-native-share-menu.
 // https://stackoverflow.com/questions/69538962
 LogBox.ignoreLogs( ["new NativeEventEmitter"] );
+
+// better to ping our own website to check for site uptime
+// with no rendering required, per issue #1770
+NetInfo.configure( {
+  reachabilityUrl: "https://www.inaturalist.org/ping"
+} );
 
 const geolocationConfig = {
   skipPermissionRequests: true

--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -50,7 +50,7 @@ type Props = {
   count: Object,
   filterByIconicTaxonUnknown: Function,
   hideBackButton: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   loadingStatus: boolean,
   openFiltersModal: Function,
   queryParams: Object,
@@ -71,7 +71,7 @@ const Explore = ( {
   count,
   filterByIconicTaxonUnknown,
   hideBackButton,
-  isOnline,
+  isConnected,
   loadingStatus,
   openFiltersModal,
   queryParams,
@@ -118,7 +118,7 @@ const Explore = ( {
   );
 
   const renderMainContent = ( ) => {
-    if ( !isOnline ) {
+    if ( !isConnected ) {
       return (
         <OfflineNotice
           onPress={() => refresh()}
@@ -155,7 +155,7 @@ const Explore = ( {
         {currentExploreView === "species" && (
           <SpeciesView
             count={count}
-            isOnline={isOnline}
+            isConnected={isConnected}
             queryParams={queryParams}
             updateCount={updateCount}
           />
@@ -163,7 +163,7 @@ const Explore = ( {
         {currentExploreView === "observers" && (
           <ObserversView
             count={count}
-            isOnline={isOnline}
+            isConnected={isConnected}
             queryParams={queryParams}
             updateCount={updateCount}
           />
@@ -171,7 +171,7 @@ const Explore = ( {
         {currentExploreView === "identifiers" && (
           <IdentifiersView
             count={count}
-            isOnline={isOnline}
+            isConnected={isConnected}
             queryParams={queryParams}
             updateCount={updateCount}
           />

--- a/src/components/Explore/ExploreContainer.js
+++ b/src/components/Explore/ExploreContainer.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
 import {
   EXPLORE_ACTION,
@@ -8,7 +11,7 @@ import {
 } from "providers/ExploreContext.tsx";
 import type { Node } from "react";
 import React, { useEffect, useState } from "react";
-import { useCurrentUser, useIsConnected } from "sharedHooks";
+import { useCurrentUser } from "sharedHooks";
 import useLocationPermission from "sharedHooks/useLocationPermission.tsx";
 import useStore from "stores/useStore";
 
@@ -19,7 +22,7 @@ import useParams from "./hooks/useParams";
 
 const ExploreContainerWithContext = ( ): Node => {
   const navigation = useNavigation( );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const setStoredParams = useStore( state => state.setStoredParams );
 
   const {

--- a/src/components/Explore/ExploreContainer.js
+++ b/src/components/Explore/ExploreContainer.js
@@ -22,7 +22,7 @@ import useParams from "./hooks/useParams";
 
 const ExploreContainerWithContext = ( ): Node => {
   const navigation = useNavigation( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const setStoredParams = useStore( state => state.setStoredParams );
 
   const {
@@ -109,7 +109,7 @@ const ExploreContainerWithContext = ( ): Node => {
         filterByIconicTaxonUnknown={
           () => dispatch( { type: EXPLORE_ACTION.FILTER_BY_ICONIC_TAXON_UNKNOWN } )
         }
-        isOnline={isOnline}
+        isConnected={isConnected}
         loadingStatus={loadingStatus}
         openFiltersModal={openFiltersModal}
         queryParams={queryParams}

--- a/src/components/Explore/ExploreFlashList.js
+++ b/src/components/Explore/ExploreFlashList.js
@@ -14,7 +14,7 @@ type Props = {
   fetchNextPage: boolean,
   hideLoadingWheel: boolean,
   isFetchingNextPage: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   keyExtractor: Function,
   layout?: string,
   numColumns?: number,
@@ -31,7 +31,7 @@ const ExploreFlashList = ( {
   fetchNextPage,
   hideLoadingWheel,
   isFetchingNextPage,
-  isOnline,
+  isConnected,
   keyExtractor,
   layout,
   numColumns,
@@ -47,9 +47,9 @@ const ExploreFlashList = ( {
       hideLoadingWheel={hideLoadingWheel}
       layout={layout}
       explore
-      isOnline={isOnline}
+      isConnected={isConnected}
     />
-  ), [hideLoadingWheel, layout, isOnline] );
+  ), [hideLoadingWheel, layout, isConnected] );
 
   const renderEmptyComponent = useCallback( ( ) => (
     <View className="flex-1 justify-center items-center">

--- a/src/components/Explore/IdentifiersView.js
+++ b/src/components/Explore/IdentifiersView.js
@@ -11,7 +11,7 @@ import ExploreFlashList from "./ExploreFlashList";
 
 type Props = {
   count: Object,
-  isOnline: boolean,
+  isConnected: boolean,
   queryParams: Object,
   updateCount: Function
 };
@@ -20,7 +20,7 @@ const LIST_STYLE = { paddingTop: 44 };
 
 const IdentifiersView = ( {
   count,
-  isOnline,
+  isConnected,
   queryParams,
   updateCount
 }: Props ): Node => {
@@ -66,7 +66,7 @@ const IdentifiersView = ( {
       fetchNextPage={fetchNextPage}
       hideLoadingWheel={!isFetchingNextPage}
       isFetchingNextPage={isFetchingNextPage}
-      isOnline={isOnline}
+      isConnected={isConnected}
       keyExtractor={item => item.user.id}
       renderItem={renderItem}
       renderItemSeparator={renderItemSeparator}

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -49,7 +49,7 @@ const ObservationsView = ( {
     }
   }, [totalResults, updateCount, count, isFetchingNextPage] );
 
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
 
   if ( !layout ) { return null; }
 
@@ -87,7 +87,7 @@ const ObservationsView = ( {
         explore
         hideLoadingWheel={!isFetchingNextPage}
         isFetchingNextPage={isFetchingNextPage}
-        isOnline={isOnline}
+        isConnected={isConnected}
         layout={layout}
         onEndReached={fetchNextPage}
         status={status}

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import useInfiniteExploreScroll from "components/Explore/hooks/useInfiniteExploreScroll";
 import { ObservationsFlashList } from "components/SharedComponents";
 import { View } from "components/styledComponents";
@@ -7,8 +10,7 @@ import type { Node } from "react";
 import React, { useEffect } from "react";
 import { Dimensions } from "react-native";
 import {
-  useDeviceOrientation,
-  useIsConnected
+  useDeviceOrientation
 } from "sharedHooks";
 
 import MapView from "./MapView";
@@ -47,7 +49,7 @@ const ObservationsView = ( {
     }
   }, [totalResults, updateCount, count, isFetchingNextPage] );
 
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
 
   if ( !layout ) { return null; }
 

--- a/src/components/Explore/ObserversView.js
+++ b/src/components/Explore/ObserversView.js
@@ -11,7 +11,7 @@ import ExploreFlashList from "./ExploreFlashList";
 
 type Props = {
   count: Object,
-  isOnline: boolean,
+  isConnected: boolean,
   queryParams: Object,
   updateCount: Function
 };
@@ -20,7 +20,7 @@ const LIST_STYLE = { paddingTop: 44 };
 
 const ObserversView = ( {
   count,
-  isOnline,
+  isConnected,
   queryParams,
   updateCount
 }: Props ): Node => {
@@ -66,7 +66,7 @@ const ObserversView = ( {
       fetchNextPage={fetchNextPage}
       hideLoadingWheel={!isFetchingNextPage}
       isFetchingNextPage={isFetchingNextPage}
-      isOnline={isOnline}
+      isConnected={isConnected}
       keyExtractor={item => item.user.id}
       renderItem={renderItem}
       renderItemSeparator={renderItemSeparator}

--- a/src/components/Explore/RootExploreContainer.js
+++ b/src/components/Explore/RootExploreContainer.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
 import {
   EXPLORE_ACTION,
@@ -11,7 +14,7 @@ import React, {
   useEffect,
   useState
 } from "react";
-import { useCurrentUser, useIsConnected } from "sharedHooks";
+import { useCurrentUser } from "sharedHooks";
 import useLocationPermission from "sharedHooks/useLocationPermission.tsx";
 import useStore from "stores/useStore";
 
@@ -21,7 +24,7 @@ import useHeaderCount from "./hooks/useHeaderCount";
 
 const RootExploreContainerWithContext = ( ): Node => {
   const navigation = useNavigation( );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const currentUser = useCurrentUser( );
   const rootStoredParams = useStore( state => state.rootStoredParams );
   const setRootStoredParams = useStore( state => state.setRootStoredParams );

--- a/src/components/Explore/RootExploreContainer.js
+++ b/src/components/Explore/RootExploreContainer.js
@@ -24,7 +24,7 @@ import useHeaderCount from "./hooks/useHeaderCount";
 
 const RootExploreContainerWithContext = ( ): Node => {
   const navigation = useNavigation( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const currentUser = useCurrentUser( );
   const rootStoredParams = useStore( state => state.rootStoredParams );
   const setRootStoredParams = useStore( state => state.setRootStoredParams );
@@ -127,7 +127,7 @@ const RootExploreContainerWithContext = ( ): Node => {
         filterByIconicTaxonUnknown={
           () => dispatch( { type: EXPLORE_ACTION.FILTER_BY_ICONIC_TAXON_UNKNOWN } )
         }
-        isOnline={isOnline}
+        isConnected={isConnected}
         loadingStatus={loadingStatus}
         openFiltersModal={openFiltersModal}
         queryParams={queryParams}

--- a/src/components/Explore/SpeciesView.js
+++ b/src/components/Explore/SpeciesView.js
@@ -16,14 +16,14 @@ const GUTTER = 15;
 
 type Props = {
   count: Object,
-  isOnline: boolean,
+  isConnected: boolean,
   queryParams: Object,
   updateCount: Function
 }
 
 const SpeciesView = ( {
   count,
-  isOnline,
+  isConnected,
   queryParams,
   updateCount
 }: Props ): Node => {
@@ -101,7 +101,7 @@ const SpeciesView = ( {
       fetchNextPage={fetchNextPage}
       hideLoadingWheel={!isFetchingNextPage}
       isFetchingNextPage={isFetchingNextPage}
-      isOnline={isOnline}
+      isConnected={isConnected}
       keyExtractor={item => item?.taxon?.id || item}
       layout="grid"
       numColumns={numColumns}

--- a/src/components/Identify/Identify.js
+++ b/src/components/Identify/Identify.js
@@ -1,17 +1,19 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { ActivityAnimation, ObservationsFlashList, ViewWrapper } from "components/SharedComponents";
 import type { Node } from "react";
 import React from "react";
 import {
   useCurrentUser,
-  useInfiniteObservationsScroll,
-  useIsConnected
+  useInfiniteObservationsScroll
 } from "sharedHooks";
 
 const Identify = (): Node => {
   const currentUser = useCurrentUser();
-  const isOnline = useIsConnected();
+  const { isInternetReachable: isOnline } = useNetInfo( );
 
   const params = {
     iconic_taxa: "unknown",

--- a/src/components/Identify/Identify.js
+++ b/src/components/Identify/Identify.js
@@ -13,7 +13,7 @@ import {
 
 const Identify = (): Node => {
   const currentUser = useCurrentUser();
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
 
   const params = {
     iconic_taxa: "unknown",
@@ -41,7 +41,7 @@ const Identify = (): Node => {
         data={observations}
         hideLoadingWheel={!isFetchingNextPage || !currentUser}
         isFetchingNextPage={isFetchingNextPage}
-        isOnline={isOnline}
+        isConnected={isConnected}
         layout="list"
         onEndReached={fetchNextPage}
         showObservationsEmptyScreen

--- a/src/components/MyObservations/Announcements.js
+++ b/src/components/MyObservations/Announcements.js
@@ -43,11 +43,11 @@ const AutoheightWebView = ( webshellProps ): Node => {
 };
 
 type Props = {
-  isOnline: boolean
+  isConnected: boolean
 }
 
 const Announcements = ( {
-  isOnline
+  isConnected
 }: Props ): Node => {
   const { t } = useTranslation( );
   const queryClient = useQueryClient( );
@@ -78,7 +78,7 @@ const Announcements = ( {
     ["searchAnnouncements", apiParams],
     optsWithAuth => searchAnnouncements( apiParams, optsWithAuth ),
     {
-      enabled: !!isOnline && !!currentUser
+      enabled: !!isConnected && !!currentUser
     }
   );
 
@@ -97,7 +97,7 @@ const Announcements = ( {
     }
   );
 
-  if ( !isOnline ) {
+  if ( !isConnected ) {
     return null;
   }
   if ( !currentUser ) {

--- a/src/components/MyObservations/InfiniteScrollLoadingWheel.js
+++ b/src/components/MyObservations/InfiniteScrollLoadingWheel.js
@@ -9,13 +9,13 @@ import { useTranslation } from "sharedHooks";
 
 type Props = {
   layout?: string,
-  isOnline?: boolean,
+  isConnected?: boolean,
   hideLoadingWheel: boolean,
   explore: boolean
 }
 
 const InfiniteScrollLoadingWheel = ( {
-  hideLoadingWheel, layout, isOnline, explore
+  hideLoadingWheel, layout, isConnected, explore
 }: Props ): Node => {
   const { t } = useTranslation( );
 
@@ -30,7 +30,7 @@ const InfiniteScrollLoadingWheel = ( {
       "border-t border-lightGray": layout === "list"
     } )}
     >
-      {!isOnline
+      {!isConnected
         ? (
           <Body3 className="text-center">
             {t( "An-Internet-connection-is-required" )}

--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -16,7 +16,7 @@ type Props = {
   handleIndividualUploadPress: Function,
   handleSyncButtonPress: Function,
   isFetchingNextPage: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   layout: "list" | "grid",
   observations: Array<Object>,
   onEndReached: Function,
@@ -31,7 +31,7 @@ const MyObservations = ( {
   handleIndividualUploadPress,
   handleSyncButtonPress,
   isFetchingNextPage,
-  isOnline,
+  isConnected,
   layout,
   observations,
   onEndReached,
@@ -62,14 +62,14 @@ const MyObservations = ( {
             handleScroll={onScroll}
             hideLoadingWheel={!isFetchingNextPage || !currentUser}
             isFetchingNextPage={isFetchingNextPage}
-            isOnline={isOnline}
+            isConnected={isConnected}
             layout={layout}
             onEndReached={onEndReached}
             showObservationsEmptyScreen
             status={status}
             testID="MyObservationsAnimatedList"
             renderHeader={(
-              <Announcements isOnline={isOnline} />
+              <Announcements isConnected={isConnected} />
             )}
           />
         )}

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -58,10 +58,10 @@ const MyObservationsContainer = ( ): Node => {
   const { observationList: observations } = useLocalObservations( );
   const { layout, writeLayoutToStorage } = useStoredLayout( "myObservationsLayout" );
 
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const currentUser = useCurrentUser( );
   const currentUserId = currentUser?.id;
-  const canUpload = currentUser && isOnline;
+  const canUpload = currentUser && isConnected;
 
   const { uploadObservations } = useUploadObservations( canUpload );
   useSyncObservations(
@@ -92,14 +92,14 @@ const MyObservationsContainer = ( ): Node => {
   };
 
   const confirmInternetConnection = useCallback( ( ) => {
-    if ( !isOnline ) {
+    if ( !isConnected ) {
       Alert.alert(
         t( "Internet-Connection-Required" ),
         t( "Please-try-again-when-you-are-connected-to-the-internet" )
       );
     }
-    return isOnline;
-  }, [t, isOnline] );
+    return isConnected;
+  }, [t, isConnected] );
 
   const confirmLoggedIn = useCallback( ( ) => {
     if ( !currentUser ) {
@@ -180,7 +180,7 @@ const MyObservationsContainer = ( ): Node => {
     <MyObservations
       currentUser={currentUser}
       isFetchingNextPage={isFetchingNextPage}
-      isOnline={isOnline}
+      isConnected={isConnected}
       handleIndividualUploadPress={handleIndividualUploadPress}
       handleSyncButtonPress={handleSyncButtonPress}
       layout={layout}

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
 import { RealmContext } from "providers/contexts";
 import type { Node } from "react";
@@ -12,7 +15,6 @@ import { log } from "sharedHelpers/logger";
 import {
   useCurrentUser,
   useInfiniteObservationsScroll,
-  useIsConnected,
   useLocalObservations,
   useObservationsUpdates,
   useStoredLayout,
@@ -56,7 +58,7 @@ const MyObservationsContainer = ( ): Node => {
   const { observationList: observations } = useLocalObservations( );
   const { layout, writeLayoutToStorage } = useStoredLayout( "myObservationsLayout" );
 
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const currentUser = useCurrentUser( );
   const currentUserId = currentUser?.id;
   const canUpload = currentUser && isOnline;

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -1,10 +1,13 @@
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { INatApiError } from "api/error";
 import { deleteRemoteObservation } from "api/observations";
 import { RealmContext } from "providers/contexts";
 import { useCallback, useEffect } from "react";
 import Observation from "realmModels/Observation";
 import { log } from "sharedHelpers/logger";
-import { useAuthenticatedMutation, useIsConnected } from "sharedHooks";
+import { useAuthenticatedMutation } from "sharedHooks";
 import {
   AUTOMATIC_SYNC_IN_PROGRESS,
   BEGIN_AUTOMATIC_SYNC,
@@ -21,7 +24,7 @@ const logger = log.extend( "useSyncObservations" );
 const { useRealm } = RealmContext;
 
 const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const loggedIn = !!currentUserId;
   const deleteQueue = useStore( state => state.deleteQueue );
   const deletionsCompletedAt = useStore( state => state.deletionsCompletedAt );

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -24,7 +24,7 @@ const logger = log.extend( "useSyncObservations" );
 const { useRealm } = RealmContext;
 
 const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const loggedIn = !!currentUserId;
   const deleteQueue = useStore( state => state.deleteQueue );
   const deletionsCompletedAt = useStore( state => state.deletionsCompletedAt );
@@ -37,7 +37,7 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
   const resetSyncToolbar = useStore( state => state.resetSyncToolbar );
   const removeFromDeleteQueue = useStore( state => state.removeFromDeleteQueue );
 
-  const canSync = loggedIn && isOnline;
+  const canSync = loggedIn && isConnected;
 
   const realm = useRealm( );
 

--- a/src/components/Notifications/NotificationsContainer.js
+++ b/src/components/Notifications/NotificationsContainer.js
@@ -1,14 +1,16 @@
 // @flow
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
 import NotificationsList from "components/Notifications/NotificationsList";
 import type { Node } from "react";
 import React, { useEffect } from "react";
-import { useIsConnected } from "sharedHooks";
 import useInfiniteNotificationsScroll from "sharedHooks/useInfiniteNotificationsScroll";
 
 const NotificationsContainer = (): Node => {
   const navigation = useNavigation( );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
 
   const {
     notifications,

--- a/src/components/Notifications/NotificationsContainer.js
+++ b/src/components/Notifications/NotificationsContainer.js
@@ -10,7 +10,7 @@ import useInfiniteNotificationsScroll from "sharedHooks/useInfiniteNotifications
 
 const NotificationsContainer = (): Node => {
   const navigation = useNavigation( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
 
   const {
     notifications,
@@ -23,11 +23,11 @@ const NotificationsContainer = (): Node => {
 
   useEffect( ( ) => {
     navigation.addListener( "focus", ( ) => {
-      if ( isOnline ) {
+      if ( isConnected ) {
         refetch();
       }
     } );
-  }, [isOnline, navigation, refetch] );
+  }, [isConnected, navigation, refetch] );
 
   return (
     <NotificationsList
@@ -35,7 +35,7 @@ const NotificationsContainer = (): Node => {
       isError={isError}
       isFetching={isFetching}
       isInitialLoading={isInitialLoading}
-      isOnline={isOnline}
+      isConnected={isConnected}
       onEndReached={fetchNextPage}
       reload={refetch}
     />

--- a/src/components/Notifications/NotificationsList.js
+++ b/src/components/Notifications/NotificationsList.js
@@ -16,7 +16,7 @@ type Props = {
   isError?: boolean,
   isFetching?: boolean,
   isInitialLoading?: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   onEndReached: Function,
   reload: Function
 };
@@ -26,7 +26,7 @@ const NotificationsList = ( {
   isError,
   isFetching,
   isInitialLoading,
-  isOnline,
+  isConnected,
   onEndReached,
   reload
 }: Props ): Node => {
@@ -43,9 +43,9 @@ const NotificationsList = ( {
     <InfiniteScrollLoadingWheel
       explore={false}
       hideLoadingWheel={!isFetching || data?.length === 0}
-      isOnline={isOnline}
+      isConnected={isConnected}
     />
-  ), [isFetching, isOnline, data.length] );
+  ), [isFetching, isConnected, data.length] );
 
   const renderEmptyComponent = useCallback( ( ) => {
     if ( isInitialLoading ) {
@@ -56,7 +56,7 @@ const NotificationsList = ( {
       );
     }
 
-    if ( !isOnline ) {
+    if ( !isConnected ) {
       return <OfflineNotice onPress={reload} />;
     }
 
@@ -80,7 +80,7 @@ const NotificationsList = ( {
     user,
     isError,
     isInitialLoading,
-    isOnline,
+    isConnected,
     reload,
     t
   ] );

--- a/src/components/ObsDetails/ActivityTab/ActivityHeader.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityHeader.js
@@ -21,7 +21,7 @@ type Props = {
   deleteComment: Function,
   flagged: boolean,
   idWithdrawn?: boolean,
-  isOnline?: boolean,
+  isConnected?: boolean,
   item: Object,
   loading: boolean,
   updateCommentBody: Function,
@@ -34,7 +34,7 @@ const ActivityHeader = ( {
   deleteComment,
   flagged,
   idWithdrawn,
-  isOnline,
+  isConnected,
   item,
   loading,
   updateCommentBody,
@@ -115,7 +115,7 @@ const ActivityHeader = ( {
 
   return (
     <View className={classnames( "flex-row justify-between h-[26px] my-[11px]", classNameMargin )}>
-      <InlineUser user={user} isOnline={isOnline} />
+      <InlineUser user={user} isConnected={isConnected} />
       <View className="flex-row items-center space-x-[15px] -mr-[15px]">
         {renderIcon()}
         {renderStatus()}

--- a/src/components/ObsDetails/ActivityTab/ActivityHeaderContainer.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityHeaderContainer.js
@@ -12,7 +12,7 @@ import ActivityHeader from "./ActivityHeader";
 type Props = {
   classNameMargin?: string,
   idWithdrawn?: boolean,
-  isOnline?: boolean,
+  isConnected?: boolean,
   item: Object,
   refetchRemoteObservation?: Function
 }
@@ -20,7 +20,7 @@ type Props = {
 const ActivityHeaderContainer = ( {
   classNameMargin,
   idWithdrawn,
-  isOnline,
+  isConnected,
   item,
   refetchRemoteObservation
 }:Props ): Node => {
@@ -124,7 +124,7 @@ const ActivityHeaderContainer = ( {
       updateCommentBody={updateCommentBody}
       deleteComment={deleteUserComment}
       updateIdentification={updateIdentification}
-      isOnline={isOnline}
+      isConnected={isConnected}
     />
   );
 };

--- a/src/components/ObsDetails/ActivityTab/ActivityItem.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityItem.js
@@ -19,7 +19,7 @@ import DisagreementText from "./DisagreementText";
 type Props = {
   currentUserId?: number,
   isFirstDisplay: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   item: Object,
   openAgreeWithIdSheet: Function,
   refetchRemoteObservation: Function,
@@ -29,7 +29,7 @@ type Props = {
 const ActivityItem = ( {
   currentUserId,
   isFirstDisplay,
-  isOnline,
+  isConnected,
   item,
   openAgreeWithIdSheet,
   refetchRemoteObservation,
@@ -57,7 +57,7 @@ const ActivityItem = ( {
           item={item}
           refetchRemoteObservation={refetchRemoteObservation}
           idWithdrawn={idWithdrawn}
-          isOnline={isOnline}
+          isConnected={isConnected}
         />
         {taxon && (
           <View className="flex-row items-center justify-between mr-[23px] mb-4">

--- a/src/components/ObsDetails/ActivityTab/ActivityTab.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityTab.js
@@ -12,7 +12,7 @@ type Props = {
   refetchRemoteObservation: Function,
   activityItems: Array<Object>,
   openAgreeWithIdSheet: Function,
-  isOnline: boolean
+  isConnected: boolean
 }
 
 const ActivityTab = ( {
@@ -20,7 +20,7 @@ const ActivityTab = ( {
   refetchRemoteObservation,
   activityItems,
   openAgreeWithIdSheet,
-  isOnline
+  isConnected
 }: Props ): Node => {
   const currentUser = useCurrentUser( );
   const userId = currentUser?.id;
@@ -57,7 +57,7 @@ const ActivityTab = ( {
           <ActivityItem
             currentUserId={userId}
             isFirstDisplay={index === indexOfFirstTaxonDisplayed( item.taxon?.id )}
-            isOnline={isOnline}
+            isConnected={isConnected}
             item={item}
             key={item.uuid}
             openAgreeWithIdSheet={openAgreeWithIdSheet}

--- a/src/components/ObsDetails/DQAContainer.js
+++ b/src/components/ObsDetails/DQAContainer.js
@@ -29,7 +29,7 @@ import useRemoteObservation from "sharedHooks/useRemoteObservation";
 const logger = log.extend( "DQAContainer" );
 
 const DQAContainer = ( ): React.Node => {
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const { params } = useRoute( );
   const { observationUUID } = params;
   const [loadingAgree, setLoadingAgree] = useState( false );
@@ -277,8 +277,8 @@ const DQAContainer = ( ): React.Node => {
         removeNeedsIDVote={removeNeedsIDVote}
         ifMajorityAgree={ifMajorityAgree}
         checkTest={checkTest}
-        isOnline={isOnline}
-        recheckIsOnline={refreshNetInfo}
+        isConnected={isConnected}
+        recheckisConnected={refreshNetInfo}
       />
       <BottomSheet
         headerText={t( "ERROR-VOTING-IN-DQA" )}

--- a/src/components/ObsDetails/DataQualityAssessment.js
+++ b/src/components/ObsDetails/DataQualityAssessment.js
@@ -43,13 +43,13 @@ const titleDescription = option => {
 type Props = {
   checkTest: Function,
   ifMajorityAgree: Function,
-  isOnline?: boolean,
+  isConnected?: boolean,
   loadingAgree: boolean,
   loadingDisagree: boolean,
   loadingMetric: string,
   qualityGrade: string,
   qualityMetrics: Object,
-  recheckIsOnline: Function,
+  recheckisConnected: Function,
   removeMetricVote: Function,
   removeNeedsIDVote: Function,
   setMetricVote: Function,
@@ -59,13 +59,13 @@ type Props = {
 const DataQualityAssessment = ( {
   checkTest,
   ifMajorityAgree,
-  isOnline,
+  isConnected,
   loadingAgree,
   loadingDisagree,
   loadingMetric,
   qualityGrade,
   qualityMetrics,
-  recheckIsOnline,
+  recheckisConnected,
   removeMetricVote,
   removeNeedsIDVote,
   setMetricVote,
@@ -113,10 +113,10 @@ const DataQualityAssessment = ( {
     );
   };
 
-  if ( isOnline === false ) {
+  if ( isConnected === false ) {
     return (
       <ViewWrapper>
-        <OfflineNotice onPress={( ) => recheckIsOnline( )} />
+        <OfflineNotice onPress={( ) => recheckisConnected( )} />
       </ViewWrapper>
     );
   }

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -50,7 +50,7 @@ type Props = {
   currentTabId: string,
   currentUser: Object,
   hideAddCommentSheet: Function,
-  isOnline: boolean,
+  isConnected: boolean,
   isRefetching: boolean,
   navToSuggestions: Function,
   observation: Object,
@@ -84,7 +84,7 @@ const ObsDetails = ( {
   currentTabId,
   currentUser,
   hideAddCommentSheet,
-  isOnline,
+  isConnected,
   isRefetching,
   navToSuggestions,
   observation,
@@ -127,7 +127,7 @@ const ObsDetails = ( {
     <HideView show={showActivityTab}>
       <ActivityTab
         activityItems={activityItems}
-        isOnline={isOnline}
+        isConnected={isConnected}
         observation={observation}
         openAgreeWithIdSheet={openAgreeWithIdSheet}
         refetchRemoteObservation={refetchRemoteObservation}
@@ -161,7 +161,7 @@ const ObsDetails = ( {
         <View className="mr-8">
           <ObsDetailsOverview
             belongsToCurrentUser={belongsToCurrentUser}
-            isOnline={isOnline}
+            isConnected={isConnected}
             isRefetching={isRefetching}
             observation={observation}
           />
@@ -229,7 +229,7 @@ const ObsDetails = ( {
         </View>
         <ObsDetailsOverview
           belongsToCurrentUser={belongsToCurrentUser}
-          isOnline={isOnline}
+          isConnected={isConnected}
           isRefetching={isRefetching}
           observation={observation}
         />

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -1,4 +1,7 @@
 // @flow
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
 import { useQueryClient } from "@tanstack/react-query";
 import { createComment } from "api/comments";
@@ -17,7 +20,6 @@ import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import {
   useAuthenticatedMutation,
   useCurrentUser,
-  useIsConnected,
   useLocalObservation,
   useObservationsUpdates,
   useTranslation
@@ -138,7 +140,7 @@ const ObsDetailsContainer = ( ): Node => {
   const navigation = useNavigation( );
   const realm = useRealm( );
   const { t } = useTranslation( );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const vision = currentObservation?.owners_identification_from_vision;
 
   const [state, dispatch] = useReducer( reducer, initialState );

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -140,7 +140,7 @@ const ObsDetailsContainer = ( ): Node => {
   const navigation = useNavigation( );
   const realm = useRealm( );
   const { t } = useTranslation( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const vision = currentObservation?.owners_identification_from_vision;
 
   const [state, dispatch] = useReducer( reducer, initialState );
@@ -165,7 +165,7 @@ const ObsDetailsContainer = ( ): Node => {
   const fetchRemoteObservationEnabled = !!(
     !remoteObsWasDeleted
     && ( !localObservation || localObservation?.wasSynced( ) )
-    && isOnline
+    && isConnected
   );
 
   const {
@@ -538,7 +538,7 @@ const ObsDetailsContainer = ( ): Node => {
       currentUser={currentUser}
       onPotentialDisagreePressed={onPotentialDisagreePressed}
       hideAddCommentSheet={hideAddCommentSheet}
-      isOnline={isOnline}
+      isConnected={isConnected}
       isRefetching={isRefetching}
       navToSuggestions={navToSuggestions}
       // saving observation in state (i.e. using observationShown)

--- a/src/components/ObsDetails/ObsDetailsOverview.js
+++ b/src/components/ObsDetails/ObsDetailsOverview.js
@@ -20,14 +20,14 @@ import {
 
 type Props = {
   belongsToCurrentUser?: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   isRefetching: boolean,
   observation: Object,
 }
 
 const ObsDetailsOverview = ( {
   belongsToCurrentUser,
-  isOnline,
+  isConnected,
   isRefetching,
   observation
 }: Props ): Node => {
@@ -67,7 +67,7 @@ const ObsDetailsOverview = ( {
     <View className="bg-white">
       <View className="flex-row justify-between mx-[15px] mt-[13px]">
         {( !observation || isRefetching ) && loadingIndicator}
-        <InlineUser user={observation?.user} isOnline={isOnline} />
+        <InlineUser user={observation?.user} isConnected={isConnected} />
         {observation && (
           <DateDisplay
             dateString={

--- a/src/components/ObsDetails/SoundContainer.js
+++ b/src/components/ObsDetails/SoundContainer.js
@@ -46,7 +46,7 @@ const SoundContainer = ( {
   sound
 } ) => {
   const needsInternet = sound.file_url.includes( "https://" );
-  const { isInternetReachable } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const playerRef = useRef( new AudioRecorderPlayer( ) );
   const player = playerRef.current;
   const { t } = useTranslation( );
@@ -180,7 +180,7 @@ const SoundContainer = ( {
     }
   }, [autoPlay, isVisible, playSound] );
 
-  if ( isInternetReachable === false && needsInternet ) {
+  if ( isConnected === false && needsInternet ) {
     return (
       <OfflineNotice
         onPress={( ) => refreshNetInfo( )}

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
 import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/LocationPicker";
@@ -13,7 +16,7 @@ import type { Node } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 import Observation from "realmModels/Observation";
 import { writeExifToFile } from "sharedHelpers/parseExif";
-import { useCurrentUser, useIsConnected, useTranslation } from "sharedHooks";
+import { useCurrentUser, useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
 
 import { log } from "../../../react-native-logs.config";
@@ -41,7 +44,7 @@ const BottomButtons = ( {
   observations,
   setCurrentObservationIndex
 }: Props ): Node => {
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const currentUser = useCurrentUser( );
   const cameraRollUris = useStore( state => state.cameraRollUris );
   const unsavedChanges = useStore( state => state.unsavedChanges );

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -44,7 +44,7 @@ const BottomButtons = ( {
   observations,
   setCurrentObservationIndex
 }: Props ): Node => {
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const currentUser = useCurrentUser( );
   const cameraRollUris = useStore( state => state.cameraRollUris );
   const unsavedChanges = useStore( state => state.unsavedChanges );
@@ -214,7 +214,7 @@ const BottomButtons = ( {
   ), [buttonPressed, loading, handlePress, t, passesTests] );
 
   const renderButtons = useCallback( ( ) => {
-    if ( !currentUser || !isOnline ) {
+    if ( !currentUser || !isConnected ) {
       return renderSaveButton( );
     }
     if ( currentObservation?._synced_at ) {
@@ -232,7 +232,7 @@ const BottomButtons = ( {
   }, [
     currentObservation,
     currentUser,
-    isOnline,
+    isConnected,
     passesEvidenceTest,
     renderSaveButton,
     renderSaveChangesButton,

--- a/src/components/SharedComponents/InlineUser/InlineUser.js
+++ b/src/components/SharedComponents/InlineUser/InlineUser.js
@@ -20,10 +20,10 @@ type Props = {
     id: number,
     icon_url?: string
   },
-  isOnline: boolean
+  isConnected: boolean
 };
 
-const InlineUser = ( { user, isOnline }: Props ): Node => {
+const InlineUser = ( { user, isConnected }: Props ): Node => {
   const navigation = useNavigation();
   const userImgUri = User.uri( user );
   const userHandle = User.userHandle( user );
@@ -31,7 +31,7 @@ const InlineUser = ( { user, isOnline }: Props ): Node => {
   const { t } = useTranslation( );
 
   const renderUserIcon = () => {
-    if ( !userImgUri || !isOnline ) {
+    if ( !userImgUri || !isConnected ) {
       return (
         <INatIcon
           testID="InlineUser.FallbackPicture"

--- a/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
@@ -25,7 +25,7 @@ type Props = {
   handleScroll?: Function,
   hideLoadingWheel: boolean,
   isFetchingNextPage?: boolean,
-  isOnline: boolean,
+  isConnected: boolean,
   layout: "list" | "grid",
   onEndReached: Function,
   renderHeader?: Function,
@@ -45,7 +45,7 @@ const ObservationsFlashList = ( {
   handleScroll,
   hideLoadingWheel,
   isFetchingNextPage,
-  isOnline,
+  isConnected,
   layout,
   onEndReached,
   renderHeader,
@@ -105,10 +105,10 @@ const ObservationsFlashList = ( {
     <InfiniteScrollLoadingWheel
       hideLoadingWheel={hideLoadingWheel}
       layout={layout}
-      isOnline={isOnline}
+      isConnected={isConnected}
       explore={explore}
     />
-  ), [hideLoadingWheel, layout, isOnline, explore] );
+  ), [hideLoadingWheel, layout, isConnected, explore] );
 
   const contentContainerStyle = useMemo( ( ) => {
     if ( layout === "list" ) { return contentContainerStyleProp; }

--- a/src/components/Suggestions/SuggestionsContainer.tsx
+++ b/src/components/Suggestions/SuggestionsContainer.tsx
@@ -1,3 +1,6 @@
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import MediaViewerModal from "components/MediaViewer/MediaViewerModal";
 import _ from "lodash";
@@ -9,7 +12,6 @@ import React, {
 } from "react";
 import ObservationPhoto from "realmModels/ObservationPhoto";
 import {
-  useIsConnected,
   useLastScreen,
   useLocationPermission
 } from "sharedHooks";
@@ -103,7 +105,7 @@ const reducer = ( state, action ) => {
 const SuggestionsContainer = ( ) => {
   const navigation = useNavigation( );
   const { params } = useRoute( );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   // clearing the cache of resized images for the score_image API
   // placing this here means we can keep the app size small
   // and only have the latest resized image stored in computerVisionSuggestions

--- a/src/components/Suggestions/SuggestionsContainer.tsx
+++ b/src/components/Suggestions/SuggestionsContainer.tsx
@@ -105,7 +105,7 @@ const reducer = ( state, action ) => {
 const SuggestionsContainer = ( ) => {
   const navigation = useNavigation( );
   const { params } = useRoute( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   // clearing the cache of resized images for the score_image API
   // placing this here means we can keep the app size small
   // and only have the latest resized image stored in computerVisionSuggestions
@@ -130,10 +130,10 @@ const SuggestionsContainer = ( ) => {
   } = useLocationPermission( );
   const lastScreen = useLastScreen( );
   const showImproveWithLocationButton = useMemo( ( ) => hasPermissions === false
-    && isOnline
+    && isConnected
     && lastScreen === "Camera", [
     hasPermissions,
-    isOnline,
+    isConnected,
     lastScreen
   ] );
   const improveWithLocationButtonOnPress = useCallback( ( ) => {
@@ -317,15 +317,15 @@ const SuggestionsContainer = ( ) => {
   const reloadSuggestions = useCallback( ( ) => {
     // used when offline text is tapped to try to get online
     // suggestions
-    if ( !isOnline ) { return; }
+    if ( !isConnected ) { return; }
     resetTimeout( );
     dispatch( { type: "SET_FETCH_STATUS", fetchStatus: "loading" } );
-  }, [isOnline, resetTimeout] );
+  }, [isConnected, resetTimeout] );
 
   const hideLocationToggleButton = usingOfflineSuggestions
     || isLoading
     || showImproveWithLocationButton
-    || !isOnline;
+    || !isConnected;
 
   const setImageParams = useCallback( async ( ) => {
     const newImageParams = await createUploadParams( selectedPhotoUri, shouldUseEvidenceLocation );

--- a/src/components/Suggestions/hooks/useOnlineSuggestions.ts
+++ b/src/components/Suggestions/hooks/useOnlineSuggestions.ts
@@ -34,7 +34,7 @@ const useOnlineSuggestions = (
 
   const queryClient = useQueryClient( );
   const [timedOut, setTimedOut] = useState( false );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
 
   async function queryFn( optsWithAuth ) {
     const params = flattenedUploadParams;
@@ -79,10 +79,10 @@ const useOnlineSuggestions = (
   }, [] );
 
   useEffect( () => {
-    if ( isOnline === false ) {
+    if ( isConnected === false ) {
       setTimedOut( true );
     }
-  }, [isOnline, dispatch] );
+  }, [isConnected, dispatch] );
 
   useEffect( ( ) => {
     if ( onlineSuggestions !== undefined ) {

--- a/src/components/Suggestions/hooks/useOnlineSuggestions.ts
+++ b/src/components/Suggestions/hooks/useOnlineSuggestions.ts
@@ -1,11 +1,13 @@
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useQueryClient } from "@tanstack/react-query";
 import scoreImage from "api/computerVision";
 import {
   useCallback, useEffect, useState
 } from "react";
 import {
-  useAuthenticatedQuery,
-  useIsConnected
+  useAuthenticatedQuery
 } from "sharedHooks";
 
 const SCORE_IMAGE_TIMEOUT = 5_000;
@@ -32,7 +34,7 @@ const useOnlineSuggestions = (
 
   const queryClient = useQueryClient( );
   const [timedOut, setTimedOut] = useState( false );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
 
   async function queryFn( optsWithAuth ) {
     const params = flattenedUploadParams;

--- a/src/components/UserProfile/UserProfile.js
+++ b/src/components/UserProfile/UserProfile.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { fetchRelationships } from "api/relationships";
 import { fetchRemoteUser } from "api/users";
@@ -22,7 +25,6 @@ import { formatUserProfileDate } from "sharedHelpers/dateAndTime";
 import {
   useAuthenticatedQuery,
   useCurrentUser,
-  useIsConnected,
   useTranslation
 } from "sharedHooks";
 import useStore from "stores/useStore";
@@ -38,7 +40,7 @@ const UserProfile = ( ): Node => {
   const { userId } = params;
   const [showLoginSheet, setShowLoginSheet] = useState( false );
   const [showUnfollowSheet, setShowUnfollowSheet] = useState( false );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const { t } = useTranslation( );
 
   const { data: remoteUser } = useAuthenticatedQuery(

--- a/src/components/UserProfile/UserProfile.js
+++ b/src/components/UserProfile/UserProfile.js
@@ -40,7 +40,7 @@ const UserProfile = ( ): Node => {
   const { userId } = params;
   const [showLoginSheet, setShowLoginSheet] = useState( false );
   const [showUnfollowSheet, setShowUnfollowSheet] = useState( false );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const { t } = useTranslation( );
 
   const { data: remoteUser } = useAuthenticatedQuery(
@@ -61,7 +61,7 @@ const UserProfile = ( ): Node => {
       ttl: -1
     }, optsWithAuth ),
     {
-      enabled: !!isOnline && !!currentUser
+      enabled: !!isConnected && !!currentUser
     }
   );
   let relationshipResults = null;

--- a/src/navigation/BottomTabNavigator/NotificationsIconContainer.js
+++ b/src/navigation/BottomTabNavigator/NotificationsIconContainer.js
@@ -1,4 +1,7 @@
 // @flow
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { fetchUnviewedObservationUpdatesCount } from "api/observations";
 import NotificationsIcon from "navigation/BottomTabNavigator/NotificationsIcon";
 import type { Node } from "react";
@@ -6,8 +9,7 @@ import React, { useEffect, useState } from "react";
 import {
   useAuthenticatedQuery,
   useCurrentUser,
-  useInterval,
-  useIsConnected
+  useInterval
 } from "sharedHooks";
 import useStore from "stores/useStore";
 
@@ -39,7 +41,7 @@ const NotificationsIconContainer = ( {
   const [hasUnread, setHasUnread] = useState( false );
   const [numFetchIntervals, setNumFetchIntervals] = useState( 0 );
   const currentUser = useCurrentUser( );
-  const isOnline = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const observationMarkedAsViewedAt = useStore( state => state.observationMarkedAsViewedAt );
 
   const { data: unviewedUpdatesCount } = useAuthenticatedQuery(

--- a/src/navigation/BottomTabNavigator/NotificationsIconContainer.js
+++ b/src/navigation/BottomTabNavigator/NotificationsIconContainer.js
@@ -41,7 +41,7 @@ const NotificationsIconContainer = ( {
   const [hasUnread, setHasUnread] = useState( false );
   const [numFetchIntervals, setNumFetchIntervals] = useState( 0 );
   const currentUser = useCurrentUser( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const observationMarkedAsViewedAt = useStore( state => state.observationMarkedAsViewedAt );
 
   const { data: unviewedUpdatesCount } = useAuthenticatedQuery(
@@ -56,7 +56,7 @@ const NotificationsIconContainer = ( {
     ],
     optsWithAuth => fetchUnviewedObservationUpdatesCount( optsWithAuth ),
     {
-      enabled: !!currentUser && !!isOnline
+      enabled: !!currentUser && !!isConnected
     }
   );
 

--- a/src/sharedHelpers/fetchPlaceName.js
+++ b/src/sharedHelpers/fetchPlaceName.js
@@ -37,8 +37,8 @@ const setPlaceName = ( results: Array<Object> ): string => {
 
 const fetchPlaceName = async ( lat: ?number, lng: ?number ): Promise<?string> => {
   if ( !lat || !lng ) { return null; }
-  const { isInternetReachable } = await NetInfo.fetch( );
-  if ( !isInternetReachable ) { return null; }
+  const { isConnected } = await NetInfo.fetch( );
+  if ( !isConnected ) { return null; }
   try {
     const results = await Geocoder.geocodePosition( { lat, lng } );
     if ( results.length === 0 || typeof results !== "object" ) { return null; }

--- a/src/sharedHooks/index.js
+++ b/src/sharedHooks/index.js
@@ -8,7 +8,6 @@ export { default as useInfiniteNotificationsScroll } from "./useInfiniteNotifica
 export { default as useInfiniteObservationsScroll } from "./useInfiniteObservationsScroll";
 export { default as useInfiniteScroll } from "./useInfiniteScroll";
 export { default as useInterval } from "./useInterval";
-export { default as useIsConnected } from "./useIsConnected";
 export { default as useLastScreen } from "./useLastScreen";
 export { default as useLocalObservation } from "./useLocalObservation";
 export { default as useLocalObservations } from "./useLocalObservations";

--- a/src/sharedHooks/useIconicTaxa.js
+++ b/src/sharedHooks/useIconicTaxa.js
@@ -1,18 +1,21 @@
 // @flow
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { searchTaxa } from "api/taxa";
 import { RealmContext } from "providers/contexts";
 import { useEffect, useState } from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
-import { useAuthenticatedQuery, useIsConnected } from "sharedHooks";
+import { useAuthenticatedQuery } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
 const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ): Object => {
   const { reload } = options;
   const realm = useRealm( );
-  const isConnected = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
   const [isUpdatingRealm, setIsUpdatingRealm] = useState( );
-  const enabled = !!isConnected && !!reload;
+  const enabled = !!isOnline && !!reload;
 
   const queryKey = ["searchTaxa", reload];
   const { data: iconicTaxa } = useAuthenticatedQuery(

--- a/src/sharedHooks/useIconicTaxa.js
+++ b/src/sharedHooks/useIconicTaxa.js
@@ -13,9 +13,9 @@ const { useRealm } = RealmContext;
 const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ): Object => {
   const { reload } = options;
   const realm = useRealm( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
   const [isUpdatingRealm, setIsUpdatingRealm] = useState( );
-  const enabled = !!isOnline && !!reload;
+  const enabled = !!isConnected && !!reload;
 
   const queryKey = ["searchTaxa", reload];
   const { data: iconicTaxa } = useAuthenticatedQuery(

--- a/src/sharedHooks/useInfiniteObservationsScroll.js
+++ b/src/sharedHooks/useInfiniteObservationsScroll.js
@@ -17,7 +17,8 @@ const { useRealm } = RealmContext;
 const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const netInfo = useNetInfo( );
+  const isConnected = netInfo?.isConnected;
 
   const baseParams = {
     ...newInputParams,
@@ -62,7 +63,7 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
     getNextPageParam: lastPage => last( lastPage )?.id,
     // allow a user to see the Explore screen Observations
     // content while logged out
-    enabled: !!isOnline && ( !!currentUser || upsert === false )
+    enabled: !!isConnected && ( !!currentUser || upsert === false )
   } );
 
   useEffect( ( ) => {

--- a/src/sharedHooks/useInfiniteObservationsScroll.js
+++ b/src/sharedHooks/useInfiniteObservationsScroll.js
@@ -1,5 +1,8 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { searchObservations } from "api/observations";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
@@ -7,14 +10,14 @@ import { flatten, last, noop } from "lodash";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
 import Observation from "realmModels/Observation";
-import { useCurrentUser, useIsConnected } from "sharedHooks";
+import { useCurrentUser } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
 const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
-  const isConnected = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
 
   const baseParams = {
     ...newInputParams,
@@ -59,7 +62,7 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
     getNextPageParam: lastPage => last( lastPage )?.id,
     // allow a user to see the Explore screen Observations
     // content while logged out
-    enabled: !!isConnected && ( !!currentUser || upsert === false )
+    enabled: !!isOnline && ( !!currentUser || upsert === false )
   } );
 
   useEffect( ( ) => {

--- a/src/sharedHooks/useIsConnected.ts
+++ b/src/sharedHooks/useIsConnected.ts
@@ -1,9 +1,0 @@
-import { useNetInfo } from "@react-native-community/netinfo";
-
-// Note that a return value of null means the state is unknown
-const useIsConnected = ( ): boolean | null => {
-  const { isInternetReachable } = useNetInfo( );
-  return isInternetReachable;
-};
-
-export default useIsConnected;

--- a/src/sharedHooks/useObservationsUpdates.js
+++ b/src/sharedHooks/useObservationsUpdates.js
@@ -1,10 +1,13 @@
 // @flow
 
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { fetchObservationUpdates } from "api/observations";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
-import { useAuthenticatedQuery, useIsConnected } from "sharedHooks";
+import { useAuthenticatedQuery } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
@@ -12,7 +15,7 @@ export const fetchObservationUpdatesKey = "fetchObservationUpdates";
 
 const useObservationsUpdates = ( enabled: boolean ): Object => {
   const realm = useRealm();
-  const isConnected = useIsConnected( );
+  const { isInternetReachable: isOnline } = useNetInfo( );
 
   // Request params for fetching unviewed updates
   const baseParams = {
@@ -28,7 +31,7 @@ const useObservationsUpdates = ( enabled: boolean ): Object => {
   } = useAuthenticatedQuery(
     [fetchObservationUpdatesKey],
     optsWithAuth => fetchObservationUpdates( baseParams, optsWithAuth ),
-    { enabled: !!isConnected && !!enabled }
+    { enabled: !!isOnline && !!enabled }
   );
 
   /*

--- a/src/sharedHooks/useObservationsUpdates.js
+++ b/src/sharedHooks/useObservationsUpdates.js
@@ -15,7 +15,7 @@ export const fetchObservationUpdatesKey = "fetchObservationUpdates";
 
 const useObservationsUpdates = ( enabled: boolean ): Object => {
   const realm = useRealm();
-  const { isInternetReachable: isOnline } = useNetInfo( );
+  const { isConnected } = useNetInfo( );
 
   // Request params for fetching unviewed updates
   const baseParams = {
@@ -31,7 +31,7 @@ const useObservationsUpdates = ( enabled: boolean ): Object => {
   } = useAuthenticatedQuery(
     [fetchObservationUpdatesKey],
     optsWithAuth => fetchObservationUpdates( baseParams, optsWithAuth ),
-    { enabled: !!isOnline && !!enabled }
+    { enabled: !!isConnected && !!enabled }
   );
 
   /*

--- a/src/sharedHooks/useUserMe.js
+++ b/src/sharedHooks/useUserMe.js
@@ -1,12 +1,14 @@
 // @flow
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { fetchUserMe } from "api/users";
 import { RealmContext } from "providers/contexts";
 import { useCallback, useEffect } from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import {
   useAuthenticatedQuery,
-  useCurrentUser,
-  useIsConnected
+  useCurrentUser
 } from "sharedHooks";
 
 const { useRealm } = RealmContext;
@@ -15,8 +17,8 @@ const useUserMe = ( options: ?Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
   const updateRealm = options?.updateRealm;
-  const isConnected = useIsConnected( );
-  const enabled = !!isConnected && !!currentUser;
+  const { isInternetReachable: isOnline } = useNetInfo( );
+  const enabled = !!isOnline && !!currentUser;
 
   const {
     data: remoteUser,

--- a/src/sharedHooks/useUserMe.js
+++ b/src/sharedHooks/useUserMe.js
@@ -17,8 +17,8 @@ const useUserMe = ( options: ?Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
   const updateRealm = options?.updateRealm;
-  const { isInternetReachable: isOnline } = useNetInfo( );
-  const enabled = !!isOnline && !!currentUser;
+  const { isConnected } = useNetInfo( );
+  const enabled = !!isConnected && !!currentUser;
 
   const {
     data: remoteUser,

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -66,7 +66,7 @@ describe( "ObsEdit offline", ( ) => {
 
     // Mock NetInfo so it says internet is not reachable
     NetInfo.fetch.mockImplementation( async ( ) => ( {
-      isInternetReachable: false
+      isConnected: false
     } ) );
   } );
 

--- a/tests/integration/SuggestionsWithUnsyncedObs.test.js
+++ b/tests/integration/SuggestionsWithUnsyncedObs.test.js
@@ -332,7 +332,7 @@ describe( "from AICamera", ( ) => {
 
   describe( "suggestions while offline", ( ) => {
     it( "should not call score_image and should not show any location buttons", async ( ) => {
-      useNetInfo.mockImplementation( ( ) => ( { isInternetReachable: false } ) );
+      useNetInfo.mockImplementation( ( ) => ( { isConnected: false } ) );
       const { observations } = await setupAppWithSignedInUser( );
       await navigateToSuggestionsViaAICamera( observations[0] );
       expect( inatjs.computervision.score_image ).not.toHaveBeenCalled( );

--- a/tests/integration/SuggestionsWithUnsyncedObs.test.js
+++ b/tests/integration/SuggestionsWithUnsyncedObs.test.js
@@ -1,5 +1,8 @@
 import Geolocation from "@react-native-community/geolocation";
 import {
+  useNetInfo
+} from "@react-native-community/netinfo";
+import {
   screen,
   userEvent,
   waitFor,
@@ -7,7 +10,6 @@ import {
 } from "@testing-library/react-native";
 import * as usePredictions from "components/Camera/AICamera/hooks/usePredictions.ts";
 import inatjs from "inaturalistjs";
-import * as useIsConnected from "sharedHooks/useIsConnected.ts";
 import * as useLocationPermission from "sharedHooks/useLocationPermission.tsx";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
@@ -330,7 +332,7 @@ describe( "from AICamera", ( ) => {
 
   describe( "suggestions while offline", ( ) => {
     it( "should not call score_image and should not show any location buttons", async ( ) => {
-      jest.spyOn( useIsConnected, "default" ).mockImplementation( ( ) => false );
+      useNetInfo.mockImplementation( ( ) => ( { isInternetReachable: false } ) );
       const { observations } = await setupAppWithSignedInUser( );
       await navigateToSuggestionsViaAICamera( observations[0] );
       expect( inatjs.computervision.score_image ).not.toHaveBeenCalled( );

--- a/tests/performance/MyObservations.perf-test.js
+++ b/tests/performance/MyObservations.perf-test.js
@@ -82,7 +82,7 @@
 //       isFetchingNextPage={false}
 //       onEndReached={mockOnEndReached}
 //       currentUser={mockUser}
-//       isOnline
+//       isConnected
 //       uploadState={mockState}
 //     /> );
 //   } );

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -1,8 +1,10 @@
+import {
+  useNetInfo
+} from "@react-native-community/netinfo";
 import { screen } from "@testing-library/react-native";
 import CustomTabBarContainer from "navigation/BottomTabNavigator/CustomTabBarContainer";
 import React from "react";
 import * as useCurrentUser from "sharedHooks/useCurrentUser.ts";
-import * as useIsConnected from "sharedHooks/useIsConnected.ts";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
@@ -45,7 +47,7 @@ describe( "CustomTabBar", () => {
   } );
 
   it( "should display person icon while user is logged out", async () => {
-    renderComponent( <CustomTabBarContainer navigation={jest.fn( )} isOnline /> );
+    renderComponent( <CustomTabBarContainer navigation={jest.fn( )} /> );
 
     const personIcon = screen.getByTestId( "NavButton.personIcon" );
     await expect( personIcon ).toBeVisible( );
@@ -53,15 +55,15 @@ describe( "CustomTabBar", () => {
 
   it( "should display avatar while user is logged in", async () => {
     jest.spyOn( useCurrentUser, "default" ).mockImplementation( () => mockUser );
-    renderComponent( <CustomTabBarContainer navigation={jest.fn( )} isOnline /> );
+    renderComponent( <CustomTabBarContainer navigation={jest.fn( )} /> );
 
     const avatar = screen.getByTestId( "UserIcon.photo" );
     await expect( avatar ).toBeVisible( );
   } );
 
   it( "should display person icon when connectivity is low", async ( ) => {
-    jest.spyOn( useIsConnected, "default" ).mockImplementation( () => false );
-    renderComponent( <CustomTabBarContainer navigation={jest.fn( )} isOnline={false} /> );
+    useNetInfo.mockImplementation( ( ) => ( { isInternetReachable: false } ) );
+    renderComponent( <CustomTabBarContainer navigation={jest.fn( )} /> );
 
     const personIcon = screen.getByTestId( "NavButton.personIcon" );
     await expect( personIcon ).toBeVisible( );
@@ -79,6 +81,7 @@ describe( "CustomTabBar with advanced user layout", () => {
 
   beforeEach( ( ) => {
     jest.resetAllMocks();
+    useNetInfo.mockImplementation( ( ) => ( { isInternetReachable: true } ) );
   } );
 
   it( "should render correctly", async () => {

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -62,7 +62,7 @@ describe( "CustomTabBar", () => {
   } );
 
   it( "should display person icon when connectivity is low", async ( ) => {
-    useNetInfo.mockImplementation( ( ) => ( { isInternetReachable: false } ) );
+    useNetInfo.mockImplementation( ( ) => ( { isConnected: false } ) );
     renderComponent( <CustomTabBarContainer navigation={jest.fn( )} /> );
 
     const personIcon = screen.getByTestId( "NavButton.personIcon" );
@@ -81,7 +81,7 @@ describe( "CustomTabBar with advanced user layout", () => {
 
   beforeEach( ( ) => {
     jest.resetAllMocks();
-    useNetInfo.mockImplementation( ( ) => ( { isInternetReachable: true } ) );
+    useNetInfo.mockImplementation( ( ) => ( { isConnected: true } ) );
   } );
 
   it( "should render correctly", async () => {

--- a/tests/unit/components/Explore/IdentifiersView.test.js
+++ b/tests/unit/components/Explore/IdentifiersView.test.js
@@ -19,7 +19,7 @@ describe( "IdentifiersView", () => {
     renderComponent(
       <ExploreFlashList
         hideLoadingWheel={false}
-        isOnline
+        isConnected
       />
     );
 
@@ -31,7 +31,7 @@ describe( "IdentifiersView", () => {
     renderComponent(
       <ExploreFlashList
         hideLoadingWheel={false}
-        isOnline={false}
+        isConnected={false}
       />
     );
 
@@ -43,7 +43,7 @@ describe( "IdentifiersView", () => {
     renderComponent(
       <ExploreFlashList
         hideLoadingWheel
-        isOnline
+        isConnected
       />
     );
 
@@ -55,7 +55,7 @@ describe( "IdentifiersView", () => {
     renderComponent(
       <ExploreFlashList
         hideLoadingWheel
-        isOnline
+        isConnected
         data={[]}
         status="loading"
       />
@@ -69,7 +69,7 @@ describe( "IdentifiersView", () => {
     renderComponent(
       <ExploreFlashList
         hideLoadingWheel
-        isOnline
+        isConnected
         data={[]}
       />
     );

--- a/tests/unit/components/Explore/ObservationsView.test.js
+++ b/tests/unit/components/Explore/ObservationsView.test.js
@@ -20,7 +20,7 @@ describe( "ObservationsView", () => {
     renderComponent(
       <ObservationsFlashList
         hideLoadingWheel={false}
-        isOnline
+        isConnected
       />
     );
 
@@ -32,7 +32,7 @@ describe( "ObservationsView", () => {
     renderComponent(
       <ObservationsFlashList
         hideLoadingWheel={false}
-        isOnline={false}
+        isConnected={false}
       />
     );
 
@@ -44,7 +44,7 @@ describe( "ObservationsView", () => {
     renderComponent(
       <ObservationsFlashList
         hideLoadingWheel
-        isOnline
+        isConnected
       />
     );
 
@@ -57,7 +57,7 @@ describe( "ObservationsView", () => {
       <ObservationsFlashList
         dataCanBeFetched
         hideLoadingWheel
-        isOnline
+        isConnected
         data={[]}
         status="loading"
       />
@@ -71,7 +71,7 @@ describe( "ObservationsView", () => {
     renderComponent(
       <ObservationsFlashList
         hideLoadingWheel
-        isOnline
+        isConnected
         data={[]}
       />
     );

--- a/tests/unit/components/MyObservations/Announcements.test.js
+++ b/tests/unit/components/MyObservations/Announcements.test.js
@@ -58,7 +58,7 @@ describe( "Announcements", () => {
   } );
 
   test( "should call inaturalistjs with locale as param", async () => {
-    renderComponent( <Announcements isOnline /> );
+    renderComponent( <Announcements isConnected /> );
     await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalledWith(
       expect.objectContaining( { locale: "en" } ),
       expect.anything()
@@ -66,7 +66,7 @@ describe( "Announcements", () => {
   } );
 
   test( "should not render without announcements", async () => {
-    renderComponent( <Announcements isOnline /> );
+    renderComponent( <Announcements isConnected /> );
 
     await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalled() );
 
@@ -83,7 +83,7 @@ describe( "Announcements", () => {
     } );
 
     test( "should render correctly", async () => {
-      renderComponent( <Announcements isOnline /> );
+      renderComponent( <Announcements isConnected /> );
 
       await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalled() );
 
@@ -92,7 +92,7 @@ describe( "Announcements", () => {
     } );
 
     test( "should show body text", async () => {
-      renderComponent( <Announcements isOnline /> );
+      renderComponent( <Announcements isConnected /> );
 
       await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalled() );
 
@@ -104,7 +104,7 @@ describe( "Announcements", () => {
     } );
 
     test( "should not show dismiss button", async () => {
-      renderComponent( <Announcements isOnline /> );
+      renderComponent( <Announcements isConnected /> );
 
       await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalled() );
 
@@ -122,7 +122,7 @@ describe( "Announcements", () => {
     } );
 
     test( "should show dismiss button", async () => {
-      renderComponent( <Announcements isOnline /> );
+      renderComponent( <Announcements isConnected /> );
 
       await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalled() );
 
@@ -141,7 +141,7 @@ describe( "Announcements", () => {
     } );
 
     test( "show announcement with oldest start date", async () => {
-      renderComponent( <Announcements isOnline /> );
+      renderComponent( <Announcements isConnected /> );
 
       await waitFor( () => expect( inaturalistjs.announcements.search ).toHaveBeenCalled() );
 

--- a/tests/unit/components/ObsDetails/DetailsTab.test.js
+++ b/tests/unit/components/ObsDetails/DetailsTab.test.js
@@ -7,11 +7,6 @@ import factory from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
 
-jest.mock( "sharedHooks/useIsConnected", ( ) => ( {
-  __esModule: true,
-  default: ( ) => true
-} ) );
-
 // Before migrating to Jest 27 this line was:
 // jest.useFakeTimers();
 // TODO: replace with modern usage of jest.useFakeTimers

--- a/tests/unit/components/ObsDetails/Flags.test.js
+++ b/tests/unit/components/ObsDetails/Flags.test.js
@@ -10,8 +10,6 @@ const mockObservation = factory( "LocalObservation", {
   time_observed_at: "2023-12-14T21:07:41-09:30"
 } );
 
-jest.mock( "sharedHooks/useIsConnected" );
-
 jest.mock( "sharedHelpers/dateAndTime", ( ) => ( {
   __esModule: true,
   formatIdDate: jest.fn()

--- a/tests/unit/components/ObsDetails/ObsDetails.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetails.test.js
@@ -7,7 +7,6 @@ import { View } from "react-native";
 import { formatApiDatetime } from "sharedHelpers/dateAndTime";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 import * as useCurrentUser from "sharedHooks/useCurrentUser.ts";
-import useIsConnected from "sharedHooks/useIsConnected.ts";
 import * as useLocalObservation from "sharedHooks/useLocalObservation";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
@@ -146,8 +145,6 @@ jest.mock(
   }
 );
 
-jest.mock( "sharedHooks/useIsConnected" );
-
 const renderObsDetails = ( ) => renderComponent(
   <ObsDetailsContainer />
 );
@@ -178,7 +175,6 @@ describe( "ObsDetails", () => {
   // } );
 
   it( "renders obs details from remote call", async () => {
-    useIsConnected.mockImplementation( () => true );
     renderObsDetails( );
 
     const obs = await screen.findByTestId( `ObsDetails.${mockObservation.uuid}` );
@@ -218,7 +214,6 @@ describe( "ObsDetails", () => {
     } );
 
     it( "should render fallback image icon instead of photos", async () => {
-      useIsConnected.mockImplementation( () => true );
       renderObsDetails( );
 
       const labelText = t( "Observation-has-no-photos-and-no-sounds" );
@@ -253,7 +248,6 @@ describe( "ObsDetails", () => {
     // it(
     //   "shows network error image instead of observation photos if user is offline",
     //   async () => {
-    //     useIsConnected.mockImplementation( () => false );
     //     renderObsDetails( );
     //     const labelText = t( "Observation-photos-unavailable-without-internet" );
     //     const noInternet = await screen.findByLabelText( labelText );

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -45,7 +45,7 @@ describe( "InlineUser", ( ) => {
     render( <InlineUser user={mockUser} isOnline /> );
     // Check for user name text
     expect( screen.getByText( `@${mockUser.login}` ) ).toBeTruthy( );
-    // This image appears after useIsConnected returns true
+    // This image appears after useNetInfo returns true
     // so we have to use await and findByTestId
     const profilePicture = await screen.findByTestId( "mockUserIcon" );
     expect( profilePicture ).toBeTruthy( );
@@ -67,7 +67,7 @@ describe( "InlineUser", ( ) => {
       render( <InlineUser user={mockUserWithoutImage} isOnline /> );
 
       expect( screen.getByText( `@${mockUserWithoutImage.login}` ) ).toBeTruthy();
-      // This icon appears after useIsConnected returns true
+      // This icon appears after useNetInfo returns true
       // so we have to use await and findByTestId
       expect(
         await screen.findByTestId( "InlineUser.FallbackPicture" )
@@ -87,7 +87,7 @@ describe( "InlineUser", ( ) => {
       render( <InlineUser user={mockUser} isOnline={false} /> );
 
       expect( screen.getByText( `@${mockUser.login}` ) ).toBeTruthy();
-      // This icon appears after useIsConnected returns false
+      // This icon appears after useNetInfo returns false
       // so we have to use await and findByTestId
       expect( await screen.findByTestId( "InlineUser.FallbackPicture" ) ).toBeTruthy();
       expect( screen.queryByTestId( "mockUserIcon" ) ).not.toBeTruthy();

--- a/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
+++ b/tests/unit/components/SharedComponents/InlineUser/InlineUser.test.js
@@ -36,13 +36,13 @@ describe( "InlineUser", ( ) => {
 
   it( "renders reliably", () => {
     // Snapshot test
-    render( <InlineUser user={snapshotUser} isOnline /> );
+    render( <InlineUser user={snapshotUser} isConnected /> );
 
     expect( screen ).toMatchSnapshot();
   } );
 
   it( "displays user handle and image correctly", async ( ) => {
-    render( <InlineUser user={mockUser} isOnline /> );
+    render( <InlineUser user={mockUser} isConnected /> );
     // Check for user name text
     expect( screen.getByText( `@${mockUser.login}` ) ).toBeTruthy( );
     // This image appears after useNetInfo returns true
@@ -53,7 +53,7 @@ describe( "InlineUser", ( ) => {
   } );
 
   it( "fires onPress handler", ( ) => {
-    render( <InlineUser user={mockUser} isOnline /> );
+    render( <InlineUser user={mockUser} isConnected /> );
 
     const inlineUserComponent = screen.getByRole( "link" );
     fireEvent.press( inlineUserComponent );
@@ -64,7 +64,7 @@ describe( "InlineUser", ( ) => {
 
   describe( "when user has no icon set", () => {
     it( "displays user handle and fallback image correctly", async () => {
-      render( <InlineUser user={mockUserWithoutImage} isOnline /> );
+      render( <InlineUser user={mockUserWithoutImage} isConnected /> );
 
       expect( screen.getByText( `@${mockUserWithoutImage.login}` ) ).toBeTruthy();
       // This icon appears after useNetInfo returns true
@@ -77,14 +77,14 @@ describe( "InlineUser", ( ) => {
 
     it( "renders reliably", ( ) => {
       // Snapshot test
-      render( <InlineUser user={snapshotUserWithoutImage} isOnline /> );
+      render( <InlineUser user={snapshotUserWithoutImage} isConnected /> );
       expect( screen ).toMatchSnapshot();
     } );
   } );
 
   describe( "when offline", () => {
     it( "displays no internet fallback image correctly", async () => {
-      render( <InlineUser user={mockUser} isOnline={false} /> );
+      render( <InlineUser user={mockUser} isConnected={false} /> );
 
       expect( screen.getByText( `@${mockUser.login}` ) ).toBeTruthy();
       // This icon appears after useNetInfo returns false
@@ -95,7 +95,7 @@ describe( "InlineUser", ( ) => {
 
     it( "renders reliably", ( ) => {
       // Snapshot test
-      render( <InlineUser user={snapshotUser} isOnline={false} /> );
+      render( <InlineUser user={snapshotUser} isConnected={false} /> );
       expect( screen ).toMatchSnapshot();
     } );
   } );


### PR DESCRIPTION
Closes #1770
- pings our own endpoint to check for internet connectivity, rather than pinging Google's
- also removes `useIsConnected`, which is a redundant hook we were using to check for internet connectivity. instead, we can use `useNetInfo` directly to check for connectivity since they already have a built-in hook with more functionality
- removing `useIsConnected` also means slightly less mocking in jest