### PR TITLE
Support FlashList in RTL mode

### DIFF
--- a/src/components/Developer/UiLibrary/Misc.js
+++ b/src/components/Developer/UiLibrary/Misc.js
@@ -332,8 +332,8 @@ const Misc = (): Node => {
         <View className="my-2 bg-lightGray p-2 rounded-lg flex-row justify-evenly">
           <PhotoCount count={0} />
           <PhotoCount count={2} />
-          <PhotoCount count={12} size={50} />
-          <PhotoCount count={1000} size={50} shadow />
+          <PhotoCount count={12} />
+          <PhotoCount count={1000} />
         </View>
 
         <Heading2 className="my-2">ActivityItem</Heading2>

--- a/src/components/Explore/ExploreFlashList.js
+++ b/src/components/Explore/ExploreFlashList.js
@@ -1,7 +1,6 @@
 // @flow
-import { FlashList } from "@shopify/flash-list";
 import InfiniteScrollLoadingWheel from "components/MyObservations/InfiniteScrollLoadingWheel";
-import { ActivityIndicator, Body3 } from "components/SharedComponents";
+import { ActivityIndicator, Body3, CustomFlashList } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback } from "react";
@@ -71,27 +70,17 @@ const ExploreFlashList = ( {
     </View>
   ), [canFetch, renderLoading, t] );
 
-  const headerComponentStyle = layout === "grid" && {
-    marginLeft: -7,
-    marginRight: -7
-  };
-
   return (
-    <FlashList
+    <CustomFlashList
       ItemSeparatorComponent={renderItemSeparator}
       ListEmptyComponent={renderEmptyComponent}
       ListFooterComponent={renderFooter}
-      ListHeaderComponentStyle={headerComponentStyle}
-      accessible
       contentContainerStyle={contentContainerStyle}
       data={data}
       estimatedItemSize={estimatedItemSize}
-      horizontal={false}
-      initialNumToRender={5}
       keyExtractor={keyExtractor}
       numColumns={numColumns}
       onEndReached={fetchNextPage}
-      onEndReachedThreshold={1}
       refreshing={isFetchingNextPage}
       renderItem={renderItem}
       testID={testID}

--- a/src/components/Explore/SearchScreens/ExploreLocationSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreLocationSearch.js
@@ -4,8 +4,6 @@ import fetchSearchResults from "api/search";
 import {
   Body3,
   Button,
-  Heading4,
-  INatIconButton,
   SearchBar,
   ViewWrapper
 } from "components/SharedComponents";
@@ -26,6 +24,7 @@ import useLocationPermission from "sharedHooks/useLocationPermission.tsx";
 import { getShadow } from "styles/global";
 
 import EmptySearchResults from "./EmptySearchResults";
+import ExploreSearchHeader from "./ExploreSearchHeader";
 
 const DROP_SHADOW = getShadow( {
   offsetHeight: 4
@@ -125,20 +124,12 @@ const ExploreLocationSearch = ( { closeModal, updateLocation }: Props ): Node =>
 
   return (
     <ViewWrapper testID="explore-location-search">
-      <View className="flex-row justify-center p-5 bg-white">
-        <INatIconButton
-          testID="ExploreLocationSearch.close"
-          size={18}
-          icon="back"
-          className="absolute top-2 left-3 z-10"
-          onPress={( ) => closeModal()}
-          accessibilityLabel={t( "SEARCH-LOCATION" )}
-        />
-        <Heading4>{t( "SEARCH-LOCATION" )}</Heading4>
-        <Body3 onPress={resetPlace} className="absolute top-4 right-4">
-          {t( "Reset-verb" )}
-        </Body3>
-      </View>
+      <ExploreSearchHeader
+        closeModal={closeModal}
+        headerText={t( "SEARCH-LOCATION" )}
+        resetFilters={resetPlace}
+        testID="ExploreLocationSearch.close"
+      />
       <View
         className="bg-white pt-2 pb-5"
         style={DROP_SHADOW}

--- a/src/components/Explore/SearchScreens/ExploreProjectSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreProjectSearch.js
@@ -2,10 +2,7 @@
 
 import { searchProjects } from "api/projects";
 import {
-  Body3,
   CustomFlashList,
-  Heading4,
-  INatIconButton,
   ProjectListItem,
   SearchBar,
   ViewWrapper
@@ -20,6 +17,7 @@ import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
 import { getShadow } from "styles/global";
 
 import EmptySearchResults from "./EmptySearchResults";
+import ExploreSearchHeader from "./ExploreSearchHeader";
 
 const DROP_SHADOW = getShadow( {
   offsetHeight: 4
@@ -88,20 +86,12 @@ const ExploreProjectSearch = ( { closeModal, updateProject }: Props ): Node => {
 
   return (
     <ViewWrapper>
-      <View className="flex-row justify-center p-5 bg-white">
-        <INatIconButton
-          testID="ExploreProjectSearch.close"
-          size={18}
-          icon="back"
-          className="absolute top-2 left-3 z-10"
-          onPress={( ) => closeModal()}
-          accessibilityLabel={t( "SEARCH-PROJECTS" )}
-        />
-        <Heading4>{t( "SEARCH-PROJECTS" )}</Heading4>
-        <Body3 onPress={resetProject} className="absolute top-4 right-4">
-          {t( "Reset-verb" )}
-        </Body3>
-      </View>
+      <ExploreSearchHeader
+        closeModal={closeModal}
+        headerText={t( "SEARCH-PROJECTS" )}
+        resetFilters={resetProject}
+        testID="ExploreProjectSearch.close"
+      />
       <View
         className="bg-white px-6 pt-2 pb-8"
         style={DROP_SHADOW}

--- a/src/components/Explore/SearchScreens/ExploreProjectSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreProjectSearch.js
@@ -1,9 +1,9 @@
 // @flow
 
-import { FlashList } from "@shopify/flash-list";
 import { searchProjects } from "api/projects";
 import {
   Body3,
+  CustomFlashList,
   Heading4,
   INatIconButton,
   ProjectListItem,
@@ -112,9 +112,8 @@ const ExploreProjectSearch = ( { closeModal, updateProject }: Props ): Node => {
           testID="SearchProject"
         />
       </View>
-      <FlashList
+      <CustomFlashList
         data={projects}
-        initialNumToRender={5}
         estimatedItemSize={100}
         testID="SearchProjectList"
         keyExtractor={item => item.id}
@@ -122,7 +121,6 @@ const ExploreProjectSearch = ( { closeModal, updateProject }: Props ): Node => {
         ListEmptyComponent={renderEmptyList}
         ListHeaderComponent={renderItemSeparator}
         ItemSeparatorComponent={renderItemSeparator}
-        accessible
       />
     </ViewWrapper>
   );

--- a/src/components/Explore/SearchScreens/ExploreSearchHeader.tsx
+++ b/src/components/Explore/SearchScreens/ExploreSearchHeader.tsx
@@ -23,17 +23,20 @@ const ExploreSearchHeader = ( {
   const { t } = useTranslation( );
 
   return (
-    <View className="flex-row justify-between p-5 bg-white">
-      <BackButton
-        testID={testID}
-        onPress={closeModal}
-        accessibilityLabel={headerText}
-        className="w-[60px]"
-      />
+    <View className="flex-row items-center justify-between p-5 bg-white">
+      <View className="w-[50px]">
+        <BackButton
+          testID={testID}
+          onPress={closeModal}
+          accessibilityLabel={headerText}
+        />
+      </View>
       <Heading4>{headerText}</Heading4>
-      <Body3 onPress={resetFilters} className="w-[60px]">
-        {t( "Reset-verb" )}
-      </Body3>
+      <View className="w-[50px] items-end">
+        <Body3 onPress={resetFilters}>
+          {t( "Reset-verb" )}
+        </Body3>
+      </View>
     </View>
   );
 };

--- a/src/components/Explore/SearchScreens/ExploreSearchHeader.tsx
+++ b/src/components/Explore/SearchScreens/ExploreSearchHeader.tsx
@@ -1,0 +1,41 @@
+import {
+  BackButton,
+  Body3,
+  Heading4
+} from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import React from "react";
+import { useTranslation } from "sharedHooks";
+
+interface Props {
+  closeModal: ( ) => void;
+  headerText: string;
+  resetFilters: ( ) => void;
+  testID: string;
+}
+
+const ExploreSearchHeader = ( {
+  closeModal,
+  headerText,
+  resetFilters,
+  testID
+}: Props ) => {
+  const { t } = useTranslation( );
+
+  return (
+    <View className="flex-row justify-between p-5 bg-white">
+      <BackButton
+        testID={testID}
+        onPress={closeModal}
+        accessibilityLabel={headerText}
+        className="w-[60px]"
+      />
+      <Heading4>{headerText}</Heading4>
+      <Body3 onPress={resetFilters} className="w-[60px]">
+        {t( "Reset-verb" )}
+      </Body3>
+    </View>
+  );
+};
+
+export default ExploreSearchHeader;

--- a/src/components/Explore/SearchScreens/ExploreTaxonSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreTaxonSearch.js
@@ -1,9 +1,6 @@
 // @flow
 
 import {
-  Body3,
-  Heading4,
-  INatIconButton,
   SearchBar,
   TaxaList,
   TaxonResult,
@@ -18,6 +15,8 @@ import React, {
 import { useTranslation } from "sharedHooks";
 import useTaxonSearch from "sharedHooks/useTaxonSearch";
 import { getShadow } from "styles/global";
+
+import ExploreSearchHeader from "./ExploreSearchHeader";
 
 const DROP_SHADOW = getShadow( {
   offsetHeight: 4
@@ -72,20 +71,12 @@ const ExploreTaxonSearch = ( {
 
   return (
     <ViewWrapper>
-      <View className="flex-row justify-center p-5 bg-white">
-        <INatIconButton
-          testID="ExploreTaxonSearch.close"
-          size={18}
-          icon="back"
-          className="absolute top-2 left-3 z-10"
-          onPress={( ) => closeModal()}
-          accessibilityLabel={t( "SEARCH-TAXA" )}
-        />
-        <Heading4>{t( "SEARCH-TAXA" )}</Heading4>
-        <Body3 onPress={resetTaxon} className="absolute top-4 right-4">
-          {t( "Reset-verb" )}
-        </Body3>
-      </View>
+      <ExploreSearchHeader
+        closeModal={closeModal}
+        headerText={t( "SEARCH-TAXA" )}
+        resetFilters={resetTaxon}
+        testID="ExploreTaxonSearch.close"
+      />
       <View
         className="bg-white px-6 pt-2 pb-8"
         style={DROP_SHADOW}

--- a/src/components/Explore/SearchScreens/ExploreUserSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreUserSearch.js
@@ -2,10 +2,7 @@
 
 import fetchSearchResults from "api/search";
 import {
-  Body3,
   CustomFlashList,
-  Heading4,
-  INatIconButton,
   SearchBar,
   ViewWrapper
 } from "components/SharedComponents";
@@ -20,6 +17,7 @@ import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
 import { getShadow } from "styles/global";
 
 import EmptySearchResults from "./EmptySearchResults";
+import ExploreSearchHeader from "./ExploreSearchHeader";
 
 const DROP_SHADOW = getShadow( {
   offsetHeight: 4
@@ -93,20 +91,12 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ): Node => {
 
   return (
     <ViewWrapper>
-      <View className="flex-row justify-center p-5 bg-white">
-        <INatIconButton
-          testID="ExploreUserSearch.close"
-          size={18}
-          icon="back"
-          className="absolute top-2 left-3 z-10"
-          onPress={( ) => closeModal()}
-          accessibilityLabel={t( "SEARCH-USERS" )}
-        />
-        <Heading4>{t( "SEARCH-USERS" )}</Heading4>
-        <Body3 onPress={resetUser} className="absolute top-4 right-4">
-          {t( "Reset-verb" )}
-        </Body3>
-      </View>
+      <ExploreSearchHeader
+        closeModal={closeModal}
+        headerText={t( "SEARCH-USERS" )}
+        resetFilters={resetUser}
+        testID="ExploreUserSearch.close"
+      />
       <View
         className="bg-white px-6 pt-2 pb-8"
         style={DROP_SHADOW}

--- a/src/components/Explore/SearchScreens/ExploreUserSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreUserSearch.js
@@ -1,9 +1,9 @@
 // @flow
 
-import { FlashList } from "@shopify/flash-list";
 import fetchSearchResults from "api/search";
 import {
   Body3,
+  CustomFlashList,
   Heading4,
   INatIconButton,
   SearchBar,
@@ -117,14 +117,12 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ): Node => {
           testID="SearchUser"
         />
       </View>
-      <FlashList
+      <CustomFlashList
         ItemSeparatorComponent={renderItemSeparator}
         ListEmptyComponent={renderEmptyList}
         ListHeaderComponent={renderItemSeparator}
-        accessible
         data={userList}
         estimatedItemSize={100}
-        initialNumToRender={5}
         keyExtractor={item => item.id}
         keyboardShouldPersistTaps="handled"
         renderItem={renderItem}

--- a/src/components/Explore/SpeciesView.js
+++ b/src/components/Explore/SpeciesView.js
@@ -6,17 +6,14 @@ import _ from "lodash";
 import type { Node } from "react";
 import React, { useEffect, useMemo, useState } from "react";
 import Taxon from "realmModels/Taxon";
-import { BREAKPOINTS } from "sharedHelpers/breakpoint";
 import {
   useCurrentUser,
-  useDeviceOrientation,
+  useGridLayout,
   useInfiniteScroll,
   useQuery
 } from "sharedHooks";
 
 import ExploreFlashList from "./ExploreFlashList";
-
-const GUTTER = 15;
 
 type Props = {
   canFetch?: boolean,
@@ -39,31 +36,11 @@ const SpeciesView = ( {
   const [observedTaxonIds, setObservedTaxonIds] = useState( new Set( ) );
   const currentUser = useCurrentUser( );
   const {
-    isLandscapeMode,
-    isTablet,
-    screenHeight,
-    screenWidth
-  } = useDeviceOrientation( );
-
-  const calculateGridItemWidth = columns => {
-    const combinedGutter = ( columns + 1 ) * GUTTER;
-    const gridWidth = isTablet
-      ? screenWidth
-      : Math.min( screenWidth, screenHeight );
-    return Math.floor(
-      ( gridWidth - combinedGutter ) / columns
-    );
-  };
-
-  const calculateNumColumns = ( ) => {
-    if ( !isTablet ) return 2;
-    if ( isLandscapeMode ) return 6;
-    if ( screenWidth <= BREAKPOINTS.xl ) return 2;
-    return 4;
-  };
-
-  const numColumns = calculateNumColumns( );
-  const gridItemWidth = calculateGridItemWidth( numColumns );
+    estimatedGridItemSize,
+    flashListStyle,
+    gridItemStyle,
+    numColumns
+  } = useGridLayout( );
 
   const {
     data,
@@ -119,11 +96,7 @@ const SpeciesView = ( {
     <TaxonGridItem
       setCurrentExploreView={setCurrentExploreView}
       count={item?.count}
-      style={{
-        height: gridItemWidth,
-        width: gridItemWidth,
-        margin: GUTTER / 2
-      }}
+      style={gridItemStyle}
       taxon={item?.taxon}
       showSpeciesSeenCheckmark={observedTaxonIds.has( item?.taxon.id )}
     />
@@ -133,17 +106,16 @@ const SpeciesView = ( {
   }, [totalResults, handleUpdateCount] );
 
   const contentContainerStyle = useMemo( ( ) => ( {
-    paddingLeft: GUTTER / 2,
-    paddingRight: GUTTER / 2,
+    ...flashListStyle,
     paddingTop: 50
-  } ), [] );
+  } ), [flashListStyle] );
 
   return (
     <ExploreFlashList
       canFetch={canFetch}
       contentContainerStyle={contentContainerStyle}
       data={data}
-      estimatedItemSize={gridItemWidth}
+      estimatedItemSize={estimatedGridItemSize}
       fetchNextPage={fetchNextPage}
       hideLoadingWheel={!isFetchingNextPage}
       isFetchingNextPage={isFetchingNextPage}

--- a/src/components/Explore/TaxonGridItem.tsx
+++ b/src/components/Explore/TaxonGridItem.tsx
@@ -27,6 +27,16 @@ const TaxonGridItem = ( {
   const currentUser = useCurrentUser( );
   const accessibleName = accessibleTaxonName( taxon, currentUser, t );
 
+  const source = {
+    uri: Photo.displayLocalOrRemoteMediumPhoto(
+      taxon?.default_photo
+    )
+  };
+
+  const obsPhotosCount = taxon?.default_photo
+    ? 1
+    : 0;
+
   return (
     <Pressable
       accessibilityRole="button"
@@ -35,17 +45,10 @@ const TaxonGridItem = ( {
       accessibilityLabel={accessibleName}
     >
       <ObsImagePreview
-        source={{
-          uri: Photo.displayLocalOrRemoteMediumPhoto(
-            taxon?.default_photo
-          )
-        }}
-        width="w-full"
+        source={source}
         style={style}
         isMultiplePhotosTop
-        obsPhotosCount={taxon?.default_photo
-          ? 1
-          : 0}
+        obsPhotosCount={obsPhotosCount}
         testID={`TaxonGridItem.${taxon.id}`}
         iconicTaxonName={taxon.iconic_taxon_name}
       >

--- a/src/components/Notifications/NotificationsList.js
+++ b/src/components/Notifications/NotificationsList.js
@@ -1,10 +1,10 @@
 // @flow
 
-import { FlashList } from "@shopify/flash-list";
 import InfiniteScrollLoadingWheel from "components/MyObservations/InfiniteScrollLoadingWheel";
 import NotificationsListItem from "components/Notifications/NotificationsListItem";
 import {
-  ActivityIndicator, Body2, OfflineNotice, ViewWrapper
+  ActivityIndicator, Body2, CustomFlashList,
+  OfflineNotice, ViewWrapper
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
@@ -87,7 +87,7 @@ const NotificationsList = ( {
 
   return (
     <ViewWrapper>
-      <FlashList
+      <CustomFlashList
         ItemSeparatorComponent={renderItemSeparator}
         ListEmptyComponent={renderEmptyComponent}
         ListFooterComponent={renderFooter}

--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -1,10 +1,15 @@
 // @flow
 
 import { useNavigation } from "@react-navigation/native";
-import { FlashList } from "@shopify/flash-list";
 import { MAX_PHOTOS_ALLOWED } from "components/Camera/StandardCamera/StandardCamera";
 import {
-  Body2, Button, FloatingActionBar, INatIcon, INatIconButton, StickyToolbar
+  Body2,
+  Button,
+  CustomFlashList,
+  FloatingActionBar,
+  INatIcon,
+  INatIconButton,
+  StickyToolbar
 } from "components/SharedComponents";
 import ViewWrapper from "components/SharedComponents/ViewWrapper";
 import { Pressable, View } from "components/styledComponents";
@@ -148,11 +153,10 @@ const GroupPhotos = ( {
 
   return (
     <ViewWrapper>
-      <FlashList
+      <CustomFlashList
         contentContainerStyle={flashListStyle}
         ListHeaderComponent={renderHeader}
         data={data}
-        initialNumToRender={4}
         keyExtractor={extractKey}
         numColumns={numColumns}
         key={numColumns}

--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -17,8 +17,7 @@ import { t } from "i18next";
 import type { Node } from "react";
 import React, { useCallback, useMemo } from "react";
 import { useTheme } from "react-native-paper";
-import { BREAKPOINTS } from "sharedHelpers/breakpoint";
-import { useDeviceOrientation } from "sharedHooks";
+import { useGridLayout } from "sharedHooks";
 
 import GroupPhotoImage from "./GroupPhotoImage";
 
@@ -34,8 +33,6 @@ type Props = {
   totalPhotos: number
 }
 
-const GUTTER = 15;
-
 const GroupPhotos = ( {
   combinePhotos,
   groupedPhotos,
@@ -50,8 +47,12 @@ const GroupPhotos = ( {
   const navigation = useNavigation( );
   const theme = useTheme();
   const {
-    isLandscapeMode, isTablet, screenWidth, screenHeight
-  } = useDeviceOrientation();
+    estimatedGridItemSize,
+    flashListStyle,
+    gridItemStyle,
+    gridItemWidth,
+    numColumns
+  } = useGridLayout( );
   const extractKey = ( item, index ) => ( item.empty
     ? "empty"
     : `${item.photos[0].uri}${index}` );
@@ -61,39 +62,14 @@ const GroupPhotos = ( {
   const obsWithMultiplePhotosSelected
     = selectedObservations?.[0]?.photos?.length > 1;
 
-  const calculateNumColumns = () => {
-    if ( screenWidth <= BREAKPOINTS.sm ) {
-      return 1;
-    }
-    if ( !isTablet ) return 2;
-    if ( isLandscapeMode ) return 6;
-    if ( screenWidth <= BREAKPOINTS.xl ) return 2;
-    return 4;
-  };
-  const numColumns = calculateNumColumns();
-  const calculateGridItemWidth = () => {
-    const combinedGutter = ( numColumns + 1 ) * GUTTER;
-    const gridWidth = isTablet
-      ? screenWidth
-      : Math.min( screenWidth, screenHeight );
-    return Math.floor( ( gridWidth - combinedGutter ) / numColumns );
-  };
-  const itemWidth = calculateGridItemWidth();
-
-  const itemStyle = useMemo( ( ) => ( {
-    height: itemWidth,
-    width: itemWidth,
-    margin: GUTTER / 2
-  } ), [itemWidth] );
-
   const renderImage = useCallback( item => (
     <GroupPhotoImage
       item={item}
       selectedObservations={selectedObservations}
       selectObservationPhotos={selectObservationPhotos}
-      style={itemStyle}
+      style={gridItemStyle}
     />
-  ), [itemStyle, selectedObservations, selectObservationPhotos] );
+  ), [gridItemStyle, selectedObservations, selectObservationPhotos] );
 
   const addPhotos = useCallback( () => {
     navigation.navigate( "NoBottomTabStackNavigator", {
@@ -112,7 +88,7 @@ const GroupPhotos = ( {
           className="rounded-[15px] justify-center items-center"
           // Sorry, couldn't get this to work with tailwind
           // eslint-disable-next-line react-native/no-inline-styles
-          style={[itemStyle, {
+          style={[gridItemStyle, {
             borderWidth: 4,
             borderStyle: "dashed",
             borderColor: theme.colors.mediumGray
@@ -124,7 +100,7 @@ const GroupPhotos = ( {
     }
     // $FlowIgnore
     return renderImage( item );
-  }, [itemStyle, renderImage, theme, addPhotos] );
+  }, [gridItemStyle, renderImage, theme, addPhotos] );
 
   const renderHeader = ( ) => (
     <View className="m-5">
@@ -140,30 +116,24 @@ const GroupPhotos = ( {
     return newData;
   }, [groupedPhotos, totalPhotos] );
 
-  const flashListStyle = {
-    paddingLeft: GUTTER / 2,
-    paddingRight: GUTTER / 2,
-    paddingBottom: 80 + GUTTER / 2
-  };
-
   const extraData = {
     selectedObservations,
-    itemWidth
+    gridItemWidth
   };
 
   return (
     <ViewWrapper>
       <CustomFlashList
-        contentContainerStyle={flashListStyle}
         ListHeaderComponent={renderHeader}
+        contentContainerStyle={flashListStyle}
         data={data}
+        estimatedItemSize={estimatedGridItemSize}
+        extraData={extraData}
+        key={numColumns}
         keyExtractor={extractKey}
         numColumns={numColumns}
-        key={numColumns}
         renderItem={renderItem}
         testID="GroupPhotos.list"
-        extraData={extraData}
-        estimatedItemSize={itemWidth + GUTTER}
       />
       <FloatingActionBar
         show={selectedObservations.length > 0}

--- a/src/components/SharedComponents/CustomFlashList.tsx
+++ b/src/components/SharedComponents/CustomFlashList.tsx
@@ -1,16 +1,19 @@
 import { FlashList } from "@shopify/flash-list";
-import React from "react";
+import React, {
+  forwardRef
+} from "react";
 
-const CustomFlashList = props => (
+const CustomFlashList: Function = forwardRef( ( props, ref ) => (
   <FlashList
     // eslint-disable-next-line react/jsx-props-no-spreading
     {...props}
-    ref={props.innerRef}
+    ref={ref}
     accessible
     disableAutoLayout
     horizontal={false}
     initialNumToRender={5}
     onEndReachedThreshold={0.2}
   />
-);
+) );
+
 export default CustomFlashList;

--- a/src/components/SharedComponents/CustomFlashList.tsx
+++ b/src/components/SharedComponents/CustomFlashList.tsx
@@ -5,6 +5,7 @@ const CustomFlashList = props => (
   <FlashList
     // eslint-disable-next-line react/jsx-props-no-spreading
     {...props}
+    ref={props.innerRef}
     accessible
     disableAutoLayout
     horizontal={false}

--- a/src/components/SharedComponents/CustomFlashList.tsx
+++ b/src/components/SharedComponents/CustomFlashList.tsx
@@ -1,0 +1,15 @@
+import { FlashList } from "@shopify/flash-list";
+import React from "react";
+
+const CustomFlashList = props => (
+  <FlashList
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    {...props}
+    accessible
+    disableAutoLayout
+    horizontal={false}
+    initialNumToRender={5}
+    onEndReachedThreshold={0.2}
+  />
+);
+export default CustomFlashList;

--- a/src/components/SharedComponents/ObservationsFlashList/ObsItem.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObsItem.js
@@ -13,17 +13,15 @@ const { useRealm } = RealmContext;
 type Props = {
   explore: boolean,
   handleIndividualUploadPress: Function,
-  gridItemWidth: number,
+  gridItemStyle: Object,
   layout: "list" | "grid",
   observation: Object
 };
 
-const GUTTER = 15;
-
 const ObsItem = ( {
   explore,
   handleIndividualUploadPress,
-  gridItemWidth,
+  gridItemStyle,
   layout,
   observation
 }: Props ): Node => {
@@ -48,11 +46,7 @@ const ObsItem = ( {
               showUploadStatus={showUploadStatus}
               // 03022023 it seems like Flatlist is designed to work
               // better with RN styles than with Tailwind classes
-              style={{
-                height: gridItemWidth,
-                width: gridItemWidth,
-                margin: GUTTER / 2
-              }}
+              style={gridItemStyle}
 
             />
           )

--- a/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/SharedComponents/ObservationsFlashList/ObservationsFlashList.js
@@ -1,7 +1,8 @@
 // @flow
 import InfiniteScrollLoadingWheel from "components/MyObservations/InfiniteScrollLoadingWheel";
 import MyObservationsEmpty from "components/MyObservations/MyObservationsEmpty";
-import { ActivityIndicator, Body3, CustomFlashList } from "components/SharedComponents";
+import { ActivityIndicator, Body3 } from "components/SharedComponents";
+import CustomFlashList from "components/SharedComponents/CustomFlashList.tsx";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, {
@@ -152,7 +153,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
       data={data}
       estimatedItemSize={estimatedItemSize}
       extraData={extraData}
-      innerRef={ref}
+      ref={ref}
       key={numColumns}
       keyExtractor={keyExtractor}
       numColumns={numColumns}

--- a/src/components/SharedComponents/PhotoCount.js
+++ b/src/components/SharedComponents/PhotoCount.js
@@ -1,28 +1,27 @@
 // @flow
 
+import classnames from "classnames";
 import { Body3, INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
+import { I18nManager } from "react-native";
 import { useTheme } from "react-native-paper";
 import Svg, { Path } from "react-native-svg";
 import { dropShadow } from "styles/global";
 
+const HEIGHT = 24;
+
 type Props = {
-  count: number,
-  size?: number,
-  shadow?: boolean
+  count: number
 };
 
-const PhotoCount = ( {
-  count,
-  size,
-  shadow
-}: Props ): Node => {
+const PhotoCount = ( { count }: Props ): Node => {
+  const { isRTL } = I18nManager;
   const theme = useTheme( );
 
   if ( count === 0 ) {
-    return <INatIcon name="noevidence" size={size} color={theme.colors.inverseOnSurface} />;
+    return <INatIcon name="noevidence" size={HEIGHT} color={theme.colors.inverseOnSurface} />;
   }
 
   let photoCount = count;
@@ -30,34 +29,26 @@ const PhotoCount = ( {
     photoCount = 99;
   }
 
-  let paddingHorizontal = size === 50
-    ? 12.5
-    : 5;
-
-  if ( photoCount > 9 ) {
-    paddingHorizontal = 2;
-  }
-
-  const textStyle = {
-    position: "absolute",
-    zIndex: 10,
-    paddingHorizontal,
-    top: size === 50
-      ? 22
-      : 6
-  };
-
   return (
     <View
-      style={[{ height: size, width: size }, shadow && dropShadow]}
+      style={dropShadow}
       testID="photo-count"
     >
-      <Body3 style={textStyle}>
+      <Body3 className={classnames(
+        "absolute z-10",
+        "left-1.5 top-1.5",
+        {
+          "left-0.5": photoCount > 9,
+          "right-1.5": isRTL && photoCount < 9,
+          "right-0.5": photoCount > 9 && isRTL
+        }
+      )}
+      >
         {photoCount}
       </Body3>
       <Svg
-        height={size}
-        width={size}
+        height={HEIGHT}
+        width={HEIGHT}
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -81,8 +72,3 @@ const PhotoCount = ( {
 };
 
 export default PhotoCount;
-
-PhotoCount.defaultProps = {
-  size: 24,
-  shadow: false
-};

--- a/src/components/SharedComponents/index.js
+++ b/src/components/SharedComponents/index.js
@@ -13,6 +13,7 @@ export { default as RotatingINatIconButton } from "./Buttons/RotatingINatIconBut
 export { default as TransparentCircleButton } from "./Buttons/TransparentCircleButton";
 export { default as Checkbox } from "./Checkbox";
 export { default as ConfidenceInterval } from "./ConfidenceInterval";
+export { default as CustomFlashList } from "./CustomFlashList";
 export { default as DateDisplay } from "./DateDisplay";
 export { default as DateTimePicker } from "./DateTimePicker";
 export { default as DisplayTaxon } from "./DisplayTaxon";

--- a/src/sharedHooks/index.js
+++ b/src/sharedHooks/index.js
@@ -4,6 +4,7 @@ export { default as useAuthenticatedQuery } from "./useAuthenticatedQuery";
 export { default as useCurrentUser } from "./useCurrentUser";
 export { default as useDebugMode } from "./useDebugMode";
 export { default as useDeviceOrientation } from "./useDeviceOrientation";
+export { default as useGridLayout } from "./useGridLayout";
 export { default as useIconicTaxa } from "./useIconicTaxa";
 export { default as useInfiniteNotificationsScroll } from "./useInfiniteNotificationsScroll";
 export { default as useInfiniteObservationsScroll } from "./useInfiniteObservationsScroll";

--- a/src/sharedHooks/useGridLayout.ts
+++ b/src/sharedHooks/useGridLayout.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import { BREAKPOINTS } from "sharedHelpers/breakpoint";
+import { useDeviceOrientation } from "sharedHooks";
+
+const GUTTER = 15;
+const HALF_GUTTER = GUTTER / 2;
+const TAB_BAR_HEIGHT = 80;
+
+const flashListStyle = {
+  paddingLeft: HALF_GUTTER,
+  paddingRight: HALF_GUTTER,
+  paddingBottom: TAB_BAR_HEIGHT + HALF_GUTTER
+};
+
+const useGridLayout = layout => {
+  const {
+    isLandscapeMode, isTablet, screenWidth, screenHeight
+  } = useDeviceOrientation();
+
+  const calculateNumColumns = () => {
+    if ( layout === "list" || screenWidth <= BREAKPOINTS.sm ) {
+      return 1;
+    }
+    if ( !isTablet ) return 2;
+    if ( isLandscapeMode ) return 6;
+    if ( screenWidth <= BREAKPOINTS.xl ) return 2;
+    return 4;
+  };
+  const numColumns = calculateNumColumns();
+
+  const calculateGridItemWidth = () => {
+    const combinedGutter = ( numColumns + 1 ) * GUTTER;
+    const gridWidth = isTablet
+      ? screenWidth
+      : Math.min( screenWidth, screenHeight );
+    return Math.floor( ( gridWidth - combinedGutter ) / numColumns );
+  };
+  const gridItemWidth = calculateGridItemWidth();
+  const estimatedGridItemSize = gridItemWidth + GUTTER;
+
+  const gridItemStyle = useMemo( ( ) => ( {
+    height: gridItemWidth,
+    width: gridItemWidth,
+    margin: HALF_GUTTER
+  } ), [gridItemWidth] );
+
+  return {
+    estimatedGridItemSize,
+    flashListStyle,
+    gridItemStyle,
+    numColumns
+  };
+};
+
+export default useGridLayout;

--- a/tests/unit/components/SharedComponents/PhotoCount/PhotoCount.test.js
+++ b/tests/unit/components/SharedComponents/PhotoCount/PhotoCount.test.js
@@ -4,7 +4,7 @@ import React from "react";
 
 describe( "PhotoCount", () => {
   it( "renders correctly", () => {
-    render( <PhotoCount count={7} size={50} shadow /> );
+    render( <PhotoCount count={7} /> );
 
     expect( screen ).toMatchSnapshot();
   } );

--- a/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
@@ -4,22 +4,16 @@ exports[`PhotoCount renders correctly 1`] = `
 <View
   style={
     [
-      [
-        {
-          "height": 50,
-          "width": 50,
+      {
+        "elevation": 5,
+        "shadowColor": "rgba( 0, 0, 0, 0.25 )",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
         },
-        {
-          "elevation": 5,
-          "shadowColor": "rgba( 0, 0, 0, 0.25 )",
-          "shadowOffset": {
-            "height": 2,
-            "width": 0,
-          },
-          "shadowOpacity": 0.25,
-          "shadowRadius": 2,
-        },
-      ],
+        "shadowOpacity": 0.25,
+        "shadowRadius": 2,
+      },
     ]
   }
   testID="photo-count"
@@ -38,12 +32,20 @@ exports[`PhotoCount renders correctly 1`] = `
         {
           "fontFamily": "Lato-Medium",
         },
-        {
-          "paddingHorizontal": 12.5,
-          "position": "absolute",
-          "top": 22,
-          "zIndex": 10,
-        },
+        [
+          {
+            "position": "absolute",
+          },
+          {
+            "zIndex": 10,
+          },
+          {
+            "left": 6,
+          },
+          {
+            "top": 6,
+          },
+        ],
       ]
     }
   >
@@ -51,11 +53,11 @@ exports[`PhotoCount renders correctly 1`] = `
   </Text>
   <RNSVGSvgView
     align="xMidYMid"
-    bbHeight={50}
-    bbWidth={50}
+    bbHeight={24}
+    bbWidth={24}
     fill="none"
     focusable={false}
-    height={50}
+    height={24}
     meetOrSlice={0}
     minX={0}
     minY={0}
@@ -67,14 +69,14 @@ exports[`PhotoCount renders correctly 1`] = `
         },
         {
           "flex": 0,
-          "height": 50,
-          "width": 50,
+          "height": 24,
+          "width": 24,
         },
       ]
     }
     vbHeight={24}
     vbWidth={24}
-    width={50}
+    width={24}
     xmlns="http://www.w3.org/2000/svg"
   >
     <RNSVGGroup


### PR DESCRIPTION
Closes #2144

- Uses `CustomFlashList` component to disable auto layout and remove the unexpected blank space in grid view while user is viewing a RTL language
- Standardizes the way we calculate grid item sizes across the app (GroupPhotos, Explore Observations GridView, Explore SpeciesView, MyObservations GridView, etc.) via a `useGridLayout` hook
- Standardizes the Explore search screen header and uses `BackButton` within that header to automatically flip back arrow into RTL mode
- Fixes PhotoCount rendering in RTL mode & removes unused props