### PR TITLE
fix: prevent git push after Crowdin pull

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -50,6 +50,7 @@ jobs:
           download_translations: true
           skip_untranslated_strings: true
           export_only_approved: true
+          push_translations: false
           # Pull request options
           create_pull_request: false
         env:

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -50,6 +50,9 @@ jobs:
           download_translations: true
           skip_untranslated_strings: true
           export_only_approved: true
+          # Without this, the action will force push changes to the branch
+          # before we get a chance to normalize and validate in the next
+          # step
           push_translations: false
           # Pull request options
           create_pull_request: false
@@ -63,13 +66,7 @@ jobs:
       # separate those things in the future if it's easier to notice
       # validation failures in the PR
       - name: Normalize and validate
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          echo "debug: git status before normalizing"
-          git status
-          npm run translate
-          echo "debug: git status after normalizing"
-          git status
+        run: npm run translate
 
       - name: Make pull request
         # The original doesn't support making a pull request without

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -63,8 +63,11 @@ jobs:
       # validation failures in the PR
       - name: Normalize and validate
         run: |
-          npm run translate
           git config --global --add safe.directory $GITHUB_WORKSPACE
+          echo "debug: git status before normalizing"
+          git status
+          npm run translate
+          echo "debug: git status after normalizing"
           git status
 
       - name: Make pull request

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Normalize and validate
         run: |
           npm run translate
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           git status
 
       - name: Make pull request

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -84,12 +84,10 @@ jobs:
           download_translations: false
           # Pull request options
           create_pull_request: true
-          # localization_branch_name: l10n_main
-          localization_branch_name: l10n-2103-post-to-crowdin
+          localization_branch_name: l10n_main
           pull_request_title: 'New Crowdin Translations'
           pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
-          # pull_request_base_branch_name: main
-          pull_request_base_branch_name: 2103-post-to-crowdin
+          pull_request_base_branch_name: main
         env:
           GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -62,7 +62,9 @@ jobs:
       # separate those things in the future if it's easier to notice
       # validation failures in the PR
       - name: Normalize and validate
-        run: npm run translate
+        run: |
+          npm run translate
+          git status
 
       - name: Make pull request
         # The original doesn't support making a pull request without
@@ -80,10 +82,12 @@ jobs:
           download_translations: false
           # Pull request options
           create_pull_request: true
-          localization_branch_name: l10n_main
+          # localization_branch_name: l10n_main
+          localization_branch_name: l10n-2103-post-to-crowdin
           pull_request_title: 'New Crowdin Translations'
           pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
-          pull_request_base_branch_name: 'main'
+          # pull_request_base_branch_name: main
+          pull_request_base_branch_name: 2103-post-to-crowdin
         env:
           GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/src/i18n/i18ncli.js
+++ b/src/i18n/i18ncli.js
@@ -90,10 +90,24 @@ const jsonifyPath = async ( inPath, outPath, options = { } ) => {
 
   // Allow us to await a result to this callback-based method so we can return
   // true when we know it succeeded
-  // TODO un-promisify this and use { respectComments: false } to exclude
-  // comments, which are going to add a lot of bulk to these files
+  fluent.ftl2js[util.promisify.custom] = (
+    str,
+    params = {}
+  ) => new Promise( ( resolve, reject ) => {
+    fluent.ftl2js(
+      str,
+      ( err, res ) => {
+        if ( err ) {
+          reject( err );
+        } else {
+          resolve( res );
+        }
+      },
+      params
+    );
+  } );
   const ftl2js = util.promisify( fluent.ftl2js );
-  const localizations = await ftl2js( ftlTxt.toString( ) );
+  const localizations = await ftl2js( ftlTxt.toString( ), { respectComments: false } );
   const massagedLocalizations = options.checkify
     ? checkifyLocalizations( localizations )
     : localizations;

--- a/src/i18n/i18ncli.js
+++ b/src/i18n/i18ncli.js
@@ -305,16 +305,22 @@ async function untranslatable( ) {
 async function normalizeFileNames( ) {
   const paths = await l10nFtlPaths();
   return Promise.all( paths.map( async l10nPath => {
+    console.log( "[DEBUG i18ncli.js] normalizing ", l10nPath );
     const locale = path.basename( l10nPath, ".ftl" );
     const [lng, region] = locale.split( "-" );
     // No need to move anything if there's no region
-    if ( !region ) return;
+    if ( !region ) {
+      console.log( "[DEBUG i18ncli.js]   no region, skipping" );
+      return;
+    }
     // We need to keep some regions
     if ( SUPPORTED_REGIONAL_LOCALES.indexOf( locale ) >= 0 ) {
+      console.log( "[DEBUG i18ncli.js]   region supported, skipping" );
       return;
     }
     // Everything else needs to be regionless
     const newPath = path.join( path.dirname( l10nPath ), `${lng}.ftl` );
+    console.log( "[DEBUG i18ncli.js]   moving to ", newPath );
     await fsp.rename( l10nPath, newPath );
   } ) );
 }

--- a/src/i18n/i18ncli.js
+++ b/src/i18n/i18ncli.js
@@ -305,22 +305,16 @@ async function untranslatable( ) {
 async function normalizeFileNames( ) {
   const paths = await l10nFtlPaths();
   return Promise.all( paths.map( async l10nPath => {
-    console.log( "[DEBUG i18ncli.js] normalizing ", l10nPath );
     const locale = path.basename( l10nPath, ".ftl" );
     const [lng, region] = locale.split( "-" );
     // No need to move anything if there's no region
-    if ( !region ) {
-      console.log( "[DEBUG i18ncli.js]   no region, skipping" );
-      return;
-    }
+    if ( !region ) return;
+
     // We need to keep some regions
-    if ( SUPPORTED_REGIONAL_LOCALES.indexOf( locale ) >= 0 ) {
-      console.log( "[DEBUG i18ncli.js]   region supported, skipping" );
-      return;
-    }
+    if ( SUPPORTED_REGIONAL_LOCALES.indexOf( locale ) >= 0 ) return;
+
     // Everything else needs to be regionless
     const newPath = path.join( path.dirname( l10nPath ), `${lng}.ftl` );
-    console.log( "[DEBUG i18ncli.js]   moving to ", newPath );
     await fsp.rename( l10nPath, newPath );
   } ) );
 }

--- a/src/i18n/l10n/af.ftl.json
+++ b/src/i18n/l10n/af.ftl.json
@@ -1,7 +1,4 @@
 {
   "Welcome-to-iNaturalist": "Welkom by iNaturalist!",
-  "Welcome-user": {
-    "comment": "Welcome user back to app",
-    "val": "<0>Welkom terug,</0><1>{ $userHandle }</1>"
-  }
+  "Welcome-user": "<0>Welkom terug,</0><1>{ $userHandle }</1>"
 }

--- a/src/i18n/l10n/ar.ftl.json
+++ b/src/i18n/l10n/ar.ftl.json
@@ -1,7 +1,4 @@
 {
   "Welcome-to-iNaturalist": "مرحبا بكم في iNaturalist!",
-  "Welcome-user": {
-    "comment": "Welcome user back to app",
-    "val": "<0>مرحبا بعودتك،</0><1>{ $userHandle }</1>"
-  }
+  "Welcome-user": "<0>مرحبا بعودتك،</0><1>{ $userHandle }</1>"
 }

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -1,307 +1,127 @@
 {
-  "ABOUT": {
-    "comment": "Header for a general description, e.g. of a user, or of iNaturalist itself",
-    "val": "ABOUT"
-  },
+  "ABOUT": "ABOUT",
   "ABOUT-COLLECTION-PROJECTS": "ABOUT COLLECTION PROJECTS",
   "ABOUT-INATURALIST": "ABOUT INATURALIST",
-  "ABOUT-THE-DQA": {
-    "comment": "About the Data Quality Assement",
-    "val": "ABOUT THE DQA"
-  },
+  "ABOUT-THE-DQA": "ABOUT THE DQA",
   "About-the-DQA-description": "The Quality Grade summarizes the accuracy, precision, completeness, relevance, and appropriateness of an iNaturalist observation as biodiversity data. Some attributes are automatically determined, while others are subject to a vote by iNat users. iNaturalist shares licensed \"Research Grade\" observations with a number of data partners for use in science and conservation.",
   "ABOUT-TRADITIONAL-PROJECTS": "ABOUT TRADITIONAL PROJECTS",
   "ABOUT-UMBRELLA-PROJECTS": "ABOUT UMBRELLA PROJECTS",
-  "accessible-comname-sciname": {
-    "comment": "Label for a taxon when a user prefers to see or hear the common name first",
-    "val": "{ $commonName } ({ $scientificName })"
-  },
-  "accessible-sciname-comname": {
-    "comment": "Label for a taxon when a user prefers to see or hear the scientific name first",
-    "val": "{ $scientificName } ({ $commonName })"
-  },
-  "Account-Deleted": {
-    "comment": "Alert message shown after account deletion",
-    "val": "Account Deleted"
-  },
+  "accessible-comname-sciname": "{ $commonName } ({ $scientificName })",
+  "accessible-sciname-comname": "{ $scientificName } ({ $commonName })",
+  "Account-Deleted": "Account Deleted",
   "ACTIVITY": "ACTIVITY",
-  "Add-agreement": {
-    "comment": "Label for a button that adds a vote of agreement",
-    "val": "Add agreement"
-  },
+  "Add-agreement": "Add agreement",
   "ADD-AN-ID": "ADD AN ID",
   "Add-an-ID-Later": "Add an ID Later",
   "ADD-COMMENT": "ADD COMMENT",
   "Add-Date-Time": "Add Date/Time",
-  "Add-disagreement": {
-    "comment": "Label for a button that adds a vote of disagreement",
-    "val": "Add disagreement"
-  },
+  "Add-disagreement": "Add disagreement",
   "ADD-EVIDENCE": "ADD EVIDENCE",
-  "Add-evidence": {
-    "comment": "Label for a button that shows options for adding evidence, e.g. camera,\ngallery, sound, etc",
-    "val": "Add evidence"
-  },
+  "Add-evidence": "Add evidence",
   "Add-favorite": "Add favorite",
   "Add-Location": "Add Location",
-  "Add-observations": {
-    "comment": "Accessibility label for a button that starts the process of adding an\nobservation, e.g. the button in the tab bar",
-    "val": "Add observations"
-  },
+  "Add-observations": "Add observations",
   "ADD-OPTIONAL-COMMENT": "ADD OPTIONAL COMMENT",
   "Add-optional-notes": "Add optional notes",
-  "Adds-your-vote-of-agreement": {
-    "comment": "Hint for a button that adds a vote of agreement",
-    "val": "Adds your vote of agreement"
-  },
-  "Adds-your-vote-of-disagreement": {
-    "comment": "Hint for a button that adds a vote of disagreement",
-    "val": "Adds your vote of disagreement"
-  },
+  "Adds-your-vote-of-agreement": "Adds your vote of agreement",
+  "Adds-your-vote-of-disagreement": "Adds your vote of disagreement",
   "Affiliation": "Affiliation: { $site }",
-  "Agree": {
-    "comment": "Label for button that adds an identification of the same taxon as another identification",
-    "val": "Agree"
-  },
-  "AGREE": {
-    "comment": "Label for button that adds an identification of the same taxon as another identification",
-    "val": "AGREE"
-  },
-  "Agree-to-all-of-the-above": {
-    "comment": "Checkbox label that checks all of the consent agreements a user must make\nbefore signing up",
-    "val": "Agree to all of the above"
-  },
+  "Agree": "Agree",
+  "AGREE": "AGREE",
+  "Agree-to-all-of-the-above": "Agree to all of the above",
   "AGREE-WITH-ID": "AGREE WITH ID?",
   "Agree-with-ID-description": "Would you like to agree with the ID and suggest the following identification?",
-  "AI-Camera": {
-    "comment": "This is what we call the camera that\noverlays identification suggestions in real time",
-    "val": "AI Camera"
-  },
+  "AI-Camera": "AI Camera",
   "ALL": "ALL",
   "All": "All",
   "All-observation-option": "All observation options (including iNaturalist AI Camera, Standard Camera, Uploading from Gallery, and Sound Recorder)",
   "All-observations": "All observations",
   "All-organisms": "All organisms",
-  "all-rights-reserved": {
-    "comment": "As in intellectual property rights over a photo or other creative work",
-    "val": "all rights reserved"
-  },
+  "all-rights-reserved": "all rights reserved",
   "All-taxa": "All taxa",
   "ALLOW-LOCATION-ACCESS": "ALLOW LOCATION ACCESS",
-  "Almost-done": {
-    "comment": "As in automated identification suggestions",
-    "val": "Almost done!"
-  },
+  "Almost-done": "Almost done!",
   "Already-have-an-account": "Already have an account? Log in",
   "An-Internet-connection-is-required": "An Internet connection is required to load more observations.",
-  "Any": {
-    "comment": "Generic option in a menu of choices that indicates that any of the choices\nwould be acceptable",
-    "val": "Any"
-  },
-  "Anyone-using-iNaturalist-can-see": {
-    "comment": " Geoprivacy sheet descriptions",
-    "val": "Anyone using iNaturalist can see where this species was observed, and scientists can most easily use it for research."
-  },
+  "Any": "Any",
+  "Anyone-using-iNaturalist-can-see": "Anyone using iNaturalist can see where this species was observed, and scientists can most easily use it for research.",
   "APP-LANGUAGE": "APP LANGUAGE",
   "APPLY-FILTERS": "APPLY FILTERS",
   "Apply-filters": "Apply filters",
-  "April": {
-    "comment": "Month of April",
-    "val": "April"
-  },
+  "April": "April",
   "Are-you-an-educator": "Are you an educator wanting to use iNaturalist with your students?",
   "Are-you-sure-you-want-to-log-out": "Are you sure you want to log out of your iNaturalist account? All observations that haven’t been uploaded to iNaturalist will be deleted.",
-  "As-you-upload-more-observations": {
-    "comment": "Onboarding text on MyObservations: 0-10 observations",
-    "val": "As you upload more observations, others in our community may be able to help you identify them!"
-  },
+  "As-you-upload-more-observations": "As you upload more observations, others in our community may be able to help you identify them!",
   "attribution-cc-by": "some rights reserved (CC BY)",
   "attribution-cc-by-nc": "some rights reserved (CC BY-NC)",
   "attribution-cc-by-nc-nd": "some rights reserved (CC BY-NC-ND)",
   "attribution-cc-by-nc-sa": "some rights reserved (CC BY-NC-SA)",
   "attribution-cc-by-nd": "some rights reserved (CC BY-ND)",
   "attribution-cc-by-sa": "some rights reserved (CC BY-SA)",
-  "August": {
-    "comment": "Month of August",
-    "val": "August"
-  },
-  "BACK-TO-LOGIN": {
-    "comment": "Returns user to login screen",
-    "val": "BACK TO LOGIN"
-  },
+  "August": "August",
+  "BACK-TO-LOGIN": "BACK TO LOGIN",
   "BLOG": "BLOG",
-  "Bulk-importer": {
-    "comment": "Accessibility label for bulk import / photo import button\nThese are used by screen readers to label actionable elements iOS: https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel\niOS Guidelines \"A string that succinctly identifies the accessibility element.\" Starts with capital letter, no ending punctuation.",
-    "val": "Bulk importer"
-  },
+  "Bulk-importer": "Bulk importer",
   "By-exiting-changes-not-saved": "By exiting, changes to your observation will not be saved.",
   "By-exiting-observation-not-saved": "By exiting, your observation will not be saved.",
   "By-exiting-your-observations-not-saved": "By exiting, your observations will not be saved. You can save them to your device, or you can delete them.",
   "By-exiting-your-photos-will-not-be-saved": "By exiting, your photos will not be saved.",
   "By-exiting-your-recorded-sound-will-not-be-saved": "By exiting, your recorded sound will not be saved.",
-  "By-uploading-your-observation-to-iNaturalist-you-can": {
-    "comment": "Lead in to a list including \"Get your identifcation verified...\" and \"Share your observation...\"",
-    "val": "By uploading your observation to iNaturalist, you can:"
-  },
+  "By-uploading-your-observation-to-iNaturalist-you-can": "By uploading your observation to iNaturalist, you can:",
   "Camera": "Camera",
   "CANCEL": "CANCEL",
   "Cancel": "Cancel",
   "Captive-Cultivated": "Captive/Cultivated",
-  "Casual--quality-grade": {
-    "comment": "Quality grade indicating observation does not quality for Needs ID or\nResearch Grade, e.g. missing media, voted out, etc.",
-    "val": "Casual"
-  },
-  "CC-BY": {
-    "comment": "Short label for the Creative Commons Attribution license",
-    "val": "CC BY"
-  },
-  "CC-BY-NC": {
-    "comment": "Short label for the Creative Commons Attribution-NonCommercial license",
-    "val": "CC BY-NC"
-  },
-  "CC-BY-NC-ND": {
-    "comment": "Short label for the Creative Commons Attribution-NonCommercial-NoDerivatives license",
-    "val": "CC BY-NC-ND"
-  },
-  "CC-BY-NC-SA": {
-    "comment": "Short label for the Creative Commons Attribution-NonCommercial-ShareAlike license",
-    "val": "CC BY-NC-SA"
-  },
-  "CC-BY-ND": {
-    "comment": "Short label for the Creative Commons Attribution-NoDerivatives license",
-    "val": "CC BY-ND"
-  },
-  "CC-BY-SA": {
-    "comment": "Short label for the Creative Commons Attribution-ShareAlike license",
-    "val": "CC BY-SA"
-  },
-  "CC0": {
-    "comment": "Short label for the Creative Commons Zero declaration",
-    "val": "CC0"
-  },
+  "Casual--quality-grade": "Casual",
+  "CC-BY": "CC BY",
+  "CC-BY-NC": "CC BY-NC",
+  "CC-BY-NC-ND": "CC BY-NC-ND",
+  "CC-BY-NC-SA": "CC BY-NC-SA",
+  "CC-BY-ND": "CC BY-ND",
+  "CC-BY-SA": "CC BY-SA",
+  "CC0": "CC0",
   "CHANGE-APP-LANGUAGE": "CHANGE APP LANGUAGE",
-  "CHANGE-DATE": {
-    "comment": "Label for a button that changes a selected date",
-    "val": "CHANGE DATE"
-  },
-  "Change-date": {
-    "comment": "Label for a button that changes a selected date",
-    "val": "Change date"
-  },
-  "CHANGE-END-DATE": {
-    "comment": "Label for a button that changes a selected end date",
-    "val": "CHANGE END DATE"
-  },
-  "Change-end-date": {
-    "comment": "Label for a button that changes a selected end date",
-    "val": "Change end date"
-  },
+  "CHANGE-DATE": "CHANGE DATE",
+  "Change-date": "Change date",
+  "CHANGE-END-DATE": "CHANGE END DATE",
+  "Change-end-date": "Change end date",
   "Change-project": "Change project",
-  "CHANGE-START-DATE": {
-    "comment": "Label for a button that changes a selected start date",
-    "val": "CHANGE START DATE"
-  },
-  "Change-start-date": {
-    "comment": "Label for a button that changes a selected start date",
-    "val": "Change start date"
-  },
+  "CHANGE-START-DATE": "CHANGE START DATE",
+  "Change-start-date": "Change start date",
   "Change-taxon": "Change taxon",
-  "Change-taxon-filter": {
-    "comment": "Button that changes the taxon filter on Explore",
-    "val": "Change taxon filter"
-  },
+  "Change-taxon-filter": "Change taxon filter",
   "Change-user": "Change user",
-  "Change-zoom": {
-    "comment": "Label for a button that cycles through zoom levels for the camera",
-    "val": "Change zoom"
-  },
+  "Change-zoom": "Change zoom",
   "Check-this-box-if-you-want-to-apply-a-Creative-Commons": "Check this box if you want to apply a Creative Commons Attribution-NonCommercial license to uploaded content. This means anyone can copy and reuse your photos and/or observations without asking for permission as long as they give you credit and don't use the works commercially. You can choose a different license or remove the license later, but this is the best license for sharing with researchers.",
-  "CHECK-YOUR-EMAIL": {
-    "comment": "Notification that appears after pressing the reset password button",
-    "val": "CHECK YOUR EMAIL!"
-  },
-  "CHOOSE-PHOTOS": {
-    "comment": "Text for a button prompting the user to grant access to the gallery",
-    "val": "CHOOSE PHOTOS"
-  },
-  "Choose-taxon": {
-    "comment": "Label for button that chooses a taxon",
-    "val": "Choose taxon"
-  },
-  "Choose-top-taxon": {
-    "comment": "Label for button that chooses top taxon",
-    "val": "Choose top taxon"
-  },
-  "Clear": {
-    "comment": "Label for a button that clears content, like the text entered in a text\nfield",
-    "val": "Clear"
-  },
-  "Close": {
-    "comment": "Label for a button that closes a window or popup",
-    "val": "Close"
-  },
-  "Close-permission-request-screen": {
-    "comment": "Accessibility label for a button that closes the permission request screen",
-    "val": "Close permission request screen"
-  },
-  "Close-search": {
-    "comment": "Label for a button that closes a search interface",
-    "val": "Close search"
-  },
+  "CHECK-YOUR-EMAIL": "CHECK YOUR EMAIL!",
+  "CHOOSE-PHOTOS": "CHOOSE PHOTOS",
+  "Choose-taxon": "Choose taxon",
+  "Choose-top-taxon": "Choose top taxon",
+  "Clear": "Clear",
+  "Close": "Close",
+  "Close-permission-request-screen": "Close permission request screen",
+  "Close-search": "Close search",
   "Closes-new-observation-options": "Closes new observation options.",
   "Closes-withdraw-id-sheet": "Closes \"Withdraw ID\" sheet",
-  "COLLABORATORS": {
-    "comment": "Heading for a section that describes people and organizations that\ncollaborate with iNaturalist",
-    "val": "COLLABORATORS"
-  },
+  "COLLABORATORS": "COLLABORATORS",
   "Collection-Project": "Collection Project",
-  "Combine-Photos": {
-    "comment": "Button that combines multiple photos into a single observation",
-    "val": "Combine Photos"
-  },
-  "COMMENT": {
-    "comment": "Title for a form that let's you enter a comment",
-    "val": "COMMENT"
-  },
-  "Comment-options": {
-    "comment": "Label for a button that shows options for a comment",
-    "val": "Comment options"
-  },
-  "Common-Name-Scientific-Name": {
-    "comment": "Label for a setting that shows the common name first",
-    "val": "Common Name (Scientific Name)"
-  },
+  "Combine-Photos": "Combine Photos",
+  "COMMENT": "COMMENT",
+  "Comment-options": "Comment options",
+  "Common-Name-Scientific-Name": "Common Name (Scientific Name)",
   "Community-Guidelines": "Community Guidelines",
   "COMMUNITY-GUIDELINES": "COMMUNITY GUIDELINES",
-  "CONFIRM": {
-    "comment": "Button that confirms a choice the user has made",
-    "val": "CONFIRM"
-  },
+  "CONFIRM": "CONFIRM",
   "Connect-with-other-naturalists": "Connect with other naturalists and engage in conversations.",
   "Connection-problem-Please-try-again-later": "Connection problem. Please try again later.",
   "CONTACT-SUPPORT": "CONTACT SUPPORT",
   "Continue-to-iNaturalist": "Continue to iNaturalist",
-  "Coordinates-copied-to-clipboard": {
-    "comment": "Notification when coordinates have been copied",
-    "val": "Coordinates copied to clipboard"
-  },
-  "Copy-coordinates": {
-    "comment": "Button that copies coordinates to the clipboard",
-    "val": "Copy Coordinates"
-  },
-  "Copyright": {
-    "comment": "Right to control copies of a creative work; this string may be used as a\nheading to describe general information about rights, attribution, and\nlicensing",
-    "val": "Copyright"
-  },
-  "Could-not-complete-at-this-time": {
-    "comment": "Error message potentially realating to not enough space on device",
-    "val": "Could not complete action this time."
-  },
+  "Coordinates-copied-to-clipboard": "Coordinates copied to clipboard",
+  "Copy-coordinates": "Copy Coordinates",
+  "Copyright": "Copyright",
+  "Could-not-complete-at-this-time": "Could not complete action this time.",
   "Could-not-complete-at-this-time-description": "Please try freeing up memory on device or restarting the app and try again.",
-  "Could-not-find-a-camera-on-this-device": {
-    "comment": "Error message when no camera can be found",
-    "val": "Could not find a camera on this device"
-  },
+  "Could-not-find-a-camera-on-this-device": "Could not find a camera on this device",
   "Couldnt-create-comment": "Couldn't create comment",
   "Couldnt-create-identification-error": "Couldn't create identification { $error }",
   "Couldnt-create-identification-unknown-error": "Couldn't create identification, unknown error.",
@@ -312,261 +132,105 @@
   "DATA-QUALITY-ASSESSMENT": "DATA QUALITY ASSESSMENT",
   "Data-quality-assessment-can-taxon-still-be-confirmed-improved-based-on-the-evidence": "Based on the evidence, can the Community Taxon still be improved?",
   "Data-quality-assessment-community-taxon-species-level-or-lower": "Community taxon at species level or lower",
-  "Data-quality-assessment-date-is-accurate": {
-    "comment": "Data Quality Assessment section label: whether or not the observation date is accurate",
-    "val": "Date is accurate"
-  },
-  "Data-quality-assessment-date-specified": {
-    "comment": "Data Quality Assessment section label: whether or not the observation date was specified",
-    "val": "Date specified"
-  },
+  "Data-quality-assessment-date-is-accurate": "Date is accurate",
+  "Data-quality-assessment-date-specified": "Date specified",
   "Data-quality-assessment-description-casual": "This observation has not met the conditions for Research Grade status.",
   "Data-quality-assessment-description-needs-id": "This observation has not yet met the conditions for Research Grade status:",
-  "Data-quality-assessment-description-research": {
-    "comment": "Data Quality Assessment explanation when quality is Research Grade",
-    "val": "It can now be used for research and featured on other websites."
-  },
-  "Data-quality-assessment-evidence-of-organism": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Evidence of organism"
-  },
-  "Data-quality-assessment-has-photos-or-sounds": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Has Photos or Sounds"
-  },
-  "Data-quality-assessment-id-supported-by-two-or-more": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Has ID supported by two or more"
-  },
-  "Data-quality-assessment-location-is-accurate": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Location is accurate"
-  },
-  "Data-quality-assessment-location-specified": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Location specified"
-  },
-  "Data-quality-assessment-organism-is-wild": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Organism is wild"
-  },
-  "Data-quality-assessment-recent-evidence-of-organism": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Recent evidence of an organism"
-  },
-  "Data-quality-assessment-single-subject": {
-    "comment": "Data Quality Assessment metric",
-    "val": "Evidence related to a single subject"
-  },
-  "Data-quality-assessment-title-casual": {
-    "comment": "Data Quality Assessment description of the final quality grade when Casual",
-    "val": "This observation is Casual Grade"
-  },
-  "Data-quality-assessment-title-needs-id": {
-    "comment": "Data Quality Assessment description of the final quality grade when Needs ID",
-    "val": "This observation Needs ID"
-  },
-  "Data-quality-assessment-title-research": {
-    "comment": "Data Quality Assessment description of the final quality grade when Research Grade",
-    "val": "This observation is Research Grade!"
-  },
+  "Data-quality-assessment-description-research": "It can now be used for research and featured on other websites.",
+  "Data-quality-assessment-evidence-of-organism": "Evidence of organism",
+  "Data-quality-assessment-has-photos-or-sounds": "Has Photos or Sounds",
+  "Data-quality-assessment-id-supported-by-two-or-more": "Has ID supported by two or more",
+  "Data-quality-assessment-location-is-accurate": "Location is accurate",
+  "Data-quality-assessment-location-specified": "Location specified",
+  "Data-quality-assessment-organism-is-wild": "Organism is wild",
+  "Data-quality-assessment-recent-evidence-of-organism": "Recent evidence of an organism",
+  "Data-quality-assessment-single-subject": "Evidence related to a single subject",
+  "Data-quality-assessment-title-casual": "This observation is Casual Grade",
+  "Data-quality-assessment-title-needs-id": "This observation Needs ID",
+  "Data-quality-assessment-title-research": "This observation is Research Grade!",
   "Data-quality-casual-description": "This observation needs more information verified to be considered verifiable",
   "Data-quality-needs-id-description": "This observation needs more identifications to reach research grade",
   "Data-quality-research-description": "This observation has enough identifications to be considered research grade",
   "DATE": "DATE",
-  "Date": {
-    "comment": "label in project requirements",
-    "val": "Date"
-  },
-  "date-format-long": {
-    "comment": "Date formatting using date-fns\nUsed for things like User Profile join date\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
-    "val": "PP"
-  },
-  "date-format-month-day": {
-    "comment": "Used when displaying a relative time - in this case, shows only month+year (same year) - e.g. Jul 3\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
-    "val": "MMM d"
-  },
-  "date-format-month-year": {
-    "comment": "Use when only showing an observations month and year\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
-    "val": "MMM yyyy"
-  },
-  "date-format-short": {
-    "comment": "Short date, e.g. on notifications from over a year ago\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
-    "val": "M/d/yy"
-  },
+  "Date": "Date",
+  "date-format-long": "PP",
+  "date-format-month-day": "MMM d",
+  "date-format-month-year": "MMM yyyy",
+  "date-format-short": "M/d/yy",
   "DATE-OBSERVED": "DATE OBSERVED",
   "Date-observed": "Date observed",
   "Date-observed-header-short": "Observed",
   "DATE-OBSERVED-NEWEST": "DATE OBSERVED - NEWEST TO OLDEST",
   "DATE-OBSERVED-OLDEST": "DATE OBSERVED - OLDEST TO NEWEST",
-  "Date-Range": {
-    "comment": "Label for controls over a range of dates",
-    "val": "Date Range"
-  },
-  "DATE-RANGE": {
-    "comment": "Label for controls over a range of dates",
-    "val": "DATE RANGE"
-  },
+  "Date-Range": "Date Range",
+  "DATE-RANGE": "DATE RANGE",
   "DATE-UPLOADED": "DATE UPLOADED",
   "Date-uploaded": "Date uploaded",
   "Date-uploaded-header-short": "Uploaded",
   "DATE-UPLOADED-NEWEST": "DATE UPLOADED - NEWEST TO OLDEST",
   "DATE-UPLOADED-OLDEST": "DATE UPLOADED - OLDEST TO NEWEST",
-  "datetime-difference-days": {
-    "comment": "Used when displaying a relative time - in this case, X days ago (e.g. 3d = 3 days ago)",
-    "val": "{ $count }d"
-  },
-  "datetime-difference-hours": {
-    "comment": "Used when displaying a relative time - in this case, X hours ago (e.g. 3h = 3 hours ago)",
-    "val": "{ $count }h"
-  },
-  "datetime-difference-minutes": {
-    "comment": "Used when displaying a relative time - in this case, X minutes ago (e.g. 3m = 3 minutes ago)",
-    "val": "{ $count }m"
-  },
-  "datetime-difference-weeks": {
-    "comment": "Used when displaying a relative time - in this case, X weeks ago (e.g. 3w = 3 weeks ago)",
-    "val": "{ $count }w"
-  },
-  "datetime-format-long": {
-    "comment": "Longer datetime, e.g. on ObsEdit\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
-    "val": "Pp"
-  },
-  "datetime-format-short": {
-    "comment": "Shorter datetime, e.g. on comments and IDs\nSee complete list of formatting styles: https://date-fns.org/v2.29.3/docs/format",
-    "val": "M/d/yy h:mm a"
-  },
-  "December": {
-    "comment": "Month of December",
-    "val": "December"
-  },
+  "datetime-difference-days": "{ $count }d",
+  "datetime-difference-hours": "{ $count }h",
+  "datetime-difference-minutes": "{ $count }m",
+  "datetime-difference-weeks": "{ $count }w",
+  "datetime-format-long": "Pp",
+  "datetime-format-short": "M/d/yy h:mm a",
+  "December": "December",
   "DELETE": "DELETE",
   "Delete-all-observations": "Delete all observations",
   "Delete-comment": "Delete comment",
   "DELETE-COMMENT--question": "DELETE COMMENT?",
   "Delete-observation": "Delete observation",
   "DELETE-OBSERVATION--question": "DELETE OBSERVATION?",
-  "Delete-photo": {
-    "comment": "Button label or accessibility label for an element that deletes a photo",
-    "val": "Delete photo"
-  },
+  "Delete-photo": "Delete photo",
   "Delete-sound": "Delete sound",
-  "Deletes-entered-text": {
-    "comment": "Hint for a button that clears text you entered",
-    "val": "Deletes entered text"
-  },
-  "Deleting-x-of-y": {
-    "comment": "Shows the progress of deletions for X of Y",
-    "val": "Deleting { $currentDeleteCount } of { $total }"
-  },
-  "Deleting-x-of-y-observations": {
-    "comment": "Shows the number of observations a user is currently deleting out of total on my observations page",
-    "val": "Deleting { $currentDeleteCount } of { $total ->\n  [one] 1 observation\n *[other] { $total } observations\n}"
-  },
-  "DETAILS": {
-    "comment": "Tab label or section title for content that describes further details, e.g.\nthe details of an observation",
-    "val": "DETAILS"
-  },
+  "Deletes-entered-text": "Deletes entered text",
+  "Deleting-x-of-y": "Deleting { $currentDeleteCount } of { $total }",
+  "Deleting-x-of-y-observations": "Deleting { $currentDeleteCount } of { $total ->\n  [one] 1 observation\n *[other] { $total } observations\n}",
+  "DETAILS": "DETAILS",
   "Device-storage-full": "Device storage full",
   "Device-storage-full-description": "iNaturalist may not be able to save your photos or may crash.",
-  "Disable-flash": {
-    "comment": "Button that disables the camera's flash",
-    "val": "Disable flash"
-  },
-  "Disagreement": {
-    "comment": "Disagreement notice with an identificaiton, <0/> will get replaced by a\ntaxon name",
-    "val": "*@{ $username } disagrees this is <0/>"
-  },
-  "DISCARD": {
-    "comment": "Button that discards changes or an item, e.g. a photo",
-    "val": "DISCARD"
-  },
-  "DISCARD-ALL": {
-    "comment": "Button that discards all items, e.g. imported photos",
-    "val": "DISCARD ALL"
-  },
-  "DISCARD-CHANGES": {
-    "comment": "Button that discards changes",
-    "val": "DISCARD CHANGES"
-  },
+  "Disable-flash": "Disable flash",
+  "Disagreement": "*@{ $username } disagrees this is <0/>",
+  "DISCARD": "DISCARD",
+  "DISCARD-ALL": "DISCARD ALL",
+  "DISCARD-CHANGES": "DISCARD CHANGES",
   "DISCARD-FILTER-CHANGES": "DISCARD FILTER CHANGES",
   "DISCARD-MEDIA--question": "DISCARD MEDIA?",
   "DISCARD-OBSERVATION": "DISCARD OBSERVATION",
   "DISCARD-PHOTOS--question": "DISCARD PHOTOS?",
-  "DISCARD-RECORDING": {
-    "comment": "Label for a button that discards a sound recording",
-    "val": "DISCARD RECORDING"
-  },
-  "DISCARD-SOUND--question": {
-    "comment": "Header of a popup confirming that the user wants to discard a sound\nrecording",
-    "val": "DISCARD SOUND?"
-  },
+  "DISCARD-RECORDING": "DISCARD RECORDING",
+  "DISCARD-SOUND--question": "DISCARD SOUND?",
   "DISCARD-X-OBSERVATIONS": "{ $count ->\n  [one] DISCARD OBSERVATION\n *[other] DISCARD { $count } OBSERVATIONS\n}",
   "DISMISS": "DISMISS",
   "DONATE": "DONATE",
   "DONATE-TO-INATURALIST": "DONATE TO INATURALIST",
-  "DONE": {
-    "comment": "Label for a button the user taps when a task is complete",
-    "val": "DONE"
-  },
+  "DONE": "DONE",
   "Dont-have-an-account": "Don't have an account? Sign up",
   "During-app-start-no-model-found": "During app start there was no computer vision model found. There will be no AI camera.",
-  "Edit": {
-    "comment": "Button for editing something",
-    "val": "Edit"
-  },
+  "Edit": "Edit",
   "EDIT-COMMENT": "EDIT COMMENT",
   "Edit-comment": "Edit comment",
-  "Edit-identification": {
-    "comment": "Label for button that edits an identification",
-    "val": "Edit identification"
-  },
+  "Edit-identification": "Edit identification",
   "EDIT-LOCATION": "EDIT LOCATION",
-  "Edit-location": {
-    "comment": "Label for interactive element that takes you to a location choosing screen",
-    "val": "Edit location"
-  },
+  "Edit-location": "Edit location",
   "Edit-Observation": "Edit Observation",
-  "Edits-this-observations-taxon": {
-    "comment": "Label for button that edits an observation's taxon",
-    "val": "Edits this observation's taxon"
-  },
+  "Edits-this-observations-taxon": "Edits this observation's taxon",
   "EDUCATORS": "EDUCATORS",
   "EMAIL": "EMAIL",
   "EMAIL-DEBUG-LOGS": "EMAIL DEBUG LOGS",
-  "Enable-flash": {
-    "comment": "Button that enables the camera's flash",
-    "val": "Enable flash"
-  },
-  "Endemic": {
-    "comment": "Indicates a species only occurs in a specific place",
-    "val": "Endemic"
-  },
-  "Endemic-to-place": {
-    "comment": "TODO this and many other uses of placeables are not currently translatable\nwithout knowing the vowel/consonant state of the first letter of the\nplaceable",
-    "val": "Endemic to { $place }"
-  },
-  "Error": {
-    "comment": "Title for a section describing an error",
-    "val": "Error"
-  },
+  "Enable-flash": "Enable flash",
+  "Endemic": "Endemic",
+  "Endemic-to-place": "Endemic to { $place }",
+  "Error": "Error",
   "ERROR": "ERROR",
   "ERROR-LOADING-DQA": "ERROR LOADING IN DQA",
-  "Error-title": {
-    "comment": "Title of dialog or section describing an error",
-    "val": "Error"
-  },
+  "Error-title": "Error",
   "ERROR-VOTING-IN-DQA": "ERROR VOTING IN DQA",
   "Error-voting-in-DQA-description": "Your vote may not have been cast in the DQA. Check your internet connection and try again.",
-  "Establishment": {
-    "comment": "label in project requirements",
-    "val": "Establishment"
-  },
+  "Establishment": "Establishment",
   "ESTABLISHMENT-MEANS": "ESTABLISHMENT MEANS",
-  "ESTABLISHMENT-MEANS-header": {
-    "comment": "Header for a section describing how a taxon arrived in a given place",
-    "val": "ESTABLISHMENT MEANS"
-  },
+  "ESTABLISHMENT-MEANS-header": "ESTABLISHMENT MEANS",
   "Every-observation-needs": "Every observation needs a location, date, and time to be helpful to identifiers. You can edit geoprivacy if you’re concerned about location privacy.",
   "Every-time-a-collection-project": "Every time a collection project's page is loaded, iNaturalist will perform a quick search and display all observations that match the project's requirements. It is an easy way to display a set of observations, such as for a class project, a park, or a bioblitz without making participants take the extra step of manually adding their observations to a project.",
   "EVIDENCE": "EVIDENCE",
@@ -582,18 +246,9 @@
   "EXPLORE-OBSERVERS": "EXPLORE OBSERVERS",
   "EXPLORE-SPECIES": "EXPLORE SPECIES",
   "Failed-to-delete-sound": "Failed to delete sound",
-  "Failed-to-log-in": {
-    "comment": "Error message with log in fails",
-    "val": "Failed to log in"
-  },
-  "FEATURED": {
-    "comment": "Header for featured projects",
-    "val": "FEATURED"
-  },
-  "February": {
-    "comment": "Month of February",
-    "val": "February"
-  },
+  "Failed-to-log-in": "Failed to log in",
+  "FEATURED": "FEATURED",
+  "February": "February",
   "FEEDBACK": "FEEDBACK",
   "Feedback-Submitted": "Feedback Submitted",
   "Fetching-location": "Fetching location...",
@@ -611,51 +266,21 @@
   "Flag-Item-Other": "Flagged as Other Description Box",
   "Flag-Item-Other-Description": "Some other reason you can explain below.",
   "Flag-Item-Other-Input-Hint": "Specify the reason you're flagging this item",
-  "Flagged": {
-    "comment": "Status when an item has been flagged",
-    "val": "Flagged"
-  },
+  "Flagged": "Flagged",
   "Flash": "flash",
-  "Flip-camera": {
-    "comment": "Label for a button that toggles between the front and back cameras",
-    "val": "Flip camera"
-  },
+  "Flip-camera": "Flip camera",
   "FOLLOW": "FOLLOW",
-  "Forgot-Password": {
-    "comment": "Forgot password link",
-    "val": "Forgot Password"
-  },
+  "Forgot-Password": "Forgot Password",
   "GEOPRIVACY": "GEOPRIVACY",
   "Geoprivacy-status": "Geoprivacy: { $status }",
-  "Get-more-accurate-suggestions-create-useful-data": {
-    "comment": "Title of screen asking for permission to access location",
-    "val": "Get more accurate suggestions & create useful data for science using your location"
-  },
-  "Get-your-identification-verified-by-real-people": {
-    "comment": "Preceded by the fragment, \"By uploading your observation to iNaturalist, you can:\"",
-    "val": "Get your identification verified by real people in the iNaturalist community"
-  },
-  "Go-back": {
-    "comment": "Label for button that returns to the previous screen",
-    "val": "Go back"
-  },
-  "GRANT-PERMISSION": {
-    "comment": "Text for a button that asks the user to grant permission",
-    "val": "GRANT PERMISSION"
-  },
-  "Grant-Permission-title": {
-    "comment": "Title of a screen asking for permission",
-    "val": "Grant Permission"
-  },
-  "Grid-layout": {
-    "comment": "Label for button to switch to a grid layout of observations",
-    "val": "Grid layout"
-  },
+  "Get-more-accurate-suggestions-create-useful-data": "Get more accurate suggestions & create useful data for science using your location",
+  "Get-your-identification-verified-by-real-people": "Get your identification verified by real people in the iNaturalist community",
+  "Go-back": "Go back",
+  "GRANT-PERMISSION": "GRANT PERMISSION",
+  "Grant-Permission-title": "Grant Permission",
+  "Grid-layout": "Grid layout",
   "Group-Photos": "Group Photos",
-  "Group-photos-onboarding": {
-    "comment": "Onboarding for users learning to group photos in the camera roll",
-    "val": "Group photos into observations– make sure there is only one species per observation"
-  },
+  "Group-photos-onboarding": "Group photos into observations– make sure there is only one species per observation",
   "HELP": "HELP",
   "Hide": "Hide",
   "Highest": "Highest",
@@ -664,15 +289,9 @@
   "I-consent-to-allow-iNaturalist-to-store": "I consent to allow iNaturalist to store and process limited kinds of personal information about me in order to manage my account (required)",
   "I-consent-to-allow-my-personal-information": "I consent to allow my personal information to be transferred to the United States of America (required)",
   "Iconic-taxon-name": "Iconic taxon name: { $iconicTaxon }",
-  "ID-Withdrawn": {
-    "comment": "Identification Status",
-    "val": "ID Withdrawn"
-  },
+  "ID-Withdrawn": "ID Withdrawn",
   "IDENTIFICATION": "IDENTIFICATION",
-  "Identification-options": {
-    "comment": "Accessibility label for a button that shows options for an identification",
-    "val": "Identification options"
-  },
+  "Identification-options": "Identification options",
   "IDENTIFICATIONS-WITHOUT-NUMBER": "{ $count ->\n  [one] IDENTIFICATION\n *[other] IDENTIFICATIONS\n}",
   "Identifiers": "Identifiers",
   "Identifiers-View": "Identifiers View",
@@ -683,15 +302,9 @@
   "If-youre-seeing-this-error": "If you're seeing this and you're online, iNat staff have already been notified. Thanks for finding a bug! If you're offline, please take a screenshot and send us an email when you're back on the Internet.",
   "IGNORE-LOCATION": "IGNORE LOCATION",
   "Import-Photos-From": "Import Photos From",
-  "IMPORT-X-OBSERVATIONS": {
-    "comment": "Shows the number of observations a user is about to import",
-    "val": "IMPORT { $count ->\n  [one] 1 OBSERVATION\n *[other] { $count } OBSERVATIONS\n}"
-  },
+  "IMPORT-X-OBSERVATIONS": "IMPORT { $count ->\n  [one] 1 OBSERVATION\n *[other] { $count } OBSERVATIONS\n}",
   "IMPROVE-THESE-SUGGESTIONS-BY-USING-YOUR-LOCATION": "IMPROVE THESE SUGGESTIONS BY USING YOUR LOCATION",
-  "improving--identification": {
-    "comment": "Identification category",
-    "val": "Improving"
-  },
+  "improving--identification": "Improving",
   "INATURALIST-ACCOUNT-SETTINGS": "INATURALIST ACCOUNT SETTINGS",
   "iNaturalist-AI-Camera": "iNaturalist AI Camera",
   "iNaturalist-can-save-photos-you-take-in-the-app-to-your-devices-gallery": "iNaturalist can save photos you take in the app to your device’s gallery.",
@@ -710,10 +323,7 @@
   "INATURALIST-MISSION-VISION": "INATURALIST'S MISSION & VISION",
   "INATURALIST-NETWORK": "INATURALIST NETWORK",
   "INATURALIST-SETTINGS": "INATURALIST SETTINGS",
-  "INATURALIST-STAFF": {
-    "comment": "Label for the role a user plays on iNaturalist, e.g. \"INATURALIST STAFF\"\nor \"INATURALIST CURATOR\". Since the name \"INATURALIST\" should not be\ntranslated or locally it is inserted as a variable here, but it will always\nbe \"INATURALIST\"",
-    "val": "{ $inaturalist } STAFF"
-  },
+  "INATURALIST-STAFF": "{ $inaturalist } STAFF",
   "INATURALIST-STORE": "INATURALIST STORE",
   "INATURALIST-TEAM": "INATURALIST TEAM",
   "iNaturalist-users-who-have-left-an-identification": "iNaturalist users who have left an identification on another user's observation",
@@ -723,64 +333,31 @@
   "iNaturalists-vision-is-a-world": "iNaturalist's vision is a world where everyone can understand and sustain biodiversity through the practice of observing wild organisms and sharing information about them.",
   "Individual-encounters-with-organisms": "Individual encounters with organisms at a particular time and location, usually with evidence",
   "INFO-TRANSFER": "INFO TRANSFER",
-  "Internet-Connection-Required": {
-    "comment": "Title for dialog telling the user that an Internet connection is required",
-    "val": "Internet Connection Required"
-  },
+  "Internet-Connection-Required": "Internet Connection Required",
   "Intl-number": "{ $val }",
   "Introduced": "Introduced",
   "Introduced-to-place": "Introduced to { $place }",
   "It-may-take-up-to-an-hour-to-remove-content": "It may take up to an hour to completely delete all associated content",
-  "January": {
-    "comment": "Month of January",
-    "val": "January"
-  },
+  "January": "January",
   "JOIN": "JOIN",
   "JOIN-PROJECT": "JOIN PROJECT",
   "Join-the-largest-community-of-naturalists": "Join the largest community of naturalists in the world!",
-  "JOINED": {
-    "comment": "Header for joined projects",
-    "val": "JOINED"
-  },
-  "Joined-date": {
-    "comment": "Shows date user joined iNaturalist on user profile",
-    "val": "Joined: { $date }"
-  },
+  "JOINED": "JOINED",
+  "Joined-date": "Joined: { $date }",
   "JOURNAL-POSTS-WITHOUT-NUMBER": "{ $count ->\n  [one] JOURNAL POST\n *[other] JOURNAL POSTS\n}",
-  "July": {
-    "comment": "Month of July",
-    "val": "July"
-  },
-  "June": {
-    "comment": "Month of June",
-    "val": "June"
-  },
+  "July": "July",
+  "June": "June",
   "Just-make-sure-the-organism-is-wild": "Just make sure the organism is wild (not a pet, zoo animal, or garden plant)",
-  "Last-Active-date": {
-    "comment": "Shows date user last active on iNaturalist on user profile",
-    "val": "Last Active: { $date }"
-  },
-  "Lat-Lon": {
-    "comment": "Latitude, longitude on a single line",
-    "val": "{ NUMBER($latitude, maximumFractionDigits: \"6\") }, { NUMBER($longitude, maximumFractionDigits: \"6\") }"
-  },
-  "Lat-Lon-Acc": {
-    "comment": "Latitude, longitude, and accuracy on a single line",
-    "val": "Lat: { NUMBER($latitude, maximumFractionDigits: \"6\") }, Lon: { NUMBER($longitude, maximumFractionDigits: \"6\") }, Acc: { $accuracy }"
-  },
-  "leading--identification": {
-    "comment": "Identification category",
-    "val": "Leading"
-  },
+  "Last-Active-date": "Last Active: { $date }",
+  "Lat-Lon": "{ NUMBER($latitude, maximumFractionDigits: \"6\") }, { NUMBER($longitude, maximumFractionDigits: \"6\") }",
+  "Lat-Lon-Acc": "Lat: { NUMBER($latitude, maximumFractionDigits: \"6\") }, Lon: { NUMBER($longitude, maximumFractionDigits: \"6\") }, Acc: { $accuracy }",
+  "leading--identification": "Leading",
   "Learn-More": "Learn More",
   "LEAVE": "LEAVE",
   "LEAVE-PROJECT": "LEAVE PROJECT",
   "LEAVE-US-A-REVIEW": "LEAVE US A REVIEW!",
   "LICENSES": "LICENSES",
-  "List-layout": {
-    "comment": "Label for button to switch to a list layout of observations",
-    "val": "List layout"
-  },
+  "List-layout": "List layout",
   "Loading-iNaturalists-AI-Camera": "Loading iNaturalist's AI Camera",
   "Loads-content-that-requires-an-Internet-connection": "Loads content that requires an Internet connection",
   "LOCATION": "LOCATION",
@@ -788,46 +365,25 @@
   "Location-accuracy-is-too-imprecise": "Location accuracy is too imprecise to help identifiers. Please zoom in.",
   "LOCATION-TOO-IMPRECISE": "LOCATION TOO IMPRECISE",
   "LOG-IN": "LOG IN",
-  "Log-in": {
-    "comment": "Second person imperative label to go to log in screen",
-    "val": "Log in"
-  },
+  "Log-in": "Log in",
   "Log-in-to-contribute-and-sync": "Log in to contribute & sync",
   "Log-in-to-contribute-your-observations": "Log in to contribute your observations to science!",
   "LOG-IN-TO-INATURALIST": "LOG IN TO INATURALIST",
   "Log-in-to-iNaturalist": "Log in to iNaturalist",
   "LOG-OUT": "LOG OUT",
   "LOG-OUT--question": "LOG OUT?",
-  "Login-sub-title": {
-    "comment": "Appears in the login screen",
-    "val": "Document living things, identify organisms & contribute to science"
-  },
+  "Login-sub-title": "Document living things, identify organisms & contribute to science",
   "Lowest": "Lowest",
   "LOWEST-RANK": "LOWEST RANK",
   "MAP": "MAP",
   "Map-Area": "Map Area",
-  "March": {
-    "comment": "Month of March",
-    "val": "March"
-  },
-  "maverick--identification": {
-    "comment": "Identification category",
-    "val": "Maverick"
-  },
-  "May": {
-    "comment": "Month of May",
-    "val": "May"
-  },
+  "March": "March",
+  "maverick--identification": "Maverick",
+  "May": "May",
   "MEDIA": "MEDIA",
-  "Media-Type": {
-    "comment": "label in project requirements",
-    "val": "Media Type"
-  },
+  "Media-Type": "Media Type",
   "MEMBERS-WITHOUT-NUMBER": "{ $count ->\n  [one] MEMBER\n *[other] MEMBERS\n}",
-  "Menu": {
-    "comment": "Accessibility label for a button that opens a menu of options",
-    "val": "Menu"
-  },
+  "Menu": "Menu",
   "Missing-Date": "Missing Date",
   "MISSING-EVIDENCE": "MISSING EVIDENCE",
   "Monthly-Donor": "Monthly Donor",
@@ -853,178 +409,79 @@
   "Navigates-to-suggest-identification": "Navigates to suggest identification",
   "Navigates-to-taxon-details": "Navigates to taxon details",
   "Navigates-to-user-profile": "Navigates to user profile",
-  "Navigates-to-your-observations": {
-    "comment": "Label for button that takes you to your observations",
-    "val": "Navigates to your observations"
-  },
-  "NEARBY": {
-    "comment": "Header or button label for content that is near the user's current location",
-    "val": "NEARBY"
-  },
-  "Nearby": {
-    "comment": "Header or button label for content that is near the user's current location",
-    "val": "Nearby"
-  },
-  "Needs-ID--quality-grade": {
-    "comment": "Quality grade indicating observation still needs more identifications",
-    "val": "Needs ID"
-  },
-  "New-Observation": {
-    "comment": "Heading when creating a new observation",
-    "val": "New Observation"
-  },
-  "Newest-to-oldest": {
-    "comment": "Sort order, refers to newest or oldest date",
-    "val": "Newest to oldest"
-  },
+  "Navigates-to-your-observations": "Navigates to your observations",
+  "NEARBY": "NEARBY",
+  "Nearby": "Nearby",
+  "Needs-ID--quality-grade": "Needs ID",
+  "New-Observation": "New Observation",
+  "Newest-to-oldest": "Newest to oldest",
   "Next-observation": "Next observation",
-  "No-Camera-Available": {
-    "comment": "Error message when no camera can be found",
-    "val": "No Camera Available"
-  },
-  "No-email-app-installed": {
-    "comment": "Alert dialog title when attempting to send email but no email is installed",
-    "val": "No email app installed"
-  },
+  "No-Camera-Available": "No Camera Available",
+  "No-email-app-installed": "No email app installed",
   "No-email-app-installed-body": "If you have another way of sending email, the address is { $address }",
   "No-email-app-installed-body-check-other": "Try checking your email in a web browser or on another device.",
   "No-Location": "No Location",
   "No-Media": "No Media",
-  "No-model-found": {
-    "comment": "As in a machine learning model that powers automated suggestions",
-    "val": "No model found"
-  },
+  "No-model-found": "No model found",
   "No-Notifications-Found": "You have no notifications! Get started by creating your own observations.",
   "No-projects-match-that-search": "No projects match that search",
-  "No-results-found-for-that-search": {
-    "comment": "Used for explore screen when search params lead to a search with no data",
-    "val": "No results found for that search."
-  },
+  "No-results-found-for-that-search": "No results found for that search.",
   "No-results-found-try-different-search": "No results found. Try a different search or adjust your filters.",
-  "no-rights-reserved-cc0": {
-    "comment": "license code",
-    "val": "no rights reserved (CC0)"
-  },
-  "No-space-left-on-device": {
-    "comment": "Error message when not enough memory on device",
-    "val": "No space left on device."
-  },
+  "no-rights-reserved-cc0": "no rights reserved (CC0)",
+  "No-space-left-on-device": "No space left on device.",
   "No-space-left-on-device-try-again": "Not enough memory left on device. Please clear some memory and try again.",
   "NONE": "NONE",
   "none": "none",
-  "NOTES": {
-    "comment": "Header for observation description on observation detail",
-    "val": "NOTES"
-  },
+  "NOTES": "NOTES",
   "NOTIFICATIONS": "NOTIFICATIONS",
   "Notifications": "Notifications",
-  "notifications-user-added-comment-to-observation-by-you": {
-    "comment": "notification when someone adds a comment to your observation",
-    "val": "<0>{ $userName }</0> added a comment to an observation by you"
-  },
-  "notifications-user-added-identification-to-observation-by-you": {
-    "comment": "notification when someone adds an identification to your observation",
-    "val": "<0>{ $userName }</0> added an identification to an observation by you"
-  },
-  "November": {
-    "comment": "Month of November",
-    "val": "November"
-  },
+  "notifications-user-added-comment-to-observation-by-you": "<0>{ $userName }</0> added a comment to an observation by you",
+  "notifications-user-added-identification-to-observation-by-you": "<0>{ $userName }</0> added an identification to an observation by you",
+  "November": "November",
   "Obervations-must-be-manually-added": "Observations must be manually added to a traditional project, either during the upload stage or after the observation has been shared to iNaturalist. A user must also join a traditional project in order to add their observations to it.",
   "Obscured": "Obscured",
-  "Obscured-observation-location-map-description": {
-    "comment": "Displayed when user views an obscured location on the ObsDetail map screen",
-    "val": "This observation’s location is obscured. You are seeing a randomized point within the obscuration polygon."
-  },
+  "Obscured-observation-location-map-description": "This observation’s location is obscured. You are seeing a randomized point within the obscuration polygon.",
   "Observation-Attribution": "Observation: © { $userName } · { $restrictions }",
   "OBSERVATION-BUTTON": "OBSERVATION BUTTON",
   "Observation-has-no-photos-and-no-sounds": "This observation has no photos and no sounds.",
   "Observation-Name": "Observation { $scientificName }",
-  "Observation-options": {
-    "comment": "Label for a menu that shows various actions you can take for an observation",
-    "val": "Observation options"
-  },
+  "Observation-options": "Observation options",
   "OBSERVATION-WAS-DELETED": "OBSERVATION WAS DELETED",
   "Observation-with-no-evidence": "Observation with no evidence",
   "Observations": "Observations",
   "Observations-created-on-iNaturalist": "Observations created on iNaturalist are used by scientists around the world.",
   "Observations-View": "Observations View",
-  "OBSERVATIONS-WITHOUT-NUMBER": {
-    "comment": "Might be used when the number is represented using an image or other\nelement, not text",
-    "val": "{ $count ->\n  [one] OBSERVATION\n *[other] OBSERVATIONS\n}"
-  },
-  "Observations-you-upload-to-iNaturalist": {
-    "comment": "Onboarding text on MyObservations: Onboarding text on MyObservations: 11-50 observations",
-    "val": "Observations you upload to iNaturalist can be used by scientists and researchers worldwide."
-  },
-  "Observe": {
-    "comment": "Button that starts a new observation",
-    "val": "Observe"
-  },
-  "Observe-and-identify-organisms-from-your-gallery": {
-    "comment": "Title of screen asking for permission to access the gallery",
-    "val": "Observe and identify organisms from your gallery"
-  },
-  "Observe-and-identify-organisms-in-real-time-with-your-camera": {
-    "comment": "Title of screen asking for permission to access the camera",
-    "val": "Observe and identify organisms in real-time with your camera"
-  },
-  "OBSERVE-ORGANISMS": {
-    "comment": "Text for a button prompting the user to grant access to the camera",
-    "val": "OBSERVE ORGANISMS"
-  },
+  "OBSERVATIONS-WITHOUT-NUMBER": "{ $count ->\n  [one] OBSERVATION\n *[other] OBSERVATIONS\n}",
+  "Observations-you-upload-to-iNaturalist": "Observations you upload to iNaturalist can be used by scientists and researchers worldwide.",
+  "Observe": "Observe",
+  "Observe-and-identify-organisms-from-your-gallery": "Observe and identify organisms from your gallery",
+  "Observe-and-identify-organisms-in-real-time-with-your-camera": "Observe and identify organisms in real-time with your camera",
+  "OBSERVE-ORGANISMS": "OBSERVE ORGANISMS",
   "Observers": "Observers",
-  "Observers-View": {
-    "comment": "Section in Explore that shows people who added observations given a set of search filters",
-    "val": "Observers View"
-  },
-  "October": {
-    "comment": "Month of October",
-    "val": "October"
-  },
+  "Observers-View": "Observers View",
+  "October": "October",
   "Offensive-Inappropriate": "Offensive/Inappropriate",
   "Offensive-Inappropriate-Examples": "Misleading or illegal content, racial or ethnic slurs, etc. For more on our defintion of \"appropriate,\" see the FAQ.",
   "Offline-DQA-description": "The DQA may not be accurate. Check your internet connection and try again.",
   "Offline-suggestions-do-not-use-your-location": "Offline suggestions do not use your location and may differ from online suggestions. Taxon images and common names may not load.",
-  "OK": {
-    "comment": "Generic confirmation, e.g. button on a warning alert",
-    "val": "OK"
-  },
-  "Oldest-to-newest": {
-    "comment": "Sort order, refers to newest or oldest date",
-    "val": "Oldest to newest"
-  },
+  "OK": "OK",
+  "Oldest-to-newest": "Oldest to newest",
   "Once-you-create-and-upload-observations": "Once you create & upload observations, other members of our community can add identifications to help your observations reach research grade.",
   "One-last-step": "One last step!",
-  "Open": {
-    "comment": "Adjective, as in geoprivacy",
-    "val": "Open"
-  },
+  "Open": "Open",
   "Open-drawer": "Open drawer",
   "OPEN-EMAIL": "OPEN EMAIL",
   "Open-menu": "Open menu.",
-  "OPEN-SETTINGS": {
-    "comment": "Text for a button that opens the operating system Settings app",
-    "val": "OPEN SETTINGS"
-  },
+  "OPEN-SETTINGS": "OPEN SETTINGS",
   "Opens-add-comment-modal": "Opens add comment modal.",
   "Opens-add-observation-modal": "Opens add observation modal.",
   "Opens-AI-camera": "Opens AI camera.",
   "Opens-location-permission-prompt": "Opens location permission prompt",
-  "Opens-the-AI-camera": {
-    "comment": "Accessibility hint for button that opens the AI camera",
-    "val": "Opens the AI camera"
-  },
+  "Opens-the-AI-camera": "Opens the AI camera",
   "Opens-the-side-drawer-menu": "Opens the side drawer menu.",
-  "Organism-is-captive": {
-    "comment": "Picker prompt on observation edit",
-    "val": "Organism is captive"
-  },
+  "Organism-is-captive": "Organism is captive",
   "Organisms-that-are-identified-to-species": "Organisms that are identified to species rank or below",
-  "Other": {
-    "comment": "Generic option in a list for unanticipated cases, e.g. a choice to manually\nenter an explanation for why you are flagging something instead of choosing\none of the existing options",
-    "val": "Other"
-  },
+  "Other": "Other",
   "OTHER-DATA": "OTHER DATA",
   "OTHER-SUGGESTIONS": "OTHER SUGGESTIONS",
   "PASSWORD": "PASSWORD",
@@ -1033,27 +490,12 @@
   "PHOTO-LICENSING": "PHOTO LICENSING",
   "Photos": "Photos",
   "Photos-you-take-will-appear-here": "Photos you take will appear here",
-  "Please-allow-Camera-Access": {
-    "comment": "Title of screen asking for permission to access the camera when access was denied",
-    "val": "Please allow Camera Access"
-  },
-  "Please-Allow-Gallery-Access": {
-    "comment": "Title of screen asking for permission to access the gallery when access was denied",
-    "val": "Please Allow Gallery Access"
-  },
-  "Please-allow-Location-Access": {
-    "comment": "Title of screen asking for permission to access location when access was denied",
-    "val": "Please allow Location Access"
-  },
-  "Please-allow-Microphone-Access": {
-    "comment": "Title of screen asking for permission to access the microphone when access was denied",
-    "val": "Please allow Microphone Access"
-  },
+  "Please-allow-Camera-Access": "Please allow Camera Access",
+  "Please-Allow-Gallery-Access": "Please Allow Gallery Access",
+  "Please-allow-Location-Access": "Please allow Location Access",
+  "Please-allow-Microphone-Access": "Please allow Microphone Access",
   "Please-click-the-link": "Please click the link in the email within 60 minutes  to confirm your account",
-  "Please-Grant-Permission": {
-    "comment": "Title of a screen asking for permission when permission has been denied",
-    "val": "Please Grant Permission"
-  },
+  "Please-Grant-Permission": "Please Grant Permission",
   "PLEASE-LOG-IN": "PLEASE LOG IN",
   "Please-try-again-when-you-are-connected-to-the-internet": "Please try again when you are connected to the Internet.",
   "Please-try-again-when-you-are-online": "Please try again when you are online!",
@@ -1061,45 +503,21 @@
   "Potential-disagreement-description": "<0>Is the evidence enough to confirm this is </0><1></1><0>?<0>",
   "Potential-disagreement-disagree": "<0>No, but this is a member of </0><1></1>",
   "Potential-disagreement-unsure": "<0>I don't know but I am sure this is </0><1></1>",
-  "Press-record-to-start": {
-    "comment": "Help text for beginning a sound recording",
-    "val": "Press record to start"
-  },
+  "Press-record-to-start": "Press record to start",
   "Previous-observation": "Previous observation",
   "Privacy-Policy": "Privacy Policy",
   "PRIVACY-POLICY": "PRIVACY POLICY",
   "Private": "Private",
-  "PROJECT": {
-    "comment": "As in an iNat project, a collection of observations or observation search filters",
-    "val": "PROJECT"
-  },
+  "PROJECT": "PROJECT",
   "Project-Members-Only": "Project Members Only",
   "PROJECT-REQUIREMENTS": "PROJECT REQUIREMENTS",
-  "PROJECTS": {
-    "comment": "As in iNat project, collections of observations or observation search filters",
-    "val": "PROJECTS"
-  },
-  "Projects": {
-    "comment": "As in iNat projects, collections of observations or observation search filters",
-    "val": "Projects"
-  },
+  "PROJECTS": "PROJECTS",
+  "Projects": "Projects",
   "QUALITY-GRADE": "QUALITY GRADE",
-  "Quality-Grade": {
-    "comment": "label in project requirements",
-    "val": "Quality Grade"
-  },
-  "Quality-Grade-Casual--label": {
-    "comment": "Screen reader label for the Casual quality grade label",
-    "val": "Quality Grade: Casual"
-  },
-  "Quality-Grade-Needs-ID--label": {
-    "comment": "Screen reader label for the Needs ID quality grade label",
-    "val": "Quality Grade: Needs ID"
-  },
-  "Quality-Grade-Research--label": {
-    "comment": "Screen reader label for the Research quality grade label",
-    "val": "Quality Grade: Research"
-  },
+  "Quality-Grade": "Quality Grade",
+  "Quality-Grade-Casual--label": "Quality Grade: Casual",
+  "Quality-Grade-Needs-ID--label": "Quality Grade: Needs ID",
+  "Quality-Grade-Research--label": "Quality Grade: Research",
   "Ranks-CLASS": "CLASS",
   "Ranks-Class": "Class",
   "Ranks-COMPLEX": "COMPLEX",
@@ -1173,103 +591,40 @@
   "Ranks-ZOOSUBSECTION": "ZOOSUBSECTION",
   "Ranks-Zoosubsection": "Zoosubsection",
   "Read-more-on-Wikipedia": "Read more on Wikipedia",
-  "RECORD-NEW-SOUND": {
-    "comment": "Heading for the sound recorder",
-    "val": "RECORD NEW SOUND"
-  },
-  "Record-organism-sounds-with-the-microphone": {
-    "comment": "Title of screen asking for permission to access the microphone",
-    "val": "Record organism sounds with the microphone"
-  },
-  "RECORD-SOUND": {
-    "comment": "Text for a button prompting the user to grant access to the microphone",
-    "val": "RECORD SOUND"
-  },
+  "RECORD-NEW-SOUND": "RECORD NEW SOUND",
+  "Record-organism-sounds-with-the-microphone": "Record organism sounds with the microphone",
+  "RECORD-SOUND": "RECORD SOUND",
   "Record-sounds": "Record sounds with your microphone",
-  "Record-verb": {
-    "comment": "Imperative verb for recording a sound",
-    "val": "Record"
-  },
-  "Recording-sound": {
-    "comment": "Status while recording a sound",
-    "val": "Recording sound"
-  },
+  "Record-verb": "Record",
+  "Recording-sound": "Recording sound",
   "Recording-stopped-Tap-play-the-current-recording": "Recording stopped. Tap play the current recording.",
   "REDO-SEARCH-IN-MAP-AREA": "REDO SEARCH IN MAP AREA",
-  "Remove-agreement": {
-    "comment": "Label for a button that removes a vote of agreement",
-    "val": "Remove agreement"
-  },
-  "Remove-disagreement": {
-    "comment": "Label for a button that removes a vote of disagreement",
-    "val": "Remove disagreement"
-  },
+  "Remove-agreement": "Remove agreement",
+  "Remove-disagreement": "Remove disagreement",
   "Remove-favorite": "Remove favorite",
-  "Remove-identification": {
-    "comment": "Label for button that removes an identification",
-    "val": "Remove identification"
-  },
+  "Remove-identification": "Remove identification",
   "Remove-Photos": "Remove Photos",
   "Remove-project-filter": "Remove project filter",
   "Remove-taxon-filter": "Remove taxon filter",
   "Remove-user-filter": "Remove user filter",
-  "Removes-this-observations-taxon": {
-    "comment": "Label for button that removes an observation's taxon",
-    "val": "Removes this observation's taxon"
-  },
-  "Removes-your-vote-of-agreement": {
-    "comment": "Hint for a button that removes a vote of agreement",
-    "val": "Removes your vote of agreement"
-  },
-  "Removes-your-vote-of-disagreement": {
-    "comment": "Hint for a button that removes a vote of disagreement",
-    "val": "Removes your vote of disagreement"
-  },
-  "Research-Grade--quality-grade": {
-    "comment": "Quality grade indicating observation is accurate and complete enough to\nshare outside of iNat",
-    "val": "Research Grade"
-  },
-  "RESET-PASSWORD": {
-    "comment": "Reset password button",
-    "val": "RESET PASSWORD"
-  },
-  "RESET-RECORDING": {
-    "comment": "Label for a button that resets a sound recording",
-    "val": "RESET RECORDING"
-  },
+  "Removes-this-observations-taxon": "Removes this observation's taxon",
+  "Removes-your-vote-of-agreement": "Removes your vote of agreement",
+  "Removes-your-vote-of-disagreement": "Removes your vote of disagreement",
+  "Research-Grade--quality-grade": "Research Grade",
+  "RESET-PASSWORD": "RESET PASSWORD",
+  "RESET-RECORDING": "RESET RECORDING",
   "RESET-SEARCH": "RESET SEARCH",
-  "RESET-SOUND-header": {
-    "comment": "Header of a popup confirming that the user wants to reset a sound\nrecording",
-    "val": "RESET SOUND?"
-  },
-  "Reset-verb": {
-    "comment": "Label for a button that resets the state of an interface, e.g. a button that\nresets the sound recorder to its original state",
-    "val": "Reset"
-  },
+  "RESET-SOUND-header": "RESET SOUND?",
+  "Reset-verb": "Reset",
   "RESTART-APP": "RESTART APP",
-  "Restore": {
-    "comment": "Label for button that restores a withdrawn identification",
-    "val": "Restore"
-  },
+  "Restore": "Restore",
   "Reveal": "Reveal",
   "REVIEW-INATURALIST": "REVIEW INATURALIST",
-  "REVIEWED": {
-    "comment": "Title for section of observation filters for controls over whether you have\nreviewed the observations or not",
-    "val": "REVIEWED"
-  },
+  "REVIEWED": "REVIEWED",
   "Reviewed-observations-only": "Reviewed observations only",
-  "Satellite--map-type": {
-    "comment": "Label for the satellite map type",
-    "val": "Satellite"
-  },
-  "SAVE": {
-    "comment": "Label for a button that persists something",
-    "val": "SAVE"
-  },
-  "Save": {
-    "comment": "Label for a button that persists something",
-    "val": "Save"
-  },
+  "Satellite--map-type": "Satellite",
+  "SAVE": "SAVE",
+  "Save": "Save",
   "SAVE-ALL": "SAVE ALL",
   "SAVE-CHANGES": "SAVE CHANGES",
   "SAVE-FOR-LATER": "SAVE FOR LATER",
@@ -1280,14 +635,8 @@
   "Scan-the-area-around-you-for-organisms": "Scan the area around you for organisms.",
   "Scientific-Name": "Scientific Name",
   "Scientific-Name-Common-Name": "Scientific Name (Common Name)",
-  "SEARCH": {
-    "comment": "Title for a search interface",
-    "val": "SEARCH"
-  },
-  "Search": {
-    "comment": "Title for a search interface",
-    "val": "Search"
-  },
+  "SEARCH": "SEARCH",
+  "Search": "Search",
   "Search-for-a-project": "Search for a project",
   "SEARCH-FOR-A-TAXON": "SEARCH FOR A TAXON",
   "Search-for-a-taxon": "Search for a taxon",
@@ -1297,82 +646,40 @@
   "Search-suggestions-without-location": "Search suggestions without location",
   "SEARCH-TAXA": "SEARCH TAXA",
   "SEARCH-USERS": "SEARCH USERS",
-  "See-all-your-observations-in-explore": {
-    "comment": "Accessibility label for Explore button on MyObservations toolbar",
-    "val": "See all your observations in explore"
-  },
-  "See-observations-by-this-user-in-Explore": {
-    "comment": "Accessibility label for Observations button on UserProfile screen",
-    "val": "See observations by this user in Explore"
-  },
-  "See-observations-in-explore": {
-    "comment": "Accessibility label for Explore button in MyObservationsEmpty for logged out user",
-    "val": "See observations in explore"
-  },
-  "See-observations-of-this-taxon-in-explore": {
-    "comment": "Accessibility label for Explore button on TaxonDetails screen",
-    "val": "See observations of this taxon in explore"
-  },
-  "See-project-members": {
-    "comment": "Accessibility label for navigating to project members screen",
-    "val": "See project members"
-  },
-  "See-species-observed-by-this-user-in-Explore": {
-    "comment": "Accessibility label for Species button on UserProfile screen",
-    "val": "See species observed by this user in Explore"
-  },
+  "See-all-your-observations-in-explore": "See all your observations in explore",
+  "See-observations-by-this-user-in-Explore": "See observations by this user in Explore",
+  "See-observations-in-explore": "See observations in explore",
+  "See-observations-of-this-taxon-in-explore": "See observations of this taxon in explore",
+  "See-project-members": "See project members",
+  "See-species-observed-by-this-user-in-Explore": "See species observed by this user in Explore",
   "Select-a-date-and-time-for-observation": "Select a date and time for observation",
   "Select-captive-or-cultivated-status": "Select captive or cultivated status",
   "Select-geoprivacy-status": "Select geoprivacy status",
   "Select-or-drag-media": "Select or drag media",
   "Select-photo": "Select photo",
   "SELECT-THIS-TAXON": "SELECT THIS TAXON",
-  "Select-user": {
-    "comment": "Label for an element that let's you select a user",
-    "val": "Select user"
-  },
+  "Select-user": "Select user",
   "Selects-iconic-taxon-X-for-identification": "Selects iconic taxon { $iconicTaxon } for identification.",
   "Separate-Photos": "Separate Photos",
-  "September": {
-    "comment": "Month of September",
-    "val": "September"
-  },
+  "September": "September",
   "SETTINGS": "SETTINGS",
   "Share": "Share",
   "SHARE-DEBUG-LOGS": "SHARE DEBUG LOGS",
   "Share-location": "Share Location",
   "Share-map": "Share map",
-  "Share-your-observation-where-it-can-help-scientists": {
-    "comment": "Preceded by the fragment # Preceded by the fragment, \"By uploading your observation to iNaturalist, you can:\"",
-    "val": "Share your observation, where it can help scientists across the world better understand biodiversity."
-  },
+  "Share-your-observation-where-it-can-help-scientists": "Share your observation, where it can help scientists across the world better understand biodiversity.",
   "SHOP-INATURALIST-MERCH": "SHOP INATURALIST MERCH",
   "Show-observation-options": "Show observation options.",
-  "Shows-identification-suggestions": {
-    "comment": "Label for button that shows identification suggestions",
-    "val": "Shows identification suggestions"
-  },
+  "Shows-identification-suggestions": "Shows identification suggestions",
   "Shows-iNaturalist-bird-logo": "Shows iNaturalist bird logo.",
-  "Shows-observation-creation-options": {
-    "comment": "Accessibility hint for button that shows observation creation options",
-    "val": "Shows observation creation options"
-  },
+  "Shows-observation-creation-options": "Shows observation creation options",
   "Some-data-privacy-laws": "Some data privacy laws, like the European Union's General Data Protection Regulation (GDPR), require explicit consent to transfer personal information from their jurisdictions to other jurisdictions where the legal protection of this information is not considered adequate. As of 2020, the European Union no longer considers the United States to be a jurisdiction that provides adequate legal protection of personal information, specifically because of the possibility of the US government surveilling data entering the US. It is possible other jurisdictions may have the same opinion.",
-  "Something-went-wrong": {
-    "comment": "Generic error message",
-    "val": "Something went wrong."
-  },
+  "Something-went-wrong": "Something went wrong.",
   "Sorry-this-observation-was-deleted": "Sorry, this observation was deleted",
-  "Sorry-we-dont-know-how-to-open-that-URL": {
-    "comment": "Error message if the app tries to open a URL the operating system can't\nhandle",
-    "val": "Sorry, we don't know how to open that URL: { $url }"
-  },
+  "Sorry-we-dont-know-how-to-open-that-URL": "Sorry, we don't know how to open that URL: { $url }",
   "SORT-BY": "SORT BY",
   "Sort-by": "Sort by",
-  "sound-playback-separator": {
-    "comment": "Character separating current position and total duration when playing a\nsound, e.g. 00:12 / 03:00 uses \"/\" as the separator. This can be anything,\nbut it should be very short.",
-    "val": "/"
-  },
+  "sound-playback-separator": "/",
   "Sound-recorder": "Sound recorder",
   "sound-recorder-help-A-recording-of": "A recording of 5-15 seconds is best to help identifiers.",
   "sound-recorder-help-Get-as-close-as-you-can": "Get as close as you safely can to record the organism.",
@@ -1389,61 +696,31 @@
   "Species": "Species",
   "Species-View": "Species View",
   "SPECIES-WITHOUT-NUMBER": "{ $count ->\n  [one] SPECIES\n *[other] SPECIES\n}",
-  "Standard--map-type": {
-    "comment": "Label for the standard map type",
-    "val": "Standard"
-  },
+  "Standard--map-type": "Standard",
   "Start-must-be-before-end": "The start date must be before the end date.",
   "Start-time": "Start time: { $date }",
   "Start-upload": "Start upload",
-  "Starts-recording-sound": {
-    "comment": "Accessibility hint for button that starts recording a sound",
-    "val": "Starts recording sound"
-  },
+  "Starts-recording-sound": "Starts recording sound",
   "Stay-on-this-screen": "Stay on this screen while your location loads.",
   "Still-need-help": "Still need help? You can file a support request here.",
-  "Stop-upload": {
-    "comment": "Button or accessibility label for an interactive element that stops an upload",
-    "val": "Stop upload"
-  },
-  "Stop-verb": {
-    "comment": "Imperative verb for stopping the recording of a sound",
-    "val": "Stop"
-  },
-  "Stops-recording-sound": {
-    "comment": "Accessibility hint for a button that stops the recording of a sound",
-    "val": "Stops recording sound"
-  },
+  "Stop-upload": "Stop upload",
+  "Stop-verb": "Stop",
+  "Stops-recording-sound": "Stops recording sound",
   "SUBMIT": "SUBMIT",
   "SUBMIT-ID-SUGGESTION": "SUBMIT ID SUGGESTION",
   "SUGGEST-ID": "SUGGEST ID",
-  "Suggest-ID": {
-    "comment": "Label for element that suggest an identification",
-    "val": "SUGGEST ID"
-  },
-  "supporting--identification": {
-    "comment": "Identification category",
-    "val": "Supporting"
-  },
+  "Suggest-ID": "SUGGEST ID",
+  "supporting--identification": "Supporting",
   "Switches-to-tab": "Switches to { $tab } tab.",
   "Sync-observations": "Sync observations",
   "Syncing": "Syncing...",
   "Take-photo": "Take photo",
   "Take-photos-with-the-camera": "Take photos of a single organism with the camera",
-  "Taxa": {
-    "comment": "label in project requirements",
-    "val": "Taxa"
-  },
+  "Taxa": "Taxa",
   "TAXON": "TAXON",
-  "TAXON-NAMES-DISPLAY": {
-    "comment": "Settings screen",
-    "val": "TAXON NAMES DISPLAY"
-  },
+  "TAXON-NAMES-DISPLAY": "TAXON NAMES DISPLAY",
   "TAXONOMIC-RANKS": "TAXONOMIC RANKS",
-  "TAXONOMY-header": {
-    "comment": "Header for a block of text describing a taxon's taxonomy",
-    "val": "TAXONOMY"
-  },
+  "TAXONOMY-header": "TAXONOMY",
   "TEAM": "TEAM",
   "Terms-of-Use": "Terms of Use",
   "TERMS-OF-USE": "TERMS OF USE",
@@ -1456,10 +733,7 @@
   "The-location-will-not-be-visible": "The location will not be visible to others, which means it may be difficult to identify.",
   "The-models-that-suggest-species": "The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sarah Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.",
   "There-is-no-way": "There is no way to have an iNaturalist account without storing personal information, so the only way to revoke this consent is to delete your account.",
-  "This-is-a-wild-organism": {
-    "comment": " Wild status sheet descriptions",
-    "val": "This is a wild organism and wasn't placed in this location by humans."
-  },
+  "This-is-a-wild-organism": "This is a wild organism and wasn't placed in this location by humans.",
   "This-is-how-taxon-names-will-be-displayed": "This is how all taxon names will be displayed to you across iNaturalist:",
   "This-observer-has-opted-out-of-the-Community-Taxon": "This observer has opted out of the Community Taxon",
   "This-organism-was-placed-by-humans": "This organism was placed in this location by humans. This applies to things like garden plants, pets, and zoo animals.",
@@ -1474,22 +748,10 @@
   "Umbrella-Project": "Umbrella Project",
   "UNFOLLOW": "UNFOLLOW",
   "UNFOLLOW-USER": "UNFOLLOW USER?",
-  "Unknown--rank": {
-    "comment": "Text to show when a taoxn rank is unknown or missing",
-    "val": "Unknown"
-  },
-  "Unknown--taxon": {
-    "comment": "Text to show when a taxon or identification is unknown or missing",
-    "val": "Unknown"
-  },
-  "Unknown--user": {
-    "comment": "Text to show when a user (or their name) is unknown or missing",
-    "val": "Unknown"
-  },
-  "Unknown-error": {
-    "comment": "Generic error message",
-    "val": "Unknown error"
-  },
+  "Unknown--rank": "Unknown",
+  "Unknown--taxon": "Unknown",
+  "Unknown--user": "Unknown",
+  "Unknown-error": "Unknown error",
   "Unknown-organism": "Unknown organism",
   "Unreviewed-observations-only": "Unreviewed observations only",
   "Upload-Complete": "Upload Complete",
@@ -1499,46 +761,22 @@
   "Upload-photos-from-your-gallery-and-create-observations": "Upload photos from your gallery and create observations and get identifications of organisms you’ve already observed!",
   "Upload-Progress": "Upload { $uploadProgress } percent complete",
   "UPLOAD-TO-INATURALIST": "UPLOAD TO INATURALIST",
-  "Upload-x-observations": {
-    "comment": "Shows the number of observations a user can upload to iNat from my observations page",
-    "val": "Upload { $count ->\n  [one] 1 observation\n *[other] { $count } observations\n}"
-  },
-  "Uploaded-via-application": {
-    "comment": "Describes whether a user made this observation from web, iOS, or Android",
-    "val": "Uploaded via: { $application }"
-  },
-  "Uploading-x-of-y": {
-    "comment": "Shows the progress of uploads for X of Y",
-    "val": "Uploading { $currentUploadCount } of { $total }"
-  },
-  "Uploading-x-of-y-observations": {
-    "comment": "Shows the number of observations a user is currently uploading out of total on my observations page",
-    "val": "{ $total ->\n  [one] Uploading { $currentUploadCount } observation\n *[other] Uploading { $currentUploadCount } of { $total } observations\n}"
-  },
+  "Upload-x-observations": "Upload { $count ->\n  [one] 1 observation\n *[other] { $count } observations\n}",
+  "Uploaded-via-application": "Uploaded via: { $application }",
+  "Uploading-x-of-y": "Uploading { $currentUploadCount } of { $total }",
+  "Uploading-x-of-y-observations": "{ $total ->\n  [one] Uploading { $currentUploadCount } observation\n *[other] Uploading { $currentUploadCount } of { $total } observations\n}",
   "Use-iNaturalists-AI-Camera": "Use iNaturalist's AI Camera to identify organisms in real-time",
-  "USE-LOCATION": {
-    "comment": "Text for a button prompting the user to grant access to location",
-    "val": "USE LOCATION"
-  },
+  "USE-LOCATION": "USE LOCATION",
   "Use-the-devices-other-camera": "Use the device's other camera.",
   "Use-the-iNaturalist-camera-to-observe": "Use the iNaturalist camera to observe and identify organisms on-screen in real-time, and share them with our community to get identifications and contribute to science!",
   "Use-your-devices-microphone-to-record": "Use your device’s microphone to record sounds made by organisms and share them with our community to get identifications and contribute to science!",
   "USER": "USER",
   "User": "User { $userHandle }",
   "USERNAME": "USERNAME",
-  "USERNAME-OR-EMAIL": {
-    "comment": "Appears above the text fields",
-    "val": "USERNAME OR EMAIL"
-  },
-  "Users": {
-    "comment": "label in project requirements",
-    "val": "Users"
-  },
+  "USERNAME-OR-EMAIL": "USERNAME OR EMAIL",
+  "Users": "Users",
   "Using-iNaturalist-requires-the-storage": "Using iNaturalist requires the storage of personal information like your email address, all iNaturalist data is stored in the United States, and we cannot be sure what legal jurisdiction you are in when you are using iNaturalist, so in order to comply with privacy laws like the GDPR, you must acknowledge that you understand and accept this risk and consent to transferring your personal information to iNaturalist's servers in the US.",
-  "Version-app-build": {
-    "comment": "Listing of app and build versions",
-    "val": "Version { $appVersion } ({ $buildVersion })"
-  },
+  "Version-app-build": "Version { $appVersion } ({ $buildVersion })",
   "VIEW-ALL-X-PLACES": "VIEW ALL { $count } PLACES",
   "VIEW-ALL-X-PROJECTS": "VIEW ALL { $count } PROJECTS",
   "VIEW-ALL-X-TAXA": "VIEW ALL { $count } TAXA",
@@ -1549,39 +787,24 @@
   "View-in-browser": "View in browser",
   "VIEW-IN-EXPLORE": "VIEW IN EXPLORE",
   "VIEW-INATURALIST-HELP": "VIEW INATURALIST HELP",
-  "View-photo": {
-    "comment": "Button or accessibility label for an element that lets the user view a\nphoto",
-    "val": "View photo"
-  },
+  "View-photo": "View photo",
   "View-photo-licensing-info": "View photo licensing info",
   "VIEW-PROJECT-REQUIREMENTS": "VIEW PROJECT REQUIREMENTS",
   "VIEW-PROJECTS": "VIEW PROJECTS",
-  "View-suggestions": {
-    "comment": "Label for a button that shows identification suggestions for an observation\nor photo",
-    "val": "View suggestions"
-  },
+  "View-suggestions": "View suggestions",
   "We-are-not-confident-enough-to-make-a-top-ID-suggestion": "We’re not confident enough to make a top ID suggestion, but here are some other suggestions:",
   "We-sent-a-confirmation-email": "We sent a confirmation email to the email you signed up with.",
   "We-store-personal-information": "We store personal information like usernames and email addresses in order to manage accounts, and to comply with privacy laws, we need you to check this box to indicate that you consent to this use of personal information. To learn more about what information we collect and how we use it, please see our Privacy Policy and our Terms of Use.",
   "Welcome-to-iNaturalist": "Welcome to iNaturalist!",
-  "Welcome-user": {
-    "comment": "Welcome user back to app",
-    "val": "<0>Welcome back,</0><1>{ $userHandle }</1>"
-  },
+  "Welcome-user": "<0>Welcome back,</0><1>{ $userHandle }</1>",
   "WHAT-IS-INATURALIST": "WHAT IS INATURALIST?",
   "Whats-more-by-recording": "What's more, by recording and sharing your observations, you'll create research-quality data for scientists working to better understand and protect nature. So if you like recording your findings from the outdoors, or if you just like learning about life, join us!",
   "When-tapping-the-green-observation-button": "When tapping the green observation button, open:",
   "WIKIPEDIA": "WIKIPEDIA",
   "Wild": "Wild",
   "WILD-STATUS": "WILD STATUS",
-  "Withdraw": {
-    "comment": "Label for a button that withdraws an identification",
-    "val": "Withdraw"
-  },
-  "WITHDRAW-ID": {
-    "comment": "Button to Withdraw identification made by user",
-    "val": "WITHDRAW ID"
-  },
+  "Withdraw": "Withdraw",
+  "WITHDRAW-ID": "WITHDRAW ID",
   "WITHDRAW-ID-QUESTION": "WITHDRAW ID?",
   "Withdraws-identification": "Withdraws identification",
   "Worldwide": "Worldwide",
@@ -1592,38 +815,17 @@
   "X-Identifications": "{ $count ->\n  [one] { $count } Identification\n *[other] { $count } Identifications\n}",
   "x-identifications": "{ $count ->\n  [one] { $count } identification\n *[other] { $count } identifications\n}",
   "X-Identifiers": "{ $count ->\n  [one] { $count } Identifier\n *[other] { $count } Identifiers\n}",
-  "X-MEMBERS": {
-    "comment": "Subheader for number of project members screen",
-    "val": "{ $count } MEMBERS"
-  },
-  "X-Observations": {
-    "comment": "Shows number of observations in a variety of contexts",
-    "val": "{ $count ->\n  [one] 1 Observation\n *[other] { $count } Observations\n}"
-  },
-  "X-observations": {
-    "comment": "Shows number of observations in a variety of contexts",
-    "val": "{ $count ->\n  [one] 1 observation\n *[other] { $count } observations\n}"
-  },
+  "X-MEMBERS": "{ $count } MEMBERS",
+  "X-Observations": "{ $count ->\n  [one] 1 Observation\n *[other] { $count } Observations\n}",
+  "X-observations": "{ $count ->\n  [one] 1 observation\n *[other] { $count } observations\n}",
   "X-observations-deleted": "{ $count ->\n  [one] 1 observation deleted\n *[other] { $count } observations deleted\n}",
   "X-observations-uploaded": "{ $count ->\n  [one] 1 observation uploaded\n *[other] { $count } observations uploaded\n}",
   "X-Observers": "{ $count ->\n  [one] { $count } Observer\n *[other] { $count } Observers\n}",
   "X-of-Y": "{ $x ->\n  [one] 1\n *[other] { $x }\n} { $y ->\n  [one] of { $y }\n *[other] of { $y }\n}",
-  "X-PHOTOS": {
-    "comment": "Displays number of photos attached to an observation in the Media Viewer",
-    "val": "{ $photoCount ->\n  [one] 1 PHOTO\n *[other] { $photoCount } PHOTOS\n}"
-  },
-  "X-PHOTOS-X-OBSERVATIONS": {
-    "comment": "Displays number of photos and observations a user has selected from the camera roll",
-    "val": "{ $photoCount ->\n  [one] 1 PHOTO\n *[other] { $photoCount } PHOTOS\n}, { $observationCount ->\n  [one] 1 OBSERVATION\n *[other] { $observationCount } OBSERVATIONS\n}"
-  },
-  "X-PHOTOS-Y-SOUNDS": {
-    "comment": "Displays number of photos and sounds attached to an observation in the Media\nViewer",
-    "val": "{ $photoCount ->\n  [one] 1 PHOTO\n *[other] { $photoCount } PHOTOS\n}, { $soundCount ->\n  [one] 1 SOUND\n *[other] { $soundCount } SOUNDS\n}"
-  },
-  "X-SOUNDS": {
-    "comment": "Displays number of sounds attached to an observation in the Media Viewer",
-    "val": "{ $count ->\n  [one] 1 SOUND\n *[other] { $count } SOUNDS\n}"
-  },
+  "X-PHOTOS": "{ $photoCount ->\n  [one] 1 PHOTO\n *[other] { $photoCount } PHOTOS\n}",
+  "X-PHOTOS-X-OBSERVATIONS": "{ $photoCount ->\n  [one] 1 PHOTO\n *[other] { $photoCount } PHOTOS\n}, { $observationCount ->\n  [one] 1 OBSERVATION\n *[other] { $observationCount } OBSERVATIONS\n}",
+  "X-PHOTOS-Y-SOUNDS": "{ $photoCount ->\n  [one] 1 PHOTO\n *[other] { $photoCount } PHOTOS\n}, { $soundCount ->\n  [one] 1 SOUND\n *[other] { $soundCount } SOUNDS\n}",
+  "X-SOUNDS": "{ $count ->\n  [one] 1 SOUND\n *[other] { $count } SOUNDS\n}",
   "X-Species": "{ $count ->\n  [one] { $count } Species\n *[other] { $count } Species\n}",
   "x-uploads-failed": "{ $count ->\n  [one] { $count } upload failed\n *[other] { $count } uploads failed\n}",
   "Yes-license-my-photos": "Yes, license my photos, sounds, and observations so scientists can use my data (recommended)",
@@ -1636,41 +838,26 @@
   "You-can-click-join-on-the-project-page": "You can click “join” on the project page.",
   "You-can-find-answers-on-our-help-page": "You can find answers on our help page.",
   "You-can-only-add-20-photos-per-observation": "You can only add 20 photos per observation",
-  "You-can-search-observations-of-any-plant-or-animal": {
-    "comment": "Onboarding text on MyObservations: Onboarding text on MyObservations: 51-100 observations",
-    "val": "You can search observations of any plant or animal anywhere in the world with Explore!"
-  },
+  "You-can-search-observations-of-any-plant-or-animal": "You can search observations of any plant or animal anywhere in the world with Explore!",
   "You-can-still-share-the-file": "You can still share the file with another app. If you can email it, please send it to { $email }",
   "You-can-upload-this-observation-to-our-community": "You can upload this observation to our community to get an identification from a real person, and help our AI improve its identifications in the future",
   "You-changed-filters-will-be-discarded": "You changed filters, but they were not applied to your explore search results.",
   "You-have-opted-out-of-the-Community-Taxon": "You have opted out of the Community Taxon",
   "You-havent-joined-any-projects-yet": "You haven’t joined any projects yet!",
   "You-must-be-logged-in-to-view-messages": "You must be logged in to view messages",
-  "You-need-an-Internet-connection-to-do-that": {
-    "comment": "Error message when you try to do something that requires an Internet\nconnection but such a connection is, tragically, missing",
-    "val": "You need an Internet connection to do that."
-  },
-  "You-need-log-in-to-do-that": {
-    "comment": "Error message when you try to do something that requires log in",
-    "val": "You need to log in to do that."
-  },
+  "You-need-an-Internet-connection-to-do-that": "You need an Internet connection to do that.",
+  "You-need-log-in-to-do-that": "You need to log in to do that.",
   "You-will-see-notifications": "You’ll see notifications here once you log in & upload observations.",
   "Your-donation-to-iNaturalist": "Your donation to iNaturalist supports the improvement and stability of the mobile apps and website that connects millions of people to nature and enables the protection of biodiversity worldwide!",
   "Your-email-is-confirmed": "Your email is confirmed! Please log in to continue.",
   "Your-location-uncertainty-is-over-x-km": "Your location uncertainty is over { $x } km, which is too high to be helpful to identifiers. Edit the location and zoom in until the accuracy circle turns green and is centered on where you observed the organism.",
   "Youre-always-in-control-of-the-location-privacy": "You’re always in control of the location privacy of every observation you create.",
-  "Youve-denied-permission-prompt": {
-    "comment": "Text prompting the user to open Settings to grant permission after\npermission has been denied",
-    "val": "You’ve denied permission. Please grant permission in the settings app."
-  },
+  "Youve-denied-permission-prompt": "You’ve denied permission. Please grant permission in the settings app.",
   "Youve-previously-denied-camera-permissions": "You've previously denied camera permissions, so please enable them in settings.",
   "Youve-previously-denied-gallery-permissions": "You’ve previously denied gallery permissions, so please enable them in settings.",
   "Youve-previously-denied-location-permissions": "You’ve previously denied location permissions, so please enable them in settings.",
   "Youve-previously-denied-microphone-permissions": "You’ve previously denied microphone permissions, so please enable them in settings.",
   "Zoom-in-as-much-as-possible-to-improve": "Zoom in as much as possible to improve location accuracy and get better identifications.",
   "Zoom-to-current-location": "Zoom to current location",
-  "zoom-x": {
-    "comment": "Label for button that shows zoom level, e.g. on a camera",
-    "val": "{ $zoom }×"
-  }
+  "zoom-x": "{ $zoom }×"
 }

--- a/src/i18n/l10n/es-MX.ftl.json
+++ b/src/i18n/l10n/es-MX.ftl.json
@@ -4,14 +4,8 @@
   "date-observed": "Date observed: { $date }",
   "date-uploaded": "Date uploaded: { $date }",
   "datetime-format-short": "d/M/yy h:mm a",
-  "Grid-View": {
-    "comment": "Label for a view that shows observations as a grid of photos",
-    "val": "Grid View"
-  },
-  "List-View": {
-    "comment": "Label for a view that shows observations a list",
-    "val": "List View"
-  },
+  "Grid-View": "Grid View",
+  "List-View": "List View",
   "Observations": "Observations",
   "Your-Observations": "Tus observaciones"
 }

--- a/src/i18n/l10n/es.ftl.json
+++ b/src/i18n/l10n/es.ftl.json
@@ -1,18 +1,9 @@
 {
   "date-observed": "Fecha de observación: { $date }",
   "date-uploaded": "Fecha de subido: { $date }",
-  "Grid-View": {
-    "comment": "Label for a view that shows observations as a grid of photos",
-    "val": "Ver rejilla"
-  },
-  "Lat-Lon-Acc": {
-    "comment": "Latitude, longitude, and accuracy on a single line",
-    "val": "Lat: { NUMBER($latitude, maximumFractionDigits: \"6\") }, Lon: { NUMBER($longitude, maximumFractionDigits: \"6\") }, Pre: { $accuracy }"
-  },
-  "List-View": {
-    "comment": "Label for a view that shows observations a list",
-    "val": "Ver lista"
-  },
+  "Grid-View": "Ver rejilla",
+  "Lat-Lon-Acc": "Lat: { NUMBER($latitude, maximumFractionDigits: \"6\") }, Lon: { NUMBER($longitude, maximumFractionDigits: \"6\") }, Pre: { $accuracy }",
+  "List-View": "Ver lista",
   "Observation": "Observación",
   "Observations": "Observaciones",
   "TAXONOMY-header": "TAXONOMIE es bueno",

--- a/src/i18n/l10n/ru.ftl.json
+++ b/src/i18n/l10n/ru.ftl.json
@@ -2,14 +2,8 @@
   "count-observations": "{ $count ->\n  [one] { $count } наблюдение\n  [few] { $count } наблюдения\n  [many] { $count } наблюдений\n *[other] { $count } наблюдений\n}",
   "date-observed": "Дата наблюдения: { $date }",
   "date-uploaded": "Дата загрузки: { $date }",
-  "Grid-View": {
-    "comment": "Label for a view that shows observations as a grid of photos",
-    "val": "Вид сетки"
-  },
-  "List-View": {
-    "comment": "Label for a view that shows observations a list",
-    "val": "Вид списка"
-  },
+  "Grid-View": "Вид сетки",
+  "List-View": "Вид списка",
   "Observations": "Замечания",
   "Your-Observations": "Your Observations"
 }


### PR DESCRIPTION
By default, the Crowdin action was pushing changes to the git branch even if it wasn't making a PR, which was messing up the state of the repo before we ran our normalization script, resulting in some files / changes getting omitted. This skips that push and allows our scripts to run on the dirty repo as intended.

Also modified the FTL-to-JSON processing to omit comments, which will slim down those files a bit.