### PR TITLE
Match projects empty button width to Figma

### DIFF
--- a/src/components/MyObservations/MyObservationsEmpty.js
+++ b/src/components/MyObservations/MyObservationsEmpty.js
@@ -52,7 +52,7 @@ const MyObservationsEmpty = ( { isFetchingNextPage }: Props ): Node => {
       >
         <GradientButton
           accessibilityLabel={t( "Add-observations" )}
-          sizeClassName="w-[141px] h-[141px]"
+          sizeClassName="w-[141px] h-[141px] self-center"
           onPress={navToARCamera}
           iconSize={76}
         />

--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -108,9 +108,10 @@ const Projects = ( {
             ? HEADER_HEIGHT_WITH_TABS
             : HEADER_HEIGHT_WITHOUT_TABS}
           emptyItemHeight={90}
+          containerClassName="self-center w-full"
         >
           <Body1 className="self-center">{t( "No-projects-match-that-search" )}</Body1>
-          <View className="w-full px-4 mt-5">
+          <View className="p-4 mt-2">
             <Button
               level="neutral"
               text={t( "RESET-SEARCH" )}

--- a/src/components/SharedComponents/FlashList/FlashListEmptyWrapper.tsx
+++ b/src/components/SharedComponents/FlashList/FlashListEmptyWrapper.tsx
@@ -8,12 +8,14 @@ const FOOTER_HEIGHT = 77;
 
 interface Props {
   children: React.Node;
+  containerClassName?: string;
   headerHeight: number;
   emptyItemHeight: number;
 }
 
 const FlashListEmptyWrapper = ( {
   children,
+  containerClassName,
   headerHeight: HEADER_HEIGHT,
   emptyItemHeight: EMPTY_ITEM_HEIGHT
 }: Props ) => {
@@ -30,13 +32,15 @@ const FlashListEmptyWrapper = ( {
   // The following workaround is to roughly center the content.
   // https://github.com/Shopify/flash-list/discussions/517
     <View
-      className="px-[67px] items-center"
+      className={classnames(
+        containerClassName,
+        {
+          "px-[67px] items-center": !containerClassName
+        }
+      )}
       style={{ height: outerViewHeight }}
     >
-      <View className={classnames(
-        "items-center absolute top-[50%]"
-      )}
-      >
+      <View className={classnames( "top-[50%]" )}>
         {children}
       </View>
     </View>


### PR DESCRIPTION
Closes #2107

The main issue wasn't happening anymore and was probably fixed by https://github.com/inaturalist/iNaturalistReactNative/pull/2185. This fixes the second issue of making the empty project results screen match what's in Figma.