### PR TITLE
Sync with Crowdin

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -1,8 +1,8 @@
-name: Crowdin Sync
+name: Crowdin Pull
 
 on:
-  push:
-    branches: [ 2103-post-to-crowdin ]
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -39,12 +39,10 @@ jobs:
       - name: Sync with Crowdin
         uses: crowdin/github-action@v2
         with:
-          # Debug
-          command_args: '--verbose'
           # Note: a lot of the way this behaves is controlled in crowdin.yml,
           # e.g. the path to the source files and paths to translations
           # Upload options
-          upload_sources: true
+          upload_sources: false
           upload_translations: false
           # Download options
           download_translations: true
@@ -52,28 +50,25 @@ jobs:
           export_only_approved: true
           # Pull request options
           create_pull_request: false
-          # localization_branch_name: l10n_2103_post_to_crowdin
-          # pull_request_title: 'New Crowdin Translations'
-          # pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
-          # pull_request_base_branch_name: '2103-post-to-crowdin'
         env:
-          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
           GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
-
-          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-
-          # Visit https://crowdin.com/settings#api-key to create this token
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      # Move files named with crowdin locales to files named with iNat
+      # locales. This will also fail if there's invalid FTL. We might want to
+      # separate those things in the future if it's easier to notice
+      # validation failures in the PR
       - name: Normalize and validate
         run: npm run translate
 
       - name: Make pull request
+        # The original doesn't support making a pull request without
+        # downloading, which we don't want to do b/c that would recreate the
+        # Crowdin-named files that we just removed in the previous step, so
+        # we're using a fork.
         uses: inaturalist/crowdin-github-action@pr-without-download
         with:
-          # Debug
-          command_args: '--verbose'
           # Note: a lot of the way this behaves is controlled in crowdin.yml,
           # e.g. the path to the source files and paths to translations
           # Upload options
@@ -88,11 +83,6 @@ jobs:
           pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
           pull_request_base_branch_name: '2103-post-to-crowdin'
         env:
-          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
           GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
-
-          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-
-          # Visit https://crowdin.com/settings#api-key to create this token
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -10,8 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  synchronize-with-crowdin:
+  pull-from-crowdin:
     runs-on: ubuntu-latest
+
+    # Apparently needed to rename files, though maybe there's a better way
     container:
       image: node:18
       options: --user root
@@ -78,10 +80,10 @@ jobs:
           download_translations: false
           # Pull request options
           create_pull_request: true
-          localization_branch_name: l10n_2103_post_to_crowdin
+          localization_branch_name: l10n_main
           pull_request_title: 'New Crowdin Translations'
           pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
-          pull_request_base_branch_name: '2103-post-to-crowdin'
+          pull_request_base_branch_name: 'main'
         env:
           GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -2,7 +2,7 @@ name: Crowdin Push
 
 on:
   push:
-    branches: [ 2103-post-to-crowdin ]
+    branches: [ main ]
   workflow_dispatch:
 
 concurrency:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  synchronize-with-crowdin:
+  push-to-crowdin:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -3,6 +3,7 @@ name: Crowdin Push
 on:
   push:
     branches: [ main ]
+    paths: ["src/i18n/strings.ftl"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -1,0 +1,35 @@
+name: Crowdin Push
+
+on:
+  push:
+    branches: [ 2103-post-to-crowdin ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync with Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          # Note: a lot of the way this behaves is controlled in crowdin.yml,
+          # e.g. the path to the source files and paths to translations
+          # Upload options
+          upload_sources: true
+          upload_translations: false
+          # Download options
+          download_translations: false
+          # Pull request options
+          create_pull_request: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,4 +1,4 @@
-name: Crowdin Action
+name: Crowdin Sync
 
 on:
   push:
@@ -17,7 +17,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: crowdin action
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install node dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
+
+      # These will run `npm run translate`
+      - name: Set up commit hooks
+        run: npm run postinstall
+
+      - name: Sync with Crowdin
         uses: crowdin/github-action@v2
         with:
           # Debug

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -20,6 +20,10 @@ jobs:
       - name: crowdin action
         uses: crowdin/github-action@v2
         with:
+          # Debug
+          command_args: '--verbose'
+          upload_sources_args: '--verbose'
+          download_sources_args: '--verbose'
           # Note: a lot of the way this behaves is controlled in crowdin.yml,
           # e.g. the path to the source files and paths to translations
           # Upload options

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,7 +13,7 @@ jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu-latest
+      image: alpine:latest
       options: --user root
 
     steps:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,6 +13,7 @@ jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
     container:
+      image: ubuntu-latest
       options: --user root
 
     steps:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,47 @@
+name: Crowdin Action
+
+on:
+  push:
+    branches: [ 2103-post-to-crowdin ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          # Note: a lot of the way this behaves is controlled in crowdin.yml,
+          # e.g. the path to the source files and paths to translations
+          # Upload options
+          upload_sources: true
+          upload_translations: false
+          # Download options
+          download_translations: true
+          skip_untranslated_strings: true
+          skip_untranslated_files: true
+          export_only_approved: true
+          # Pull request options
+          localization_branch_name: l10n_2103_post_to_crowdin
+          create_pull_request: true
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: '2103-post-to-crowdin'
+        env:
+          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
+          GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm run translate
 
       - name: Make pull request
-        uses: crowdin/github-action@v2
+        uses: inaturalist/crowdin-github-action@pr-without-download
         with:
           # Debug
           command_args: '--verbose'

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -30,7 +30,6 @@ jobs:
           # Download options
           download_translations: true
           skip_untranslated_strings: true
-          skip_untranslated_files: true
           export_only_approved: true
           # Pull request options
           localization_branch_name: l10n_2103_post_to_crowdin

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           # Debug
           command_args: '--verbose'
-          upload_sources_args: '--verbose'
-          download_sources_args: '--verbose'
           # Note: a lot of the way this behaves is controlled in crowdin.yml,
           # e.g. the path to the source files and paths to translations
           # Upload options

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    container:
+      options: --user root
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,7 +13,7 @@ jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
     container:
-      image: alpine:latest
+      image: node:18
       options: --user root
 
     steps:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -33,10 +33,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
-      # These will run `npm run translate`
-      - name: Set up commit hooks
-        run: npm run postinstall
-
       - name: Sync with Crowdin
         uses: crowdin/github-action@v2
         with:
@@ -52,15 +48,46 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           # Pull request options
-          localization_branch_name: l10n_2103_post_to_crowdin
+          create_pull_request: false
+          # localization_branch_name: l10n_2103_post_to_crowdin
+          # pull_request_title: 'New Crowdin Translations'
+          # pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          # pull_request_base_branch_name: '2103-post-to-crowdin'
+        env:
+          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
+          GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Normalize and validate
+        run: npm run translate
+
+      - name: Make pull request
+        uses: crowdin/github-action@v2
+        with:
+          # Debug
+          command_args: '--verbose'
+          # Note: a lot of the way this behaves is controlled in crowdin.yml,
+          # e.g. the path to the source files and paths to translations
+          # Upload options
+          upload_sources: false
+          upload_translations: false
+          # Download options
+          download_translations: false
+          # Pull request options
           create_pull_request: true
+          localization_branch_name: l10n_2103_post_to_crowdin
           pull_request_title: 'New Crowdin Translations'
           pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
           pull_request_base_branch_name: '2103-post-to-crowdin'
         env:
           # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
           GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
-          
+
           # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -9,20 +9,16 @@ files:
     type: ftl
     languages_mapping:
       two_letters_code:
-        bg-FR: bg
         en-AU: en-AU
         en-GB: en-GB
         en-NZ: en-NZ
-        en-US: en
+        en-US: en-US
         es-AR: es-AR
         es-CO: es-CO
         es-CR: es-CR
         es-ES: es
         es-MX: es-MX
         fr-CA: fr-CA
-        fr-FR: fr
-        gu-IN: gu
-        ml-IN: ml
         pa-IN: pa
         pt-BR: pt-BR
         pt-PT: pt

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,13 +1,34 @@
-base_path" : "."
-base_url : "https://api.crowdin.com"
+project_id_env: INATRN_CROWDIN_PROJECT_ID
+api_token_env: INATRN_CROWDIN_PERSON_TOKEN
 preserve_hierarchy: true
 
 files:
-  - source: "/src/i18n/strings.ftl"
-    dest: "/iNaturalistReactNative/%original_file_name%"
-    translation: "/src/i18n/l10n/%locale%.ftl"
-    export_only_approved: true
+  - source: /src/i18n/strings.ftl
+    dest: /ReactNative/strings.ftl
+    translation: /src/i18n/l10n/%two_letters_code%.ftl
+    type: ftl
     languages_mapping:
-      locale:
+      two_letters_code:
+        bg-FR: bg
+        en-AU: en-AU
+        en-GB: en-GB
+        en-NZ: en-NZ
+        en-US: en
+        es-AR: es-AR
+        es-CO: es-CO
+        es-CR: es-CR
         es-ES: es
-        ru: ru
+        es-MX: es-MX
+        fr-CA: fr-CA
+        fr-FR: fr
+        gu-IN: gu
+        ml-IN: ml
+        pa-IN: pa
+        pt-BR: pt-BR
+        pt-PT: pt
+        si-LK: si
+        sr-CS: sr
+        sv-SE: sv
+        zh-CN: zh-CN
+        zh-HK: zh-HK
+        zh-TW: zh-TW

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,5 @@
-project_id_env: INATRN_CROWDIN_PROJECT_ID
-api_token_env: INATRN_CROWDIN_PERSON_TOKEN
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
 preserve_hierarchy: true
 
 files:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,26 +5,7 @@ preserve_hierarchy: true
 files:
   - source: /src/i18n/strings.ftl
     dest: /ReactNative/strings.ftl
-    translation: /src/i18n/l10n/%two_letters_code%.ftl
+    # Note: this uses the Crowdin locale which always has a region. We need to
+    # mess with this later in i18ncli
+    translation: /src/i18n/l10n/%locale%.ftl
     type: ftl
-    languages_mapping:
-      two_letters_code:
-        en-AU: en-AU
-        en-GB: en-GB
-        en-NZ: en-NZ
-        en-US: en-US
-        es-AR: es-AR
-        es-CO: es-CO
-        es-CR: es-CR
-        es-ES: es
-        es-MX: es-MX
-        fr-CA: fr-CA
-        pa-IN: pa
-        pt-BR: pt-BR
-        pt-PT: pt
-        si-LK: si
-        sr-CS: sr
-        sv-SE: sv
-        zh-CN: zh-CN
-        zh-HK: zh-HK
-        zh-TW: zh-TW

--- a/src/components/TaxonDetails/Wikipedia.js
+++ b/src/components/TaxonDetails/Wikipedia.js
@@ -33,7 +33,6 @@ const Wikipedia = ( { taxon }: Props ): React.Node => {
     openExternalWebBrowser( taxon.wikipedia_url );
   };
 
-
   if ( !taxon.wikipedia_summary || taxon.wikipedia_summary.length === 0 ) {
     return null;
   }

--- a/src/i18n/i18ncli.js
+++ b/src/i18n/i18ncli.js
@@ -8,8 +8,7 @@ const {
   serialize: serializeFtl,
   Resource
 } = require( "@fluent/syntax" );
-
-const { readFile, writeFile } = fs.promises;
+const fsp = require( "fs/promises" );
 const path = require( "path" );
 const util = require( "util" );
 const { glob } = require( "glob" );
@@ -20,6 +19,23 @@ const {
   uniq
 } = require( "lodash" );
 
+// Exceptions to the rule that all locales should be specified as two-letter
+// language code only
+const SUPPORTED_REGIONAL_LOCALES = [
+  "en-GB",
+  "en-NZ",
+  "es-AR",
+  "es-CO",
+  "es-CR",
+  "es-MX",
+  "fr-CA",
+  "pt-BR",
+  "zh-CN",
+  "zh-HK",
+  "zh-TW"
+];
+
+// Prepends an FTL translation with a checkmark for testing
 function checkifyText( ftlTxt ) {
   if ( ftlTxt.indexOf( "<0>" ) >= 0 ) {
     return ftlTxt.replace( "<0>", "<0>✅" );
@@ -52,11 +68,16 @@ function checkifyLocalizations( localizations ) {
   }, {} );
 }
 
+// Paths to all existing localizations
+async function l10nFtlPaths() {
+  return glob( path.join( __dirname, "l10n", "*.ftl" ) );
+}
+
 // Convert a single FTL file to JSON
 const jsonifyPath = async ( inPath, outPath, options = { } ) => {
   let ftlTxt;
   try {
-    ftlTxt = await readFile( inPath );
+    ftlTxt = await fsp.readFile( inPath );
   } catch ( readFileErr ) {
     console.error( `Could not read ${inPath}, skipping...` );
     if ( options.debug ) {
@@ -77,7 +98,7 @@ const jsonifyPath = async ( inPath, outPath, options = { } ) => {
     ? checkifyLocalizations( localizations )
     : localizations;
   try {
-    await writeFile( outPath, `${JSON.stringify( massagedLocalizations, null, 2 )}\n` );
+    await fsp.writeFile( outPath, `${JSON.stringify( massagedLocalizations, null, 2 )}\n` );
   } catch ( writeFileErr ) {
     console.error( `Failed to write ${outPath} with error:` );
     console.error( writeFileErr );
@@ -89,7 +110,7 @@ const jsonifyPath = async ( inPath, outPath, options = { } ) => {
 
 // Assume all existing localized locales are supported
 const supportedLocales = async ( ) => {
-  const paths = await glob( path.join( __dirname, "l10n", "*.ftl" ) );
+  const paths = await l10nFtlPaths( );
   return paths.map( f => path.basename( f, ".ftl" ) );
 };
 
@@ -139,12 +160,8 @@ const writeLoadTranslations = async ( ) => {
   out.write( "};\n" );
 };
 
-async function l10nFtlPaths() {
-  return glob( path.join( __dirname, "l10n", "*.ftl" ) );
-}
-
 async function validateFtlFile( ftlPath, options = {} ) {
-  const ftlTxt = await readFile( ftlPath );
+  const ftlTxt = await fsp.readFile( ftlPath );
   const ftl = parseFtl( ftlTxt.toString( ) );
   const errors = [];
   // Chalk does not expose a CommonJS module, so we have to do this
@@ -203,7 +220,7 @@ async function validate() {
 }
 
 async function normalizeFtlFile( ftlPath, options = {} ) {
-  const ftlTxt = await readFile( ftlPath );
+  const ftlTxt = await fsp.readFile( ftlPath );
   const ftl = parseFtl( ftlTxt.toString( ) );
   const resourceComments = [];
   const messages = [];
@@ -225,7 +242,7 @@ async function normalizeFtlFile( ftlPath, options = {} ) {
     ...sortedMessages
   ] );
   const newFtlTxt = serializeFtl( newResource );
-  await writeFile( ftlPath, newFtlTxt );
+  await fsp.writeFile( ftlPath, newFtlTxt );
   if ( !options.quiet ) {
     console.log( `✅ ${ftlPath} normalized` );
   }
@@ -240,7 +257,7 @@ async function normalize( ) {
 
 async function getKeys( ) {
   const stringsPath = path.join( __dirname, "strings.ftl" );
-  const ftlTxt = await readFile( stringsPath );
+  const ftlTxt = await fsp.readFile( stringsPath );
   const ftl = parseFtl( ftlTxt.toString( ) );
   return ftl.body.filter( item => item.type === "Message" ).map( msg => msg.id.name );
 }
@@ -248,7 +265,7 @@ async function getKeys( ) {
 async function getKeysInUse( ) {
   const paths = await glob( path.join( __dirname, "..", "**", "*.{js,ts,jsx,tsx}" ) );
   const allKeys = await Promise.all( paths.map( async srcPath => {
-    const src = await readFile( srcPath );
+    const src = await fsp.readFile( srcPath );
     const tMatches = [...src.toString( ).matchAll( /[^a-z]t\(\s*["']([\w-_\s]+?)["']/g )];
     const i18nkeyMatches = [...src.toString( ).matchAll( /i18nKey=["']([\w-_\s]+?)["']/g )];
     return [...tMatches, ...i18nkeyMatches].map( match => match[1] );
@@ -268,6 +285,7 @@ async function unused( ) {
   }
 }
 
+// Look for keys in the code that aren't in the source strings
 async function untranslatable( ) {
   const keys = await getKeys( );
   const keysInUse = await getKeysInUse( );
@@ -280,6 +298,25 @@ async function untranslatable( ) {
     );
     process.exit( 1 );
   }
+}
+
+// Ensure localization file names match iNat convention and not Crowdin, e.g.
+// we use "fr" instead of "fr-FR"
+async function normalizeFileNames( ) {
+  const paths = await l10nFtlPaths();
+  return Promise.all( paths.map( async l10nPath => {
+    const locale = path.basename( l10nPath, ".ftl" );
+    const [lng, region] = locale.split( "-" );
+    // No need to move anything if there's no region
+    if ( !region ) return;
+    // We need to keep some regions
+    if ( SUPPORTED_REGIONAL_LOCALES.indexOf( locale ) >= 0 ) {
+      return;
+    }
+    // Everything else needs to be regionless
+    const newPath = path.join( path.dirname( l10nPath ), `${lng}.ftl` );
+    await fsp.rename( l10nPath, newPath );
+  } ) );
 }
 
 // eslint-disable-next-line no-unused-expressions
@@ -309,6 +346,9 @@ yargs
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     ( ) => {},
     async argv => {
+      // Make sure all files are iNat locales before validating and
+      // normalizing FT
+      await normalizeFileNames( );
       await validate( );
       await normalize( );
       await untranslatable( );

--- a/src/i18n/initI18next.js
+++ b/src/i18n/initI18next.js
@@ -48,6 +48,19 @@ export const I18NEXT_CONFIG = {
         )
       }
     }
+  },
+  // All languages should fallback to English, some regional variants should
+  // fall back to another region
+  fallbackLng: code => {
+    const fallbacks = [];
+    if ( code.match( /^es-/ ) ) {
+      fallbacks.push( "es" );
+    } else if ( code.match( /^fr-/ ) ) {
+      fallbacks.push( "fr" );
+    } else if ( code.match( /^pt-/ ) ) {
+      fallbacks.push( "pt" );
+    }
+    return [...fallbacks, "en"];
   }
 };
 

--- a/src/i18n/l10n/af.ftl
+++ b/src/i18n/l10n/af.ftl
@@ -1,0 +1,22 @@
+### Source strings for iNaturalistReactNative
+###
+### Notes
+### * GroupComments (comments beginning w/ ##) are not allowed because all
+###   strings in this file will be alphabetized and it's impossible to
+###   determine where group comments should fit in.
+### * Keys should match their content closesly but not exceed 100 chars
+### * Try to annotate all strings with comments to provide context for
+###   translators, especially for fragments and any situation where the
+###   meaning is open to interpretation without context
+### * Use different strings for synonyms, e.g. stop-noun and stop-verb, as
+###   these might have different translations in different languages
+### * Accessibility hints are used by screen readers to describe what happens
+###   when the user interacts with an element
+###   (https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619585-accessibilityhint).
+###   The iOS Guidelines defines it as "A string that briefly describes the
+###   result of performing an action on the accessibility element." We write
+###   them in third person singular ending with a period.
+
+Welcome-to-iNaturalist = Welkom by iNaturalist!
+# Welcome user back to app
+Welcome-user = <0>Welkom terug,</0><1>{ $userHandle }</1>

--- a/src/i18n/l10n/af.ftl.json
+++ b/src/i18n/l10n/af.ftl.json
@@ -1,0 +1,7 @@
+{
+  "Welcome-to-iNaturalist": "Welkom by iNaturalist!",
+  "Welcome-user": {
+    "comment": "Welcome user back to app",
+    "val": "<0>Welkom terug,</0><1>{ $userHandle }</1>"
+  }
+}

--- a/src/i18n/l10n/ar.ftl
+++ b/src/i18n/l10n/ar.ftl
@@ -1,0 +1,22 @@
+### Source strings for iNaturalistReactNative
+###
+### Notes
+### * GroupComments (comments beginning w/ ##) are not allowed because all
+###   strings in this file will be alphabetized and it's impossible to
+###   determine where group comments should fit in.
+### * Keys should match their content closesly but not exceed 100 chars
+### * Try to annotate all strings with comments to provide context for
+###   translators, especially for fragments and any situation where the
+###   meaning is open to interpretation without context
+### * Use different strings for synonyms, e.g. stop-noun and stop-verb, as
+###   these might have different translations in different languages
+### * Accessibility hints are used by screen readers to describe what happens
+###   when the user interacts with an element
+###   (https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619585-accessibilityhint).
+###   The iOS Guidelines defines it as "A string that briefly describes the
+###   result of performing an action on the accessibility element." We write
+###   them in third person singular ending with a period.
+
+Welcome-to-iNaturalist = مرحبا بكم في iNaturalist!
+# Welcome user back to app
+Welcome-user = <0>مرحبا بعودتك،</0><1>{ $userHandle }</1>

--- a/src/i18n/l10n/ar.ftl.json
+++ b/src/i18n/l10n/ar.ftl.json
@@ -1,0 +1,7 @@
+{
+  "Welcome-to-iNaturalist": "مرحبا بكم في iNaturalist!",
+  "Welcome-user": {
+    "comment": "Welcome user back to app",
+    "val": "<0>مرحبا بعودتك،</0><1>{ $userHandle }</1>"
+  }
+}

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -243,8 +243,6 @@ Data-quality-research-description = This observation has enough identifications 
 DATE = DATE
 # label in project requirements
 Date = Date
-# Used when displaying a relative time - in this case, X days ago (e.g. 3d = 3 days ago)
-Date-days = { $count }d
 # Date formatting using date-fns
 # Used for things like User Profile join date
 # See complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -342,12 +342,8 @@
     "comment": "label in project requirements",
     "val": "Date"
   },
-  "Date-days": {
-    "comment": "Used when displaying a relative time - in this case, X days ago (e.g. 3d = 3 days ago)",
-    "val": "{ $count }d"
-  },
   "date-format-long": {
-    "comment": "Used for things like User Profile join date\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
+    "comment": "Date formatting using date-fns\nUsed for things like User Profile join date\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
     "val": "PP"
   },
   "date-format-month-day": {
@@ -1493,14 +1489,14 @@
     "val": "Users"
   },
   "Using-iNaturalist-requires-the-storage": "Using iNaturalist requires the storage of personal information like your email address, all iNaturalist data is stored in the United States, and we cannot be sure what legal jurisdiction you are in when you are using iNaturalist, so in order to comply with privacy laws like the GDPR, you must acknowledge that you understand and accept this risk and consent to transferring your personal information to iNaturalist's servers in the US.",
-  "VIEW-ALL-X-PLACES": "VIEW ALL { $count } PLACES",
-  "VIEW-ALL-X-PROJECTS": "VIEW ALL { $count } PROJECTS",
-  "VIEW-ALL-X-TAXA": "VIEW ALL { $count } TAXA",
-  "VIEW-ALL-X-USERS": "VIEW ALL { $count } USERS",
   "Version-app-build": {
     "comment": "Listing of app and build versions",
     "val": "Version { $appVersion } ({ $buildVersion })"
   },
+  "VIEW-ALL-X-PLACES": "VIEW ALL { $count } PLACES",
+  "VIEW-ALL-X-PROJECTS": "VIEW ALL { $count } PROJECTS",
+  "VIEW-ALL-X-TAXA": "VIEW ALL { $count } TAXA",
+  "VIEW-ALL-X-USERS": "VIEW ALL { $count } USERS",
   "VIEW-CHILDREN-TAXA": "VIEW CHILDREN TAXA",
   "VIEW-DATA-QUALITY-ASSESSMENT": "VIEW DATA QUALITY ASSESSMENT",
   "VIEW-EDUCATORS-GUIDE": "VIEW EDUCATOR'S GUIDE",

--- a/src/i18n/loadTranslations.js
+++ b/src/i18n/loadTranslations.js
@@ -5,5 +5,7 @@ export default locale => {
   if ( locale === "es" ) { return require( "./l10n/es.ftl.json" ); }
   if ( locale === "es-MX" ) { return require( "./l10n/es-MX.ftl.json" ); }
   if ( locale === "en" ) { return require( "./l10n/en.ftl.json" ); }
+  if ( locale === "ar" ) { return require( "./l10n/ar.ftl.json" ); }
+  if ( locale === "af" ) { return require( "./l10n/af.ftl.json" ); }
   return require( "./l10n/en.ftl.json" );
 };

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -243,8 +243,6 @@ Data-quality-research-description = This observation has enough identifications 
 DATE = DATE
 # label in project requirements
 Date = Date
-# Used when displaying a relative time - in this case, X days ago (e.g. 3d = 3 days ago)
-Date-days = { $count }d
 # Date formatting using date-fns
 # Used for things like User Profile join date
 # See complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format


### PR DESCRIPTION
More complicated than maybe it needed to be, but this accomplishes a few things

* strings.ftl gets pushed to Crowdin when it changes
* translations get pulled from Crowdin every day and a PR should get made if there are changes
* FTL validation and normalization happens in the action and will *prevent* a PR from being created; we may want to change that if we find ourselves ignoring the failed action
* Right now only Arabic and Afrikaans are enabled for this file. I'll enable the rest when I'm ready to deal with all the questions from translators

Some details for future reference:

* Crowdin locale names don't match iNat locale names, or at least I was not able to find a way to get their Github Action and CLI to perform this mapping, so I ended up doing it in our out i18ncli script (will happen when `npm run translate` happens). There is a `languages_mapping` setting in Crowdin that should do this, but a) you can't really set it in the crowdin.yml file as documented b/c the equivalent setting on the web overrides it, and b) I'm afraid of setting a project-wide mapping on the website b/c iNaturalistAndroid and INaturalistIOS also pull translations from that project
* I needed to fork the Crowdin github action to rename those files after download but before the PR gets created. We might want to issue a PR for that if the Crowdin folks want that functionality
* You can use the CLI to pre-translate a file in a language like this: `crowdin pre-translate --language ar --file /ReactNative/strings.ftl --method tm`. That will add translations to Arabic for the RN source strings using Translation Memory, Crowdin's feature that remembers similar translations from elsewhere in your account. Not sure how translators will feel about that, but it might be useful to fill in content incompletely-translated languages like Arabic.

Closes #2103
Closes #2104