### PR TITLE
Bugfix for useInfiniteObservationsScroll

### DIFF
--- a/src/sharedHooks/useInfiniteObservationsScroll.js
+++ b/src/sharedHooks/useInfiniteObservationsScroll.js
@@ -61,9 +61,7 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
     },
     initialPageParam: 0,
     getNextPageParam: lastPage => last( lastPage )?.id,
-    // allow a user to see the Explore screen Observations
-    // content while logged out
-    enabled: !!isConnected && ( !!currentUser || upsert === false )
+    enabled: !!( isConnected && currentUser )
   } );
 
   useEffect( ( ) => {


### PR DESCRIPTION
- Make sure query is only fetched if there's a logged in user