### PR TITLE
Preserve MyObs scroll position

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -15,12 +15,15 @@ type Props = {
   currentUser: Object,
   handleIndividualUploadPress: Function,
   handleSyncButtonPress: Function,
-  isFetchingNextPage: boolean,
   isConnected: boolean,
+  isFetchingNextPage: boolean,
   layout: "list" | "grid",
+  listRef?: Object,
   numUnuploadedObservations: number,
   observations: Array<Object>,
   onEndReached: Function,
+  onListLayout?: Function,
+  onScroll?: Function,
   setShowLoginSheet: Function,
   showLoginSheet: boolean,
   status: string,
@@ -31,12 +34,15 @@ const MyObservations = ( {
   currentUser,
   handleIndividualUploadPress,
   handleSyncButtonPress,
-  isFetchingNextPage,
   isConnected,
+  isFetchingNextPage,
   layout,
+  listRef,
   numUnuploadedObservations,
   observations,
   onEndReached,
+  onListLayout,
+  onScroll,
   setShowLoginSheet,
   showLoginSheet,
   status,
@@ -45,6 +51,7 @@ const MyObservations = ( {
   <>
     <ViewWrapper>
       <ScrollableWithStickyHeader
+        onScroll={onScroll}
         renderHeader={setStickyAt => (
           <MyObservationsHeader
             currentUser={currentUser}
@@ -57,17 +64,19 @@ const MyObservations = ( {
             toggleLayout={toggleLayout}
           />
         )}
-        renderScrollable={onScroll => (
+        renderScrollable={animatedScrollEvent => (
           <ObservationsFlashList
             dataCanBeFetched={!!currentUser}
             data={observations.filter( o => o.isValid() )}
             handleIndividualUploadPress={handleIndividualUploadPress}
-            handleScroll={onScroll}
+            onScroll={animatedScrollEvent}
             hideLoadingWheel={!isFetchingNextPage || !currentUser}
             isFetchingNextPage={isFetchingNextPage}
             isConnected={isConnected}
             layout={layout}
             onEndReached={onEndReached}
+            onLayout={onListLayout}
+            ref={listRef}
             showObservationsEmptyScreen
             showNoResults={( status === "success" && !!( currentUser ) ) || !currentUser}
             testID="MyObservationsAnimatedList"

--- a/src/components/ObsDetails/ObsDetailsHeader.tsx
+++ b/src/components/ObsDetails/ObsDetailsHeader.tsx
@@ -38,6 +38,7 @@ const ObsDetailsHeader = ( {
   const localObservation = useLocalObservation( uuid );
   const { t } = useTranslation( );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
+  const setMyObsOffsetToRestore = useStore( state => state.setMyObsOffsetToRestore );
 
   return (
     <LinearGradient
@@ -65,7 +66,7 @@ const ObsDetailsHeader = ( {
                 testID="ObsDetail.editButton"
                 onPress={() => {
                   prepareObsEdit( localObservation );
-                  navigateToObsEdit( navigation );
+                  navigateToObsEdit( navigation, setMyObsOffsetToRestore );
                 }}
                 icon="pencil"
                 color={!rightIconBlack

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -46,6 +46,7 @@ const BottomButtons = ( {
   const addToUploadQueue = useStore( state => state.addToUploadQueue );
   const setStartUploadObservations = useStore( state => state.setStartUploadObservations );
   const addTotalToolbarIncrements = useStore( state => state.addTotalToolbarIncrements );
+  const resetMyObsOffsetToRestore = useStore( state => state.resetMyObsOffsetToRestore );
   const navigation = useNavigation( );
   const isNewObs = !currentObservation?._created_at;
   const hasPhotos = currentObservation?.observationPhotos?.length > 0;
@@ -90,6 +91,12 @@ const BottomButtons = ( {
 
   const setNextScreen = useCallback( async ( { type }: Object ) => {
     const savedObservation = await saveObservation( currentObservation );
+    // If we are saving a new observations, reset the stored my obs offset to
+    // restore b/c we want MyObs rendered in its default state with this new
+    // observation visible at the top
+    if ( isNewObs ) {
+      resetMyObsOffsetToRestore( );
+    }
     if ( type === "upload" ) {
       const { uuid } = savedObservation;
       addTotalToolbarIncrements( savedObservation );
@@ -120,7 +127,9 @@ const BottomButtons = ( {
     addToUploadQueue,
     currentObservation,
     currentObservationIndex,
+    isNewObs,
     navigation,
+    resetMyObsOffsetToRestore,
     saveObservation,
     observations,
     setCurrentObservationIndex,

--- a/src/components/ObsEdit/helpers/navigateToObsEdit.ts
+++ b/src/components/ObsEdit/helpers/navigateToObsEdit.ts
@@ -1,6 +1,6 @@
 import { CommonActions } from "@react-navigation/native";
 
-const navigateToObsEdit = navigation => {
+const navigateToObsEdit = ( navigation, setMyObsOffsetToRestore ) => {
   // since we can access ObsEdit from two separate stacks, the TabStackNavigator
   // and the NoBottomTabStackNavigator, we don't want ObsEdit to land on the previous
   // history of the NoBottomTabStackNavigator (i.e. anything from the ObsCreate flow)
@@ -23,6 +23,7 @@ const navigateToObsEdit = navigation => {
       ]
     } )
   );
+  setMyObsOffsetToRestore();
 };
 
 export default navigateToObsEdit;

--- a/src/components/SharedComponents/ObservationsFlashList/MyObservationsPressable.js
+++ b/src/components/SharedComponents/ObservationsFlashList/MyObservationsPressable.js
@@ -19,6 +19,7 @@ const MyObservationsPressable = ( { observation, testID, children }: Props ): No
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
+  const setMyObsOffsetToRestore = useStore( state => state.setMyObsOffsetToRestore );
 
   const unsynced = typeof observation.wasSynced !== "undefined" && !observation.wasSynced( );
 
@@ -26,7 +27,7 @@ const MyObservationsPressable = ( { observation, testID, children }: Props ): No
     const { uuid } = observation;
     if ( unsynced ) {
       prepareObsEdit( observation );
-      navigateToObsEdit( navigation );
+      navigateToObsEdit( navigation, setMyObsOffsetToRestore );
     } else {
       navigation.push( "ObsDetails", { uuid } );
     }

--- a/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
@@ -6,7 +6,9 @@ import { ActivityIndicator, Body3 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, {
-  useCallback, useMemo
+  forwardRef,
+  useCallback,
+  useMemo
 } from "react";
 import { Animated } from "react-native";
 import { BREAKPOINTS } from "sharedHelpers/breakpoint";
@@ -22,37 +24,39 @@ type Props = {
   dataCanBeFetched?: boolean,
   explore: boolean,
   handleIndividualUploadPress: Function,
-  handleScroll?: Function,
+  onScroll?: Function,
   hideLoadingWheel: boolean,
-  isFetchingNextPage?: boolean,
   isConnected: boolean,
+  isFetchingNextPage?: boolean,
   layout: "list" | "grid",
   onEndReached: Function,
+  onLayout?: Function,
   renderHeader?: Function,
-  showObservationsEmptyScreen?: boolean,
   showNoResults?: boolean,
+  showObservationsEmptyScreen?: boolean,
   testID: string
 };
 
 const GUTTER = 15;
 
-const ObservationsFlashList = ( {
+const ObservationsFlashList: Function = forwardRef( ( {
   contentContainerStyle: contentContainerStyleProp = {},
   data,
   dataCanBeFetched,
   explore,
   handleIndividualUploadPress,
-  handleScroll,
+  onScroll,
   hideLoadingWheel,
-  isFetchingNextPage,
   isConnected,
+  isFetchingNextPage,
   layout,
   onEndReached,
+  onLayout,
   renderHeader,
   showNoResults,
   showObservationsEmptyScreen,
   testID
-}: Props ): Node => {
+}: Props, ref ): Node => {
   const {
     isLandscapeMode,
     isTablet,
@@ -170,18 +174,20 @@ const ObservationsFlashList = ( {
       // react thinks we've rendered a second item w/ a duplicate key
       keyExtractor={item => item.uuid || item.id}
       numColumns={numColumns}
+      ref={ref}
       onEndReachedThreshold={0.2}
+      onLayout={onLayout}
       onMomentumScrollEnd={( ) => {
         if ( dataCanBeFetched ) {
           onEndReached( );
         }
       }}
-      onScroll={handleScroll}
+      onScroll={onScroll}
       refreshing={isFetchingNextPage}
       renderItem={renderItem}
       testID={testID}
     />
   );
-};
+} );
 
 export default ObservationsFlashList;

--- a/src/components/SharedComponents/ScrollableWithStickyHeader.js
+++ b/src/components/SharedComponents/ScrollableWithStickyHeader.js
@@ -12,7 +12,7 @@
 // the setStickyAt function, that sets the scroll offset at which the header
 // sticks (this is probably dependent on the height of the rendered layout).
 //
-// renderScrollable takes a single argument, the onScroll callback, which
+// renderScrollable takes a single argument, the animatedScrollEvent, which
 // should be passed to the scrollable's onScroll prop, and/or get called with
 // the same event
 //
@@ -42,11 +42,13 @@ import { Animated } from "react-native";
 import { useDeviceOrientation } from "sharedHooks";
 
 type Props = {
+  onScroll?: Function,
   renderHeader: Function,
   renderScrollable: Function
 };
 
 const ScrollableWithStickyHeader = ( {
+  onScroll,
   renderHeader,
   renderScrollable
 }: Props ): Node => {
@@ -63,7 +65,7 @@ const ScrollableWithStickyHeader = ( {
   // https://medium.com/swlh/making-a-collapsible-sticky-header-animations-with-react-native-6ad7763875c3
   const scrollY = useRef( new Animated.Value( 0 ) );
 
-  const onScroll = Animated.event(
+  const animatedScrollEvent = Animated.event(
     [
       {
         nativeEvent: {
@@ -72,7 +74,8 @@ const ScrollableWithStickyHeader = ( {
       }
     ],
     {
-      useNativeDriver: true
+      useNativeDriver: true,
+      listener: onScroll
     }
   );
 
@@ -148,7 +151,7 @@ const ScrollableWithStickyHeader = ( {
         }}
       >
         {renderHeader( setStickyAt )}
-        {renderScrollable( onScroll )}
+        {renderScrollable( animatedScrollEvent )}
       </Animated.View>
     </View>
   );

--- a/src/stores/createMyObsSlice.ts
+++ b/src/stores/createMyObsSlice.ts
@@ -1,0 +1,12 @@
+const createMyObsSlice = ( set, get ) => ( {
+  // Stores y offset of MyObs so we can scroll back to the user's position
+  // when returning from the NoBottomTabStackNavigator (MyObs will be trashed
+  // when navigating to ObsEdit, so we lose scroll position)
+  myObsOffset: 0,
+  myObsOffsetToRestore: 0,
+  resetMyObsOffsetToRestore: ( ) => set( { myObsOffsetToRestore: 0 } ),
+  setMyObsOffset: newOffset => set( { myObsOffset: newOffset } ),
+  setMyObsOffsetToRestore: ( ) => set( { myObsOffsetToRestore: get( ).myObsOffset } )
+} );
+
+export default createMyObsSlice;

--- a/src/stores/useStore.js
+++ b/src/stores/useStore.js
@@ -4,6 +4,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 import createExploreSlice from "./createExploreSlice";
 import createLayoutSlice from "./createLayoutSlice";
+import createMyObsSlice from "./createMyObsSlice";
 import createObservationFlowSlice from "./createObservationFlowSlice";
 import createRootExploreSlice from "./createRootExploreSlice";
 import createSyncObservationsSlice from "./createSyncObservationsSlice";
@@ -26,11 +27,12 @@ const useStore = create( persist(
   ( ...args ) => {
     // Let's make our slices
     const slices = [
-      createSyncObservationsSlice( ...args ),
       createExploreSlice( ...args ),
-      createRootExploreSlice( ...args ),
-      createObservationFlowSlice( ...args ),
       createLayoutSlice( ...args ),
+      createMyObsSlice( ...args ),
+      createObservationFlowSlice( ...args ),
+      createRootExploreSlice( ...args ),
+      createSyncObservationsSlice( ...args ),
       createUploadObservationsSlice( ...args )
     ];
 


### PR DESCRIPTION
Symptom: when you scroll MyObs, tap an unsynced obs to enter ObsEdit, then go back, MyObs is always scrolled back to the top.

Diagnosis: entering ObsEdit requires opening a parallel stack navigator to the one that contains MyObs, which means the MyObs screen gets destroyed and it loses its scroll position.

Treatment: the ideal treatment would be to not use parallel stack navigators, but since we don't have a way to do that *and* ditch the bottom tabs for certain screens, my approach here was to store the scroll offset in Zustand when we navigate to ObsEdit, and when we return to MyObs we scroll the list to that position. We do *not* want this behavior after creating an observation, b/c we want the newly-created obs to be visible at the top of the list.

Questions for review:

* Feels real awkward. Is there a better way?
* Is there a way to test this? I want to write a test that scrolls MyObs, expects the first obs to be off-screen, taps an unsynced obs, then goes back, then expects the first obs to still be off-screen, but I don't see a way to test if view is off-screen.

Closes #1957