### PR TITLE
Unify global shadow styling

### DIFF
--- a/src/components/Camera/Buttons/TakePhoto.tsx
+++ b/src/components/Camera/Buttons/TakePhoto.tsx
@@ -8,10 +8,9 @@ import {
 import React from "react";
 import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.black, { offsetHeight: 4 } );
+const DROP_SHADOW = getShadow( { offsetHeight: 4 } );
 
 interface Props {
   takePhoto: () => Promise<void>;

--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -22,8 +22,7 @@ import {
   useStoredLayout,
   useTranslation
 } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
 import ExploreHeader from "./Header/ExploreHeader";
 import IdentifiersView from "./IdentifiersView";
@@ -32,7 +31,7 @@ import ObservationsViewBar from "./ObservationsViewBar";
 import ObserversView from "./ObserversView";
 import SpeciesView from "./SpeciesView";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
   elevation: 6
 } );

--- a/src/components/Explore/MapView.tsx
+++ b/src/components/Explore/MapView.tsx
@@ -10,12 +10,11 @@ import { MapBoundaries, PLACE_MODE, useExplore } from "providers/ExploreContext.
 import React, { useEffect, useState } from "react";
 import { Platform } from "react-native";
 import { useDebugMode, useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
 import useMapLocation from "./hooks/useMapLocation";
 
-const DROP_SHADOW = getShadowForColor( colors?.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
   elevation: 6
 } );

--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -41,8 +41,7 @@ import {
 import React, { useState } from "react";
 import { useTheme } from "react-native-paper";
 import { useCurrentUser, useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
 import placeGuessText from "../helpers/placeGuessText";
 import ExploreLocationSearchModal from "./ExploreLocationSearchModal";
@@ -50,7 +49,7 @@ import ExploreProjectSearchModal from "./ExploreProjectSearchModal";
 import ExploreTaxonSearchModal from "./ExploreTaxonSearchModal";
 import ExploreUserSearchModal from "./ExploreUserSearchModal";
 
-const DROP_SHADOW = getShadowForColor( colors?.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
   elevation: 6
 } );

--- a/src/components/Explore/NumberBadge.tsx
+++ b/src/components/Explore/NumberBadge.tsx
@@ -3,12 +3,12 @@ import { Body3 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
-  elevation: 6
+  elevation: 6,
+  shadowRadius: 4
 } );
 
 interface Props {

--- a/src/components/Explore/ObservationsViewBar.js
+++ b/src/components/Explore/ObservationsViewBar.js
@@ -4,7 +4,7 @@ import { INatIconButton } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { getShadowForColor } from "styles/global";
+import { getShadow } from "styles/global";
 import colors from "styles/tailwindColors";
 
 type Props = {
@@ -12,7 +12,7 @@ type Props = {
   updateObservationsView: Function
 };
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
   elevation: 6
 } );

--- a/src/components/Explore/SearchScreens/ExploreLocationSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreLocationSearch.js
@@ -24,10 +24,9 @@ import React, {
 import { FlatList } from "react-native";
 import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
 import useLocationPermission from "sharedHooks/useLocationPermission.tsx";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4
 } );
 

--- a/src/components/Explore/SearchScreens/ExploreProjectSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreProjectSearch.js
@@ -18,10 +18,9 @@ import React, {
   useState
 } from "react";
 import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4
 } );
 

--- a/src/components/Explore/SearchScreens/ExploreTaxonSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreTaxonSearch.js
@@ -17,10 +17,9 @@ import React, {
 } from "react";
 import { useTranslation } from "sharedHooks";
 import useTaxonSearch from "sharedHooks/useTaxonSearch";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4
 } );
 

--- a/src/components/Explore/SearchScreens/ExploreUserSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreUserSearch.js
@@ -18,10 +18,9 @@ import React, {
   useState
 } from "react";
 import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4
 } );
 

--- a/src/components/LocationPicker/DisplayLatLng.js
+++ b/src/components/LocationPicker/DisplayLatLng.js
@@ -6,10 +6,9 @@ import {
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 type Props = {
   region: Object,

--- a/src/components/LocationPicker/LoadingIndicator.js
+++ b/src/components/LocationPicker/LoadingIndicator.js
@@ -5,10 +5,9 @@ import { ActivityIndicator } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 const LoadingIndicator = ( ): Node => (
   <View

--- a/src/components/LocationPicker/LocationSearch.tsx
+++ b/src/components/LocationPicker/LocationSearch.tsx
@@ -8,10 +8,9 @@ import { Pressable, View } from "components/styledComponents";
 import React, { useRef } from "react";
 import { Keyboard, TextInput } from "react-native";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 interface Place {
   id: string;

--- a/src/components/LocationPicker/WarningText.js
+++ b/src/components/LocationPicker/WarningText.js
@@ -8,10 +8,9 @@ import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
 import useTranslation from "sharedHooks/useTranslation";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 type Props = {
   accuracyTest: string

--- a/src/components/ObsDetails/ActivityTab/FloatingButtons.js
+++ b/src/components/ObsDetails/ActivityTab/FloatingButtons.js
@@ -8,10 +8,9 @@ import React from "react";
 import {
   useTranslation
 } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.black, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: -3,
   shadowOpacity: 0.2
 } );

--- a/src/components/ObsDetails/DetailsTab/CoordinatesCopiedNotification.js
+++ b/src/components/ObsDetails/DetailsTab/CoordinatesCopiedNotification.js
@@ -9,7 +9,7 @@ import { View } from "components/styledComponents";
 import { t } from "i18next";
 import * as React from "react";
 import { useTheme } from "react-native-paper";
-import { getShadowForColor } from "styles/global";
+import { getShadow } from "styles/global";
 
 const CoordinatesCopiedNotification = ( ): React.Node => {
   const theme = useTheme( );
@@ -25,7 +25,7 @@ const CoordinatesCopiedNotification = ( ): React.Node => {
         "p-3",
         "rounded-xl"
       )}
-      style={getShadowForColor( theme.colors.primary )}
+      style={getShadow( )}
     >
       <Body2 className="mr-3">
         {t( "Coordinates-copied-to-clipboard" )}

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -9,8 +9,7 @@ import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view
 import shouldFetchObservationLocation from "sharedHelpers/shouldFetchObservationLocation.ts";
 import { useCurrentUser, useLocationPermission, useWatchPosition } from "sharedHooks";
 import useStore from "stores/useStore";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
 import BottomButtons from "./BottomButtons";
 import EvidenceSectionContainer from "./EvidenceSectionContainer";
@@ -19,7 +18,7 @@ import MultipleObservationsArrows from "./MultipleObservationsArrows";
 import ObsEditHeader from "./ObsEditHeader";
 import OtherDataSection from "./OtherDataSection";
 
-const DROP_SHADOW = getShadowForColor( colors.black, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: -2
 } );
 

--- a/src/components/SharedComponents/FloatingActionBar.js
+++ b/src/components/SharedComponents/FloatingActionBar.js
@@ -4,13 +4,12 @@ import { View } from "components/styledComponents";
 import * as React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { Animated, Keyboard } from "react-native";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
   shadowOpacity: 0.4,
-  shadowRadius: 4
+  shadowRadius: 8
 } );
 
 type Props = {

--- a/src/components/SharedComponents/Map/CurrentLocationButton.tsx
+++ b/src/components/SharedComponents/Map/CurrentLocationButton.tsx
@@ -2,10 +2,9 @@ import classnames from "classnames";
 import { INatIconButton } from "components/SharedComponents";
 import React from "react";
 import useTranslation from "sharedHooks/useTranslation";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 interface Props {
   currentLocationButtonClassName?: string;

--- a/src/components/SharedComponents/Map/DetailsMap.js
+++ b/src/components/SharedComponents/Map/DetailsMap.js
@@ -20,7 +20,7 @@ import type { Node } from "react";
 import React, { useState } from "react";
 import openMap from "react-native-open-maps";
 import { useTheme } from "react-native-paper";
-import { getShadowForColor } from "styles/global";
+import { getShadow } from "styles/global";
 
 type Props = {
   latitude: number,
@@ -39,8 +39,7 @@ const FloatingActionButton = ( {
   buttonClassName,
   onPress,
   accessibilityLabel,
-  icon,
-  theme
+  icon
 } ) => {
   const fabClassNames = classnames(
     "absolute",
@@ -52,7 +51,7 @@ const FloatingActionButton = ( {
 
   return (
     <INatIconButton
-      style={getShadowForColor( theme.colors.primary )}
+      style={getShadow( )}
       className={fabClassNames}
       icon={icon}
       onPress={onPress}
@@ -126,14 +125,12 @@ const DetailsMap = ( {
                 onPress={( ) => copyCoordinates( )}
                 accessibilityLabel={t( "Copy-coordinates" )}
                 buttonClassName="top-0 left-0"
-                theme={theme}
               />
               <FloatingActionButton
                 icon="share"
                 onPress={( ) => shareMap( )}
                 accessibilityLabel={t( "Share-map" )}
                 buttonClassName="top-0 right-0"
-                theme={theme}
               />
             </>
           )}

--- a/src/components/SharedComponents/Map/SwitchMapTypeButton.tsx
+++ b/src/components/SharedComponents/Map/SwitchMapTypeButton.tsx
@@ -5,10 +5,9 @@ import React, {
 } from "react";
 import { useTranslation } from "sharedHooks";
 import { zustandStorage } from "stores/useStore";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 interface Props {
   currentMapType?: string;

--- a/src/components/SharedComponents/ObservationsFlashList/ObsImagePreview.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObsImagePreview.js
@@ -5,11 +5,11 @@ import { LinearGradient, View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback } from "react";
 import { useTheme } from "react-native-paper";
-import { getShadowForColor } from "styles/global";
+import { getShadow } from "styles/global";
 
 import ObsImage from "./ObsImage";
 
-const ICON_DROP_SHADOW = getShadowForColor( "#000000", {
+const ICON_DROP_SHADOW = getShadow( {
   offsetHeight: 1
 } );
 

--- a/src/components/SharedComponents/SearchBar.tsx
+++ b/src/components/SharedComponents/SearchBar.tsx
@@ -6,10 +6,9 @@ import React from "react";
 import { TextInput as RNTextInput } from "react-native";
 import { TextInput, useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 interface Props {
   autoFocus?: boolean;

--- a/src/components/SharedComponents/Sheets/BottomSheet.js
+++ b/src/components/SharedComponents/Sheets/BottomSheet.js
@@ -15,9 +15,6 @@ import React, {
 import { Dimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "sharedHooks";
-import colors from "styles/tailwindColors";
-
-const borderRadius = 24;
 
 type Props = {
   children: Node,
@@ -47,19 +44,6 @@ const StandardBottomSheet = ( {
   if ( snapPoints ) {
     throw new Error( "BottomSheet does not accept snapPoints as a prop." );
   }
-
-  const shadow = {
-    shadowColor: colors.black,
-    borderTopStartRadius: borderRadius,
-    borderTopEndRadius: borderRadius,
-    shadowOffset: {
-      width: 0,
-      height: 12
-    },
-    shadowOpacity: 0.75,
-    shadowRadius: 16.0,
-    elevation: 24
-  };
 
   const { t } = useTranslation( );
   const sheetRef = useRef( null );
@@ -120,7 +104,7 @@ const StandardBottomSheet = ( {
       index={0}
       onChange={onChange || handleBackdropPress}
       ref={sheetRef}
-      style={[shadow, marginOnWide]}
+      style={marginOnWide}
     >
       <BottomSheetScrollView
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}

--- a/src/components/SharedComponents/SpeciesSeenCheckmark.js
+++ b/src/components/SharedComponents/SpeciesSeenCheckmark.js
@@ -9,10 +9,9 @@ import type { Node } from "react";
 import React from "react";
 import { useTheme } from "react-native-paper";
 import { useAuthenticatedQuery, useCurrentUser } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray );
+const DROP_SHADOW = getShadow( );
 
 type Props = {
   taxonId: number

--- a/src/components/SharedComponents/StickyToolbar.js
+++ b/src/components/SharedComponents/StickyToolbar.js
@@ -2,10 +2,9 @@
 import classNames from "classnames";
 import { View } from "components/styledComponents";
 import * as React from "react";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: -2
 } );
 

--- a/src/components/Suggestions/TaxonSearch.js
+++ b/src/components/Suggestions/TaxonSearch.js
@@ -13,12 +13,11 @@ import React, {
   useState
 } from "react";
 import { useTaxonSearch, useTranslation } from "sharedHooks";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
 import useNavigateWithTaxonSelected from "./hooks/useNavigateWithTaxonSelected";
 
-const DROP_SHADOW = getShadowForColor( colors.darkGray, {
+const DROP_SHADOW = getShadow( {
   offsetHeight: 4
 } );
 

--- a/src/navigation/BottomTabNavigator/CustomTabBar.js
+++ b/src/navigation/BottomTabNavigator/CustomTabBar.js
@@ -5,14 +5,12 @@ import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { getShadowForColor } from "styles/global";
-import colors from "styles/tailwindColors";
+import { getShadow } from "styles/global";
 
 import NavButton from "./NavButton";
 
-const DROP_SHADOW = getShadowForColor( colors.black, {
-  offsetHeight: -3,
-  shadowOpacity: 0.2,
+const DROP_SHADOW = getShadow( {
+  offsetHeight: -2,
   elevation: 20
 } );
 

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -1,12 +1,10 @@
 import { StyleSheet } from "react-native";
 
-import colors from "./tailwindColors";
-
 const DEFAULT_SHADOW = {
   elevation: 5,
   offsetHeight: 2,
   offsetWidth: 0,
-  shadowColor: colors.black,
+  shadowColor: "rgba( 0, 0, 0, 0.25 )",
   shadowOpacity: 0.25,
   shadowRadius: 2
 };
@@ -40,10 +38,9 @@ export const getShadowStyle = ( {
 
 export const dropShadow = getShadowStyle( DEFAULT_SHADOW );
 
-export function getShadowForColor( shadowColor, options = {} ) {
+export function getShadow( options = {} ) {
   return getShadowStyle( {
     ...DEFAULT_SHADOW,
-    shadowColor,
     ...options
   } );
 }

--- a/tests/unit/components/BottomTabNavigator/__snapshots__/CustomTabBar.test.js.snap
+++ b/tests/unit/components/BottomTabNavigator/__snapshots__/CustomTabBar.test.js.snap
@@ -49,12 +49,12 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
             },
             {
               "elevation": 20,
-              "shadowColor": "#000000",
+              "shadowColor": "rgba( 0, 0, 0, 0.25 )",
               "shadowOffset": {
-                "height": -3,
+                "height": -2,
                 "width": 0,
               },
-              "shadowOpacity": 0.2,
+              "shadowOpacity": 0.25,
               "shadowRadius": 2,
             },
           ],
@@ -291,7 +291,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
               },
               {
                 "elevation": 5,
-                "shadowColor": "#000000",
+                "shadowColor": "rgba( 0, 0, 0, 0.25 )",
                 "shadowOffset": {
                   "height": 2,
                   "width": 0,

--- a/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
@@ -11,7 +11,7 @@ exports[`PhotoCount renders correctly 1`] = `
         },
         {
           "elevation": 5,
-          "shadowColor": "#000000",
+          "shadowColor": "rgba( 0, 0, 0, 0.25 )",
           "shadowOffset": {
             "height": 2,
             "width": 0,


### PR DESCRIPTION
Closes #1928

Doesn't quite get rid of the warning altogether, but this does:
- Remove shadows from BottomSheets, since there's a backdrop instead and this is where most of these warnings were taking over the console
- Unify shadow color, since all shadows are set to `rgba(0, 0, 0, 0.25)` in Figma

I *think* we won't be able to get rid of this warning entirely as long as we're using a shadow in the CustomTabBar. To remove this warning, we're advised to set a custom background color, and I'm suspecting react-navigation is setting the tab bar over a transparent background which will keep this error active. Anyway, considering this fixed for better dev experience purposes.