### PR TITLE
Formatting in DatePicker, ObsEdit

### DIFF
--- a/src/components/ObsEdit/DatePicker.js
+++ b/src/components/ObsEdit/DatePicker.js
@@ -4,7 +4,10 @@ import { Body3, DateTimePicker, INatIcon } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { createObservedOnStringForUpload, displayDateTimeObsEdit } from "sharedHelpers/dateAndTime";
+import {
+  createObservedOnStringFromDatePicker,
+  displayDateTimeObsEdit
+} from "sharedHelpers/dateAndTime";
 import useTranslation from "sharedHooks/useTranslation";
 
 type Props = {
@@ -20,7 +23,7 @@ const DatePicker = ( { currentObservation, updateObservationKeys }: Props ): Nod
   const closeModal = () => setShowModal( false );
 
   const handlePicked = value => {
-    const dateString = createObservedOnStringForUpload( value );
+    const dateString = createObservedOnStringFromDatePicker( value );
     updateObservationKeys( {
       observed_on_string: dateString
     } );
@@ -30,6 +33,8 @@ const DatePicker = ( { currentObservation, updateObservationKeys }: Props ): Nod
   const displayDate = ( ) => displayDateTimeObsEdit(
     currentObservation?.observed_on_string || currentObservation?.time_observed_at
   );
+
+  console.log( currentObservation, "current obs" );
 
   return (
     <>

--- a/src/components/ObsEdit/DatePicker.js
+++ b/src/components/ObsEdit/DatePicker.js
@@ -34,8 +34,6 @@ const DatePicker = ( { currentObservation, updateObservationKeys }: Props ): Nod
     currentObservation?.observed_on_string || currentObservation?.time_observed_at
   );
 
-  console.log( currentObservation, "current obs" );
-
   return (
     <>
       <DateTimePicker

--- a/src/sharedHelpers/dateAndTime.js
+++ b/src/sharedHelpers/dateAndTime.js
@@ -40,7 +40,19 @@ const createObservedOnStringForUpload = date => formatDateStringFromTimestamp(
   getUnixTime( date || new Date( ) )
 );
 
-const displayDateTimeObsEdit = date => date && format( new Date( date ), "PPpp" );
+const createObservedOnStringFromDatePicker = date => {
+  // DatePicker does not support seconds, so we're returning a date,
+  // without timezone and without seconds (just "2022-12-31T23:59")
+  const isoDate = formatISO( date );
+  const isoDateNoSeconds = isoDate.substring( 0, 16 );
+  return isoDateNoSeconds;
+};
+
+const displayDateTimeObsEdit = date => {
+  if ( !date ) { return ""; }
+  // this displays date times formatted like 08/09/2024, 12:14 PM
+  return format( new Date( date ), "Pp" );
+};
 
 const timeAgo = pastTime => formatDistanceToNow( new Date( pastTime ) );
 
@@ -99,6 +111,7 @@ const formatUserProfileDate = ( date, t ) => format( parseISO( date ), t( "date-
 
 export {
   createObservedOnStringForUpload,
+  createObservedOnStringFromDatePicker,
   displayDateTimeObsEdit,
   formatApiDatetime,
   formatDateStringFromTimestamp,

--- a/tests/unit/components/ObsEdit/DatePicker.test.js
+++ b/tests/unit/components/ObsEdit/DatePicker.test.js
@@ -14,6 +14,10 @@ const mockRemoteObservation = factory( "RemoteObservation", {
   observed_on_string: null
 } );
 
+const mockLocalObservationNoDate = factory( "LocalObservation", {
+  observed_on_string: null
+} );
+
 describe( "DatePicker", ( ) => {
   it( "has no accessibility errors", ( ) => {
     const datePicker = <DatePicker />;
@@ -32,5 +36,12 @@ describe( "DatePicker", ( ) => {
 
     const date = screen.getByText( "06/15/2024, 5:26 PM" );
     expect( date ).toBeVisible( );
+  } );
+
+  it( "displays Add Date text when observation has no date", ( ) => {
+    renderComponent( <DatePicker currentObservation={mockLocalObservationNoDate} /> );
+
+    const addDateText = screen.getByText( "Add Date/Time" );
+    expect( addDateText ).toBeVisible( );
   } );
 } );

--- a/tests/unit/components/ObsEdit/DatePicker.test.js
+++ b/tests/unit/components/ObsEdit/DatePicker.test.js
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react-native";
+import DatePicker from "components/ObsEdit/DatePicker";
+import React from "react";
+import factory from "tests/factory";
+import { renderComponent } from "tests/helpers/render";
+
+const mockLocalObservation = factory( "LocalObservation", {
+  observed_on_string: "2024-08-09T12:21"
+} );
+
+const mockRemoteObservation = factory( "RemoteObservation", {
+  // jest timezone is set to UTC time
+  time_observed_at: "2024-06-15T17:26:00-00:00",
+  observed_on_string: null
+} );
+
+describe( "DatePicker", ( ) => {
+  it( "has no accessibility errors", ( ) => {
+    const datePicker = <DatePicker />;
+    expect( datePicker ).toBeAccessible( );
+  } );
+
+  it( "displays date with no seconds from local observation", ( ) => {
+    renderComponent( <DatePicker currentObservation={mockLocalObservation} /> );
+
+    const date = screen.getByText( "08/09/2024, 12:21 PM" );
+    expect( date ).toBeVisible( );
+  } );
+
+  it( "displays date with no seconds from remote observation", ( ) => {
+    renderComponent( <DatePicker currentObservation={mockRemoteObservation} /> );
+
+    const date = screen.getByText( "06/15/2024, 5:26 PM" );
+    expect( date ).toBeVisible( );
+  } );
+} );


### PR DESCRIPTION
Closes #1920

- Removes seconds from date display, since a user can't set seconds in the native DatePicker
- Updates date displayed formatting to be closer to the Figma designs