### PR TITLE
Update react-native-exif-reader version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -907,7 +907,7 @@ PODS:
     - react-native-config/App (= 1.5.1)
   - react-native-config/App (1.5.1):
     - React-Core
-  - react-native-exif-reader (0.4.0):
+  - react-native-exif-reader (0.4.1):
     - React-Core
   - react-native-geocoder-reborn (0.9.0):
     - React
@@ -1507,7 +1507,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 6f392912435adb8fbf4c3eee0e79a0a0b4e4b717
   react-native-cameraroll: af8eec1e585d053ff485d98ec837f9a8a11b5745
   react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
-  react-native-exif-reader: 6b105a75e55cc26d2137ef46be3c97cfdd41f23a
+  react-native-exif-reader: 5ec4683035bb1b3f1c343257699ffab44dac7c1e
   react-native-geocoder-reborn: c31cbc630d9307ebbceea1dea2746d0054be35c4
   react-native-geolocation: ed9e1d132f576b9a4a503af46f9704413ea0dec1
   react-native-image-picker: ddbbe4d226d9c82a82360f5de66bf71a657a42e6
@@ -1566,7 +1566,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   VisionCamera: 4c1d19f1ac09f2f42f758e306fcf642536627357
   VisionCameraPluginInatVision: 8480b3955bc608e913135d3bebaa57939911fb82
-  Yoga: c716aea2ee01df6258550c7505fa61b248145ced
+  Yoga: 47d399a73c0c0caa9ff824e5c657eae31215bfee
 
 PODFILE CHECKSUM: c4b9a5123afaeedac9558dd67c0e10f6cf9706b0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "react-native-email-link": "^1.16.0",
         "react-native-event-listeners": "^1.0.7",
         "react-native-exception-handler": "^2.10.10",
-        "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.0",
+        "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.1",
         "react-native-fs": "^2.20.0",
         "react-native-geocoder-reborn": "^0.9.0",
         "react-native-gesture-handler": "^2.16.0",
@@ -17389,8 +17389,8 @@
       }
     },
     "node_modules/react-native-exif-reader": {
-      "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/react-native-exif-reader.git#4a6f53d8925220f3509c7d5752dcc98159a69b91",
+      "version": "0.4.1",
+      "resolved": "git+ssh://git@github.com/inaturalist/react-native-exif-reader.git#25ce732b36bd278c6a048ea0cf839a51b65163f9",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-email-link": "^1.16.0",
     "react-native-event-listeners": "^1.0.7",
     "react-native-exception-handler": "^2.10.10",
-    "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.0",
+    "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.1",
     "react-native-fs": "^2.20.0",
     "react-native-geocoder-reborn": "^0.9.0",
     "react-native-gesture-handler": "^2.16.0",


### PR DESCRIPTION
Fixes a crash when saving an observation with a photo but without location permission.

Close #1866