### PR TITLE
Remove stutter when scrolling LocationPicker

### DIFF
--- a/src/components/LocationPicker/CrosshairCircle.js
+++ b/src/components/LocationPicker/CrosshairCircle.js
@@ -9,11 +9,25 @@ import { useTheme } from "react-native-paper";
 
 import WarningText from "./WarningText";
 
-type Props = {
-  accuracyTest: string
+export const DESIRED_LOCATION_ACCURACY = 100;
+export const REQUIRED_LOCATION_ACCURACY = 500_000;
+
+const checkAccuracy = accuracy => {
+  if ( accuracy < DESIRED_LOCATION_ACCURACY ) {
+    return "pass";
+  }
+  if ( accuracy < REQUIRED_LOCATION_ACCURACY ) {
+    return "acceptable";
+  }
+  return "fail";
 };
 
-const CrosshairCircle = ( { accuracyTest }: Props ): Node => {
+type Props = {
+  accuracy: number
+};
+
+const CrosshairCircle = ( { accuracy }: Props ): Node => {
+  const accuracyTest = checkAccuracy( accuracy );
   const theme = useTheme( );
 
   return (

--- a/src/components/LocationPicker/Footer.js
+++ b/src/components/LocationPicker/Footer.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { useNavigation } from "@react-navigation/native";
 import { Button } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
@@ -8,25 +7,17 @@ import React from "react";
 import useTranslation from "sharedHooks/useTranslation";
 
 type Props = {
-  keysToUpdate: Object,
-  goBackOnSave: boolean,
-  updateObservationKeys: Function
+  handleSave: Function
 };
 
-const Footer = ( { keysToUpdate, goBackOnSave, updateObservationKeys }: Props ): Node => {
-  const navigation = useNavigation( );
+const Footer = ( { handleSave }: Props ): Node => {
   const { t } = useTranslation( );
 
   return (
     <View className="h-[73px] justify-center">
       <Button
         className="mx-[25px]"
-        onPress={( ) => {
-          updateObservationKeys( keysToUpdate );
-          if ( goBackOnSave ) {
-            navigation.goBack( );
-          }
-        }}
+        onPress={handleSave}
         testID="LocationPicker.saveButton"
         text={t( "SAVE-LOCATION" )}
         level="neutral"

--- a/src/components/LocationPicker/LocationPicker.js
+++ b/src/components/LocationPicker/LocationPicker.js
@@ -10,7 +10,7 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "sharedHooks";
 
 import CrosshairCircle from "./CrosshairCircle";
@@ -19,48 +19,40 @@ import Footer from "./Footer";
 import LoadingIndicator from "./LoadingIndicator";
 import LocationSearch from "./LocationSearch";
 
-export const DESIRED_LOCATION_ACCURACY = 100;
-export const REQUIRED_LOCATION_ACCURACY = 500_000;
-
 type Props = {
   accuracy: number,
-  accuracyTest: string,
-  goBackOnSave: Function,
+  handleSave: Function,
   hidePlaceResults: boolean,
-  keysToUpdate: Object,
   loading: boolean,
   locationName: string,
+  initialRegion: Object,
   mapType: string,
+  onCurrentLocationPress: Function,
+  onMapReady: Function,
+  onRegionChangeComplete: Function,
   region: Object,
+  regionToAnimate: Object,
   selectPlaceResult: Function,
-  setMapReady: Function,
-  showCrosshairs: boolean,
-  updateLocationName: Function,
-  updateRegion: Function,
-  updateObservationKeys: Function
+  updateLocationName: Function
 };
 
 const LocationPicker = ( {
   accuracy,
-  accuracyTest,
-  goBackOnSave,
+  handleSave,
   hidePlaceResults,
-  keysToUpdate,
   loading,
   locationName,
+  regionToAnimate,
+  initialRegion,
   mapType,
+  onCurrentLocationPress,
+  onMapReady,
+  onRegionChangeComplete,
   region,
   selectPlaceResult,
-  setMapReady = ( ) => undefined,
-  showCrosshairs,
-  updateLocationName,
-  updateRegion,
-  updateObservationKeys
+  updateLocationName
 }: Props ): Node => {
   const { t } = useTranslation( );
-
-  // prevent initial map render from resetting the coordinates and locationName
-  const [initialMapRender, setInitialMapRender] = useState( true );
 
   return (
     <KeyboardDismissableView>
@@ -98,41 +90,28 @@ const LocationPicker = ( {
             )}
             pointerEvents="none"
           >
-            {showCrosshairs && (
-              <CrosshairCircle
-                accuracyTest={accuracyTest}
-              />
-            )}
+            {!loading && <CrosshairCircle accuracy={accuracy} />}
           </View>
           <View className="top-1/2 left-1/2 absolute z-10">
             {loading && <LoadingIndicator />}
           </View>
           <Map
             className="h-full"
-            showsCompass={false}
-            region={region}
+            initialRegion={initialRegion}
             mapType={mapType}
-            onCurrentLocationPress={( ) => setInitialMapRender( false )}
-            onRegionChangeComplete={async newRegion => {
-              if ( !initialMapRender ) {
-                updateRegion( newRegion );
-              } else {
-                setInitialMapRender( false );
-              }
-            }}
-            onMapReady={setMapReady}
-            showCurrentLocationButton
-            showSwitchMapTypeButton
             obsLatitude={region.latitude}
             obsLongitude={region.longitude}
+            onCurrentLocationPress={onCurrentLocationPress}
+            onMapReady={onMapReady}
+            onRegionChangeComplete={onRegionChangeComplete}
+            regionToAnimate={regionToAnimate}
+            showCurrentLocationButton
+            showSwitchMapTypeButton
+            showsCompass={false}
             testID="LocationPicker.Map"
           />
         </View>
-        <Footer
-          keysToUpdate={keysToUpdate}
-          goBackOnSave={goBackOnSave}
-          updateObservationKeys={updateObservationKeys}
-        />
+        <Footer handleSave={handleSave} />
       </ViewWrapper>
     </KeyboardDismissableView>
   );

--- a/src/components/ObsEdit/BottomButtons.js
+++ b/src/components/ObsEdit/BottomButtons.js
@@ -5,7 +5,7 @@ import {
 } from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
-import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/LocationPicker";
+import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/CrosshairCircle";
 import {
   Button,
   StickyToolbar

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/LocationPicker";
+import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/CrosshairCircle";
 import {
   differenceInCalendarYears,
   isFuture,

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -57,7 +57,7 @@ const ObsEdit = ( ): Node => {
 
   const navToLocationPicker = useCallback( ( ) => {
     stopWatch( subscriptionId );
-    navigation.navigate( "LocationPicker", { goBackOnSave: true } );
+    navigation.navigate( "LocationPicker" );
   }, [stopWatch, subscriptionId, navigation] );
 
   const onLocationPress = ( ) => {

--- a/src/components/ObsEdit/Sheets/ImpreciseLocationSheet.js
+++ b/src/components/ObsEdit/Sheets/ImpreciseLocationSheet.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/LocationPicker";
+import { REQUIRED_LOCATION_ACCURACY } from "components/LocationPicker/CrosshairCircle";
 import { TextSheet } from "components/SharedComponents";
 import type { Node } from "react";
 import React from "react";


### PR DESCRIPTION
closes #1877

- the main thing stopping the stutter here is that we switched from passing in `region` to the map and instead started passing in an `initialRegion`, which means the map is responsible for its own region state instead of trying to keep up with panning/zooming.
- that means we also need to use the `animateToRegion` method when a user types in a place name and selects a place search result -- this is a way to set the map without using `region`
- otherwise, tried to make LocationPicker a little easier to read and removed some unnecessary `useEffects`