### PR TITLE
Update exif-reader library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "react-native-draggable-flatlist": "^4.0.1",
         "react-native-event-listeners": "^1.0.7",
         "react-native-exception-handler": "^2.10.10",
-        "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.2",
+        "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#9170d8d73ee1fc054e0f67f698be03129b04d6dd",
         "react-native-fs": "^2.20.0",
         "react-native-geocoder-reborn": "^0.9.0",
         "react-native-gesture-handler": "^2.16.0",
@@ -17380,7 +17380,8 @@
     },
     "node_modules/react-native-exif-reader": {
       "version": "0.4.2",
-      "resolved": "git+ssh://git@github.com/inaturalist/react-native-exif-reader.git#a453595ffb76ca641fd841ee7b4cce1ed9377831",
+      "resolved": "git+ssh://git@github.com/inaturalist/react-native-exif-reader.git#9170d8d73ee1fc054e0f67f698be03129b04d6dd",
+      "integrity": "sha512-T67hzpDxxOsVd7swpPkXAqJHkvwEKMOZsBJdw9oHsiw75btwNoz1q7GzMys/ErOw2+MTOINv+Xde727fbOSpAQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "react-native-draggable-flatlist": "^4.0.1",
         "react-native-event-listeners": "^1.0.7",
         "react-native-exception-handler": "^2.10.10",
-        "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#9170d8d73ee1fc054e0f67f698be03129b04d6dd",
+        "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.3",
         "react-native-fs": "^2.20.0",
         "react-native-geocoder-reborn": "^0.9.0",
         "react-native-gesture-handler": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-native-draggable-flatlist": "^4.0.1",
     "react-native-event-listeners": "^1.0.7",
     "react-native-exception-handler": "^2.10.10",
-    "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.2",
+    "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#9170d8d73ee1fc054e0f67f698be03129b04d6dd",
     "react-native-fs": "^2.20.0",
     "react-native-geocoder-reborn": "^0.9.0",
     "react-native-gesture-handler": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-native-draggable-flatlist": "^4.0.1",
     "react-native-event-listeners": "^1.0.7",
     "react-native-exception-handler": "^2.10.10",
-    "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#9170d8d73ee1fc054e0f67f698be03129b04d6dd",
+    "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.3",
     "react-native-fs": "^2.20.0",
     "react-native-geocoder-reborn": "^0.9.0",
     "react-native-gesture-handler": "^2.16.0",

--- a/src/sharedHelpers/parseExif.js
+++ b/src/sharedHelpers/parseExif.js
@@ -2,7 +2,6 @@
 
 import { utcToZonedTime } from "date-fns-tz";
 import { readExif, writeLocation } from "react-native-exif-reader";
-import * as RNLocalize from "react-native-localize";
 import { formatISONoTimezone } from "sharedHelpers/dateAndTime";
 
 class UsePhotoExifDateFormatError extends Error {}
@@ -16,11 +15,10 @@ Object.defineProperty( UsePhotoExifDateFormatError.prototype, "name", {
 export const parseExifDateToLocalTimezone = ( datetime: string ): ?Date => {
   if ( !datetime ) return null;
 
+  // react-native-exif-reader formats the date based on GMT time,
+  // so we create a date object here using GMT time, not the user's local timezone
   const isoDate = `${datetime}Z`;
-
-  // Use local timezone from device
-  const timeZone = RNLocalize.getTimeZone( );
-  const zonedDate = utcToZonedTime( isoDate, timeZone );
+  const zonedDate = utcToZonedTime( isoDate, "GMT" );
 
   if ( !zonedDate || zonedDate.toString( ).match( /invalid/i ) ) {
     throw new UsePhotoExifDateFormatError( "Date was not formatted correctly" );


### PR DESCRIPTION
Since timezone conversion is already happening on the native side of things, we don't need to also convert date to a user's local timezone in iNaturalistReactNative. Instead, we can use the GMT date returned from the (fixed) `react-native-exif-reader`.

Closes #1516

