### PR TITLE
Ensure device stays awake during uploading and can sleep after

### DIFF
--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -60,10 +60,10 @@ const MyObservationsContainer = ( ): Node => {
   const currentUserId = currentUser?.id;
   const canUpload = currentUser && isConnected;
 
-  const { uploadObservations } = useUploadObservations( canUpload );
+  const { startUploadObservations } = useUploadObservations( canUpload );
   useSyncObservations(
     currentUserId,
-    uploadObservations
+    startUploadObservations
   );
 
   useObservationsUpdates( !!currentUser );

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -1,7 +1,6 @@
 import {
   useNetInfo
 } from "@react-native-community/netinfo";
-import { deactivateKeepAwake } from "@sayem314/react-native-keep-awake";
 import { INatApiError } from "api/error";
 import { deleteRemoteObservation } from "api/observations";
 import { RealmContext } from "providers/contexts.ts";
@@ -21,7 +20,10 @@ import syncRemoteObservations from "../helpers/syncRemoteObservations";
 
 const { useRealm } = RealmContext;
 
-const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
+const useSyncObservations = (
+  currentUserId: number,
+  startUploadObservations: ( ) => void
+): void => {
   const { isConnected } = useNetInfo( );
   const loggedIn = !!currentUserId;
   const deleteQueue = useStore( state => state.deleteQueue );
@@ -39,15 +41,15 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
 
   const realm = useRealm( );
 
-  const deleteRealmObservation = useCallback( async uuid => {
+  const deleteRealmObservation = useCallback( async ( uuid: string ) => {
     await Observation.deleteLocalObservation( realm, uuid );
   }, [realm] );
 
   const handleRemoteDeletion = useAuthenticatedMutation(
-    ( params, optsWithAuth ) => deleteRemoteObservation( params, optsWithAuth ),
+    ( params: Object, optsWithAuth: Object ) => deleteRemoteObservation( params, optsWithAuth ),
     {
       onSuccess: ( ) => undefined,
-      onError: deleteObservationError => {
+      onError: ( deleteObservationError: Error ) => {
         setDeletionError( deleteObservationError?.message );
         throw deleteObservationError;
       }
@@ -57,7 +59,7 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
   const deleteLocalObservations = useCallback( async ( ) => {
     if ( deleteQueue.length === 0 ) { return; }
 
-    deleteQueue.forEach( async ( uuid, i ) => {
+    deleteQueue.forEach( async ( uuid: string, i: number ) => {
       const observation = realm.objectForPrimaryKey( "Observation", uuid );
       const hasBeenSyncedRemotely = observation?._synced_at;
 
@@ -159,14 +161,19 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
       await fetchRemoteObservations( );
     }
     resetSyncToolbar( );
+    // FYI this updates the state in the sync slice to state that "syncing" is
+    // complete, i.e. all the stuff except for uploading observations, even
+    // though this method is called "syncManually". We could use some better
+    // terminology and naming if we really want to consider those two
+    // processes as separate
+    completeSync( );
     // we want to show user error messages if upload fails from user
     // being offline, so we're not checking internet connectivity here
     if ( loggedIn ) {
-      await uploadObservations( );
-    } else {
-      deactivateKeepAwake( );
+      // In theory completeSync will get called when the upload process finishes
+      return startUploadObservations( );
     }
-    completeSync( );
+    return Promise.resolve();
   }, [
     canSync,
     completeSync,
@@ -175,7 +182,7 @@ const useSyncObservations = ( currentUserId, uploadObservations ): Object => {
     fetchRemoteObservations,
     loggedIn,
     resetSyncToolbar,
-    uploadObservations
+    startUploadObservations
   ] );
 
   useEffect( ( ) => {

--- a/src/components/MyObservations/hooks/useUploadObservations.ts
+++ b/src/components/MyObservations/hooks/useUploadObservations.ts
@@ -5,6 +5,7 @@ import {
 } from "react";
 import { EventRegister } from "react-native-event-listeners";
 import Observation from "realmModels/Observation";
+import type { RealmObservation } from "realmModels/types.d.ts";
 import {
   INCREMENT_SINGLE_UPLOAD_PROGRESS
 } from "sharedHelpers/emitUploadProgress.ts";
@@ -15,8 +16,7 @@ import {
 import {
   UPLOAD_CANCELLED,
   UPLOAD_COMPLETE,
-  UPLOAD_IN_PROGRESS,
-  UPLOAD_PENDING
+  UPLOAD_IN_PROGRESS
 } from "stores/createUploadObservationsSlice.ts";
 import useStore from "stores/useStore";
 
@@ -26,7 +26,7 @@ const MS_BEFORE_UPLOAD_TIMES_OUT = 60_000 * 5;
 const { useRealm } = RealmContext;
 
 // eslint-disable-next-line no-undef
-export default useUploadObservations = canUpload => {
+export default ( canUpload: boolean ) => {
   const realm = useRealm( );
 
   const addUploadError = useStore( state => state.addUploadError );
@@ -44,7 +44,8 @@ export default useUploadObservations = canUpload => {
   const setNumUnuploadedObservations = useStore( state => state.setNumUnuploadedObservations );
   const setTotalToolbarIncrements = useStore( state => state.setTotalToolbarIncrements );
   const addToUploadQueue = useStore( state => state.addToUploadQueue );
-  const setUploadStatus = useStore( state => state.setUploadStatus );
+  const setStartUploadObservations = useStore( state => state.setStartUploadObservations );
+  const setCannotUploadObservations = useStore( state => state.setCannotUploadObservations );
   const resetSyncToolbar = useStore( state => state.resetSyncToolbar );
   const initialNumObservationsInQueue = useStore( state => state.initialNumObservationsInQueue );
 
@@ -97,13 +98,13 @@ export default useUploadObservations = canUpload => {
       }
     );
     return ( ) => {
-      EventRegister?.removeEventListener( progressListener );
+      EventRegister?.removeEventListener( progressListener as string );
     };
   }, [
     updateTotalUploadProgress
   ] );
 
-  const uploadObservationAndCatchError = useCallback( async observation => {
+  const uploadObservationAndCatchError = useCallback( async ( observation: RealmObservation ) => {
     const { uuid } = observation;
     setCurrentUpload( observation );
     try {
@@ -152,7 +153,10 @@ export default useUploadObservations = canUpload => {
   useEffect( ( ) => {
     const startUpload = async ( ) => {
       const lastQueuedUuid = uploadQueue[uploadQueue.length - 1];
-      const localObservation = realm.objectForPrimaryKey( "Observation", lastQueuedUuid );
+      const localObservation = realm.objectForPrimaryKey<RealmObservation>(
+        "Observation",
+        lastQueuedUuid
+      );
       if ( localObservation ) {
         await uploadObservationAndCatchError( localObservation );
       }
@@ -199,39 +203,35 @@ export default useUploadObservations = canUpload => {
     }
   }, [abortController, uploadStatus] );
 
-  const startUpload = useCallback( ( ) => {
-    if ( canUpload ) {
-      setUploadStatus( UPLOAD_IN_PROGRESS );
-    } else {
-      setUploadStatus( UPLOAD_PENDING );
-    }
-  }, [
-    canUpload,
-    setUploadStatus
-  ] );
-
   const createUploadQueue = useCallback( ( ) => {
-    const uuidsQuery = unsyncedUuids.map( uploadUuid => `'${uploadUuid}'` ).join( ", " );
+    const uuidsQuery = unsyncedUuids
+      .map( ( uploadUuid: string ) => `'${uploadUuid}'` ).join( ", " );
     const uploads = realm.objects( "Observation" )
       .filtered( `uuid IN { ${uuidsQuery} }` );
     setTotalToolbarIncrements( uploads );
     addToUploadQueue( unsyncedUuids );
-    startUpload( );
+    if ( canUpload ) {
+      setStartUploadObservations( );
+    } else {
+      setCannotUploadObservations( );
+    }
   }, [
-    realm,
-    setTotalToolbarIncrements,
-    unsyncedUuids,
     addToUploadQueue,
-    startUpload
+    canUpload,
+    realm,
+    setCannotUploadObservations,
+    setStartUploadObservations,
+    setTotalToolbarIncrements,
+    unsyncedUuids
   ] );
 
-  const uploadObservations = useCallback( async ( ) => {
+  const startUploadObservations = useCallback( async ( ) => {
     createUploadQueue( );
   }, [
     createUploadQueue
   ] );
 
   return {
-    uploadObservations
+    startUploadObservations
   };
 };

--- a/src/stores/createSyncObservationsSlice.ts
+++ b/src/stores/createSyncObservationsSlice.ts
@@ -1,4 +1,3 @@
-import { activateKeepAwake } from "@sayem314/react-native-keep-awake";
 import { StateCreator } from "zustand";
 
 export const SYNC_PENDING = "sync-pending";
@@ -7,7 +6,22 @@ export const BEGIN_AUTOMATIC_SYNC = "begin-automatic-sync";
 export const MANUAL_SYNC_IN_PROGRESS = "manual-sync-progress";
 export const AUTOMATIC_SYNC_IN_PROGRESS = "automatic-sync-progress";
 
-const DEFAULT_STATE = {
+type SyncingStatus = typeof SYNC_PENDING
+  | typeof BEGIN_MANUAL_SYNC
+  | typeof BEGIN_AUTOMATIC_SYNC
+  | typeof MANUAL_SYNC_IN_PROGRESS
+  | typeof AUTOMATIC_SYNC_IN_PROGRESS;
+
+interface SyncObservationsSlice {
+  currentDeleteCount: number,
+  deleteError: string | null,
+  deleteQueue: Array<string>,
+  deletionsCompletedAt: Date | null,
+  initialNumDeletionsInQueue: number,
+  syncingStatus: SyncingStatus
+}
+
+const DEFAULT_STATE: SyncObservationsSlice = {
   currentDeleteCount: 1,
   deleteError: null,
   deleteQueue: [],
@@ -16,20 +30,9 @@ const DEFAULT_STATE = {
   syncingStatus: SYNC_PENDING
 };
 
-interface SyncObservationsSlice {
-  currentDeleteCount: number,
-  deleteError: string | null,
-  deleteQueue: Array<string>,
-  deletionsCompletedAt: Date,
-  initialNumDeletionsInQueue: number,
-  syncingStatus: typeof SYNC_PENDING
-  | typeof AUTOMATIC_SYNC_IN_PROGRESS
-  | typeof MANUAL_SYNC_IN_PROGRESS
-}
-
 const createSyncObservationsSlice: StateCreator<SyncObservationsSlice> = set => ( {
   ...DEFAULT_STATE,
-  addToDeleteQueue: uuids => set( state => {
+  addToDeleteQueue: ( uuids: string[] ) => set( state => {
     let copyOfDeleteQueue = state.deleteQueue;
     if ( typeof uuids === "string" ) {
       copyOfDeleteQueue.push( uuids );
@@ -58,10 +61,10 @@ const createSyncObservationsSlice: StateCreator<SyncObservationsSlice> = set => 
     deletionsCompletedAt: new Date( )
   } ) ),
   resetSyncObservationsSlice: ( ) => set( DEFAULT_STATE ),
-  setDeletionError: message => set( ( ) => ( {
+  setDeletionError: ( message: string ) => set( ( ) => ( {
     deleteError: message
   } ) ),
-  setSyncingStatus: syncingStatus => set( ( ) => ( {
+  setSyncingStatus: ( syncingStatus: SyncingStatus ) => set( ( ) => ( {
     syncingStatus
   } ) ),
   resetSyncToolbar: ( ) => set( ( ) => ( {
@@ -70,21 +73,14 @@ const createSyncObservationsSlice: StateCreator<SyncObservationsSlice> = set => 
     deleteQueue: [],
     initialNumDeletionsInQueue: 0
   } ) ),
-  startManualSync: ( ) => set( ( ) => {
-    activateKeepAwake( );
-    return ( {
-      syncingStatus: BEGIN_MANUAL_SYNC
-    } );
-  } ),
-  startAutomaticSync: ( ) => set( ( ) => ( {
-    syncingStatus: BEGIN_AUTOMATIC_SYNC
-  } ) ),
-  completeSync: ( ) => set( ( ) => ( {
+  startManualSync: ( ) => set( { syncingStatus: BEGIN_MANUAL_SYNC } ),
+  startAutomaticSync: ( ) => set( { syncingStatus: BEGIN_AUTOMATIC_SYNC } ),
+  completeSync: ( ) => set( {
     currentDeleteCount: 1,
     deleteError: null,
     deleteQueue: [],
     syncingStatus: SYNC_PENDING
-  } ) )
+  } )
 } );
 
 export default createSyncObservationsSlice;

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -157,9 +157,9 @@ describe( "MyObservations", ( ) => {
 
     describe( "with unsynced observations", ( ) => {
       // Mock inatjs endpoints so they return the right responses for the right test data
-      inatjs.observations.create.mockImplementation( ( params, _opts ) => {
+      inatjs.observations.create.mockImplementation( async ( params, _opts ) => {
         const mockObs = mockUnsyncedObservations.find( o => o.uuid === params.observation.uuid );
-        return Promise.resolve( makeResponse( [{ id: faker.number.int( ), uuid: mockObs.uuid }] ) );
+        return makeResponse( [{ id: faker.number.int( ), uuid: mockObs.uuid }] );
       } );
       inatjs.observations.fetch.mockImplementation( ( uuid, _params, _opts ) => {
         const mockObs = mockUnsyncedObservations.find( o => o.uuid === uuid );

--- a/tests/unit/components/MyObservations/useSyncObservations.test.js
+++ b/tests/unit/components/MyObservations/useSyncObservations.test.js
@@ -63,7 +63,7 @@ const mockUpload = jest.fn( );
 jest.mock( "components/MyObservations/hooks/useUploadObservations", ( ) => ( {
   __esModule: true,
   default: ( ) => ( {
-    uploadObservations: mockUpload
+    startUploadObservations: mockUpload
   } )
 } ) );
 


### PR DESCRIPTION
* Fix previous state in which it was never really allowed to sleep again after upload finished
* Rename `uploadObservations` to `startUploadObservations` to accurately describe what it does
* Minor improvements in ts typing