### PR TITLE
Fetch taxon common names

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -23,6 +23,7 @@ import useFreshInstall from "./hooks/useFreshInstall";
 import useLinking from "./hooks/useLinking";
 import useLockOrientation from "./hooks/useLockOrientation";
 import useReactQueryRefetch from "./hooks/useReactQueryRefetch";
+import useTaxonCommonNames from "./hooks/useTaxonCommonNames";
 
 const { useRealm } = RealmContext;
 
@@ -75,6 +76,7 @@ const App = ( { children }: Props ): Node => {
   useLockOrientation( );
   useShare( );
   useObservationUpdatesWhenFocused( );
+  useTaxonCommonNames( );
 
   useEffect( ( ) => {
     addARCameraFiles( );

--- a/src/components/hooks/useTaxonCommonNames.ts
+++ b/src/components/hooks/useTaxonCommonNames.ts
@@ -1,0 +1,76 @@
+import { fetchSpeciesCounts } from "api/observations";
+import { RealmContext } from "providers/contexts.ts";
+import { useEffect } from "react";
+import Taxon from "realmModels/Taxon";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { useAuthenticatedQuery } from "sharedHooks";
+
+const { useRealm } = RealmContext;
+
+// Some of the following code might be repetitive with useTaxon
+// since we're storing taxon data to realm in each case
+const ONE_WEEK_MS = (
+  1000 // ms / s
+  * 60 // s / min
+  * 60 // min / hr
+  * 24 // hr / day
+  * 7 // day / wk
+);
+
+const useTaxonCommonNames = ( ) => {
+  const realm = useRealm( );
+  const { data } = useAuthenticatedQuery(
+    ["fetchSpeciesCounts"],
+    ( ) => fetchSpeciesCounts( {
+      fields: {
+        taxon: {
+          id: true,
+          preferred_common_name: true,
+          name: true
+        }
+      },
+      per_page: 500
+    } )
+  );
+
+  useEffect( ( ) => {
+    if ( data?.results ) {
+      data.results.forEach( ( { taxon } ) => {
+        const taxonId = taxon?.id;
+        const localTaxon = taxonId && realm.objectForPrimaryKey( "Taxon", taxonId );
+        const missingName = localTaxon
+          ? ( !localTaxon.preferred_common_name || !localTaxon.name )
+          : false;
+        const outOfDate = localTaxon
+          ? ( localTaxon._synced_at && ( Date.now( ) - localTaxon._synced_at > ONE_WEEK_MS ) )
+          : false;
+        const localTaxonNeedsSync = (
+          // Definitely sync if there's no local copy
+          !localTaxon
+            // Sync if the local copy hasn't been synced in a week
+            || outOfDate
+            // Sync if missing a common name or name
+            || missingName
+        );
+
+        const mappedTaxon = taxon
+          ? Taxon.mapApiToRealm( taxon, realm )
+          : null;
+
+        if ( localTaxonNeedsSync ) {
+          safeRealmWrite( realm, ( ) => {
+            realm.create(
+              "Taxon",
+              { ...mappedTaxon, _synced_at: new Date( ) },
+              "modified"
+            );
+          }, "saving taxon in useTaxonCommonNames" );
+        }
+      } );
+    }
+  }, [data, realm] );
+
+  return null;
+};
+
+export default useTaxonCommonNames;

--- a/src/components/hooks/useTaxonCommonNames.ts
+++ b/src/components/hooks/useTaxonCommonNames.ts
@@ -23,8 +23,6 @@ const useTaxonCommonNames = ( ) => {
   const { hasPermissions } = useLocationPermission( );
   const [userLocation, setUserLocation] = useState( null );
 
-  console.log( hasPermissions, "has permissions" );
-
   const params = {
     per_page: 500,
     fields: {


### PR DESCRIPTION
Closes #1958

When user opens the app, check for location permissions. If they granted permission, fetch the 500 taxon closest to their location. If not, fetch the 500 most observed taxon across the globe.

Store taxon names and common names in Realm if they're not already there or if they're out of date.