### PR TITLE
Submit local ObservationSound UUID when creating observation

### DIFF
--- a/src/realmModels/ObservationSound.js
+++ b/src/realmModels/ObservationSound.js
@@ -22,20 +22,17 @@ class ObservationSound extends Realm.Object {
   }
 
   static async new( observationSound ) {
-    const soundUUID = uuid.v4( );
-
     return {
       ...observationSound,
-      uuid: soundUUID
+      uuid: uuid.v4( )
     };
-    /* eslint-enable camelcase */
   }
 
   static mapApiToRealm( observationSound, realm = null ) {
     const localObsSound = {
       ...observationSound,
       _synced_at: new Date( ),
-      photo: Sound.mapApiToRealm( observationSound.sound, realm )
+      sound: Sound.mapApiToRealm( observationSound.sound, realm )
     };
     return localObsSound;
   }
@@ -46,11 +43,7 @@ class ObservationSound extends Realm.Object {
       : "m4a";
 
     return {
-      // Sound UUIDs don't really do anything at present. When
-      // https://github.com/inaturalist/iNaturalistReactNative/issues/1068 is
-      // completed we can use them to prevent the creation of duplicate sound
-      // records
-      // "sound[uuid]": observationSound.sound.uuid,
+      uuid: observationSound.uuid,
       file: new FileUpload( {
         uri: Sound.getLocalSoundUri( observationSound.sound.file_url ),
         name: `${observationSound.uuid}.${fileExt}`,
@@ -62,7 +55,8 @@ class ObservationSound extends Realm.Object {
   static mapSoundForAttachingToObs( id, observationSound ) {
     return {
       "observation_sound[observation_id]": id,
-      "observation_sound[sound_id]": observationSound.id
+      "observation_sound[sound_id]": observationSound.id,
+      "observation_sound[uuid]": observationSound.uuid
     };
   }
 

--- a/src/realmModels/Sound.js
+++ b/src/realmModels/Sound.js
@@ -53,21 +53,20 @@ class Sound extends Realm.Object {
   }
 
   static async new( sound ) {
-    const soundUUID = uuid.v4( );
     /* eslint-disable camelcase */
     let { file_url } = sound;
     if ( sound?.file_url.match( /file:\/\// ) ) {
       file_url = await Sound.moveFromCacheToDocumentDirectory( sound.file_url, {
-        basename: soundUUID
+        basename: uuid.v4()
       } );
       // this needs a protocol for the sound player to play it when it's local
       file_url = `file://${file_url}`;
     }
     return {
       ...sound,
-      // uuid: soundUUID,
       file_url
     };
+    /* eslint-enable camelcase */
   }
 
   // this is necessary because sounds, like photos, cannot be found reliably


### PR DESCRIPTION
This just submits the ObservationSound UUID on creation to prevent duplicate sound creation.

Closes #1068