### PR TITLE
Fixes for camera zoom

### DIFF
--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -57,7 +57,7 @@ const AICamera = ( {
   const { isDebug } = useDebugMode( );
   const {
     animatedProps,
-    changeZoom,
+    handleZoomButtonPress,
     pinchToZoom,
     showZoomButton,
     zoomTextValue,
@@ -201,7 +201,7 @@ const AICamera = ( {
       )}
       <FadeInOutView takingPhoto={takingPhoto} />
       <AICameraButtons
-        changeZoom={changeZoom}
+        handleZoomButtonPress={handleZoomButtonPress}
         confidenceThreshold={confidenceThreshold}
         cropRatio={cropRatio}
         flipCamera={flipCamera}

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -16,7 +16,7 @@ import AIDebugButton from "./AIDebugButton";
 const isTablet = DeviceInfo.isTablet();
 
 interface Props {
-  changeZoom: ( _event: GestureResponderEvent ) => void;
+  handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   confidenceThreshold?: number;
   cropRatio?: string;
   flipCamera: ( _event: GestureResponderEvent ) => void;
@@ -40,7 +40,7 @@ interface Props {
 }
 
 const AICameraButtons = ( {
-  changeZoom,
+  handleZoomButtonPress,
   confidenceThreshold,
   cropRatio,
   flipCamera,
@@ -64,7 +64,7 @@ const AICameraButtons = ( {
   if ( isTablet ) {
     return (
       <TabletButtons
-        changeZoom={changeZoom}
+        handleZoomButtonPress={handleZoomButtonPress}
         disabled={!modelLoaded || takingPhoto}
         flipCamera={flipCamera}
         hasFlash={hasFlash}
@@ -111,7 +111,7 @@ const AICameraButtons = ( {
         <View>
           <Zoom
             zoomTextValue={zoomTextValue}
-            changeZoom={changeZoom}
+            handleZoomButtonPress={handleZoomButtonPress}
             showZoomButton={showZoomButton}
             rotatableAnimatedStyle={rotatableAnimatedStyle}
           />

--- a/src/components/Camera/Buttons/Zoom.tsx
+++ b/src/components/Camera/Buttons/Zoom.tsx
@@ -14,7 +14,7 @@ const isTablet = DeviceInfo.isTablet();
 
 interface Props {
   rotatableAnimatedStyle: ViewStyle;
-  changeZoom: ( _event: GestureResponderEvent ) => void;
+  handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   zoomClassName?: string;
   zoomTextValue: string;
   showZoomButton: boolean;
@@ -22,7 +22,7 @@ interface Props {
 
 const CameraZoom = ( {
   rotatableAnimatedStyle,
-  changeZoom,
+  handleZoomButtonPress,
   zoomClassName,
   zoomTextValue,
   showZoomButton
@@ -42,7 +42,7 @@ const CameraZoom = ( {
     >
       <Pressable
         className={classnames( CIRCLE_OPTIONS_CLASSES, CIRCLE_SIZE )}
-        onPress={changeZoom}
+        onPress={handleZoomButtonPress}
         accessibilityRole="button"
         accessibilityLabel={t( "Change-zoom" )}
         accessibilityState={{ disabled: false }}

--- a/src/components/Camera/CameraView.tsx
+++ b/src/components/Camera/CameraView.tsx
@@ -142,6 +142,7 @@ const CameraView = ( {
           ref={cameraRef}
           animatedProps={animatedProps}
           device={device}
+          // we can't use the native zoom since it doesn't expose a zoom value to JS
           enableZoomGesture={false}
           exposure={exposure}
           format={format}

--- a/src/components/Camera/StandardCamera/CameraOptionsButtons.js
+++ b/src/components/Camera/StandardCamera/CameraOptionsButtons.js
@@ -21,7 +21,7 @@ type Props = {
   handleCheckmarkPress: Function,
   toggleFlash: Function,
   flipCamera: Function,
-  changeZoom: Function,
+  handleZoomButtonPress: Function,
   hasFlash: boolean,
   takePhotoOptions: Object,
   zoomTextValue: string,
@@ -39,7 +39,7 @@ const CameraOptionsButtons = ( {
   flipCamera,
   hasFlash,
   takePhotoOptions,
-  changeZoom,
+  handleZoomButtonPress,
   zoomTextValue,
   showZoomButton
 }: Props ): Node => {
@@ -54,7 +54,7 @@ const CameraOptionsButtons = ( {
       />
       <Zoom
         showZoomButton={showZoomButton}
-        changeZoom={changeZoom}
+        handleZoomButtonPress={handleZoomButtonPress}
         zoomTextValue={zoomTextValue}
         rotatableAnimatedStyle={rotatableAnimatedStyle}
         zoomClassName="absolute bottom-[18px] self-center"
@@ -80,7 +80,7 @@ const CameraOptionsButtons = ( {
       flipCamera={flipCamera}
       hasFlash={hasFlash}
       takePhotoOptions={takePhotoOptions}
-      changeZoom={changeZoom}
+      handleZoomButtonPress={handleZoomButtonPress}
       zoomTextValue={zoomTextValue}
       showZoomButton={showZoomButton}
     />

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -63,7 +63,7 @@ const StandardCamera = ( {
   const hasFlash = device?.hasFlash;
   const {
     animatedProps,
-    changeZoom,
+    handleZoomButtonPress,
     pinchToZoom,
     resetZoom,
     showZoomButton,
@@ -184,7 +184,7 @@ const StandardCamera = ( {
         )}
         <FadeInOutView takingPhoto={takingPhoto} />
         <CameraOptionsButtons
-          changeZoom={changeZoom}
+          handleZoomButtonPress={handleZoomButtonPress}
           disabled={disallowAddingPhotos}
           flipCamera={flipCamera}
           handleCheckmarkPress={handleCheckmarkPress}

--- a/src/components/Camera/TabletButtons.tsx
+++ b/src/components/Camera/TabletButtons.tsx
@@ -37,7 +37,7 @@ const cameraOptionsClasses = [
 ].join( " " );
 
 interface Props {
-  changeZoom: ( _event: GestureResponderEvent ) => void;
+  handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   disabled: boolean;
   flipCamera: ( _event: GestureResponderEvent ) => void;
   handleCheckmarkPress?: ( _event: GestureResponderEvent ) => void;
@@ -70,7 +70,7 @@ const CameraButtonPlaceholder = ( { extraClassName }: { extraClassName?: string 
 );
 
 const TabletButtons = ( {
-  changeZoom,
+  handleZoomButtonPress,
   disabled,
   flipCamera,
   handleCheckmarkPress,
@@ -100,7 +100,7 @@ const TabletButtons = ( {
     <View className={classnames( tabletCameraOptionsClasses )} pointerEvents="box-none">
       { photosTaken && <CameraButtonPlaceholder extraClassName="mb-[25px]" /> }
       <Zoom
-        changeZoom={changeZoom}
+        handleZoomButtonPress={handleZoomButtonPress}
         zoomTextValue={zoomTextValue}
         showZoomButton={showZoomButton}
         rotatableAnimatedStyle={rotatableAnimatedStyle}

--- a/src/components/Camera/hooks/useZoom.ts
+++ b/src/components/Camera/hooks/useZoom.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import {
   useCallback,
   useMemo,
@@ -16,37 +17,46 @@ import {
 import type { CameraProps } from "react-native-vision-camera";
 
 // This is taken from react-native-vision library itself: https://github.com/mrousavy/react-native-vision-camera/blob/9eed89aac6155eba155595f3e006707152550d0d/package/example/src/Constants.ts#L19 https://github.com/mrousavy/react-native-vision-camera/blob/9eed89aac6155eba155595f3e006707152550d0d/package/example/src/CameraPage.tsx#L34
+
 // The maximum zoom factor you should be able to zoom in
 const MAX_ZOOM_FACTOR = 20;
+
 // Used for calculating the final zoom by pinch gesture
 const SCALE_FULL_ZOOM = 3;
 
+const zoomButtonOptions = [".5", "1", "3"];
+
 const useZoom = ( device: Object ): Object => {
-  const initialZoom = !device.isMultiCam
-    ? device.minZoom
-    : device.neutralZoom;
+  const minZoom = device?.minZoom ?? 1;
+  const neutralZoom = device?.neutralZoom ?? 2;
+  // this maxZoom zooms to 3x magnification on an iPhone 15 Pro
+  // currently the camera viewport is different than the photo taken
+  // so the photo taken with this zoom looks accurate compared with the native camera
+  // photo taken, but the camera preview looks a little too small
+  const maxZoomWithButton = neutralZoom ** 2.5;
+  const maxZoomWithPinch = Math.min( device.maxZoom ?? 1, MAX_ZOOM_FACTOR );
+  const initialZoom = !device?.isMultiCam
+    ? minZoom
+    : neutralZoom;
   const zoom = useSharedValue( initialZoom );
   const startZoom = useSharedValue( initialZoom );
-  const [zoomTextValue, setZoomTextValue] = useState( "1" );
+  const [zoomTextValue, setZoomTextValue] = useState( zoomButtonOptions[1] );
 
-  const { minZoom } = device;
-  const maxZoom = Math.min( device.maxZoom ?? 1, MAX_ZOOM_FACTOR );
+  const zoomButtonValues = [minZoom, neutralZoom, maxZoomWithButton];
 
-  const changeZoom = ( ) => {
-    const currentZoomValue = zoomTextValue;
-    if ( currentZoomValue === "1" ) {
-      zoom.value = withSpring( maxZoom );
-      setZoomTextValue( "3" );
-    } else if ( currentZoomValue === "3" ) {
-      zoom.value = withSpring( minZoom );
-      setZoomTextValue( ".5" );
+  const handleZoomButtonPress = ( ) => {
+    if ( zoomTextValue === _.last( zoomButtonOptions ) ) {
+      zoom.value = withSpring( zoomButtonValues[0] );
+      setZoomTextValue( zoomButtonOptions[0] );
     } else {
-      zoom.value = withSpring( device.neutralZoom );
-      setZoomTextValue( "1" );
+      const zoomIndex = _.indexOf( zoomButtonOptions, zoomTextValue );
+      zoom.value = withSpring( zoomButtonValues[zoomIndex + 1] );
+      setZoomTextValue( zoomButtonOptions[zoomIndex + 1] );
     }
   };
 
   const onZoomStart = useCallback( ( ) => {
+    // start pinch-to-zoom
     startZoom.value = zoom.value;
   }, [
     startZoom,
@@ -58,7 +68,7 @@ const useZoom = ( device: Object ): Object => {
   };
 
   const onZoomChange = useCallback( scale => {
-    // Calculate new zoom value (since scale factor is relative to initial pinch)
+    // Calculate new zoom value from pinch to zoom (since scale factor is relative to initial pinch)
     const newScale = interpolate(
       scale,
       [1 - 1 / SCALE_FULL_ZOOM, 1, SCALE_FULL_ZOOM],
@@ -68,12 +78,25 @@ const useZoom = ( device: Object ): Object => {
     const newZoom = interpolate(
       newScale,
       [-1, 0, 1],
-      [minZoom, startZoom.value, maxZoom],
+      [minZoom, startZoom.value, maxZoomWithPinch],
       Extrapolate.CLAMP
     );
     zoom.value = newZoom;
+
+    const closestZoomTextValue = zoomButtonOptions.reduce(
+      ( prev, curr ) => {
+        if ( newZoom === minZoom ) {
+          return zoomButtonOptions[0];
+        }
+        return (
+          Math.abs( curr - newZoom ) < Math.abs( prev - newZoom )
+            ? curr
+            : prev );
+      }
+    );
+    setZoomTextValue( closestZoomTextValue );
   }, [
-    maxZoom,
+    maxZoomWithPinch,
     minZoom,
     startZoom.value,
     zoom
@@ -86,7 +109,7 @@ const useZoom = ( device: Object ): Object => {
 
   const pinchToZoom = useMemo( ( ) => Gesture.Pinch( )
     .runOnJS( true )
-    .onStart( _ => {
+    .onStart( ( ) => {
       onZoomStart( );
     } ).onChange( ( e: GestureResponderEvent ) => {
       onZoomChange( e.scale );
@@ -97,12 +120,10 @@ const useZoom = ( device: Object ): Object => {
 
   return {
     animatedProps,
-    changeZoom,
-    onZoomChange,
-    onZoomStart,
+    handleZoomButtonPress,
     pinchToZoom,
     resetZoom,
-    showZoomButton: device.isMultiCam,
+    showZoomButton: device?.isMultiCam,
     zoomTextValue
   };
 };


### PR DESCRIPTION
Closes #1984
Closes #2053

- Show zoom button text when using pinch-to-zoom
- Set 3x zoom to a similar magnification level as the native camera app, rather than the maximum zoom level we use for pinch-to-zoom