### PR TITLE
Select taxon button always visible from Suggestions

### DIFF
--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -1,14 +1,18 @@
-import { useRoute } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import React, {
   useState
 } from "react";
+import { Alert } from "react-native";
 import {
   useCameraDevice
 } from "react-native-vision-camera";
+import { useTranslation } from "sharedHooks";
 
 import CameraWithDevice from "./CameraWithDevice";
 
 const CameraContainer = ( ) => {
+  const navigation = useNavigation( );
+  const { t } = useTranslation( );
   const { params } = useRoute( );
   const addEvidence = params?.addEvidence;
   const cameraType = params?.camera;
@@ -23,6 +27,11 @@ const CameraContainer = ( ) => {
   } );
 
   if ( !device ) {
+    Alert.alert(
+      t( "No-Camera-Available" ),
+      t( "Could-not-find-a-camera-on-this-device" )
+    );
+    navigation.goBack();
     return null;
   }
 

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -33,8 +33,9 @@ import DeviceInfo from "react-native-device-info";
 import { useTheme } from "react-native-paper";
 import { log } from "sharedHelpers/logger";
 import {
-  useAuthenticatedQuery, useCurrentUser, useLastScreen,
-  useTranslation, useUserMe
+  useAuthenticatedQuery,
+  useTranslation,
+  useUserMe
 } from "sharedHooks";
 import useStore from "stores/useStore";
 
@@ -67,40 +68,18 @@ const TaxonDetails = ( ): Node => {
   const [kebabMenuVisible, setKebabMenuVisible] = useState( false );
   const [mediaIndex, setMediaIndex] = useState( 0 );
   const navState = useNavigationState( nav => nav );
-  const history = navState?.routes.map( r => r.name );
-  const lastScreen = useLastScreen( );
-  const fromObsDetails = _.includes( history, "ObsDetails" );
-  const prevScreenSuggestions = lastScreen === "Suggestions";
-  const prevScreenTaxonSearch = lastScreen === "TaxonSearch";
-  const prevScreenTaxonDetails = lastScreen === "TaxonDetails";
-  const currentUser = useCurrentUser( );
-
-  const reversedHistory = _.reverse( history );
-  let cameFromSuggestionsOrSearch = false;
-
-  reversedHistory?.forEach( ( screen, index ) => {
-    if ( screen !== "TaxonDetails" ) {
-      if ( screen === "Suggestions" || screen === "TaxonSearch" ) {
-        if ( reversedHistory[index - 1] === "TaxonDetails" ) {
-          // see if previous index was taxon details
-          cameFromSuggestionsOrSearch = true;
-        }
-      }
-    }
-  } );
-
-  const isTaxonDetailsFromSuggestions = prevScreenTaxonDetails && cameFromSuggestionsOrSearch;
+  const history = navState?.routes.map( r => r.name ) || [];
+  const fromObsDetails = history.includes( "ObsDetails" );
+  const fromSuggestions = history.includes( "Suggestions" );
+  const fromObsEdit = history.includes( "ObsEdit" );
 
   // previous ObsDetails observation uuid
   const obsUuid = fromObsDetails
     ? _.find( navState?.routes, r => r.name === "ObsDetails" ).params.uuid
     : null;
 
-  const showSelectButton = currentUser
-    && ( prevScreenSuggestions || prevScreenTaxonSearch || isTaxonDetailsFromSuggestions );
-  const usesVision = prevScreenSuggestions
-    && !prevScreenTaxonSearch
-    && !isTaxonDetailsFromSuggestions;
+  const showSelectButton = fromSuggestions || fromObsEdit;
+  const usesVision = history[history.length - 2] === "Suggestions";
 
   const realm = useRealm( );
   const localTaxon = realm.objectForPrimaryKey( "Taxon", id );

--- a/src/components/TaxonDetails/Wikipedia.js
+++ b/src/components/TaxonDetails/Wikipedia.js
@@ -18,6 +18,15 @@ type Props = {
   taxon: Object
 }
 
+const BASE_STYLE = {
+  fontFamily: fontRegular,
+  fontSize: 16,
+  lineHeight: 22,
+  color: colors.darkGray
+};
+
+const FONTS = [fontRegular, ...defaultSystemFonts];
+
 const Wikipedia = ( { taxon }: Props ): React.Node => {
   const { width } = useWindowDimensions();
   const { t, i18n } = useTranslation();
@@ -28,14 +37,6 @@ const Wikipedia = ( { taxon }: Props ): React.Node => {
       Linking.openURL( taxon.wikipedia_url );
     }
   };
-
-  const baseStyle = {
-    fontFamily: fontRegular,
-    fontSize: 16,
-    lineHeight: 22,
-    color: colors.darkGray
-  };
-  const fonts = [fontRegular, ...defaultSystemFonts];
 
   let wikipediaUrl = taxon.wikipedia_url;
 
@@ -55,14 +56,12 @@ const Wikipedia = ( { taxon }: Props ): React.Node => {
   return (
     <>
       <Heading4 className="mb-3">{t( "WIKIPEDIA" )}</Heading4>
-      {taxon.wikipedia_summary && (
-        <HTML
-          contentWidth={width}
-          source={{ html: taxon.wikipedia_summary }}
-          systemFonts={fonts}
-          baseStyle={baseStyle}
-        />
-      )}
+      <HTML
+        contentWidth={width}
+        source={{ html: taxon.wikipedia_summary }}
+        systemFonts={FONTS}
+        baseStyle={BASE_STYLE}
+      />
       { wikipediaUrl && (
         <Body2
           onPress={openWikipedia}

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -201,6 +201,8 @@ Copy-coordinates = Copy Coordinates
 # heading to describe general information about rights, attribution, and
 # licensing
 Copyright = Copyright
+# Error message when no camera can be found
+Could-not-find-a-camera-on-this-device = Could not find a camera on this device
 Couldnt-create-comment = Couldn't create comment
 Couldnt-create-identification-error = Couldn't create identification { $error }
 Couldnt-create-identification-unknown-error = Couldn't create identification, unknown error.
@@ -590,6 +592,8 @@ New-Observation = New Observation
 # Sort order, refers to newest or oldest date
 Newest-to-oldest = Newest to oldest
 Next-observation = Next observation
+# Error message when no camera can be found
+No-Camera-Available = No Camera Available
 No-Location = No Location
 No-Media = No Media
 # As in a machine learning model that powers automated suggestions

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -282,6 +282,10 @@
     "comment": "Right to control copies of a creative work; this string may be used as a\nheading to describe general information about rights, attribution, and\nlicensing",
     "val": "Copyright"
   },
+  "Could-not-find-a-camera-on-this-device": {
+    "comment": "Error message when no camera can be found",
+    "val": "Could not find a camera on this device"
+  },
   "Couldnt-create-comment": "Couldn't create comment",
   "Couldnt-create-identification-error": "Couldn't create identification { $error }",
   "Couldnt-create-identification-unknown-error": "Couldn't create identification, unknown error.",
@@ -789,6 +793,10 @@
     "val": "Newest to oldest"
   },
   "Next-observation": "Next observation",
+  "No-Camera-Available": {
+    "comment": "Error message when no camera can be found",
+    "val": "No Camera Available"
+  },
   "No-Location": "No Location",
   "No-Media": "No Media",
   "No-model-found": {

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -201,6 +201,8 @@ Copy-coordinates = Copy Coordinates
 # heading to describe general information about rights, attribution, and
 # licensing
 Copyright = Copyright
+# Error message when no camera can be found
+Could-not-find-a-camera-on-this-device = Could not find a camera on this device
 Couldnt-create-comment = Couldn't create comment
 Couldnt-create-identification-error = Couldn't create identification { $error }
 Couldnt-create-identification-unknown-error = Couldn't create identification, unknown error.
@@ -590,6 +592,8 @@ New-Observation = New Observation
 # Sort order, refers to newest or oldest date
 Newest-to-oldest = Newest to oldest
 Next-observation = Next observation
+# Error message when no camera can be found
+No-Camera-Available = No Camera Available
 No-Location = No Location
 No-Media = No Media
 # As in a machine learning model that powers automated suggestions


### PR DESCRIPTION
It was being hidden for signed out users. Also refactors tests and sends the user back when they try to access a camera screen on a device with no camera.

Closes #1917