### PR TITLE
Set AI camera inactive immediately after taking photo

### DIFF
--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -86,6 +86,7 @@ const AICamera = ( {
     takingPhoto,
     toggleFlash
   } = useTakePhoto( camera, false, device );
+  const [active, setActive] = React.useState( true );
   const { t } = useTranslation();
   const theme = useTheme();
   const navigation = useNavigation();
@@ -112,7 +113,7 @@ const AICamera = ( {
   }, [navigation, setResult, resetZoom] );
 
   const handlePress = async ( ) => {
-    await takePhoto( { replaceExisting: true } );
+    await takePhoto( { replaceExisting: true, photoTakenCallback: () => setActive( false ) } );
     handleCheckmarkPress( showPrediction
       ? result
       : null );
@@ -140,6 +141,7 @@ const AICamera = ( {
             animatedProps={animatedProps}
             pinchToZoom={pinchToZoom}
             takingPhoto={takingPhoto}
+            active={active}
           />
         </View>
       )}

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -113,7 +113,7 @@ const AICamera = ( {
   }, [navigation, setResult, resetZoom] );
 
   const handlePress = async ( ) => {
-    await takePhoto( { replaceExisting: true, photoTakenCallback: () => setActive( false ) } );
+    await takePhoto( { replaceExisting: true, inactivateCallback: () => setActive( false ) } );
     handleCheckmarkPress( showPrediction
       ? result
       : null );

--- a/src/components/Camera/AICamera/FrameProcessorCamera.js
+++ b/src/components/Camera/AICamera/FrameProcessorCamera.js
@@ -35,7 +35,8 @@ type Props = {
   onLog: Function,
   onTaxaDetected: Function,
   pinchToZoom?: Function,
-  takingPhoto: boolean
+  takingPhoto: boolean,
+  active?: boolean
 };
 
 const DEFAULT_FPS = 1;
@@ -60,7 +61,8 @@ const FrameProcessorCamera = ( {
   onLog,
   onTaxaDetected,
   pinchToZoom,
-  takingPhoto
+  takingPhoto,
+  active
 }: Props ): Node => {
   const { deviceOrientation } = useDeviceOrientation();
   const [lastTimestamp, setLastTimestamp] = useState( Date.now() );
@@ -177,6 +179,7 @@ const FrameProcessorCamera = ( {
       onClassifierError={onClassifierError}
       onDeviceNotSupported={onDeviceNotSupported}
       pinchToZoom={pinchToZoom}
+      active={active}
     />
   );
 };

--- a/src/components/Camera/CameraView.tsx
+++ b/src/components/Camera/CameraView.tsx
@@ -32,7 +32,8 @@ interface Props {
   onClassifierError?: Function,
   onDeviceNotSupported?: Function,
   pinchToZoom?: Function,
-  resizeMode?: string
+  resizeMode?: "cover" | "contain",
+  active?: boolean
 }
 
 // A container for the Camera component
@@ -47,7 +48,8 @@ const CameraView = ( {
   onClassifierError,
   onDeviceNotSupported,
   pinchToZoom,
-  resizeMode
+  resizeMode,
+  active
 }: Props ) => {
   const {
     animatedStyle,
@@ -57,7 +59,7 @@ const CameraView = ( {
   // check if camera page is active
   const isFocused = useIsFocused( );
   const appState = useAppState( );
-  const isActive = isFocused && appState === "active";
+  const isActive = !!active && isFocused && appState === "active";
 
   // Select a format that provides the highest resolution for photos and videos
   const iosFormat = useCameraFormat( device, [

--- a/src/components/Camera/hooks/useTakePhoto.ts
+++ b/src/components/Camera/hooks/useTakePhoto.ts
@@ -79,7 +79,7 @@ const useTakePhoto = (
     inactivateCallback?: () => void,
     replaceExisting?: boolean
   }
-  const takePhoto = async ( options: Options ) => {
+  const takePhoto = async ( options: Options = {} ) => {
     setTakingPhoto( true );
     // On Android, setting the camera to inactive before taking a photo
     // crashes the app. So we only set it to inactive on iOS here.

--- a/src/components/Camera/hooks/useTakePhoto.ts
+++ b/src/components/Camera/hooks/useTakePhoto.ts
@@ -74,9 +74,14 @@ const useTakePhoto = (
     }
   };
 
-  const takePhoto = async ( options = { } ) => {
+  interface Options {
+    photoTakenCallback?: () => void,
+    replaceExisting?: boolean
+  }
+  const takePhoto = async ( options: Options ) => {
     setTakingPhoto( true );
     const cameraPhoto = await camera.current.takePhoto( takePhotoOptions );
+    if ( options.photoTakenCallback ) options.photoTakenCallback();
     const uri = await saveRotatedPhotoToDocumentsDirectory( cameraPhoto );
     await updateStore( uri, options );
     setTakingPhoto( false );

--- a/src/components/Camera/hooks/useTakePhoto.ts
+++ b/src/components/Camera/hooks/useTakePhoto.ts
@@ -2,6 +2,7 @@ import { RealmContext } from "providers/contexts.ts";
 import React, {
   useState
 } from "react";
+import { Platform } from "react-native";
 import {
   Camera, CameraDevice, PhotoFile, TakePhotoOptions
 } from "react-native-vision-camera";
@@ -75,13 +76,19 @@ const useTakePhoto = (
   };
 
   interface Options {
-    photoTakenCallback?: () => void,
+    inactivateCallback?: () => void,
     replaceExisting?: boolean
   }
   const takePhoto = async ( options: Options ) => {
     setTakingPhoto( true );
+    // On Android, setting the camera to inactive before taking a photo
+    // crashes the app. So we only set it to inactive on iOS here.
+    // We do set it to inactive on Android immediately after taking the photo,
+    // this does leave a short period of time where the camera preview is still active
+    // after taking the photo which we need to revisit on Android launch.
+    if ( Platform.OS === "ios" && options.inactivateCallback ) options.inactivateCallback();
     const cameraPhoto = await camera.current.takePhoto( takePhotoOptions );
-    if ( options.photoTakenCallback ) options.photoTakenCallback();
+    if ( options.inactivateCallback ) options.inactivateCallback();
     const uri = await saveRotatedPhotoToDocumentsDirectory( cameraPhoto );
     await updateStore( uri, options );
     setTakingPhoto( false );


### PR DESCRIPTION
This freezes the preview immediately after taking a photo. There is a delay between button press and freeze now, don't know if this is good enough.

Edit: The delay is only on Android because on iOS we set the camera to inactive just before taking the photo. On Android this errors out with the message that the camera is inactive and can't be used to take a photo. This is an inconsistency in the camera library and we would need to keep an eye on whether this function breaks on camera updates.