### PR TITLE
Add toggle button for RTL/LTR on debug screen

### DIFF
--- a/src/components/Developer/Developer.js
+++ b/src/components/Developer/Developer.js
@@ -12,9 +12,10 @@ import { fontMonoClass, View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React, { useCallback } from "react";
-import { Platform, Text } from "react-native";
+import { I18nManager, Platform, Text } from "react-native";
 import Config from "react-native-config";
 import RNFS from "react-native-fs";
+import RNRestart from "react-native-restart";
 import useLogs from "sharedHooks/useLogs";
 
 import useAppSize, {
@@ -86,6 +87,12 @@ const Developer = (): Node => {
     );
   } ), [fileSizes] );
 
+  const toggleRTLandLTR = async ( ) => {
+    const { isRTL, forceRTL } = I18nManager;
+    await forceRTL( !isRTL );
+    RNRestart.restart( );
+  };
+
   const navigation = useNavigation( );
   const { shareLogFile, emailLogFile } = useLogs();
   return (
@@ -129,6 +136,11 @@ const Developer = (): Node => {
               <Button
                 onPress={async () => { throw new Error( "Test error in promise" ); }}
                 text="TEST UNHANDLED PROMISE REJECTION"
+                className="mb-5"
+              />
+              <Button
+                onPress={toggleRTLandLTR}
+                text="TOGGLE RTL<>LTR"
                 className="mb-5"
               />
             </>

--- a/src/components/SharedComponents/Buttons/BackButton.js
+++ b/src/components/SharedComponents/Buttons/BackButton.js
@@ -3,7 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import { Image } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { Platform } from "react-native";
+import { I18nManager, Platform } from "react-native";
 import {
   useTranslation
 } from "sharedHooks";
@@ -47,6 +47,7 @@ const BackButton = ( {
   customStyles,
   testID = "BackButton"
 }: Props ): Node => {
+  const { isRTL } = I18nManager;
   const navigation = useNavigation();
   const tintColor = color || colors.black;
   const { t } = useTranslation( );
@@ -54,7 +55,8 @@ const BackButton = ( {
   const imageStyles = [
     !inCustomHeader && REACT_NAVIGATION_BACK_BUTTON_STYLES.icon,
     Boolean( tintColor ) && { tintColor },
-    customStyles
+    customStyles,
+    isRTL && { transform: [{ rotateY: "180deg" }] }
   ];
 
   const backImage = ( ) => (


### PR DESCRIPTION
This makes it possible to see what we'll need to work on to support RTL. When a user toggles this button in debug mode, the app will change into either RTL or LTR and restart.

Until we have translations, we should ignore the text alignment since it's likely this will be detected automatically if there are Hebrew or Arabic characters.

Also reverses the back arrow direction for RTL.