### PR TITLE
Navigate logged out users from join project > login screen

### DIFF
--- a/src/components/LoginSignUp/LoginForm.js
+++ b/src/components/LoginSignUp/LoginForm.js
@@ -79,7 +79,19 @@ const LoginForm = ( {
     }
     setLoading( false );
 
-    navigation.getParent( )?.goBack( );
+    if ( params?.prevScreen && params?.projectId ) {
+      navigation.navigate( "TabNavigator", {
+        screen: "TabStackNavigator",
+        params: {
+          screen: "ProjectDetails",
+          params: {
+            id: params?.projectId
+          }
+        }
+      } );
+    } else {
+      navigation.getParent( )?.goBack( );
+    }
   };
 
   const togglePasswordVisibility = () => {

--- a/tests/helpers/render.js
+++ b/tests/helpers/render.js
@@ -128,6 +128,14 @@ function wrapInNavigationContainer( component ) {
   );
 }
 
+function wrapInQueryClientContainer( component ) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {component}
+    </QueryClientProvider>
+  );
+}
+
 export {
   queryClient,
   renderApp,
@@ -135,5 +143,6 @@ export {
   renderAppWithObservations,
   renderComponent,
   renderHook,
-  wrapInNavigationContainer
+  wrapInNavigationContainer,
+  wrapInQueryClientContainer
 };

--- a/tests/unit/components/ProjectDetails/ProjectDetails.test.js
+++ b/tests/unit/components/ProjectDetails/ProjectDetails.test.js
@@ -4,7 +4,7 @@ import ProjectDetailsContainer from "components/ProjectDetails/ProjectDetailsCon
 import React from "react";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
-import { renderComponent } from "tests/helpers/render";
+import { renderComponent, wrapInQueryClientContainer } from "tests/helpers/render";
 
 const mockProject = factory( "RemoteProject", {
   title: faker.lorem.sentence( ),
@@ -47,8 +47,10 @@ beforeAll( async () => {
 
 describe( "ProjectDetails", ( ) => {
   test( "should not have accessibility errors", async ( ) => {
-    const projectDetails = <ProjectDetailsContainer />;
-    expect( projectDetails ).toBeAccessible();
+    const view = wrapInQueryClientContainer(
+      <ProjectDetailsContainer />
+    );
+    expect( view ).toBeAccessible();
   } );
 
   test( "displays project details", ( ) => {


### PR DESCRIPTION
Closes #2115

- If a user is logged out and tries to join a project, they'll navigate to the login flow
- If they log in successfully, they'll be returned to project details to try to join again
- For logged in users, instead of using a `useEffect` and a React Query refetch, we're invalidating the query key to automatically refetch the current user's latest project join/leave status