### PR TITLE
Stop location fetch when navigating to location picker

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -25,9 +25,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.73.7)
   - hermes-engine/Pre-built (0.73.7)
   - libevent (2.1.12)
-  - MMKV (1.3.7):
-    - MMKVCore (~> 1.3.7)
-  - MMKVCore (1.3.7)
+  - MMKV (1.3.9):
+    - MMKVCore (~> 1.3.9)
+  - MMKVCore (1.3.9)
   - RCT-Folly (2022.05.16.00):
     - boost
     - DoubleConversion
@@ -1482,8 +1482,8 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 39589e9c297d024e90fe68f6830ff86c4e01498a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MMKV: 36a22a9ec84c9bb960613a089ddf6f48be9312b0
-  MMKVCore: 158e61c8516401a9fac730288acb29e6fc19bbf9
+  MMKV: 817ba1eea17421547e01e087285606eb270a8dcb
+  MMKVCore: af055b00e27d88cd92fad301c5fecd1ff9b26dd9
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 77f73950d15b8c1a2b48ba5b79020c3003d1c9b5
   RCTTypeSafety: ede1e2576424d89471ef553b2aed09fbbcc038e3

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -46,7 +46,7 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
   const handleRemoteDeletion = useAuthenticatedMutation(
     ( params, optsWithAuth ) => deleteRemoteObservation( params, optsWithAuth ),
     {
-      onSuccess: ( ) => console.log( "Remote observation deleted" ),
+      onSuccess: ( ) => undefined,
       onError: deleteObservationError => {
         setDeletionError( deleteObservationError?.message );
         throw deleteObservationError;

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -99,7 +99,6 @@ const BottomButtons = ( {
     }
 
     if ( observations.length === 1 ) {
-      logger.info( "navigating back to MyObs" );
       // navigate to ObsList and start upload with uuid
       navigation.navigate( "TabNavigator", {
         screen: "TabStackNavigator",
@@ -167,7 +166,6 @@ const BottomButtons = ( {
   ] );
 
   const handlePress = useCallback( type => {
-    logger.info( `tapped ${type}` );
     if ( showMissingEvidence( ) ) { return; }
     setLoading( true );
     setButtonPressed( type );

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useIsFocused, useNavigation } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { ViewWrapper } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
@@ -33,27 +33,22 @@ const ObsEdit = ( ): Node => {
   const [passesEvidenceTest, setPassesEvidenceTest] = useState( false );
   const [passesIdentificationTest, setPassesIdentificationTest] = useState( false );
   const [resetScreen, setResetScreen] = useState( false );
-  const isFocused = useIsFocused( );
   const currentUser = useCurrentUser( );
-  const [shouldFetchLocation, setShouldFetchLocation] = useState( false );
   const {
     hasPermissions: hasLocationPermission,
     renderPermissionsGate: renderLocationPermissionGate,
     requestPermissions: requestLocationPermission
   } = useLocationPermission( );
 
+  const shouldFetchLocation = hasLocationPermission
+    && shouldFetchObservationLocation( currentObservation );
+
   const {
     isFetchingLocation,
+    stopWatch,
+    subscriptionId,
     userLocation
   } = useWatchPosition( { shouldFetchLocation } );
-
-  // Note the intended functionality is *not* to request location permission
-  // until the user taps the missing location
-  useEffect( ( ) => {
-    if ( hasLocationPermission && shouldFetchObservationLocation( currentObservation ) ) {
-      setShouldFetchLocation( true );
-    }
-  }, [currentObservation, hasLocationPermission] );
 
   useEffect( ( ) => {
     if ( userLocation?.latitude ) {
@@ -61,31 +56,20 @@ const ObsEdit = ( ): Node => {
     }
   }, [userLocation, updateObservationKeys] );
 
-  useEffect( ( ) => {
-    // this is needed to make sure watchPosition is called when a user
-    // navigates to ObsEdit a second time during an app session,
-    // otherwise, state will indicate that fetching is not needed
-    const unsubscribe = navigation.addListener( "blur", ( ) => {
-      setShouldFetchLocation( false );
-    } );
-    return unsubscribe;
-  }, [navigation] );
-
   const navToLocationPicker = useCallback( ( ) => {
+    stopWatch( subscriptionId );
     navigation.navigate( "LocationPicker", { goBackOnSave: true } );
-  }, [navigation] );
+  }, [stopWatch, subscriptionId, navigation] );
 
   const onLocationPress = ( ) => {
     // If we have location permissions, navigate to the location picker
     if ( hasLocationPermission ) {
-      navToLocationPicker();
+      navToLocationPicker( );
     } else {
       // If we don't have location permissions, request them
       requestLocationPermission( );
     }
   };
-
-  if ( !isFocused ) return null;
 
   // This should never, ever happen
   if ( currentObservation?.user && currentUser && currentUser.id !== currentObservation.user.id ) {

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useNavigation } from "@react-navigation/native";
+import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { ViewWrapper } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
@@ -33,6 +33,7 @@ const ObsEdit = ( ): Node => {
   const [passesEvidenceTest, setPassesEvidenceTest] = useState( false );
   const [passesIdentificationTest, setPassesIdentificationTest] = useState( false );
   const [resetScreen, setResetScreen] = useState( false );
+  const isFocused = useIsFocused( );
   const currentUser = useCurrentUser( );
   const {
     hasPermissions: hasLocationPermission,
@@ -70,6 +71,8 @@ const ObsEdit = ( ): Node => {
       requestLocationPermission( );
     }
   };
+
+  if ( !isFocused ) return null;
 
   // This should never, ever happen
   if ( currentObservation?.user && currentUser && currentUser.id !== currentObservation.user.id ) {

--- a/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
+++ b/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
@@ -44,9 +44,9 @@ const DeleteObservationSheet = ( {
     }
     if ( multipleObservations ) {
       updateObservations( observations.filter( o => o.uuid !== uuid ) );
+      handleClose( );
       return;
     }
-    handleClose( );
     navToObsList( );
   }, [
     handleClose,

--- a/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
+++ b/src/components/ObsEdit/Sheets/DeleteObservationSheet.js
@@ -44,9 +44,9 @@ const DeleteObservationSheet = ( {
     }
     if ( multipleObservations ) {
       updateObservations( observations.filter( o => o.uuid !== uuid ) );
-      handleClose( );
       return;
     }
+    handleClose( );
     navToObsList( );
   }, [
     handleClose,

--- a/src/sharedHelpers/shouldFetchObservationLocation.ts
+++ b/src/sharedHelpers/shouldFetchObservationLocation.ts
@@ -1,9 +1,6 @@
 import { galleryPhotosPath } from "appConstants/paths.ts";
 import RNFS from "react-native-fs";
 import { RealmObservation } from "realmModels/types.d.ts";
-import {
-  TARGET_POSITIONAL_ACCURACY
-} from "sharedHooks/useWatchPosition.ts";
 
 const shouldFetchObservationLocation = ( observation: RealmObservation ) => {
   const latitude = observation?.latitude;
@@ -20,14 +17,10 @@ const shouldFetchObservationLocation = ( observation: RealmObservation ) => {
     !observation?._created_at
     && !observation?._synced_at
   );
-  const accGoodEnough = (
-    observation?.positional_accuracy
-    && observation.positional_accuracy <= TARGET_POSITIONAL_ACCURACY
-  );
 
   return observation
     && isNewObservation
-    && ( !hasLocation || !accGoodEnough )
+    && !hasLocation
     && !isGalleryPhoto
     && !isSharedPhoto;
 };

--- a/src/sharedHooks/useWatchPosition.ts
+++ b/src/sharedHooks/useWatchPosition.ts
@@ -104,6 +104,8 @@ const useWatchPosition = ( options: {
 
   return {
     isFetchingLocation,
+    stopWatch,
+    subscriptionId,
     userLocation
   };
 };


### PR DESCRIPTION
Closes #1874

- Exposes `stopWatch` callback so we can stop location fetching from any component with a subscription id
- Removes some unnecessary `useEffects` in ObsEdit
- Removes accuracy check from `shouldFetchObservationLocation` since `useWatchPosition` already handles that