### PR TITLE
Clear user data on sign out

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { startNetworkLogging } from "react-native-network-logger";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { reactQueryRetry } from "sharedHelpers/logging";
-import { installID } from "sharedHelpers/userData.ts";
+import { installID } from "sharedHelpers/persistedInstallationId.ts";
 
 import { name as appName } from "./app.json";
 import { log } from "./react-native-logs.config";

--- a/src/api/log.ts
+++ b/src/api/log.ts
@@ -4,7 +4,7 @@ import { create } from "apisauce";
 import { getAnonymousJWT, getJWT } from "components/LoginSignUp/AuthenticationService";
 import Config from "react-native-config";
 import { transportFunctionType } from "react-native-logs";
-import { installID } from "sharedHelpers/userData.ts";
+import { installID } from "sharedHelpers/persistedInstallationId.ts";
 
 const API_HOST: string
     = Config.API_URL || process.env.API_URL || "https://api.inaturalist.org/v2";

--- a/src/components/LoginSignUp/AuthenticationService.js
+++ b/src/components/LoginSignUp/AuthenticationService.js
@@ -20,9 +20,9 @@ import RNSInfo from "react-native-sensitive-info";
 import Realm from "realm";
 import realmConfig from "realmModels/index";
 import User from "realmModels/User";
+import { installID } from "sharedHelpers/persistedInstallationId.ts";
 import removeAllFilesFromDirectory from "sharedHelpers/removeAllFilesFromDirectory.ts";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
-import { installID } from "sharedHelpers/userData.ts";
 import { sleep, unlink } from "sharedHelpers/util";
 import { storage } from "stores/useStore";
 

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -6,7 +6,6 @@ import { deleteRemoteObservation } from "api/observations";
 import { RealmContext } from "providers/contexts";
 import { useCallback, useEffect } from "react";
 import Observation from "realmModels/Observation";
-import { log } from "sharedHelpers/logger";
 import { useAuthenticatedMutation } from "sharedHooks";
 import {
   AUTOMATIC_SYNC_IN_PROGRESS,
@@ -18,8 +17,6 @@ import useStore from "stores/useStore";
 
 import syncRemoteDeletedObservations from "../helpers/syncRemoteDeletedObservations";
 import syncRemoteObservations from "../helpers/syncRemoteObservations";
-
-const logger = log.extend( "useSyncObservations" );
 
 const { useRealm } = RealmContext;
 
@@ -48,7 +45,7 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
   const handleRemoteDeletion = useAuthenticatedMutation(
     ( params, optsWithAuth ) => deleteRemoteObservation( params, optsWithAuth ),
     {
-      onSuccess: ( ) => logger.debug( "Remote observation deleted" ),
+      onSuccess: ( ) => console.log( "Remote observation deleted" ),
       onError: deleteObservationError => {
         setDeletionError( deleteObservationError?.message );
         throw deleteObservationError;
@@ -137,13 +134,10 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
 
   const syncAutomatically = useCallback( async ( ) => {
     if ( canSync ) {
-      logger.debug( "sync #1: syncing remotely deleted observations" );
       await fetchRemoteDeletions( );
     }
-    logger.debug( "sync #2: handling locally deleted observations" );
     await deleteLocalObservations( );
     if ( canSync ) {
-      logger.debug( "sync #3: fetching remote observations" );
       await fetchRemoteObservations( );
     }
     completeSync( );
@@ -157,20 +151,16 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
 
   const syncManually = useCallback( async ( ) => {
     if ( canSync ) {
-      logger.debug( "sync #1: syncing remotely deleted observations" );
       await fetchRemoteDeletions( );
     }
-    logger.debug( "sync #2: handling locally deleted observations" );
     await deleteLocalObservations( );
     if ( canSync ) {
-      logger.debug( "sync #3: fetching remote observations" );
       await fetchRemoteObservations( );
     }
     resetSyncToolbar( );
     // we want to show user error messages if upload fails from user
     // being offline, so we're not checking internet connectivity here
     if ( loggedIn ) {
-      logger.debug( "sync #4: uploading all unsynced observations" );
       await uploadObservations( );
     }
     completeSync( );

--- a/src/components/MyObservations/hooks/useUploadObservations.ts
+++ b/src/components/MyObservations/hooks/useUploadObservations.ts
@@ -9,7 +9,6 @@ import Observation from "realmModels/Observation";
 import {
   INCREMENT_SINGLE_UPLOAD_PROGRESS
 } from "sharedHelpers/emitUploadProgress";
-import { log } from "sharedHelpers/logger";
 import uploadObservation, { handleUploadError } from "sharedHelpers/uploadObservation";
 import {
   useLocalObservations,
@@ -22,8 +21,6 @@ import {
   UPLOAD_PENDING
 } from "stores/createUploadObservationsSlice.ts";
 import useStore from "stores/useStore";
-
-const logger = log.extend( "useUploadObservations" );
 
 export const MS_BEFORE_TOOLBAR_RESET = 5_000;
 const MS_BEFORE_UPLOAD_TIMES_OUT = 60_000 * 5;
@@ -206,7 +203,6 @@ export default useUploadObservations = canUpload => {
 
   const startUpload = useCallback( ( ) => {
     if ( canUpload ) {
-      logger.debug( "sync #4.2: starting upload" );
       setUploadStatus( UPLOAD_IN_PROGRESS );
     } else {
       setUploadStatus( UPLOAD_PENDING );
@@ -232,7 +228,6 @@ export default useUploadObservations = canUpload => {
   ] );
 
   const uploadObservations = useCallback( async ( ) => {
-    logger.debug( "sync #4.1: creating upload queue" );
     createUploadQueue( );
   }, [
     createUploadQueue

--- a/src/components/hooks/useFreshInstall.js
+++ b/src/components/hooks/useFreshInstall.js
@@ -4,10 +4,6 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { signOut } from "components/LoginSignUp/AuthenticationService";
 import { useEffect } from "react";
 
-import { log } from "../../../react-native-logs.config";
-
-const logger = log.extend( "useFreshInstall" );
-
 const useFreshInstall = ( currentUser: ?Object ) => {
   useEffect( ( ) => {
     const checkForSignedInUser = async ( ) => {
@@ -19,9 +15,6 @@ const useFreshInstall = ( currentUser: ?Object ) => {
       if ( !alreadyLaunched ) {
         await AsyncStorage.setItem( "alreadyLaunched", "true" );
         if ( !currentUser ) {
-          logger.debug(
-            "Signing out and deleting Realm because no signed in user found in the database"
-          );
           await signOut( { clearRealm: true } );
         }
       }

--- a/src/sharedHelpers/persistedInstallationId.ts
+++ b/src/sharedHelpers/persistedInstallationId.ts
@@ -7,15 +7,15 @@ const INSTALL_ID = "installID";
 // one wrapping zustand because we want to be able to persist the installation ID
 // even if a user logs out of the app. this means on signout, we're clearing
 // the storage for the MMKV instance wrapping zustand but leaving this one untouched
-const userData = new MMKV( {
+const persistedInstallationId = new MMKV( {
   id: "user-data"
 } );
-export default userData;
+export default persistedInstallationId;
 
 export function installID( ) {
-  const id = userData.getString( INSTALL_ID );
+  const id = persistedInstallationId.getString( INSTALL_ID );
   if ( id ) return id;
   const newID: string = uuid.v4( ).toString( );
-  userData.set( INSTALL_ID, newID );
+  persistedInstallationId.set( INSTALL_ID, newID );
   return newID;
 }

--- a/src/sharedHelpers/userData.ts
+++ b/src/sharedHelpers/userData.ts
@@ -3,6 +3,10 @@ import uuid from "react-native-uuid";
 
 const INSTALL_ID = "installID";
 
+// 20240729 amanda - we're keeping this MMKV instance separate from the
+// one wrapping zustand because we want to be able to persist the installation ID
+// even if a user logs out of the app. this means on signout, we're clearing
+// the storage for the MMKV instance wrapping zustand but leaving this one untouched
 const userData = new MMKV( {
   id: "user-data"
 } );

--- a/src/stores/useStore.js
+++ b/src/stores/useStore.js
@@ -9,7 +9,7 @@ import createRootExploreSlice from "./createRootExploreSlice";
 import createSyncObservationsSlice from "./createSyncObservationsSlice";
 import createUploadObservationsSlice from "./createUploadObservationsSlice";
 
-const storage = new MMKV();
+export const storage = new MMKV();
 
 const zustandStorage = {
   setItem: ( name, value ) => storage.set( name, value ),


### PR DESCRIPTION
Closes #1738 

- Clears all directories containing user generated data within the Documents Directory
- Deletes the MMKV instance wrapping the zustand store