### PR TITLE
Set online/offline status via event listener in React Query

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -57,7 +57,10 @@ const App = ( { children }: Props ): Node => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
 
-  // need to add this for auto refetch in React Native
+  // this ensures that React Query has the most accurate depiction of whether the
+  // app is online or offline. since queries only run when the app is online, this
+  // eventListener prevents both queries and retries (via reactQueryRetry)
+  // from running unnecessarily when the app is offline
   // https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
   onlineManager.setEventListener( setOnline => NetInfo.addEventListener( state => {
     setOnline( !!state.isConnected );

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,6 +2,7 @@
 
 import Geolocation from "@react-native-community/geolocation";
 import NetInfo from "@react-native-community/netinfo";
+import { onlineManager } from "@tanstack/react-query";
 import RootDrawerNavigator from "navigation/rootDrawerNavigator";
 import { RealmContext } from "providers/contexts.ts";
 import type { Node } from "react";
@@ -55,6 +56,12 @@ type Props = {
 const App = ( { children }: Props ): Node => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
+
+  // need to add this for auto refetch in React Native
+  // https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
+  onlineManager.setEventListener( setOnline => NetInfo.addEventListener( state => {
+    setOnline( !!state.isConnected );
+  } ) );
 
   useIconicTaxa( { reload: true } );
   useReactQueryRefetch( );

--- a/src/components/MyObservations/Announcements.js
+++ b/src/components/MyObservations/Announcements.js
@@ -68,7 +68,7 @@ const Announcements = ( {
     ["searchAnnouncements", apiParams],
     optsWithAuth => searchAnnouncements( apiParams, optsWithAuth ),
     {
-      enabled: !!isConnected && !!currentUser
+      enabled: !!( currentUser )
     }
   );
 

--- a/src/components/UserProfile/UserProfile.js
+++ b/src/components/UserProfile/UserProfile.js
@@ -1,8 +1,5 @@
 // @flow
 
-import {
-  useNetInfo
-} from "@react-native-community/netinfo";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { fetchRelationships } from "api/relationships";
 import { fetchRemoteUser } from "api/users";
@@ -40,7 +37,6 @@ const UserProfile = ( ): Node => {
   const { userId } = params;
   const [showLoginSheet, setShowLoginSheet] = useState( false );
   const [showUnfollowSheet, setShowUnfollowSheet] = useState( false );
-  const { isConnected } = useNetInfo( );
   const { t } = useTranslation( );
 
   const { data: remoteUser } = useAuthenticatedQuery(
@@ -61,7 +57,7 @@ const UserProfile = ( ): Node => {
       ttl: -1
     }, optsWithAuth ),
     {
-      enabled: !!isConnected && !!currentUser
+      enabled: !!currentUser
     }
   );
   let relationshipResults = null;

--- a/src/navigation/BottomTabNavigator/NotificationsIconContainer.js
+++ b/src/navigation/BottomTabNavigator/NotificationsIconContainer.js
@@ -1,7 +1,4 @@
 // @flow
-import {
-  useNetInfo
-} from "@react-native-community/netinfo";
 import { fetchUnviewedObservationUpdatesCount } from "api/observations";
 import NotificationsIcon from "navigation/BottomTabNavigator/NotificationsIcon";
 import type { Node } from "react";
@@ -41,7 +38,6 @@ const NotificationsIconContainer = ( {
   const [hasUnread, setHasUnread] = useState( false );
   const [numFetchIntervals, setNumFetchIntervals] = useState( 0 );
   const currentUser = useCurrentUser( );
-  const { isConnected } = useNetInfo( );
   const observationMarkedAsViewedAt = useStore( state => state.observationMarkedAsViewedAt );
 
   const { data: unviewedUpdatesCount } = useAuthenticatedQuery(
@@ -56,7 +52,7 @@ const NotificationsIconContainer = ( {
     ],
     optsWithAuth => fetchUnviewedObservationUpdatesCount( optsWithAuth ),
     {
-      enabled: !!currentUser && !!isConnected
+      enabled: !!( currentUser )
     }
   );
 

--- a/src/sharedHelpers/logging.js
+++ b/src/sharedHelpers/logging.js
@@ -1,4 +1,3 @@
-import { onlineManager } from "@tanstack/react-query";
 import handleError from "api/error";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 
@@ -15,9 +14,7 @@ function inspect( target ) {
 // returning a promise is like returning true, which means it retries
 // forever
 function reactQueryRetry( failureCount, error, options = {} ) {
-  const isOnline = onlineManager.isOnline( );
-  const isOffline = !isOnline
-    && ( error instanceof TypeError && error.message.match( "Network request failed" ) );
+  const isOffline = error instanceof TypeError && error.message.match( "Network request failed" );
   const logger = options.logger || defaultLogger;
   if ( typeof ( options.beforeRetry ) === "function" ) {
     options.beforeRetry( failureCount, error );

--- a/src/sharedHelpers/logging.js
+++ b/src/sharedHelpers/logging.js
@@ -1,3 +1,4 @@
+import { onlineManager } from "@tanstack/react-query";
 import handleError from "api/error";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 
@@ -14,23 +15,23 @@ function inspect( target ) {
 // returning a promise is like returning true, which means it retries
 // forever
 function reactQueryRetry( failureCount, error, options = {} ) {
+  const isOnline = onlineManager.isOnline( );
+  const isOffline = !isOnline
+    && ( error instanceof TypeError && error.message.match( "Network request failed" ) );
   const logger = options.logger || defaultLogger;
   if ( typeof ( options.beforeRetry ) === "function" ) {
     options.beforeRetry( failureCount, error );
   }
   logger.warn(
     `reactQueryRetry, error: ${error.message}, failureCount: ${failureCount}, options:`,
-    options,
-    error
+    inspect( options?.queryKey )
   );
   let shouldRetry = failureCount < 2;
   if (
     // If this is an actual 408 Request Timeout error, we probably want to
     // retry... but this will probably never happen because at this point the
     // error hasn't been converted to an INatApiError
-    error.status === 408
-    // If there's just no network at the moment, definitely retry
-    || ( error instanceof TypeError && error.message.match( "Network request failed" ) )
+    error.status === 408 || isOffline
   ) {
     shouldRetry = failureCount < 3;
     console.log(
@@ -38,6 +39,11 @@ function reactQueryRetry( failureCount, error, options = {} ) {
       + `failureCount: ${failureCount}, shouldRetry: ${shouldRetry}, options: `,
       options
     );
+    // 20240905 amanda - not handling error here since we want these queries to retry
+    // immediately if there is an internet connection
+    // though i'm also not sure if we need to log these network request failed errors somewhere
+    // or if it's ok to suppress them
+    return shouldRetry;
   }
   // 404 means the record does not exist, so no need to retry
   if ( error.status === 404 ) {

--- a/src/sharedHooks/index.js
+++ b/src/sharedHooks/index.js
@@ -1,3 +1,4 @@
+export { default as useAuthenticatedInfiniteQuery } from "./useAuthenticatedInfiniteQuery";
 export { default as useAuthenticatedMutation } from "./useAuthenticatedMutation";
 export { default as useAuthenticatedQuery } from "./useAuthenticatedQuery";
 export { default as useCurrentUser } from "./useCurrentUser";

--- a/src/sharedHooks/useAuthenticatedInfiniteQuery.ts
+++ b/src/sharedHooks/useAuthenticatedInfiniteQuery.ts
@@ -1,0 +1,34 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
+// import { log } from "sharedHelpers/logger";
+import { reactQueryRetry } from "sharedHelpers/logging";
+
+// const logger = log.extend( "useAuthenticatedInfiniteQuery" );
+
+// Should work like React Query's useInfiniteQuery with our custom reactQueryRetry
+// and authentication
+const useAuthenticatedInfiniteQuery = (
+  queryKey: Array<string>,
+  queryFunction: Function,
+  queryOptions: Object = {}
+): Object => useInfiniteQuery( {
+  queryKey: [...queryKey, queryOptions.allowAnonymousJWT],
+  queryFn: async params => {
+    // logger.info( queryKey, "queryKey in useAuthenticatedInfiniteQuery" );
+    // Note, getJWT() takes care of fetching a new token if the existing
+    // one is expired. We *could* store the token in state with useState if
+    // fetching from RNSInfo becomes a performance issue
+    const apiToken = await getJWT( queryOptions.allowAnonymousJWT );
+    const options = {
+      api_token: apiToken
+    };
+    return queryFunction( params, options );
+  },
+  retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
+    queryKey
+  } ),
+  initialPageParam: 0,
+  ...queryOptions
+} );
+
+export default useAuthenticatedInfiniteQuery;

--- a/src/sharedHooks/useIconicTaxa.ts
+++ b/src/sharedHooks/useIconicTaxa.ts
@@ -1,6 +1,3 @@
-import {
-  useNetInfo
-} from "@react-native-community/netinfo";
 import { searchTaxa } from "api/taxa";
 import { RealmContext } from "providers/contexts.ts";
 import { useEffect, useState } from "react";
@@ -13,9 +10,8 @@ const { useRealm } = RealmContext;
 const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ) => {
   const { reload } = options;
   const realm = useRealm( );
-  const { isConnected } = useNetInfo( );
   const [isUpdatingRealm, setIsUpdatingRealm] = useState<boolean>( );
-  const enabled = !!isConnected && !!reload;
+  const enabled = !!( reload );
 
   const queryKey = ["searchTaxa", reload];
   const { data: iconicTaxa } = useAuthenticatedQuery(

--- a/src/sharedHooks/useInfiniteObservationsScroll.js
+++ b/src/sharedHooks/useInfiniteObservationsScroll.js
@@ -1,24 +1,17 @@
 // @flow
 
-import {
-  useNetInfo
-} from "@react-native-community/netinfo";
-import { useInfiniteQuery } from "@tanstack/react-query";
 import { searchObservations } from "api/observations";
-import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import { flatten, last, noop } from "lodash";
 import { RealmContext } from "providers/contexts.ts";
 import { useEffect } from "react";
 import Observation from "realmModels/Observation";
-import { useCurrentUser } from "sharedHooks";
+import { useAuthenticatedInfiniteQuery, useCurrentUser } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
 const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
-  const netInfo = useNetInfo( );
-  const isConnected = netInfo?.isConnected;
 
   const baseParams = {
     ...newInputParams,
@@ -36,15 +29,9 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
     isFetchingNextPage,
     fetchNextPage,
     status
-  } = useInfiniteQuery( {
-    // eslint-disable-next-line
+  } = useAuthenticatedInfiniteQuery(
     queryKey,
-    queryFn: async ( { pageParam } ) => {
-      const apiToken = await getJWT( );
-      const options = {
-        api_token: apiToken
-      };
-
+    async ( { pageParam }, optsWithAuth ) => {
       const params = {
         ...baseParams
       };
@@ -56,13 +43,14 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
         // $FlowIgnore
         params.page = 1;
       }
-      const { results } = await searchObservations( params, options );
+      const { results } = await searchObservations( params, optsWithAuth );
       return results.map( observation => Observation.mapApiToRealm( observation ) ) || [];
     },
-    initialPageParam: 0,
-    getNextPageParam: lastPage => last( lastPage )?.id,
-    enabled: !!( isConnected && currentUser )
-  } );
+    {
+      getNextPageParam: lastPage => last( lastPage )?.id,
+      enabled: !!( currentUser )
+    }
+  );
 
   useEffect( ( ) => {
     if ( observations?.pages && upsert ) {

--- a/src/sharedHooks/useInfiniteScroll.js
+++ b/src/sharedHooks/useInfiniteScroll.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { useInfiniteQuery } from "@tanstack/react-query";
 import { flatten } from "lodash";
+import { useAuthenticatedInfiniteQuery } from "sharedHooks";
 
 const useInfiniteScroll = (
   queryKey: string,
@@ -22,24 +22,24 @@ const useInfiniteScroll = (
     isFetchingNextPage,
     fetchNextPage,
     status
-  } = useInfiniteQuery( {
-    // eslint-disable-next-line
-    queryKey: [queryKey, baseParams],
-    queryFn: async ( { pageParam = 0 } ) => {
+  } = useAuthenticatedInfiniteQuery(
+    [queryKey, baseParams],
+    async ( { pageParam = 0 }, optsWithAuth ) => {
       const params = {
         ...baseParams
       };
 
       params.page = pageParam;
 
-      return apiCall( params );
+      return apiCall( params, optsWithAuth );
     },
-    initialPageParam: 0,
-    getNextPageParam: lastPage => ( lastPage
-      ? lastPage.page + 1
-      : 1 ),
-    enabled: options.enabled
-  } );
+    {
+      getNextPageParam: lastPage => ( lastPage
+        ? lastPage.page + 1
+        : 1 ),
+      enabled: options.enabled
+    }
+  );
 
   const pages = data?.pages;
   const allResults = pages?.map( page => page?.results );

--- a/src/sharedHooks/useObservationsUpdates.js
+++ b/src/sharedHooks/useObservationsUpdates.js
@@ -1,8 +1,5 @@
 // @flow
 
-import {
-  useNetInfo
-} from "@react-native-community/netinfo";
 import { fetchObservationUpdates } from "api/observations";
 import { RealmContext } from "providers/contexts.ts";
 import { useEffect } from "react";
@@ -15,7 +12,6 @@ export const fetchObservationUpdatesKey = "fetchObservationUpdates";
 
 const useObservationsUpdates = ( enabled: boolean ): Object => {
   const realm = useRealm();
-  const { isConnected } = useNetInfo( );
 
   // Request params for fetching unviewed updates
   const baseParams = {
@@ -31,7 +27,7 @@ const useObservationsUpdates = ( enabled: boolean ): Object => {
   } = useAuthenticatedQuery(
     [fetchObservationUpdatesKey],
     optsWithAuth => fetchObservationUpdates( baseParams, optsWithAuth ),
-    { enabled: !!isConnected && !!enabled }
+    { enabled: !!( enabled ) }
   );
 
   /*

--- a/src/sharedHooks/useUserMe.js
+++ b/src/sharedHooks/useUserMe.js
@@ -1,7 +1,4 @@
 // @flow
-import {
-  useNetInfo
-} from "@react-native-community/netinfo";
 import { fetchUserMe } from "api/users";
 import { RealmContext } from "providers/contexts.ts";
 import { useCallback, useEffect } from "react";
@@ -17,8 +14,7 @@ const useUserMe = ( options: ?Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
   const updateRealm = options?.updateRealm;
-  const { isConnected } = useNetInfo( );
-  const enabled = !!isConnected && !!currentUser;
+  const enabled = !!( currentUser );
 
   const {
     data: remoteUser,


### PR DESCRIPTION
Addresses part of #1847

This doesn't solve the original problem where uploads fail, but it addresses the issue with React Query attempting endless retries without being online.

- Uses the `onlineManager` event listener in React Query to listen for whether the app is online or offline
- Refactors `useInfiniteQuery` into `useAuthenticatedInfiniteQuery` to make sure we're attempting retries uniformly across the app
- Removes checks for network connectivity from the `enabled` option in various individual queries, since we're instead handling that globally