### PR TITLE
Fixes for explore loading state after permissions granted

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -48,6 +48,7 @@ type Props = {
   count: Object,
   currentExploreView: string,
   setCurrentExploreView: Function,
+  startFetching: Function,
   filterByIconicTaxonUnknown: Function,
   handleUpdateCount: Function,
   hideBackButton: boolean,
@@ -71,6 +72,7 @@ const Explore = ( {
   count,
   currentExploreView,
   setCurrentExploreView,
+  startFetching,
   filterByIconicTaxonUnknown,
   handleUpdateCount,
   hideBackButton,
@@ -226,6 +228,7 @@ const Explore = ( {
         headerText={t( "EXPLORE" )}
         hidden={!showExploreBottomSheet}
         confirm={newView => {
+          startFetching( );
           setCurrentExploreView( newView );
           setShowExploreBottomSheet( false );
         }}

--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -49,13 +49,13 @@ type Props = {
   currentExploreView: string,
   setCurrentExploreView: Function,
   filterByIconicTaxonUnknown: Function,
+  handleUpdateCount: Function,
   hideBackButton: boolean,
   isConnected: boolean,
-  loadingStatus: boolean,
+  fetchingStatus: boolean,
   openFiltersModal: Function,
   queryParams: Object,
   showFiltersModal: boolean,
-  updateCount: Function,
   updateTaxon: Function,
   updateLocation: Function,
   updateUser: Function,
@@ -72,13 +72,13 @@ const Explore = ( {
   currentExploreView,
   setCurrentExploreView,
   filterByIconicTaxonUnknown,
+  handleUpdateCount,
   hideBackButton,
   isConnected,
-  loadingStatus,
+  fetchingStatus,
   openFiltersModal,
   queryParams,
   showFiltersModal,
-  updateCount,
   updateTaxon,
   updateLocation,
   updateUser,
@@ -104,13 +104,16 @@ const Explore = ( {
   const a11yLabel = exploreViewA11yLabel[currentExploreView];
   const headerCount = count[currentExploreView];
 
+  // only start fetching infinite lists if permissions are given
+  const canFetch = fetchingStatus === true;
+
   const renderHeader = ( ) => (
     <ExploreHeader
       count={headerCount}
       exploreView={currentExploreView}
       exploreViewIcon={icon}
       hideBackButton={hideBackButton}
-      loadingStatus={loadingStatus}
+      fetchingStatus={fetchingStatus}
       openFiltersModal={openFiltersModal}
       updateTaxon={updateTaxon}
       updateLocation={updateLocation}
@@ -147,35 +150,35 @@ const Explore = ( {
       <View className="flex-1">
         {currentExploreView === "observations" && (
           <ObservationsView
-            count={count}
+            canFetch={canFetch}
             layout={layout}
             queryParams={queryParams}
-            updateCount={updateCount}
+            handleUpdateCount={handleUpdateCount}
           />
         )}
         {currentExploreView === "species" && (
           <SpeciesView
-            count={count}
+            canFetch={canFetch}
             setCurrentExploreView={setCurrentExploreView}
             isConnected={isConnected}
             queryParams={queryParams}
-            updateCount={updateCount}
+            handleUpdateCount={handleUpdateCount}
           />
         )}
         {currentExploreView === "observers" && (
           <ObserversView
-            count={count}
+            canFetch={canFetch}
             isConnected={isConnected}
             queryParams={queryParams}
-            updateCount={updateCount}
+            handleUpdateCount={handleUpdateCount}
           />
         )}
         {currentExploreView === "identifiers" && (
           <IdentifiersView
-            count={count}
+            canFetch={canFetch}
             isConnected={isConnected}
             queryParams={queryParams}
-            updateCount={updateCount}
+            handleUpdateCount={handleUpdateCount}
           />
         )}
       </View>

--- a/src/components/Explore/ExploreContainer.js
+++ b/src/components/Explore/ExploreContainer.js
@@ -87,7 +87,9 @@ const ExploreContainerWithContext = ( ): Node => {
   };
 
   // need this hook to be top-level enough that ExploreHeaderCount rerenders
-  const { count, loadingStatus, updateCount } = useExploreHeaderCount( );
+  const {
+    count, fetchingStatus, handleUpdateCount, setFetchingStatus
+  } = useExploreHeaderCount( );
 
   const closeFiltersModal = ( ) => setShowFiltersModal( false );
 
@@ -102,6 +104,15 @@ const ExploreContainerWithContext = ( ): Node => {
     } );
   }, [navigation, setStoredParams, state] );
 
+  useEffect( ( ) => {
+    const nearby = state?.placeMode === "NEARBY";
+    if ( hasLocationPermissions && nearby ) {
+      setFetchingStatus( true );
+    } else if ( !nearby ) {
+      setFetchingStatus( true );
+    }
+  }, [state, setFetchingStatus, hasLocationPermissions] );
+
   return (
     <>
       <Explore
@@ -109,16 +120,16 @@ const ExploreContainerWithContext = ( ): Node => {
         count={count}
         currentExploreView={exploreView}
         setCurrentExploreView={setExploreView}
+        handleUpdateCount={handleUpdateCount}
         hideBackButton={false}
         filterByIconicTaxonUnknown={
           () => dispatch( { type: EXPLORE_ACTION.FILTER_BY_ICONIC_TAXON_UNKNOWN } )
         }
         isConnected={isConnected}
-        loadingStatus={loadingStatus}
+        fetchingStatus={fetchingStatus}
         openFiltersModal={openFiltersModal}
         queryParams={queryParams}
         showFiltersModal={showFiltersModal}
-        updateCount={updateCount}
         updateTaxon={taxon => dispatch( { type: EXPLORE_ACTION.CHANGE_TAXON, taxon } )}
         updateLocation={updateLocation}
         updateUser={updateUser}
@@ -127,7 +138,11 @@ const ExploreContainerWithContext = ( ): Node => {
         hasLocationPermissions={hasLocationPermissions}
         requestLocationPermissions={requestLocationPermissions}
       />
-      {renderPermissionsGate( )}
+      {renderPermissionsGate( {
+        onPermissionGranted: () => {
+          setFetchingStatus( true );
+        }
+      } ) }
     </>
   );
 };

--- a/src/components/Explore/ExploreContainer.js
+++ b/src/components/Explore/ExploreContainer.js
@@ -10,7 +10,7 @@ import {
   useExplore
 } from "providers/ExploreContext.tsx";
 import type { Node } from "react";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useCurrentUser } from "sharedHooks";
 import useLocationPermission from "sharedHooks/useLocationPermission.tsx";
 import useStore from "stores/useStore";
@@ -104,14 +104,18 @@ const ExploreContainerWithContext = ( ): Node => {
     } );
   }, [navigation, setStoredParams, state] );
 
-  useEffect( ( ) => {
+  const startFetching = useCallback( ( ) => {
     const nearby = state?.placeMode === "NEARBY";
     if ( hasLocationPermissions && nearby ) {
       setFetchingStatus( true );
     } else if ( !nearby ) {
       setFetchingStatus( true );
     }
-  }, [state, setFetchingStatus, hasLocationPermissions] );
+  }, [hasLocationPermissions, setFetchingStatus, state?.placeMode] );
+
+  useEffect( ( ) => {
+    startFetching( );
+  }, [startFetching] );
 
   return (
     <>
@@ -137,6 +141,7 @@ const ExploreContainerWithContext = ( ): Node => {
         placeMode={state.placeMode}
         hasLocationPermissions={hasLocationPermissions}
         requestLocationPermissions={requestLocationPermissions}
+        startFetching={startFetching}
       />
       {renderPermissionsGate( {
         onPermissionGranted: () => {

--- a/src/components/Explore/ExploreFlashList.js
+++ b/src/components/Explore/ExploreFlashList.js
@@ -8,6 +8,7 @@ import React, { useCallback } from "react";
 import { useTranslation } from "sharedHooks";
 
 type Props = {
+  canFetch: boolean,
   contentContainerStyle?: Object,
   data: Array<Object>,
   estimatedItemSize: number,
@@ -20,11 +21,11 @@ type Props = {
   numColumns?: number,
   renderItem: Function,
   renderItemSeparator?: Function,
-  status: string,
   testID: string
 };
 
 const ExploreFlashList = ( {
+  canFetch,
   contentContainerStyle,
   data,
   estimatedItemSize,
@@ -37,7 +38,6 @@ const ExploreFlashList = ( {
   numColumns,
   renderItem,
   renderItemSeparator,
-  status,
   testID
 }: Props ): Node => {
   const { t } = useTranslation( );
@@ -53,13 +53,13 @@ const ExploreFlashList = ( {
 
   const renderEmptyComponent = useCallback( ( ) => (
     <View className="flex-1 justify-center items-center">
-      {status === "loading"
+      {canFetch
         ? (
           <ActivityIndicator size={50} testID="ExploreFlashList.loading" />
         )
         : <Body3>{t( "No-results-found" )}</Body3>}
     </View>
-  ), [status, t] );
+  ), [canFetch, t] );
 
   const headerComponentStyle = layout === "grid" && {
     marginLeft: -7,

--- a/src/components/Explore/Header/ExploreHeader.js
+++ b/src/components/Explore/Header/ExploreHeader.js
@@ -27,7 +27,7 @@ type Props = {
   exploreView: string,
   exploreViewIcon: string,
   hideBackButton: boolean,
-  loadingStatus: boolean,
+  fetchingStatus: boolean,
   onPressCount?: Function,
   openFiltersModal: Function,
   updateTaxon: Function,
@@ -39,7 +39,7 @@ const Header = ( {
   exploreView,
   exploreViewIcon,
   hideBackButton,
-  loadingStatus,
+  fetchingStatus,
   onPressCount,
   openFiltersModal,
   updateTaxon,
@@ -129,7 +129,7 @@ const Header = ( {
           count={count}
           exploreView={exploreView}
           exploreViewIcon={exploreViewIcon}
-          loadingStatus={loadingStatus}
+          fetchingStatus={fetchingStatus}
           onPress={onPressCount}
         />
       </Surface>

--- a/src/components/Explore/Header/ExploreHeaderCount.js
+++ b/src/components/Explore/Header/ExploreHeaderCount.js
@@ -15,7 +15,7 @@ type Props = {
   count: ?number,
   exploreView: string,
   exploreViewIcon: string,
-  loadingStatus: boolean,
+  fetchingStatus: boolean,
   onPress: Function,
 }
 
@@ -23,7 +23,7 @@ const ExploreHeaderCount = ( {
   count,
   exploreView,
   exploreViewIcon,
-  loadingStatus,
+  fetchingStatus,
   onPress
 }: Props ): Node => {
   const { t } = useTranslation( );
@@ -42,14 +42,11 @@ const ExploreHeaderCount = ( {
     return t( "X-Observers", { count } );
   };
 
-  return (
-    <Pressable
-      className="h-[40px] flex-row items-center justify-center"
-      onPress={onPress}
-      accessibilityRole="summary"
-    >
-      {( loadingStatus && count === null ) && <ActivityIndicator size={25} />}
-      {count !== null && (
+  const renderHeader = ( ) => {
+    if ( fetchingStatus ) {
+      return <ActivityIndicator size={25} />;
+    } if ( count ) {
+      return (
         <>
           <INatIcon
             name={exploreViewIcon}
@@ -58,7 +55,18 @@ const ExploreHeaderCount = ( {
           />
           <Body2 className="text-white ml-3">{renderText( )}</Body2>
         </>
-      )}
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Pressable
+      className="h-[40px] flex-row items-center justify-center"
+      onPress={onPress}
+      accessibilityRole="summary"
+    >
+      {renderHeader( )}
     </Pressable>
   );
 };

--- a/src/components/Explore/IdentifiersView.js
+++ b/src/components/Explore/IdentifiersView.js
@@ -10,25 +10,24 @@ import { useInfiniteScroll, useTranslation } from "sharedHooks";
 import ExploreFlashList from "./ExploreFlashList";
 
 type Props = {
-  count: Object,
+  canFetch: boolean,
   isConnected: boolean,
   queryParams: Object,
-  updateCount: Function
+  handleUpdateCount: Function
 };
 
 const LIST_STYLE = { paddingTop: 44 };
 
 const IdentifiersView = ( {
-  count,
+  canFetch,
   isConnected,
   queryParams,
-  updateCount
+  handleUpdateCount
 }: Props ): Node => {
   const {
     data,
     fetchNextPage,
     isFetchingNextPage,
-    status,
     totalResults
   } = useInfiniteScroll(
     "fetchIdentifiers",
@@ -37,8 +36,11 @@ const IdentifiersView = ( {
       ...queryParams,
       fields: {
         identifications_count: true,
-        user: User.FIELDS
+        user: User.LIMITED_FIELDS
       }
+    },
+    {
+      enabled: canFetch
     }
   );
   const { t } = useTranslation( );
@@ -53,13 +55,12 @@ const IdentifiersView = ( {
   const renderItemSeparator = ( ) => <View className="border-b border-lightGray" />;
 
   useEffect( ( ) => {
-    if ( totalResults && count.identifiers !== totalResults ) {
-      updateCount( { identifiers: totalResults } );
-    }
-  }, [totalResults, updateCount, count] );
+    handleUpdateCount( "identifiers", totalResults );
+  }, [totalResults, handleUpdateCount] );
 
   return (
     <ExploreFlashList
+      canFetch={canFetch}
       contentContainerStyle={LIST_STYLE}
       data={data}
       estimatedItemSize={98}
@@ -70,7 +71,6 @@ const IdentifiersView = ( {
       keyExtractor={item => item.user.id}
       renderItem={renderItem}
       renderItemSeparator={renderItemSeparator}
-      status={status}
       testID="ExploreIdentifiersAnimatedList"
     />
   );

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -36,7 +36,6 @@ const ObservationsView = ( {
     observations,
     isFetchingNextPage,
     fetchNextPage,
-    status,
     totalBounds,
     totalResults
   } = useInfiniteExploreScroll( { params: queryParams, enabled: canFetch } );
@@ -85,14 +84,14 @@ const ObservationsView = ( {
       <ObservationsFlashList
         contentContainerStyle={OBS_LIST_CONTAINER_STYLE}
         data={observations}
-        dataCanBeFetched
+        dataCanBeFetched={canFetch}
         explore
         hideLoadingWheel={!isFetchingNextPage}
         isFetchingNextPage={isFetchingNextPage}
         isConnected={isConnected}
         layout={layout}
         onEndReached={fetchNextPage}
-        status={status}
+        showNoResults={!canFetch}
         testID="ExploreObservationsAnimatedList"
       />
       <MapView observationBounds={totalBounds} queryParams={queryParams} />

--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -16,10 +16,10 @@ import {
 import MapView from "./MapView";
 
 type Props = {
-  count: Object,
+  canFetch: boolean,
   layout: string,
   queryParams: Object,
-  updateCount: Function
+  handleUpdateCount: Function
 }
 
 const OBS_LIST_CONTAINER_STYLE = { paddingTop: 50 };
@@ -27,10 +27,10 @@ const OBS_LIST_CONTAINER_STYLE = { paddingTop: 50 };
 const { width: defaultScreenWidth } = Dimensions.get( "screen" );
 
 const ObservationsView = ( {
-  count,
+  canFetch,
   layout,
   queryParams,
-  updateCount
+  handleUpdateCount
 }: Props ): Node => {
   const {
     observations,
@@ -39,7 +39,7 @@ const ObservationsView = ( {
     status,
     totalBounds,
     totalResults
-  } = useInfiniteExploreScroll( { params: queryParams } );
+  } = useInfiniteExploreScroll( { params: queryParams, enabled: canFetch } );
   const {
     isLandscapeMode,
     isTablet,
@@ -48,10 +48,8 @@ const ObservationsView = ( {
   } = useDeviceOrientation( );
 
   useEffect( ( ) => {
-    if ( count.observations !== totalResults ) {
-      updateCount( { observations: totalResults }, isFetchingNextPage );
-    }
-  }, [totalResults, updateCount, count, isFetchingNextPage] );
+    handleUpdateCount( "observations", totalResults );
+  }, [totalResults, handleUpdateCount] );
 
   const { isConnected } = useNetInfo( );
 

--- a/src/components/Explore/ObserversView.js
+++ b/src/components/Explore/ObserversView.js
@@ -10,27 +10,26 @@ import { useInfiniteScroll, useTranslation } from "sharedHooks";
 import ExploreFlashList from "./ExploreFlashList";
 
 type Props = {
-  count: Object,
+  canFetch: boolean,
   isConnected: boolean,
   queryParams: Object,
-  updateCount: Function
+  handleUpdateCount: Function
 };
 
 const LIST_STYLE = { paddingTop: 44 };
 
 const ObserversView = ( {
-  count,
+  canFetch,
   isConnected,
   queryParams,
-  updateCount
+  handleUpdateCount
 }: Props ): Node => {
   const { t } = useTranslation( );
   const {
     data,
     isFetchingNextPage,
     fetchNextPage,
-    totalResults,
-    status
+    totalResults
   } = useInfiniteScroll(
     "fetchObservers",
     fetchObservers,
@@ -38,8 +37,11 @@ const ObserversView = ( {
       ...queryParams,
       order_by: "observation_count",
       fields: {
-        user: User.FIELDS
+        user: User.LIMITED_FIELDS
       }
+    },
+    {
+      enabled: canFetch
     }
   );
 
@@ -53,13 +55,12 @@ const ObserversView = ( {
   const renderItemSeparator = ( ) => <View className="border-b border-lightGray" />;
 
   useEffect( ( ) => {
-    if ( count.observers !== totalResults ) {
-      updateCount( { observers: totalResults } );
-    }
-  }, [totalResults, updateCount, count] );
+    handleUpdateCount( "observers", totalResults );
+  }, [totalResults, handleUpdateCount] );
 
   return (
     <ExploreFlashList
+      canFetch={canFetch}
       contentContainerStyle={LIST_STYLE}
       data={data}
       estimatedItemSize={98}
@@ -70,7 +71,6 @@ const ObserversView = ( {
       keyExtractor={item => item.user.id}
       renderItem={renderItem}
       renderItemSeparator={renderItemSeparator}
-      status={status}
       testID="ExploreObserversAnimatedList"
     />
   );

--- a/src/components/Explore/RootExploreContainer.js
+++ b/src/components/Explore/RootExploreContainer.js
@@ -97,7 +97,12 @@ const RootExploreContainerWithContext = ( ): Node => {
   };
 
   // need this hook to be top-level enough that ExploreHeaderCount rerenders
-  const { count, loadingStatus, updateCount } = useExploreHeaderCount( );
+  const {
+    count,
+    fetchingStatus,
+    setFetchingStatus,
+    handleUpdateCount
+  } = useExploreHeaderCount( );
 
   const closeFiltersModal = ( ) => setShowFiltersModal( false );
 
@@ -120,6 +125,15 @@ const RootExploreContainerWithContext = ( ): Node => {
     } );
   }, [navigation, setRootStoredParams, state, dispatch, rootStoredParams] );
 
+  useEffect( ( ) => {
+    const nearby = state?.placeMode === "NEARBY";
+    if ( hasLocationPermissions && nearby ) {
+      setFetchingStatus( true );
+    } else if ( !nearby ) {
+      setFetchingStatus( true );
+    }
+  }, [state, setFetchingStatus, hasLocationPermissions] );
+
   return (
     <>
       <Explore
@@ -132,11 +146,11 @@ const RootExploreContainerWithContext = ( ): Node => {
         currentExploreView={rootExploreView}
         setCurrentExploreView={setRootExploreView}
         isConnected={isConnected}
-        loadingStatus={loadingStatus}
+        fetchingStatus={fetchingStatus}
+        handleUpdateCount={handleUpdateCount}
         openFiltersModal={openFiltersModal}
         queryParams={queryParams}
         showFiltersModal={showFiltersModal}
-        updateCount={updateCount}
         updateTaxon={taxon => dispatch( { type: EXPLORE_ACTION.CHANGE_TAXON, taxon } )}
         updateLocation={updateLocation}
         updateUser={updateUser}
@@ -145,7 +159,12 @@ const RootExploreContainerWithContext = ( ): Node => {
         hasLocationPermissions={hasLocationPermissions}
         requestLocationPermissions={requestLocationPermissions}
       />
-      {renderPermissionsGate( { onPermissionGranted: () => updateLocation( "nearby" ) } )}
+      {renderPermissionsGate( {
+        onPermissionGranted: async ( ) => {
+          await updateLocation( "nearby" );
+          setFetchingStatus( true );
+        }
+      } )}
     </>
   );
 };

--- a/src/components/Explore/RootExploreContainer.js
+++ b/src/components/Explore/RootExploreContainer.js
@@ -11,6 +11,7 @@ import {
 } from "providers/ExploreContext.tsx";
 import type { Node } from "react";
 import React, {
+  useCallback,
   useEffect,
   useState
 } from "react";
@@ -125,14 +126,18 @@ const RootExploreContainerWithContext = ( ): Node => {
     } );
   }, [navigation, setRootStoredParams, state, dispatch, rootStoredParams] );
 
-  useEffect( ( ) => {
+  const startFetching = useCallback( ( ) => {
     const nearby = state?.placeMode === "NEARBY";
     if ( hasLocationPermissions && nearby ) {
       setFetchingStatus( true );
     } else if ( !nearby ) {
       setFetchingStatus( true );
     }
-  }, [state, setFetchingStatus, hasLocationPermissions] );
+  }, [hasLocationPermissions, setFetchingStatus, state?.placeMode] );
+
+  useEffect( ( ) => {
+    startFetching( );
+  }, [startFetching] );
 
   return (
     <>
@@ -158,6 +163,7 @@ const RootExploreContainerWithContext = ( ): Node => {
         placeMode={state.placeMode}
         hasLocationPermissions={hasLocationPermissions}
         requestLocationPermissions={requestLocationPermissions}
+        startFetching={startFetching}
       />
       {renderPermissionsGate( {
         onPermissionGranted: async ( ) => {

--- a/src/components/Explore/SpeciesView.js
+++ b/src/components/Explore/SpeciesView.js
@@ -19,19 +19,19 @@ import ExploreFlashList from "./ExploreFlashList";
 const GUTTER = 15;
 
 type Props = {
-  count: Object,
+  canFetch: boolean,
   isConnected: boolean,
   queryParams: Object,
-  updateCount: Function,
-  setCurrentExploreView: Function
+  setCurrentExploreView: Function,
+  handleUpdateCount: Function
 }
 
 const SpeciesView = ( {
-  count,
+  canFetch,
   isConnected,
   queryParams,
-  updateCount,
-  setCurrentExploreView
+  setCurrentExploreView,
+  handleUpdateCount
 }: Props ): Node => {
   // 20240814 - amanda: not sure if we actually need observedTaxonIds in state in the long
   // run, but for now, it prevents flickering when a user scrolls and new species are loaded
@@ -64,12 +64,12 @@ const SpeciesView = ( {
 
   const numColumns = calculateNumColumns( );
   const gridItemWidth = calculateGridItemWidth( numColumns );
+
   const {
     data,
     isFetchingNextPage,
     fetchNextPage,
-    totalResults,
-    status
+    totalResults
   } = useInfiniteScroll(
     "fetchSpeciesCounts",
     fetchSpeciesCounts,
@@ -78,6 +78,9 @@ const SpeciesView = ( {
       fields: {
         taxon: Taxon.LIMITED_TAXON_FIELDS
       }
+    },
+    {
+      enabled: canFetch
     }
   );
 
@@ -126,10 +129,8 @@ const SpeciesView = ( {
     />
   );
   useEffect( ( ) => {
-    if ( totalResults && count.species !== totalResults ) {
-      updateCount( { species: totalResults } );
-    }
-  }, [totalResults, updateCount, count] );
+    handleUpdateCount( "species", totalResults );
+  }, [totalResults, handleUpdateCount] );
 
   const contentContainerStyle = useMemo( ( ) => ( {
     paddingLeft: GUTTER / 2,
@@ -139,6 +140,7 @@ const SpeciesView = ( {
 
   return (
     <ExploreFlashList
+      canFetch={canFetch}
       contentContainerStyle={contentContainerStyle}
       data={data}
       estimatedItemSize={gridItemWidth}
@@ -150,7 +152,6 @@ const SpeciesView = ( {
       layout="grid"
       numColumns={numColumns}
       renderItem={renderItem}
-      status={status}
       testID="ExploreSpeciesAnimatedList"
     />
   );

--- a/src/components/Explore/hooks/useExploreHeaderCount.js
+++ b/src/components/Explore/hooks/useExploreHeaderCount.js
@@ -11,24 +11,34 @@ const useExploreHeaderCount = ( ): Object => {
     observers: null,
     identifiers: null
   } );
-  const [loadingStatus, setLoadingStatus] = useState( true );
+  const [fetchingStatus, setFetchingStatus] = useState( null );
 
-  const updateCount = useCallback( ( newCount, status = false ) => {
+  const updateCount = useCallback( newCount => {
     setCount( {
       ...count,
       ...newCount
     } );
-    if ( status ) {
-      setLoadingStatus( status );
-    }
+    setFetchingStatus( false );
   }, [count] );
 
   const memoizedCount = useMemo( ( ) => count, [count] );
 
+  const handleUpdateCount = ( exploreView, totalResults ) => {
+    if ( totalResults === null ) {
+      return;
+    }
+    if ( count[exploreView] !== totalResults ) {
+      updateCount( { [exploreView]: totalResults } );
+    } else if ( count[exploreView] === totalResults && fetchingStatus === true ) {
+      setFetchingStatus( false );
+    }
+  };
+
   return {
     count: memoizedCount,
-    loadingStatus,
-    updateCount
+    fetchingStatus,
+    handleUpdateCount,
+    setFetchingStatus
   };
 };
 

--- a/src/components/Explore/hooks/useInfiniteExploreScroll.js
+++ b/src/components/Explore/hooks/useInfiniteExploreScroll.js
@@ -8,7 +8,7 @@ import { flatten, last } from "lodash";
 import { useCallback } from "react";
 import Observation from "realmModels/Observation";
 
-const useInfiniteExploreScroll = ( { params: newInputParams }: Object ): Object => {
+const useInfiniteExploreScroll = ( { params: newInputParams, enabled }: Object ): Object => {
   const baseParams = {
     ...newInputParams,
     fields: Observation.EXPLORE_LIST_FIELDS,
@@ -90,7 +90,8 @@ const useInfiniteExploreScroll = ( { params: newInputParams }: Object ): Object 
       return response;
     },
     initialPageParam: 0,
-    getNextPageParam
+    getNextPageParam,
+    enabled
   } );
 
   const observations = flatten( data?.pages?.map( r => r.results ) ) || [];

--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -69,7 +69,7 @@ const MyObservations = ( {
             layout={layout}
             onEndReached={onEndReached}
             showObservationsEmptyScreen
-            status={status}
+            showNoResults={( status === "success" && !!( currentUser ) ) || !currentUser}
             testID="MyObservationsAnimatedList"
             renderHeader={(
               <Announcements isConnected={isConnected} />

--- a/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
@@ -30,7 +30,7 @@ type Props = {
   onEndReached: Function,
   renderHeader?: Function,
   showObservationsEmptyScreen?: boolean,
-  status?: string,
+  showNoResults?: boolean,
   testID: string
 };
 
@@ -49,8 +49,8 @@ const ObservationsFlashList = ( {
   layout,
   onEndReached,
   renderHeader,
+  showNoResults,
   showObservationsEmptyScreen,
-  status,
   testID
 }: Props ): Node => {
   const {
@@ -127,7 +127,7 @@ const ObservationsFlashList = ( {
       ? <MyObservationsEmpty isFetchingNextPage={isFetchingNextPage} />
       : <Body3 className="self-center mt-[150px]">{t( "No-results-found" )}</Body3>;
 
-    return ( ( status === "success" && dataCanBeFetched ) || !dataCanBeFetched )
+    return showNoResults
       ? showEmptyScreen
       : (
         <View className="self-center mt-[150px]">
@@ -135,10 +135,9 @@ const ObservationsFlashList = ( {
         </View>
       );
   }, [
-    dataCanBeFetched,
     isFetchingNextPage,
     showObservationsEmptyScreen,
-    status,
+    showNoResults,
     t
   ] );
 

--- a/src/providers/ExploreContext.tsx
+++ b/src/providers/ExploreContext.tsx
@@ -209,7 +209,7 @@ type State = {
   project_id: number | undefined | null,
   radius?: number,
   researchGrade: boolean,
-  return_bounds: boolean,
+  return_bounds: boolean | undefined,
   reviewedFilter: REVIEWED,
   sortBy: SORT_BY,
   swlat?: number,
@@ -333,7 +333,7 @@ const initialState: State = {
   // modes, like Nearby or Worldwide
   place_guess: "",
   place_id: undefined,
-  return_bounds: true,
+  return_bounds: undefined,
   taxon: undefined,
   taxon_id: undefined,
   verifiable: true

--- a/src/realmModels/Taxon.js
+++ b/src/realmModels/Taxon.js
@@ -20,7 +20,6 @@ class Taxon extends Realm.Object {
   };
 
   static LIMITED_TAXON_FIELDS = {
-    ancestor_ids: true,
     default_photo: {
       id: true,
       url: true

--- a/src/realmModels/User.ts
+++ b/src/realmModels/User.ts
@@ -12,6 +12,13 @@ class User extends Realm.Object {
     prefers_scientific_name_first: true
   };
 
+  static LIMITED_FIELDS = {
+    icon_url: true,
+    id: true,
+    login: true,
+    observations_count: true
+  };
+
   // getting user icon data from production instead of staging
   static uri( user: { icon_url?: string } ) {
     return user?.icon_url

--- a/src/sharedHooks/useInfiniteScroll.js
+++ b/src/sharedHooks/useInfiniteScroll.js
@@ -6,7 +6,10 @@ import { flatten } from "lodash";
 const useInfiniteScroll = (
   queryKey: string,
   apiCall: Function,
-  newInputParams: Object
+  newInputParams: Object,
+  options: {
+    enabled: boolean
+  }
 ): Object => {
   const baseParams = {
     ...newInputParams,
@@ -34,7 +37,8 @@ const useInfiniteScroll = (
     initialPageParam: 0,
     getNextPageParam: lastPage => ( lastPage
       ? lastPage.page + 1
-      : 1 )
+      : 1 ),
+    enabled: options.enabled
   } );
 
   const pages = data?.pages;

--- a/tests/integration/navigation/Explore.test.js
+++ b/tests/integration/navigation/Explore.test.js
@@ -1,6 +1,7 @@
 import {
   screen,
   userEvent,
+  waitFor,
   within
 } from "@testing-library/react-native";
 import initI18next from "i18n/initI18next";
@@ -245,19 +246,22 @@ describe( "logged in", ( ) => {
         inatjs.relationships.search.mockResolvedValue( makeResponse( {
           results: []
         } ) );
-        inatjs.observations.fetch.mockResolvedValue( makeResponse( mockObservations[0] ) );
         renderApp( );
         await navigateToRootExplore( );
         const speciesViewIcon = await screen.findByLabelText( /Species View/ );
-        expect( speciesViewIcon ).toBeVisible( );
         await actor.press( speciesViewIcon );
         const observationsRadioButton = await screen.findByText( "Observations" );
         await actor.press( observationsRadioButton );
         const confirmButton = await screen.findByText( /EXPLORE OBSERVATIONS/ );
         await actor.press( confirmButton );
+        const headerCount = await screen.findByText( /1 Observation/ );
+        expect( headerCount ).toBeVisible( );
         const gridView = await screen.findByTestId( "SegmentedButton.grid" );
         await actor.press( gridView );
-        const firstObservation = await screen.findByTestId( `MyObservationsPressable.${obs.uuid}` );
+        const firstObservation = screen.queryByTestId( `MyObservationsPressable.${obs.uuid}` );
+        await waitFor( ( ) => {
+          expect( firstObservation ).toBeVisible( );
+        }, { timeout: 10000 } );
         await actor.press( firstObservation );
         const userProfileButton = await screen.findByLabelText( `User @${mockUser.login}` );
         await actor.press( userProfileButton );

--- a/tests/unit/components/Explore/IdentifiersView.test.js
+++ b/tests/unit/components/Explore/IdentifiersView.test.js
@@ -57,7 +57,7 @@ describe( "IdentifiersView", () => {
         hideLoadingWheel
         isConnected
         data={[]}
-        status="loading"
+        canFetch
       />
     );
 

--- a/tests/unit/components/Explore/ObservationsView.test.js
+++ b/tests/unit/components/Explore/ObservationsView.test.js
@@ -73,6 +73,7 @@ describe( "ObservationsView", () => {
         hideLoadingWheel
         isConnected
         data={[]}
+        showNoResults
       />
     );
 


### PR DESCRIPTION
Closes #1918

- Hides loading wheel in dark gray header unless data is actually fetching
- Shows loading wheel within explore view if data is loading
- Speeds up query response times by removing `return_bounds` as a default parameter in each explore view
- Adds `enabled` key to make sure we're not fetching data preemptively (say, fetching worldwide data before a user has given location permissions for nearby data)