### PR TITLE
fix: ident bodies should not get set by obs descriptions

### DIFF
--- a/src/components/ObsDetails/ActivityTab/ActivityItem.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityItem.js
@@ -48,7 +48,7 @@ const ActivityItem = ( {
     && isFirstDisplay
     && currentUserId;
 
-  const navToTaxonDetails = ( ) => navigation.navigate( "TaxonDetails", { id: taxon.id } );
+  const navToTaxonDetails = ( ) => navigation.push( "TaxonDetails", { id: taxon.id } );
 
   return (
     <View className="flex-column">

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -24,7 +24,6 @@ import {
 import {
   useTranslation
 } from "sharedHooks";
-import useStore from "stores/useStore";
 
 import ActivityTab from "./ActivityTab/ActivityTab";
 import FloatingButtons from "./ActivityTab/FloatingButtons";
@@ -43,12 +42,13 @@ type Props = {
   addingActivityItem: Function,
   closeAgreeWithIdSheet: Function,
   belongsToCurrentUser: boolean,
-  comment: string,
+  comment?: string | null,
   commentIsOptional: ?boolean,
   confirmCommentFromCommentSheet: Function,
   confirmRemoteObsWasDeleted?: Function,
   currentTabId: string,
   currentUser: Object,
+  editIdentBody: Function,
   hideAddCommentSheet: Function,
   isConnected: boolean,
   isRefetching: boolean,
@@ -69,7 +69,14 @@ type Props = {
   showSuggestIdSheet: boolean,
   suggestIdSheetDiscardChanges: Function,
   tabs: Array<Object>,
-  taxonForSuggestion: ?Object
+  identBodySheetShown?: boolean,
+  onCloseIdentBodySheet?: Function,
+  newIdentification?: null | {
+    body?: string,
+    taxon: Object,
+    vision?: boolean
+  },
+  onChangeIdentBody?: Function
 }
 
 const ObsDetails = ( {
@@ -83,6 +90,7 @@ const ObsDetails = ( {
   confirmRemoteObsWasDeleted,
   currentTabId,
   currentUser,
+  editIdentBody,
   hideAddCommentSheet,
   isConnected,
   isRefetching,
@@ -103,13 +111,16 @@ const ObsDetails = ( {
   showSuggestIdSheet,
   suggestIdSheetDiscardChanges,
   tabs,
-  taxonForSuggestion
+  identBodySheetShown,
+  onCloseIdentBodySheet,
+  newIdentification,
+  onChangeIdentBody
+
 }: Props ): Node => {
   const insets = useSafeAreaInsets();
   const { params } = useRoute( );
   const { uuid } = params;
   const { t } = useTranslation( );
-  const currentObservation = useStore( state => state.currentObservation );
 
   const dynamicInsets = useMemo( () => ( {
     backgroundColor: "#ffffff",
@@ -256,7 +267,7 @@ const ObsDetails = ( {
     </>
   );
 
-  const hasComment = !!( comment || currentObservation?.description );
+  const hasComment = ( comment || newIdentification?.body || "" ).length > 0;
 
   const showAddCommentHeader = ( ) => {
     if ( hasComment ) {
@@ -275,13 +286,13 @@ const ObsDetails = ( {
       {!isTablet
         ? renderPhone()
         : renderTablet()}
-      {showAgreeWithIdSheet && (
+      {showAgreeWithIdSheet && newIdentification && (
         <AgreeWithIDSheet
-          comment={comment}
-          handleClose={closeAgreeWithIdSheet}
           onAgree={onAgree}
-          openAddCommentSheet={openAddCommentSheet}
-          taxon={taxonForSuggestion}
+          editIdentBody={editIdentBody}
+          hidden={identBodySheetShown}
+          onPressClose={closeAgreeWithIdSheet}
+          identification={newIdentification}
         />
       )}
       {/* AddCommentSheet */}
@@ -291,22 +302,35 @@ const ObsDetails = ( {
           handleClose={hideAddCommentSheet}
           headerText={showAddCommentHeader( )}
           textInputStyle={textInputStyle}
-          initialInput={comment || currentObservation?.description}
+          initialInput={comment}
           confirm={confirmCommentFromCommentSheet}
+        />
+      )}
+      {identBodySheetShown && (
+        <TextInputSheet
+          buttonText={t( "CONFIRM" )}
+          handleClose={onCloseIdentBodySheet}
+          headerText={showAddCommentHeader( )}
+          textInputStyle={textInputStyle}
+          initialInput={newIdentification?.body}
+          confirm={onChangeIdentBody}
         />
       )}
       {showSuggestIdSheet && (
         <SuggestIDSheet
-          openAddCommentSheet={openAddCommentSheet}
-          handleClose={suggestIdSheetDiscardChanges}
+          editIdentBody={editIdentBody}
+          hidden={identBodySheetShown}
+          onPressClose={suggestIdSheetDiscardChanges}
           onSuggestId={onSuggestId}
+          identification={newIdentification}
         />
       )}
-      {showPotentialDisagreementSheet && (
+      {showPotentialDisagreementSheet && newIdentification && (
         <PotentialDisagreementSheet
           onPotentialDisagreePressed={onPotentialDisagreePressed}
           handleClose={potentialDisagreeSheetDiscardChanges}
-          taxon={taxonForSuggestion}
+          newTaxon={newIdentification.taxon}
+          oldTaxon={observation.taxon}
         />
       )}
       {/*

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -17,6 +17,7 @@ import React, {
 import { Alert, LogBox } from "react-native";
 import Observation from "realmModels/Observation";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { fetchTaxonAndSave } from "sharedHelpers/taxon";
 import {
   useAuthenticatedMutation,
   useCurrentUser,
@@ -226,13 +227,18 @@ const ObsDetailsContainer = ( ): Node => {
 
   // Translates identification-related params to local state
   useEffect( ( ) => {
-    if ( identTaxonId ) {
-      // TODO sometimes this will be remote, so we need to fetch
-      const taxon = realm.objectForPrimaryKey( "Taxon", identTaxonId );
+    async function fetchAndSet() {
+      let taxon = realm.objectForPrimaryKey( "Taxon", identTaxonId );
+      if ( !taxon ) {
+        taxon = await fetchTaxonAndSave( identTaxonId, realm );
+      }
       dispatch( {
         type: SET_IDENT_TAXON,
         taxon
       } );
+    }
+    if ( identTaxonId ) {
+      fetchAndSet();
     } else {
       dispatch( { type: CLEAR_SUGGESTED_TAXON } );
     }
@@ -427,24 +433,9 @@ const ObsDetailsContainer = ( ): Node => {
   );
 
   useEffect( () => {
-    console.log( "[DEBUG ObsDetailsContainer.js]" );
-    console.log( "[DEBUG ObsDetailsContainer.js]" );
-    console.log( "[DEBUG ObsDetailsContainer.js] effect, identTaxon: ", identTaxon );
     if ( !identTaxon ) return;
-    console.log(
-      "[DEBUG ObsDetailsContainer.js] effect, showPotentialDisagreementSheet: ",
-      showPotentialDisagreementSheet
-    );
     if ( showPotentialDisagreementSheet ) return;
-    console.log(
-      "[DEBUG ObsDetailsContainer.js] effect, showSuggestIdSheet: ",
-      showSuggestIdSheet
-    );
     if ( showSuggestIdSheet ) return;
-    console.log(
-      "[DEBUG ObsDetailsContainer.js] effect, identBodySheetShown: ",
-      identBodySheetShown
-    );
     if ( identBodySheetShown ) return;
     let observationTaxon = observation.taxon;
     if (

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -49,16 +49,30 @@ const sortItems = ( ids, comments ) => ids.concat( [...comments] ).sort(
 const initialState = {
   activityItems: [],
   addingActivityItem: false,
-  comment: "",
+  comment: null,
   commentIsOptional: false,
   currentTabId: ACTIVITY_TAB_ID,
+  identBodySheetShown: false,
+  newIdentification: null,
   observationShown: null,
   showAgreeWithIdSheet: false,
   showAddCommentSheet: false,
   showPotentialDisagreementSheet: false,
   showSuggestIdSheet: false,
-  taxonForSuggestion: null // taxon for agree and disagree
+  identTaxon: null
 };
+
+const CLEAR_SUGGESTED_TAXON = "CLEAR_SUGGESTED_TAXON";
+const CONFIRM_ID = "CONFIRM_ID";
+const DISCARD_ID = "DISCARD_ID";
+const HIDE_AGREE_SHEET = "HIDE_AGREE_SHEET";
+const HIDE_EDIT_IDENT_BODY_SHEET = "HIDE_EDIT_IDENT_BODY_SHEET";
+const HIDE_POTENTIAL_DISAGREEMENT_SHEET = "HIDE_POTENTIAL_DISAGREEMENT_SHEET";
+const SET_ADD_COMMENT_SHEET = "SET_ADD_COMMENT_SHEET";
+const SET_IDENT_TAXON = "SET_IDENT_TAXON";
+const SET_NEW_IDENTIFICATION = "SET_NEW_IDENTIFICATION";
+const SHOW_AGREE_SHEET = "SHOW_AGREE_SHEET";
+const SHOW_EDIT_IDENT_BODY_SHEET = "SHOW_EDIT_IDENT_BODY_SHEET";
 
 const reducer = ( state, action ) => {
   switch ( action.type ) {
@@ -86,39 +100,71 @@ const reducer = ( state, action ) => {
         ...state,
         addingActivityItem: true
       };
-    case "SHOW_AGREE_SHEET":
+    case SHOW_AGREE_SHEET:
       return {
         ...state,
-        showAgreeWithIdSheet: action.showAgreeWithIdSheet,
-        taxonForSuggestion: action.taxonForSuggestion || state.taxonForSuggestion,
-        comment: action.comment || state.comment
+        showAgreeWithIdSheet: true,
+        newIdentification: action.newIdentification
       };
-    case "SHOW_ADD_COMMENT_SHEET":
+    case HIDE_AGREE_SHEET:
+      return {
+        ...state,
+        showAgreeWithIdSheet: false
+      };
+    case SET_ADD_COMMENT_SHEET:
       return {
         ...state,
         commentIsOptional: action.commentIsOptional,
         showAddCommentSheet: action.showAddCommentSheet
       };
+    case SHOW_EDIT_IDENT_BODY_SHEET:
+      return {
+        ...state,
+        identBodySheetShown: true
+      };
+    case HIDE_EDIT_IDENT_BODY_SHEET:
+      return {
+        ...state,
+        identBodySheetShown: false
+      };
     case "SHOW_SUGGEST_ID_SHEET":
       return {
         ...state,
-        showSuggestIdSheet: action.showSuggestIdSheet
-      };
-    case "SET_COMMENT":
-      return {
-        ...state,
-        comment: action.comment
+        showSuggestIdSheet: true
       };
     case "SHOW_POTENTIAL_DISAGREEMENT_SHEET":
       return {
         ...state,
-        showPotentialDisagreementSheet: action.showPotentialDisagreementSheet,
-        taxonForSuggestion: action.taxonForSuggestion
+        showPotentialDisagreementSheet: true
       };
-    case "CLEAR_TAXON":
+    case SET_NEW_IDENTIFICATION:
       return {
         ...state,
-        taxonForSuggestion: action.taxonForSuggestion
+        newIdentification: {
+          taxon: action.taxon,
+          body: action.body,
+          vision: action.vision
+        }
+      };
+    case SET_IDENT_TAXON:
+      return { ...state, identTaxon: action.taxon };
+    case CLEAR_SUGGESTED_TAXON:
+      return { ...state, identTaxon: null };
+    case CONFIRM_ID:
+      return { ...state, showSuggestIdSheet: true };
+    case DISCARD_ID:
+      return {
+        ...state,
+        showSuggestIdSheet: false,
+        identTaxon: null,
+        newIdentification: null
+      };
+    case HIDE_POTENTIAL_DISAGREEMENT_SHEET:
+      return {
+        ...state,
+        showPotentialDisagreementSheet: false,
+        identTaxon: null,
+        newIdentification: null
       };
     default:
       throw new Error( );
@@ -129,19 +175,18 @@ const ObsDetailsContainer = ( ): Node => {
   const setObservations = useStore( state => state.setObservations );
   const currentTabId = useStore( state => state.currentTabId );
   const setCurrentTabId = useStore( state => state.setCurrentTabId );
-  const currentObservation = useStore( state => state.currentObservation );
-  const updateObservationKeys = useStore( state => state.updateObservationKeys );
   const currentUser = useCurrentUser( );
   const { params } = useRoute();
   const {
-    suggestedTaxon,
+    identAt,
+    identTaxonId,
+    identTaxonFromVision,
     uuid
   } = params;
   const navigation = useNavigation( );
   const realm = useRealm( );
   const { t } = useTranslation( );
   const { isConnected } = useNetInfo( );
-  const vision = currentObservation?.owners_identification_from_vision;
 
   const [state, dispatch] = useReducer( reducer, initialState );
   const [remoteObsWasDeleted, setRemoteObsWasDeleted] = useState( false );
@@ -151,12 +196,14 @@ const ObsDetailsContainer = ( ): Node => {
     addingActivityItem,
     comment,
     commentIsOptional,
+    identBodySheetShown,
+    newIdentification,
     observationShown,
-    showAgreeWithIdSheet,
     showAddCommentSheet,
+    showAgreeWithIdSheet,
+    showPotentialDisagreementSheet,
     showSuggestIdSheet,
-    taxonForSuggestion,
-    showPotentialDisagreementSheet
+    identTaxon
   } = state;
   const queryClient = useQueryClient( );
 
@@ -176,6 +223,27 @@ const ObsDetailsContainer = ( ): Node => {
   } = useRemoteObservation( uuid, fetchRemoteObservationEnabled );
 
   useMarkViewedMutation( localObservation, remoteObservation );
+
+  // Translates identification-related params to local state
+  useEffect( ( ) => {
+    if ( identTaxonId ) {
+      // TODO sometimes this will be remote, so we need to fetch
+      const taxon = realm.objectForPrimaryKey( "Taxon", identTaxonId );
+      dispatch( {
+        type: SET_IDENT_TAXON,
+        taxon
+      } );
+    } else {
+      dispatch( { type: CLEAR_SUGGESTED_TAXON } );
+    }
+  }, [
+    // This should change with every new navigation event back to ObsDetails,
+    // so even if identTaxonId doesn't change, e.g. you add an ID of taxon X,
+    // cancel, then add another ID of taxon X, we still update the identTaxon
+    identAt,
+    identTaxonId,
+    realm
+  ] );
 
   // If we tried to get a remote observation but it no longer exists, the user
   // can't do anything so we need to send them back and remove the local
@@ -269,14 +337,14 @@ const ObsDetailsContainer = ( ): Node => {
 
   const openAddCommentSheet = ( { isOptional = false } ) => {
     dispatch( {
-      type: "SHOW_ADD_COMMENT_SHEET",
+      type: SET_ADD_COMMENT_SHEET,
       showAddCommentSheet: true,
       commentIsOptional: isOptional || false
     } );
   };
 
   const hideAddCommentSheet = ( ) => dispatch( {
-    type: "SHOW_ADD_COMMENT_SHEET",
+    type: SET_ADD_COMMENT_SHEET,
     showAddCommentSheet: false,
     comment: null
   } );
@@ -309,11 +377,11 @@ const ObsDetailsContainer = ( ): Node => {
     }
   );
 
-  const onCommentAdded = commentBody => {
+  const onCommentAdded = body => {
     dispatch( { type: "LOADING_ACTIVITY_ITEM" } );
     createCommentMutation.mutate( {
       comment: {
-        body: commentBody,
+        body,
         parent_id: uuid,
         parent_type: "Observation"
       }
@@ -326,22 +394,23 @@ const ObsDetailsContainer = ( ): Node => {
       onSuccess: data => {
         refetchRemoteObservation( );
         if ( belongsToCurrentUser ) {
-          const newIdentification = data[0];
-          let newIdentTaxon;
-          if ( newIdentification.taxon?.id ) {
-            newIdentTaxon = realm?.objectForPrimaryKey( "Taxon", newIdentification.taxon.id );
+          const createdIdent = data[0];
+          // Try to find an existing taxon b/c otherwise realm will try to
+          // create the taxon when updating the observation and error out
+          let taxon;
+          if ( createdIdent.taxon?.id ) {
+            taxon = realm?.objectForPrimaryKey( "Taxon", createdIdent.taxon.id );
           }
-          newIdentTaxon = newIdentTaxon || newIdentification.taxon;
+          taxon = taxon || createdIdent.taxon;
           safeRealmWrite( realm, ( ) => {
-            newIdentification.user = currentUser;
-            if ( newIdentTaxon ) newIdentification.taxon = newIdentTaxon;
-            if ( vision ) newIdentification.vision = true;
-            localObservation?.identifications?.push( newIdentification );
+            createdIdent.user = currentUser;
+            if ( taxon ) createdIdent.taxon = taxon;
+            localObservation?.identifications?.push( createdIdent );
           }, "setting local identification in ObsDetailsContainer" );
           if ( uuid ) {
             const updatedLocalObservation = realm.objectForPrimaryKey( "Observation", uuid );
             dispatch( { type: "ADD_ACTIVITY_ITEM", observationShown: updatedLocalObservation } );
-            dispatch( { type: "CLEAR_TAXON", taxonForSuggestion: null } );
+            dispatch( { type: CLEAR_SUGGESTED_TAXON } );
           }
         }
       },
@@ -357,39 +426,60 @@ const ObsDetailsContainer = ( ): Node => {
     }
   );
 
-  const openSuggestIdSheet = useCallback( () => {
-    dispatch( { type: "SHOW_SUGGEST_ID_SHEET", showSuggestIdSheet: true } );
-  }, [] );
-
-  const onIDAdded = useCallback( ( ) => {
+  useEffect( () => {
+    console.log( "[DEBUG ObsDetailsContainer.js]" );
+    console.log( "[DEBUG ObsDetailsContainer.js]" );
+    console.log( "[DEBUG ObsDetailsContainer.js] effect, identTaxon: ", identTaxon );
+    if ( !identTaxon ) return;
+    console.log(
+      "[DEBUG ObsDetailsContainer.js] effect, showPotentialDisagreementSheet: ",
+      showPotentialDisagreementSheet
+    );
+    if ( showPotentialDisagreementSheet ) return;
+    console.log(
+      "[DEBUG ObsDetailsContainer.js] effect, showSuggestIdSheet: ",
+      showSuggestIdSheet
+    );
+    if ( showSuggestIdSheet ) return;
+    console.log(
+      "[DEBUG ObsDetailsContainer.js] effect, identBodySheetShown: ",
+      identBodySheetShown
+    );
+    if ( identBodySheetShown ) return;
     let observationTaxon = observation.taxon;
     if (
       observation.prefers_community_taxon === false
-      || ( observation.user.prefers_community_taxa === false
+      || ( observation.user?.prefers_community_taxa === false
       && observation.prefers_community_taxon === null )
     ) {
       observationTaxon = observation.community_taxon || observation.taxon;
     }
+    dispatch( {
+      type: SET_NEW_IDENTIFICATION,
+      taxon: identTaxon,
+      vision: identTaxonFromVision
+    } );
     if (
       observationTaxon
-      && suggestedTaxon.id !== observationTaxon.id
-      && observationTaxon.ancestor_ids.includes( suggestedTaxon.id )
+      && identTaxon.id !== observationTaxon.id
+      && observationTaxon.ancestor_ids.includes( identTaxon.id )
     ) {
-      dispatch( {
-        type: "SHOW_POTENTIAL_DISAGREEMENT_SHEET",
-        showPotentialDisagreementSheet: true,
-        taxonForSuggestion: suggestedTaxon
-      } );
+      dispatch( { type: "SHOW_POTENTIAL_DISAGREEMENT_SHEET" } );
     } else {
-      openSuggestIdSheet();
+      dispatch( { type: CONFIRM_ID } );
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [suggestedTaxon] );
-
-  useEffect( () => {
-    if ( !suggestedTaxon ) return;
-    onIDAdded( );
-  }, [onIDAdded, openSuggestIdSheet, suggestedTaxon] );
+  }, [
+    identAt,
+    identBodySheetShown,
+    showSuggestIdSheet,
+    showPotentialDisagreementSheet,
+    identTaxon,
+    identTaxonFromVision,
+    observation?.community_taxon,
+    observation?.taxon,
+    observation?.prefers_community_taxon,
+    observation?.user?.prefers_community_taxa
+  ] );
 
   const navToSuggestions = ( ) => {
     setObservations( [observation] );
@@ -415,17 +505,15 @@ const ObsDetailsContainer = ( ): Node => {
 
   const closeAgreeWithIdSheet = ( ) => {
     dispatch( {
-      type: "SHOW_AGREE_SHEET",
-      showAgreeWithIdSheet: false,
-      comment: null
+      type: HIDE_AGREE_SHEET
     } );
   };
 
-  const onAgree = newComment => {
+  const onAgree = ident => {
     const agreeParams = {
       observation_id: observation?.uuid,
-      taxon_id: taxonForSuggestion?.id,
-      body: newComment
+      taxon_id: ident.taxon?.id,
+      body: ident.body
     };
 
     dispatch( { type: "LOADING_ACTIVITY_ITEM" } );
@@ -433,66 +521,63 @@ const ObsDetailsContainer = ( ): Node => {
     closeAgreeWithIdSheet( );
   };
 
-  const openAgreeWithIdSheet = agreeTaxon => {
+  const openAgreeWithIdSheet = taxon => {
     dispatch( {
-      type: "SHOW_AGREE_SHEET",
-      showAgreeWithIdSheet: true,
-      taxonForSuggestion: agreeTaxon
+      type: SHOW_AGREE_SHEET,
+      newIdentification: { taxon }
     } );
   };
   const potentialDisagreeSheetDiscardChanges = ( ) => {
-    dispatch( {
-      type: "SHOW_POTENTIAL_DISAGREEMENT_SHEET",
-      showPotentialDisagreementSheet: false,
-      taxonForSuggestion: null
-    } );
+    dispatch( { type: HIDE_POTENTIAL_DISAGREEMENT_SHEET } );
   };
 
-  const doSuggestId = potentialDisagree => {
-    const remark = currentObservation?.description;
+  const doSuggestId = useCallback( potentialDisagree => {
+    if ( !newIdentification?.taxon ) {
+      throw new Error( "Cannot create an identification without a taxon" );
+    }
     // New taxon identification added by user
     const idParams = {
       observation_id: uuid,
-      taxon_id: suggestedTaxon.id,
-      vision,
-      disagreement: potentialDisagree
+      taxon_id: newIdentification.taxon.id,
+      vision: newIdentification.vision,
+      disagreement: potentialDisagree,
+      body: newIdentification?.body
     };
-
-    if ( remark ) {
-      // $FlowIgnore
-      idParams.body = remark;
-    }
 
     dispatch( { type: "LOADING_ACTIVITY_ITEM" } );
     createIdentificationMutation.mutate( { identification: idParams } );
-  };
+  }, [createIdentificationMutation, newIdentification, uuid] );
 
   const onSuggestId = useCallback( ( ) => {
     // based on disagreement code in iNat web
     // https://github.com/inaturalist/inaturalist/blob/30a27d0eb79dd17af38292785b0137e6024bbdb7/app/webpack/observations/show/ducks/observation.js#L827-L838
-    let observationTaxon = observation.taxon;
+    let observationTaxon = observation?.taxon;
     if (
-      observation.prefers_community_taxon === false
-      || ( observation.user.prefers_community_taxa === false
-      && observation.prefers_community_taxon === null )
+      observation?.prefers_community_taxon === false
+      || (
+        observation?.user?.prefers_community_taxa === false
+        && observation?.prefers_community_taxon === null
+      )
     ) {
-      observationTaxon = observation.community_taxon || observation.taxon;
+      observationTaxon = observation?.community_taxon || observation.taxon;
     }
     if (
       observationTaxon
-      && suggestedTaxon.id !== observationTaxon.id
-      && observationTaxon.ancestor_ids.includes( suggestedTaxon.id )
+      && identTaxon?.id !== observationTaxon.id
+      && observationTaxon.ancestor_ids.includes( identTaxon?.id )
     ) {
-      dispatch( {
-        type: "SHOW_POTENTIAL_DISAGREEMENT_SHEET",
-        showPotentialDisagreementSheet: true,
-        taxonForSuggestion: suggestedTaxon
-      } );
+      dispatch( { type: "SHOW_POTENTIAL_DISAGREEMENT_SHEET" } );
     } else {
       doSuggestId();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [suggestedTaxon] );
+  }, [
+    doSuggestId,
+    observation?.community_taxon,
+    observation?.prefers_community_taxon,
+    observation?.taxon,
+    observation?.user?.prefers_community_taxa,
+    identTaxon
+  ] );
 
   const onPotentialDisagreePressed = potentialDisagree => {
     dispatch( {
@@ -502,31 +587,17 @@ const ObsDetailsContainer = ( ): Node => {
     doSuggestId( potentialDisagree );
   };
 
-  const suggestIdSheetDiscardChanges = ( ) => {
-    dispatch( {
-      type: "SHOW_SUGGEST_ID_SHEET",
-      showSuggestIdSheet: false,
-      taxonForSuggestion: null
-    } );
-  };
+  const suggestIdSheetDiscardChanges = ( ) => dispatch( { type: DISCARD_ID } );
 
   const confirmCommentFromCommentSheet = newComment => {
     if ( !commentIsOptional ) {
       onCommentAdded( newComment );
-    } else if ( taxonForSuggestion ) {
-      dispatch( { type: "SET_COMMENT", comment: newComment } );
-      openAgreeWithIdSheet( taxonForSuggestion );
-    } else {
-      updateObservationKeys( {
-        description: newComment
-      } );
-      openSuggestIdSheet( );
     }
   };
 
   return observationShown && (
     <ObsDetails
-      activityItems={activityItems}
+      activityItems={activityItems || []}
       addingActivityItem={addingActivityItem}
       closeAgreeWithIdSheet={closeAgreeWithIdSheet}
       belongsToCurrentUser={belongsToCurrentUser}
@@ -536,6 +607,7 @@ const ObsDetailsContainer = ( ): Node => {
       confirmRemoteObsWasDeleted={confirmRemoteObsWasDeleted}
       currentTabId={currentTabId}
       currentUser={currentUser}
+      editIdentBody={( ) => dispatch( { type: SHOW_EDIT_IDENT_BODY_SHEET } )}
       onPotentialDisagreePressed={onPotentialDisagreePressed}
       hideAddCommentSheet={hideAddCommentSheet}
       isConnected={isConnected}
@@ -552,13 +624,22 @@ const ObsDetailsContainer = ( ): Node => {
       refetchRemoteObservation={invalidateQueryAndRefetch}
       remoteObsWasDeleted={remoteObsWasDeleted}
       showActivityTab={showActivityTab}
-      showAgreeWithIdSheet={showAgreeWithIdSheet}
+      showAgreeWithIdSheet={!!showAgreeWithIdSheet}
       showAddCommentSheet={showAddCommentSheet}
-      showSuggestIdSheet={showSuggestIdSheet}
+      showSuggestIdSheet={!!showSuggestIdSheet}
       suggestIdSheetDiscardChanges={suggestIdSheetDiscardChanges}
       showPotentialDisagreementSheet={showPotentialDisagreementSheet}
       tabs={tabs}
-      taxonForSuggestion={taxonForSuggestion}
+      identBodySheetShown={identBodySheetShown}
+      newIdentification={newIdentification}
+      onChangeIdentBody={body => dispatch( {
+        type: SET_NEW_IDENTIFICATION,
+        taxon: newIdentification?.taxon,
+        body
+      } )}
+      onCloseIdentBodySheet={() => {
+        dispatch( { type: HIDE_EDIT_IDENT_BODY_SHEET } );
+      }}
     />
   );
 };

--- a/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
+++ b/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
@@ -13,11 +13,16 @@ import React from "react";
 import { Text } from "react-native";
 
 type Props = {
-  comment: string,
+  editIdentBody: Function,
+  handleClose?: Function,
+  hidden?: boolean,
+  identification: {
+    body?: string,
+    taxon: { id: number },
+    vision?: boolean
+  },
   onAgree:Function,
-  openAddCommentSheet: Function,
-  handleClose: Function,
-  taxon: Object
+  onPressClose: Function,
 }
 
 const showTaxon = taxon => {
@@ -32,15 +37,18 @@ const showTaxon = taxon => {
 };
 
 const AgreeWithIDSheet = ( {
-  comment,
-  onAgree,
-  openAddCommentSheet,
+  editIdentBody,
   handleClose,
-  taxon
+  hidden,
+  identification,
+  onAgree,
+  onPressClose
 }: Props ): Node => (
   <BottomSheet
     handleClose={handleClose}
     headerText={t( "AGREE-WITH-ID" )}
+    hidden={hidden}
+    onPressClose={onPressClose}
   >
     <View
       className="mx-[26px] space-y-[11px] my-[15px]"
@@ -48,28 +56,27 @@ const AgreeWithIDSheet = ( {
       <List2 className="text-black">
         {t( "Agree-with-ID-description" )}
       </List2>
-      { comment && (
+      { identification.body && (
         <View
           className=" flex-row items-center bg-lightGray p-[15px] rounded"
         >
           <INatIcon name="add-comment-outline" size={22} />
           <List2 className="ml-[7px] text-black">
-            {comment}
+            {identification.body}
           </List2>
         </View>
       )}
-      {showTaxon( taxon )}
+      {showTaxon( identification.taxon )}
     </View>
-    <View className="flex-row justify-evenly mx-3 mb-3">
-      {comment
+    <View className="flex-row mx-3 mb-3">
+      {identification.body
         ? (
           <Button
             text={t( "EDIT-COMMENT" )}
             onPress={( ) => {
-              openAddCommentSheet( { isOptional: true } );
-              handleClose( );
+              editIdentBody( );
             }}
-            className="mx-2 grow"
+            className="mx-2 flex-1"
             testID="ObsDetail.AgreeId.EditCommentButton"
             accessibilityHint={t( "Opens-add-comment-modal" )}
           />
@@ -78,10 +85,9 @@ const AgreeWithIDSheet = ( {
           <Button
             text={t( "ADD-COMMENT" )}
             onPress={( ) => {
-              openAddCommentSheet( { isOptional: true } );
-              handleClose( );
+              editIdentBody( );
             }}
-            className="mx-2 grow"
+            className="mx-2 flex-1"
             testID="ObsDetail.AgreeId.commentButton"
             accessibilityHint={t( "Opens-add-comment-modal" )}
           />
@@ -89,12 +95,12 @@ const AgreeWithIDSheet = ( {
 
       <Button
         text={t( "AGREE" )}
-        onPress={( ) => onAgree( comment )}
-        className="mx-2 grow"
+        onPress={( ) => onAgree( identification )}
+        className="mx-2 flex-1"
         testID="ObsDetail.AgreeId.cvSuggestionsButton"
         accessibilityRole="link"
         accessibilityHint={t( "Navigates-to-suggest-identification" )}
-        level={comment && "primary"}
+        level="primary"
       />
     </View>
   </BottomSheet>

--- a/src/components/ObsDetails/Sheets/PotentialDisagreementSheet.js
+++ b/src/components/ObsDetails/Sheets/PotentialDisagreementSheet.js
@@ -15,18 +15,20 @@ import { useCurrentUser, useTranslation } from "sharedHooks";
 interface Props {
   handleClose: Function,
   onPotentialDisagreePressed: Function,
-  taxon: Object
+  newTaxon: Object,
+  oldTaxon: Object
 }
 
 const PotentialDisagreementSheet = ( {
   handleClose,
   onPotentialDisagreePressed,
-  taxon
+  newTaxon,
+  oldTaxon
 }: Props ): Node => {
   const { t } = useTranslation( );
   const currentUser = useCurrentUser( );
 
-  const showTaxonName = fontComponent => (
+  const showTaxonName = ( taxon, fontComponent ) => (
     <DisplayTaxonName
       bottomTextComponent={fontComponent}
       layout="horizontal"
@@ -45,7 +47,7 @@ const PotentialDisagreementSheet = ( {
       labelComponent: (
         <Trans
           i18nKey="Potential-disagreement-unsure"
-          components={[<Body1 />, showTaxonName( Body1 )]}
+          components={[<Body1 />, showTaxonName( newTaxon, Body1 )]}
         />
       )
     },
@@ -54,7 +56,7 @@ const PotentialDisagreementSheet = ( {
       labelComponent: (
         <Trans
           i18nKey="Potential-disagreement-disagree"
-          components={[<Body1 />, showTaxonName( Body1 )]}
+          components={[<Body1 />, showTaxonName( newTaxon, Body1 )]}
         />
       )
     }
@@ -63,13 +65,13 @@ const PotentialDisagreementSheet = ( {
   const topDescriptionText = (
     <Trans
       i18nKey="Potential-disagreement-description"
-      components={[<List2 />, showTaxonName( List2 )]}
+      components={[<List2 />, showTaxonName( oldTaxon, List2 )]}
     />
   );
 
   const bottomComponent = (
     <View className="mx-6 mb-6">
-      <DisplayTaxon taxon={taxon} />
+      <DisplayTaxon taxon={newTaxon} />
     </View>
   );
 
@@ -82,11 +84,10 @@ const PotentialDisagreementSheet = ( {
         handleClose( );
       }}
       confirmText={t( "SUBMIT-ID-SUGGESTION" )}
-      handleClose={handleClose}
+      onPressClose={handleClose}
       radioValues={radioValues}
       selectedValue={radioValues.unsure.value}
       topDescriptionText={topDescriptionText}
-      taxon={taxon}
       bottomComponent={bottomComponent}
     />
   );

--- a/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
+++ b/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
@@ -9,96 +9,94 @@ import { View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React from "react";
-import useStore from "stores/useStore";
 
 interface Props {
+  hidden?: boolean,
+  identification: {
+    body?: string,
+    taxon: { id: number }
+  }
   onSuggestId:Function,
-  openAddCommentSheet: Function,
-  handleClose: Function
+  editIdentBody: Function,
+  handleClose: Function,
+  onPressClose: Function
 }
 
-const showTaxon = taxon => {
-  if ( !taxon ) {
-    return <List2>{t( "Unknown-organism" )}</List2>;
-  }
-  return (
-    <View className="flex-row mx-[15px]">
-      <DisplayTaxon taxon={taxon} />
-    </View>
-  );
-};
-
 const SuggestIDSheet = ( {
+  hidden,
+  identification,
   onSuggestId,
-  openAddCommentSheet,
-  handleClose
-}: Props ): Node => {
-  const currentObservation = useStore( state => state.currentObservation );
-  const comment = currentObservation?.description;
-  const taxon = currentObservation?.taxon;
-
-  return (
-    <BottomSheet
-      handleClose={handleClose}
-      headerText={t( "SUGGEST-ID" )}
-    >
-      <View className="mx-[26px] space-y-[11px] my-[15px]">
-        <List2>
-          {t( "Would-you-like-to-suggest-the-following-identification" )}
-        </List2>
-        { comment && (
-          <View
-            className=" flex-row items-center bg-lightGray p-[15px] rounded"
-          >
-            <INatIcon name="add-comment-outline" size={22} />
-            <List2 className="ml-[7px] text-black">
-              {comment}
-            </List2>
-          </View>
-        )}
-        {showTaxon( taxon )}
-      </View>
-      <View className="flex-row justify-evenly mx-3 mb-3">
-        {comment
+  editIdentBody,
+  handleClose,
+  onPressClose
+}: Props ): Node => (
+  <BottomSheet
+    handleClose={handleClose}
+    onPressClose={onPressClose}
+    headerText={t( "SUGGEST-ID" )}
+    hidden={hidden}
+  >
+    <View className="mx-[26px] space-y-[11px] my-[15px]">
+      <List2>
+        {t( "Would-you-like-to-suggest-the-following-identification" )}
+      </List2>
+      { identification.body && (
+        <View
+          className=" flex-row items-center bg-lightGray p-[15px] rounded"
+        >
+          <INatIcon name="add-comment-outline" size={22} />
+          <List2 className="ml-[7px] text-black flex-1">
+            {identification.body}
+          </List2>
+        </View>
+      )}
+      {
+        identification.taxon
           ? (
-            <Button
-              text={t( "EDIT-COMMENT" )}
-              onPress={( ) => {
-                openAddCommentSheet( { isOptional: true } );
-                handleClose( );
-              }}
-              className="mx-2 grow"
-              testID="SuggestID.EditCommentButton"
-              accessibilityHint={t( "Opens-add-comment-modal" )}
-            />
+            <View className="flex-row mx-[15px]">
+              <DisplayTaxon taxon={identification.taxon} />
+            </View>
           )
-          : (
-            <Button
-              text={t( "ADD-COMMENT" )}
-              onPress={( ) => {
-                openAddCommentSheet( { isOptional: true } );
-                handleClose( );
-              }}
-              className="mx-2 grow"
-              testID="SuggestID.commentButton"
-              accessibilityHint={t( "Opens-add-comment-modal" )}
-            />
-          )}
-        <Button
-          text={t( "SUGGEST-ID" )}
-          onPress={( ) => {
-            onSuggestId( );
-            handleClose( );
-          }}
-          className="mx-2 grow"
-          testID="SuggestIDSheet.cvSuggestionsButton"
-          accessibilityRole="link"
-          accessibilityHint={t( "Add-suggestion-and-remarks-to-observation" )}
-          level="primary"
-        />
-      </View>
-    </BottomSheet>
-  );
-};
+          : <List2>{t( "Unknown-organism" )}</List2>
+      }
+    </View>
+    <View className="flex-row justify-evenly mx-3 mb-3">
+      {identification.body
+        ? (
+          <Button
+            text={t( "EDIT-COMMENT" )}
+            onPress={( ) => {
+              editIdentBody( );
+            }}
+            className="mx-2 flex-1"
+            testID="SuggestID.EditCommentButton"
+          />
+        )
+        : (
+          <Button
+            text={t( "ADD-COMMENT" )}
+            onPress={( ) => {
+              editIdentBody( );
+            }}
+            className="mx-2 flex-1"
+            testID="SuggestID.commentButton"
+            accessibilityHint={t( "Opens-add-comment-modal" )}
+          />
+        )}
+      <Button
+        text={t( "SUGGEST-ID" )}
+        onPress={( ) => {
+          onSuggestId( );
+          onPressClose( );
+        }}
+        className="mx-2 flex-1"
+        testID="SuggestIDSheet.cvSuggestionsButton"
+        accessibilityRole="link"
+        accessibilityHint={t( "Suggest-ID" )}
+        level="primary"
+      />
+    </View>
+  </BottomSheet>
+);
 
 export default SuggestIDSheet;

--- a/src/components/SharedComponents/DisplayTaxon.js
+++ b/src/components/SharedComponents/DisplayTaxon.js
@@ -39,9 +39,9 @@ const DisplayTaxon = ( {
     : taxon?.iconic_taxon_name;
 
   const iconicTaxon = iconicTaxonName && realm?.objects( "Taxon" )
-    .filtered( "name CONTAINS[c] $0", iconicTaxonName );
+    .filtered( "name CONTAINS[c] $0", iconicTaxonName )?.[0];
 
-  const taxonPhoto = taxon?.default_photo?.url || iconicTaxon?.[0]?.default_photo?.url;
+  const taxonPhoto = taxon?.default_photo?.url || iconicTaxon?.default_photo?.url;
   const accessibleName = accessibleTaxonName( taxon, currentUser, t );
 
   return (

--- a/src/components/SharedComponents/Sheets/BottomSheet.js
+++ b/src/components/SharedComponents/Sheets/BottomSheet.js
@@ -20,10 +20,14 @@ type Props = {
   children: Node,
   hidden?: boolean,
   onChange?: Function,
+  // Callback when the sheet closes
   handleClose?: Function,
   hideCloseButton?: boolean,
   headerText?: string,
   onLayout?: Function,
+  // Callback when the user presses the close button, not whenever the sheet
+  // closes
+  onPressClose?: Function,
   snapPoints?: Array<string>,
   insideModal?: boolean,
   keyboardShouldPersistTaps: string
@@ -39,6 +43,7 @@ const StandardBottomSheet = ( {
   hideCloseButton = false,
   headerText,
   onLayout,
+  onPressClose,
   snapPoints,
   insideModal,
   keyboardShouldPersistTaps = "never"
@@ -60,7 +65,7 @@ const StandardBottomSheet = ( {
     }
   }, [handleClose] );
 
-  const handleClosePress = useCallback( ( ) => {
+  const hide = useCallback( ( ) => {
     if ( handleClose ) {
       handleClose( );
     }
@@ -81,11 +86,11 @@ const StandardBottomSheet = ( {
 
   useEffect( ( ) => {
     if ( hidden ) {
-      handleClosePress( );
+      hide( );
     } else {
       handleSnapPress( );
     }
-  }, [hidden, handleClosePress, handleSnapPress] );
+  }, [hidden, hide, handleSnapPress] );
 
   const BottomSheetComponent = insideModal
     ? BottomSheet
@@ -127,7 +132,7 @@ const StandardBottomSheet = ( {
           {!hideCloseButton && (
             <INatIconButton
               icon="close"
-              onPress={handleClose}
+              onPress={onPressClose || handleClose}
               size={19}
               className="absolute top-3.5 right-3"
               accessibilityState={{ disabled: hidden }}

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -15,6 +15,7 @@ interface Props {
   handleClose: Function,
   headerText: string,
   insideModal?: boolean,
+  onPressClose?: ( ) => void;
   radioValues: {
     [key: string]: {
       value: string,
@@ -36,6 +37,7 @@ const RadioButtonSheet = ( {
   handleClose,
   headerText,
   insideModal,
+  onPressClose,
   radioValues,
   selectedValue = "none",
   topDescriptionText
@@ -65,6 +67,7 @@ const RadioButtonSheet = ( {
       handleClose={handleClose}
       headerText={headerText}
       insideModal={insideModal}
+      onPressClose={onPressClose}
     >
       <View className="p-4 pt-2">
         {topDescriptionText}

--- a/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts
+++ b/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts
@@ -41,16 +41,9 @@ const useNavigateWithTaxonSelected = (
     if ( entryScreen === "ObsDetails" ) {
       navigation.navigate( "ObsDetails", {
         uuid: currentObservation?.uuid,
-        suggestedTaxon: selectedTaxon
-          ? {
-            id: selectedTaxon.id,
-            default_photo: selectedTaxon.default_photo,
-            rank: selectedTaxon.rank,
-            rank_level: selectedTaxon.rank_level,
-            preferred_common_name: selectedTaxon.preferred_common_name,
-            name: selectedTaxon.name
-          }
-          : null
+        identTaxonId: selectedTaxon?.id,
+        identTaxonFromVision: options?.vision,
+        identAt: Date.now()
       } );
     } else if ( entryScreen === "ObsEdit" ) {
       // Cant' go back b/c we might be on Suggestions OR TaxonSearch. Don't
@@ -66,6 +59,7 @@ const useNavigateWithTaxonSelected = (
     currentObservation?.uuid,
     entryScreen,
     navigation,
+    options?.vision,
     selectedTaxon,
     unselectTaxon,
     updateObservationKeys,

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -3,7 +3,6 @@
 import { refresh, useNetInfo } from "@react-native-community/netinfo";
 import { useNavigation, useNavigationState, useRoute } from "@react-navigation/native";
 import { fetchSpeciesCounts } from "api/observations";
-import { fetchTaxon } from "api/taxa";
 import classnames from "classnames";
 import MediaViewerModal from "components/MediaViewer/MediaViewerModal";
 import {
@@ -29,6 +28,7 @@ import {
 import DeviceInfo from "react-native-device-info";
 import { useTheme } from "react-native-paper";
 import { log } from "sharedHelpers/logger";
+import { fetchTaxonAndSave } from "sharedHelpers/taxon";
 import {
   useAuthenticatedQuery,
   useCurrentUser,
@@ -73,7 +73,7 @@ const TaxonDetails = ( ): Node => {
 
   // previous ObsDetails observation uuid
   const obsUuid = fromObsDetails
-    ? _.find( navState?.routes, r => r.name === "ObsDetails" ).params.uuid
+    ? _.find( navState?.routes?.slice().reverse(), r => r.name === "ObsDetails" ).params.uuid
     : null;
 
   const showSelectButton = fromSuggestions || fromObsEdit;
@@ -94,7 +94,7 @@ const TaxonDetails = ( ): Node => {
     error
   } = useAuthenticatedQuery(
     ["fetchTaxon", id],
-    optsWithAuth => fetchTaxon( id, taxonFetchParams, optsWithAuth )
+    optsWithAuth => fetchTaxonAndSave( id, realm, taxonFetchParams, optsWithAuth )
   );
 
   const taxon = remoteTaxon || localTaxon;
@@ -319,10 +319,6 @@ const TaxonDetails = ( ): Node => {
                   identTaxonId: taxon?.id,
                   identAt: Date.now()
                 };
-                console.log(
-                  "[DEBUG TaxonDetails.js] nav'ing to ObsDetails, param: ",
-                  obsDetailsParam
-                );
                 navigation.navigate( "ObsDetails", obsDetailsParam );
               } else {
                 navigation.navigate( "ObsEdit" );

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -314,10 +314,16 @@ const TaxonDetails = ( ): Node => {
                 owners_identification_from_vision: usesVision
               } );
               if ( fromObsDetails ) {
-                navigation.navigate( "ObsDetails", {
+                const obsDetailsParam = {
                   uuid: obsUuid,
-                  suggestedTaxon: taxon
-                } );
+                  identTaxonId: taxon?.id,
+                  identAt: Date.now()
+                };
+                console.log(
+                  "[DEBUG TaxonDetails.js] nav'ing to ObsDetails, param: ",
+                  obsDetailsParam
+                );
+                navigation.navigate( "ObsDetails", obsDetailsParam );
               } else {
                 navigation.navigate( "ObsEdit" );
               }

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -50,7 +50,6 @@ Add-Location = Add Location
 Add-observations = Add observations
 ADD-OPTIONAL-COMMENT = ADD OPTIONAL COMMENT
 Add-optional-notes = Add optional notes
-Add-suggestion-and-remarks-to-observation = Add suggestion and remarks to observation
 # Hint for a button that adds a vote of agreement
 Adds-your-vote-of-agreement = Adds your vote of agreement
 # Hint for a button that adds a vote of disagreement
@@ -940,6 +939,8 @@ Stops-recording-sound = Stops recording sound
 SUBMIT = SUBMIT
 SUBMIT-ID-SUGGESTION = SUBMIT ID SUGGESTION
 SUGGEST-ID = SUGGEST ID
+# Label for element that suggest an identification
+Suggest-ID = SUGGEST ID
 # Identification category
 supporting--identification = Supporting
 Switches-to-tab = Switches to { $tab } tab.

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -46,7 +46,6 @@
   },
   "ADD-OPTIONAL-COMMENT": "ADD OPTIONAL COMMENT",
   "Add-optional-notes": "Add optional notes",
-  "Add-suggestion-and-remarks-to-observation": "Add suggestion and remarks to observation",
   "Adds-your-vote-of-agreement": {
     "comment": "Hint for a button that adds a vote of agreement",
     "val": "Adds your vote of agreement"
@@ -1284,6 +1283,10 @@
   "SUBMIT": "SUBMIT",
   "SUBMIT-ID-SUGGESTION": "SUBMIT ID SUGGESTION",
   "SUGGEST-ID": "SUGGEST ID",
+  "Suggest-ID": {
+    "comment": "Label for element that suggest an identification",
+    "val": "SUGGEST ID"
+  },
   "supporting--identification": {
     "comment": "Identification category",
     "val": "Supporting"

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -50,7 +50,6 @@ Add-Location = Add Location
 Add-observations = Add observations
 ADD-OPTIONAL-COMMENT = ADD OPTIONAL COMMENT
 Add-optional-notes = Add optional notes
-Add-suggestion-and-remarks-to-observation = Add suggestion and remarks to observation
 # Hint for a button that adds a vote of agreement
 Adds-your-vote-of-agreement = Adds your vote of agreement
 # Hint for a button that adds a vote of disagreement
@@ -940,6 +939,8 @@ Stops-recording-sound = Stops recording sound
 SUBMIT = SUBMIT
 SUBMIT-ID-SUGGESTION = SUBMIT ID SUGGESTION
 SUGGEST-ID = SUGGEST ID
+# Label for element that suggest an identification
+Suggest-ID = SUGGEST ID
 # Identification category
 supporting--identification = Supporting
 Switches-to-tab = Switches to { $tab } tab.

--- a/src/sharedHelpers/taxon.js
+++ b/src/sharedHelpers/taxon.js
@@ -1,4 +1,8 @@
+import { fetchTaxon } from "api/taxa";
+import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import _ from "lodash";
+import Taxon from "realmModels/Taxon";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 
 const uncapitalized = new Set( [
   "à",
@@ -144,4 +148,24 @@ export function accessibleTaxonName( taxon, user, t ) {
     }
   }
   return t( "accessible-comname-sciname", { scientificName, commonName } );
+}
+
+export async function fetchTaxonAndSave( id, realm, params = {}, opts = {} ) {
+  const options = { ...opts };
+  if ( !options.api_token ) {
+    options.api_token = await getJWT( );
+  }
+  const remoteTaxon = await fetchTaxon( id, params, options );
+  const mappedRemoteTaxon = Taxon.mapApiToRealm( remoteTaxon, realm );
+  safeRealmWrite( realm, ( ) => {
+    realm.create(
+      "Taxon",
+      {
+        ...mappedRemoteTaxon,
+        _synced_at: new Date( )
+      },
+      "modified"
+    );
+  }, "saving remote taxon in ObsDetails" );
+  return mappedRemoteTaxon;
 }

--- a/tests/unit/components/ObsDetails/ObsDetails.test.js
+++ b/tests/unit/components/ObsDetails/ObsDetails.test.js
@@ -342,8 +342,7 @@ describe( "ObsDetails", () => {
       expect( mockMutate ).toHaveBeenCalledWith( {
         identification: {
           observation_id: otherUserObservation.uuid,
-          taxon_id: firstIdentification.taxon.id,
-          body: ""
+          taxon_id: firstIdentification.taxon.id
         }
       } );
     } );


### PR DESCRIPTION
* separates ident body editing into its own state and UI
* stop adding an entire Realm object to nav params, where it gets out of date and causes access bugs
* fixes bug where accessing ObsDetails from MyObs can cause you to return there when returning from TaxonDetails via Explore
* separates BottomSheet handleClose callback so it can respond differently to the sheet closing and the user intentionally closing the sheet
* Suggest ID and Agree bottom sheets both have buttons of equal width with a single primary action
* Disagree sheet prompt refers to the taxon being disagreed with, not the ident taxon
* save taxon to local db when viewed on TaxonDetails
* minor refactors for readability

Closes #2003