### PR TITLE
Reset navigator when navigating to ObsEdit from TabStack

### DIFF
--- a/src/components/ObsDetails/ObsDetailsHeader.tsx
+++ b/src/components/ObsDetails/ObsDetailsHeader.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
+import navigateToObsEdit from "components/ObsEdit/helpers/navigateToObsEdit.ts";
 import {
   BackButton,
   INatIconButton
@@ -63,9 +64,7 @@ const ObsDetailsHeader = ( {
               testID="ObsDetail.editButton"
               onPress={() => {
                 prepareObsEdit( localObservation );
-                navigation.navigate( "NoBottomTabStackNavigator", {
-                  screen: "ObsEdit"
-                } );
+                navigateToObsEdit( navigation );
               }}
               icon="pencil"
               color={!rightIconBlack

--- a/src/components/ObsEdit/Header.js
+++ b/src/components/ObsEdit/Header.js
@@ -82,9 +82,7 @@ const Header = ( {
     || ( unsynced && !unsavedChanges );
 
   const handleBackButtonPress = useCallback( ( ) => {
-    if ( params?.lastScreen === "ObsList" ) {
-      navToObsList( );
-    } else if ( params?.lastScreen === "Suggestions" ) {
+    if ( params?.lastScreen === "Suggestions" ) {
       navigation.navigate( "Suggestions", { lastScreen: "ObsEdit" } );
     } else if ( shouldNavigateBack ) {
       navigation.goBack( );
@@ -97,7 +95,6 @@ const Header = ( {
     }
   }, [
     currentObservation?.uuid,
-    navToObsList,
     shouldNavigateBack,
     navigation,
     params?.lastScreen,

--- a/src/components/ObsEdit/helpers/navigateToObsEdit.ts
+++ b/src/components/ObsEdit/helpers/navigateToObsEdit.ts
@@ -1,0 +1,28 @@
+import { CommonActions } from "@react-navigation/native";
+
+const navigateToObsEdit = navigation => {
+  // since we can access ObsEdit from two separate stacks, the TabStackNavigator
+  // and the NoBottomTabStackNavigator, we don't want ObsEdit to land on the previous
+  // history of the NoBottomTabStackNavigator (i.e. anything from the ObsCreate flow)
+  // when we're navigating via the TabStack (i.e. MyObservations, ObsDetails)
+  navigation.dispatch(
+    CommonActions.reset( {
+      index: 0,
+      routes: [
+        {
+          name: "NoBottomTabStackNavigator",
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: "ObsEdit"
+              }
+            ]
+          }
+        }
+      ]
+    } )
+  );
+};
+
+export default navigateToObsEdit;

--- a/src/components/SharedComponents/ObservationsFlashList/MyObservationsPressable.js
+++ b/src/components/SharedComponents/ObservationsFlashList/MyObservationsPressable.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { useNavigation } from "@react-navigation/native";
+import navigateToObsEdit from "components/ObsEdit/helpers/navigateToObsEdit.ts";
 import type { Node } from "react";
 import React from "react";
 import { Pressable } from "react-native";
@@ -25,12 +26,7 @@ const MyObservationsPressable = ( { observation, testID, children }: Props ): No
     const { uuid } = observation;
     if ( unsynced ) {
       prepareObsEdit( observation );
-      navigation.navigate( "NoBottomTabStackNavigator", {
-        screen: "ObsEdit",
-        params: {
-          lastScreen: "ObsList"
-        }
-      } );
+      navigateToObsEdit( navigation );
     } else {
       navigation.push( "ObsDetails", { uuid } );
     }

--- a/src/navigation/StackNavigators/SharedStackScreens.js
+++ b/src/navigation/StackNavigators/SharedStackScreens.js
@@ -45,6 +45,10 @@ const SharedStackScreens = ( ): Node => (
       <Stack.Screen
         name="ObsEdit"
         component={ObsEdit}
+        // 20240730 - amanda: we need to disable swiping on ObsEdit
+        // options={{
+        //   gestureEnabled: false
+        // }}
       />
       <Stack.Screen
         name="LocationPicker"

--- a/src/navigation/StackNavigators/SharedStackScreens.js
+++ b/src/navigation/StackNavigators/SharedStackScreens.js
@@ -45,10 +45,6 @@ const SharedStackScreens = ( ): Node => (
       <Stack.Screen
         name="ObsEdit"
         component={ObsEdit}
-        // 20240730 - amanda: we need to disable swiping on ObsEdit
-        // options={{
-        //   gestureEnabled: false
-        // }}
       />
       <Stack.Screen
         name="LocationPicker"

--- a/src/stores/createObservationFlowSlice.js
+++ b/src/stores/createObservationFlowSlice.js
@@ -148,8 +148,7 @@ const createObservationFlowSlice = ( set, get ) => ( {
   updateComment: newComment => set( { comment: newComment } ),
   updateObservations: updatedObservations => set( state => ( {
     observations: updatedObservations.map( observationToJSON ),
-    currentObservation: observationToJSON( updatedObservations[state.currentObservationIndex] ),
-    unsavedChanges: true
+    currentObservation: observationToJSON( updatedObservations[state.currentObservationIndex] )
   } ) ),
   updateObservationKeys: keysAndValues => set( state => ( {
     observations: updateObservationKeysWithState( keysAndValues, state ),


### PR DESCRIPTION
Closes #1890

We can't use the swipe gesture to go back on ObsEdit in certain situations, because ObsEdit is part of the NoBottomTab stack navigator, but there are a few scenarios where we're landing on ObsEdit from the TabStackNavigator. In these cases, swiping back in the stack will take a user back to the previous NoBottomTab screen, rather than the other stack navigator where a user came from.

So instead, we're resetting the navigator when a user is coming from MyObservations/ObsDetail, and swipe will not work on ObsEdit in these scenarios.