### PR TITLE
Audit and simplify text colors

### DIFF
--- a/src/components/AddObsModal.tsx
+++ b/src/components/AddObsModal.tsx
@@ -121,7 +121,7 @@ const AddObsModal = ( { closeModal, navAndCloseModal }: Props ) => {
       accessibilityHint={accessibilityHint}
       accessibilityLabel={accessibilityLabel}
       className={className}
-      color={theme.colors.onSecondary}
+      color={colors.white}
       icon={icon}
       onPress={onPress}
       size={30}

--- a/src/components/AddObsModal.tsx
+++ b/src/components/AddObsModal.tsx
@@ -5,7 +5,6 @@ import {
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
 import { Platform, StatusBar } from "react-native";
-import { useTheme } from "react-native-paper";
 import Observation from "realmModels/Observation";
 import { useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
@@ -20,7 +19,6 @@ interface Props {
 
 const AddObsModal = ( { closeModal, navAndCloseModal }: Props ) => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
 
   const majorVersionIOS = parseInt( Platform.Version, 10 );
 
@@ -169,8 +167,8 @@ const AddObsModal = ( { closeModal, navAndCloseModal }: Props ) => {
                     size={30}
                     color={
                       item.icon === "arcamera"
-                        ? theme.colors.secondary
-                        : theme.colors.primary
+                        ? colors.inatGreen
+                        : colors.darkGray
                     }
                   />
                   <Body3 maxFontSizeMultiplier={1.5} className="ml-[20px] shrink">

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -13,7 +13,6 @@ import type { Node } from "react";
 import React from "react";
 import DeviceInfo from "react-native-device-info";
 import LinearGradient from "react-native-linear-gradient";
-import { useTheme } from "react-native-paper";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { convertOfflineScoreToConfidence } from "sharedHelpers/convertScores.ts";
 import { useDebugMode, useTranslation } from "sharedHooks";
@@ -92,7 +91,6 @@ const AICamera = ( {
   const { deviceStorageFull, showStorageFullAlert } = useDeviceStorageFull();
 
   const { t } = useTranslation();
-  const theme = useTheme();
   const navigation = useNavigation();
 
   // only show predictions when rank is order or lower, like we do on Seek
@@ -208,7 +206,7 @@ const AICamera = ( {
             <INatIcon
               name="inaturalist"
               size={114}
-              color={theme.colors.onPrimary}
+              color={colors.white}
             />
           </View>
         </View>

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -17,6 +17,7 @@ import { useTheme } from "react-native-paper";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { convertOfflineScoreToConfidence } from "sharedHelpers/convertScores.ts";
 import { useDebugMode, useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 import {
   handleCameraError,
@@ -157,7 +158,7 @@ const AICamera = ( {
         </View>
       )}
       <LinearGradient
-        colors={["#000000", "rgba(0, 0, 0, 0)"]}
+        colors={[colors.black, "rgba(0, 0, 0, 0)"]}
         locations={[
           0.001,
           isTablet && isLandscapeMode

--- a/src/components/Camera/AICamera/AIDebugButton.js
+++ b/src/components/Camera/AICamera/AIDebugButton.js
@@ -40,7 +40,7 @@ const SliderControl = ( {
         minimumValue={min}
         maximumValue={max}
         minimumTrackTintColor="#FFFFFF"
-        maximumTrackTintColor="#000000"
+        maximumTrackTintColor={colors.black}
         renderStepNumber
         tapToSeek
         step={step}

--- a/src/components/Camera/Buttons/TakePhoto.tsx
+++ b/src/components/Camera/Buttons/TakePhoto.tsx
@@ -6,9 +6,9 @@ import {
   Pressable, View
 } from "components/styledComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 const DROP_SHADOW = getShadow( { offsetHeight: 4 } );
 
@@ -24,7 +24,6 @@ const TakePhoto = ( {
   showPrediction
 }: Props ) => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
 
   const borderClass = "border-[2px] rounded-full h-[64px] w-[64px]";
 
@@ -59,7 +58,7 @@ const TakePhoto = ( {
             <INatIcon
               name="sparkly-label"
               size={32}
-              color={theme.colors.onPrimary}
+              color={colors.white}
             />
           </View>
         )

--- a/src/components/Camera/StandardCamera/PhotoCarousel.tsx
+++ b/src/components/Camera/StandardCamera/PhotoCarousel.tsx
@@ -9,13 +9,13 @@ import {
   FlatList
 } from "react-native";
 import Modal from "react-native-modal";
-import { useTheme } from "react-native-paper";
 import Animated, {
   useAnimatedStyle,
   withTiming
 } from "react-native-reanimated";
 import { useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
+import colors from "styles/tailwindColors";
 
 interface Props {
   takingPhoto?: boolean;
@@ -58,7 +58,6 @@ const PhotoCarousel = ( {
 }: Props ) => {
   const deletePhotoFromObservation = useStore( state => state.deletePhotoFromObservation );
   const { t } = useTranslation( );
-  const theme = useTheme( );
   const [deletePhotoMode, setDeletePhotoMode] = useState( false );
   const [tappedPhotoIndex, setTappedPhotoIndex] = useState( -1 );
   const photoClasses = isLargeScreen
@@ -166,7 +165,7 @@ const PhotoCarousel = ( {
                       <INatIconButton
                         icon="trash-outline"
                         mode="contained"
-                        color={theme.colors.onPrimary}
+                        color={colors.white}
                         backgroundColor="rgba(0, 0, 0, 0.5)"
                         testID={`PhotoCarousel.deletePhoto.${photoUri}`}
                         accessibilityLabel={t( "Delete-photo" )}
@@ -199,7 +198,6 @@ const PhotoCarousel = ( {
     renderSkeleton,
     showDeletePhotoMode,
     t,
-    theme,
     viewPhotoAtIndex
   ] );
 

--- a/src/components/Developer/UiLibrary/Buttons.js
+++ b/src/components/Developer/UiLibrary/Buttons.js
@@ -141,7 +141,7 @@ const Buttons = ( ) => {
               className="my-2"
               onPress={() => Alert.alert( "", "You tapped!" )}
               mode="contained"
-              backgroundColor={theme.colors.secondary}
+              backgroundColor={colors.inatGreen}
               color={colors.white}
               accessibilityLabel="Add Observation"
             />
@@ -176,7 +176,7 @@ const Buttons = ( ) => {
               icon="compass-rose-outline"
               accessibilityLabel="Notifications"
               mode="contained"
-              backgroundColor={theme.colors.primary}
+              backgroundColor={colors.darkGray}
               color={colors.white}
             />
           </View>
@@ -186,7 +186,7 @@ const Buttons = ( ) => {
               icon="compass-rose-outline"
               accessibilityLabel="Notifications"
               mode="contained"
-              backgroundColor={theme.colors.primary}
+              backgroundColor={colors.darkGray}
               color={colors.white}
               disabled
             />

--- a/src/components/Developer/UiLibrary/Buttons.js
+++ b/src/components/Developer/UiLibrary/Buttons.js
@@ -15,6 +15,7 @@ import { View } from "components/styledComponents";
 import React, { useState } from "react";
 import { Alert } from "react-native";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable react/no-unescaped-entities */
@@ -141,7 +142,7 @@ const Buttons = ( ) => {
               onPress={() => Alert.alert( "", "You tapped!" )}
               mode="contained"
               backgroundColor={theme.colors.secondary}
-              color={theme.colors.onSecondary}
+              color={colors.white}
               accessibilityLabel="Add Observation"
             />
           </View>
@@ -151,7 +152,7 @@ const Buttons = ( ) => {
               icon="notifications-bell"
               className="my-2"
               onPress={() => Alert.alert( "", "You tapped!" )}
-              color={theme.colors.error}
+              color={colors.warningRed}
               size={25}
               accessibilityLabel="Notifications"
             />
@@ -164,8 +165,8 @@ const Buttons = ( ) => {
               icon="compass-rose-outline"
               accessibilityLabel="Notifications"
               mode="contained"
-              backgroundColor={theme.colors.error}
-              color={theme.colors.onError}
+              backgroundColor={colors.warningRed}
+              color={colors.white}
               disabled
             />
           </View>
@@ -176,7 +177,7 @@ const Buttons = ( ) => {
               accessibilityLabel="Notifications"
               mode="contained"
               backgroundColor={theme.colors.primary}
-              color={theme.colors.onPrimary}
+              color={colors.white}
             />
           </View>
           <View>
@@ -186,7 +187,7 @@ const Buttons = ( ) => {
               accessibilityLabel="Notifications"
               mode="contained"
               backgroundColor={theme.colors.primary}
-              color={theme.colors.onPrimary}
+              color={colors.white}
               disabled
             />
           </View>

--- a/src/components/Developer/UiLibrary/Buttons.js
+++ b/src/components/Developer/UiLibrary/Buttons.js
@@ -14,14 +14,12 @@ import {
 import { View } from "components/styledComponents";
 import React, { useState } from "react";
 import { Alert } from "react-native";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable react/no-unescaped-entities */
 const Buttons = ( ) => {
   const [loading, setLoading] = useState( false );
-  const theme = useTheme();
   return (
     <ScrollViewWrapper>
       <View className="p-4">
@@ -200,8 +198,8 @@ const Buttons = ( ) => {
               accessibilityLabel="Notifications"
               mode="contained"
               preventTransparency
-              color={theme.colors.deepPink}
-              backgroundColor={theme.colors.yellow}
+              color={colors.deepPink}
+              backgroundColor={colors.yellow}
               size={44}
             />
             <INatIconButton
@@ -209,8 +207,8 @@ const Buttons = ( ) => {
               accessibilityLabel="Notifications"
               mode="contained"
               preventTransparency
-              color={theme.colors.deepPink}
-              backgroundColor={theme.colors.yellow}
+              color={colors.deepPink}
+              backgroundColor={colors.yellow}
               size={44}
             />
           </View>

--- a/src/components/Developer/UiLibrary/FloatingActionBarDemo.js
+++ b/src/components/Developer/UiLibrary/FloatingActionBarDemo.js
@@ -5,6 +5,7 @@ import {
 } from "components/SharedComponents";
 import React from "react";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable react/no-unescaped-entities */
@@ -22,7 +23,7 @@ const FloatingActionBarDemo = ( ) => {
         className="mx-auto"
         icon="star-bold-outline"
         mode="contained"
-        color={theme.colors.onSecondary}
+        color={colors.white}
         backgroundColor={theme.colors.secondary}
         accessibilityLabel="Star"
       />

--- a/src/components/Developer/UiLibrary/FloatingActionBarDemo.js
+++ b/src/components/Developer/UiLibrary/FloatingActionBarDemo.js
@@ -4,31 +4,27 @@ import {
   INatIconButton
 } from "components/SharedComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable react/no-unescaped-entities */
-const FloatingActionBarDemo = ( ) => {
-  const theme = useTheme();
-  return (
-    <FloatingActionBar
-      position="bottomEnd"
-      containerClass="mx-4 px-2 pb-2 rounded-md"
-      endY={80}
-      show
-    >
-      <Heading2 className="my-2">Floating Action Bar</Heading2>
-      <INatIconButton
-        className="mx-auto"
-        icon="star-bold-outline"
-        mode="contained"
-        color={colors.white}
-        backgroundColor={theme.colors.secondary}
-        accessibilityLabel="Star"
-      />
-    </FloatingActionBar>
-  );
-};
+const FloatingActionBarDemo = ( ) => (
+  <FloatingActionBar
+    position="bottomEnd"
+    containerClass="mx-4 px-2 pb-2 rounded-md"
+    endY={80}
+    show
+  >
+    <Heading2 className="my-2">Floating Action Bar</Heading2>
+    <INatIconButton
+      className="mx-auto"
+      icon="star-bold-outline"
+      mode="contained"
+      color={colors.white}
+      backgroundColor={colors.inatGreen}
+      accessibilityLabel="Star"
+    />
+  </FloatingActionBar>
+);
 
 export default FloatingActionBarDemo;

--- a/src/components/Developer/UiLibrary/Misc.js
+++ b/src/components/Developer/UiLibrary/Misc.js
@@ -34,8 +34,8 @@ import { ScrollView, View } from "components/styledComponents";
 import { RealmContext } from "providers/contexts.ts";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { useTheme } from "react-native-paper";
 import { useCurrentUser, useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 const { useRealm } = RealmContext;
 
@@ -43,7 +43,6 @@ const { useRealm } = RealmContext;
 /* eslint-disable react/no-unescaped-entities */
 const Misc = (): Node => {
   const { t } = useTranslation();
-  const theme = useTheme();
   const currentUser = useCurrentUser();
   const userId = currentUser?.id;
   const [isChecked, setIsChecked] = useState( false );
@@ -196,19 +195,19 @@ const Misc = (): Node => {
           <View>
             <QualityGradeStatus
               qualityGrade="research"
-              color={theme.colors.secondary}
+              color={colors.inatGreen}
             />
           </View>
           <View>
             <QualityGradeStatus
               qualityGrade="needs_id"
-              color={theme.colors.secondary}
+              color={colors.inatGreen}
             />
           </View>
           <View>
             <QualityGradeStatus
               qualityGrade="casual"
-              color={theme.colors.secondary}
+              color={colors.inatGreen}
             />
           </View>
         </View>
@@ -218,33 +217,33 @@ const Misc = (): Node => {
           <View>
             <Body2 className="text-center">Progress &lt; 5%</Body2>
             <UploadStatus
-              color={theme.colors.primary}
+              color={colors.darkGray}
               progress={0.04}
-              completeColor={theme.colors.secondary}
+              completeColor={colors.inatGreen}
             />
           </View>
           <View>
             <Body2 className="text-center">10%</Body2>
             <UploadStatus
-              color={theme.colors.primary}
+              color={colors.darkGray}
               progress={0.1}
-              completeColor={theme.colors.secondary}
+              completeColor={colors.inatGreen}
             />
           </View>
           <View>
             <Body2 className="text-center">60%</Body2>
             <UploadStatus
-              color={theme.colors.primary}
+              color={colors.darkGray}
               progress={0.6}
-              completeColor={theme.colors.secondary}
+              completeColor={colors.inatGreen}
             />
           </View>
           <View>
             <Body2 className="text-center">100%</Body2>
             <UploadStatus
-              color={theme.colors.primary}
+              color={colors.darkGray}
               progress={1}
-              completeColor={theme.colors.secondary}
+              completeColor={colors.inatGreen}
             />
           </View>
         </View>

--- a/src/components/Developer/UiLibrary/ToolbarDemo.tsx
+++ b/src/components/Developer/UiLibrary/ToolbarDemo.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView
 } from "components/styledComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -14,113 +13,110 @@ const noop = () => {};
 
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable react/no-unescaped-entities */
-const ToolbarDemo = ( ) => {
-  const theme = useTheme( );
-  return (
-    <ScrollView>
-      <Heading1>Basic</Heading1>
-      <Toolbar
-        error=""
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={0}
-        statusText=""
-        stopAllUploads={noop}
-        syncIconColor={colors.darkGray}
-        toggleLayout={noop}
-      />
-      <Heading1>Needs Upload</Heading1>
-      <Toolbar
-        error=""
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={0}
-        showsExclamation
-        showsExploreIcon
-        statusText="Upload 3 observations"
-        stopAllUploads={noop}
-        syncIconColor={theme.colors.secondary}
-        toggleLayout={noop}
-      />
-      <Heading1>Uploading</Heading1>
-      <Toolbar
-        error=""
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={0.2}
-        rotating
-        showsCancelUploadButton
-        showsExploreIcon
-        statusText="doing some uploading"
-        stopAllUploads={noop}
-        syncIconColor={theme.colors.secondary}
-        toggleLayout={noop}
-      />
-      <Heading1>Uploading w/error</Heading1>
-      <Toolbar
-        error="something went terribly wrong"
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={0.5}
-        rotating
-        showsCancelUploadButton
-        showsExploreIcon
-        statusText="doing some uploading"
-        stopAllUploads={noop}
-        syncIconColor={theme.colors.secondary}
-        toggleLayout={noop}
-      />
-      <Heading1>Uploading w/ long status</Heading1>
-      <Toolbar
-        error=""
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={0.2}
-        rotating
-        showsCancelUploadButton
-        showsExploreIcon
-        statusText="doing some uploading that will be really great i promise"
-        stopAllUploads={noop}
-        syncIconColor={theme.colors.secondary}
-        toggleLayout={noop}
-      />
-      <Heading1>Finished w/error</Heading1>
-      <Toolbar
-        error="something went terribly wrong"
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={1}
-        showsExploreIcon
-        showsExclamation
-        showsCheckmark
-        statusText="3 observations uploaded"
-        stopAllUploads={noop}
-        syncIconColor={colors.warningRed}
-        toggleLayout={noop}
-      />
-      <Heading1>Error w/o status</Heading1>
-      <Toolbar
-        error="something went terribly, terribly, terribly wrong"
-        handleSyncButtonPress={noop}
-        layout="grid"
-        navToExplore={noop}
-        progress={1}
-        showsExploreIcon
-        showsExclamation
-        showsCheckmark
-        statusText=""
-        stopAllUploads={noop}
-        syncIconColor={colors.warningRed}
-        toggleLayout={noop}
-      />
-    </ScrollView>
-  );
-};
+const ToolbarDemo = ( ) => (
+  <ScrollView>
+    <Heading1>Basic</Heading1>
+    <Toolbar
+      error=""
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={0}
+      statusText=""
+      stopAllUploads={noop}
+      syncIconColor={colors.darkGray}
+      toggleLayout={noop}
+    />
+    <Heading1>Needs Upload</Heading1>
+    <Toolbar
+      error=""
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={0}
+      showsExclamation
+      showsExploreIcon
+      statusText="Upload 3 observations"
+      stopAllUploads={noop}
+      syncIconColor={colors.inatGreen}
+      toggleLayout={noop}
+    />
+    <Heading1>Uploading</Heading1>
+    <Toolbar
+      error=""
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={0.2}
+      rotating
+      showsCancelUploadButton
+      showsExploreIcon
+      statusText="doing some uploading"
+      stopAllUploads={noop}
+      syncIconColor={colors.inatGreen}
+      toggleLayout={noop}
+    />
+    <Heading1>Uploading w/error</Heading1>
+    <Toolbar
+      error="something went terribly wrong"
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={0.5}
+      rotating
+      showsCancelUploadButton
+      showsExploreIcon
+      statusText="doing some uploading"
+      stopAllUploads={noop}
+      syncIconColor={colors.inatGreen}
+      toggleLayout={noop}
+    />
+    <Heading1>Uploading w/ long status</Heading1>
+    <Toolbar
+      error=""
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={0.2}
+      rotating
+      showsCancelUploadButton
+      showsExploreIcon
+      statusText="doing some uploading that will be really great i promise"
+      stopAllUploads={noop}
+      syncIconColor={colors.inatGreen}
+      toggleLayout={noop}
+    />
+    <Heading1>Finished w/error</Heading1>
+    <Toolbar
+      error="something went terribly wrong"
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={1}
+      showsExploreIcon
+      showsExclamation
+      showsCheckmark
+      statusText="3 observations uploaded"
+      stopAllUploads={noop}
+      syncIconColor={colors.warningRed}
+      toggleLayout={noop}
+    />
+    <Heading1>Error w/o status</Heading1>
+    <Toolbar
+      error="something went terribly, terribly, terribly wrong"
+      handleSyncButtonPress={noop}
+      layout="grid"
+      navToExplore={noop}
+      progress={1}
+      showsExploreIcon
+      showsExclamation
+      showsCheckmark
+      statusText=""
+      stopAllUploads={noop}
+      syncIconColor={colors.warningRed}
+      toggleLayout={noop}
+    />
+  </ScrollView>
+);
 
 export default ToolbarDemo;

--- a/src/components/Developer/UiLibrary/ToolbarDemo.tsx
+++ b/src/components/Developer/UiLibrary/ToolbarDemo.tsx
@@ -101,7 +101,7 @@ const ToolbarDemo = ( ) => {
         showsCheckmark
         statusText="3 observations uploaded"
         stopAllUploads={noop}
-        syncIconColor={theme.colors.error}
+        syncIconColor={colors.warningRed}
         toggleLayout={noop}
       />
       <Heading1>Error w/o status</Heading1>
@@ -116,7 +116,7 @@ const ToolbarDemo = ( ) => {
         showsCheckmark
         statusText=""
         stopAllUploads={noop}
-        syncIconColor={theme.colors.error}
+        syncIconColor={colors.warningRed}
         toggleLayout={noop}
       />
     </ScrollView>

--- a/src/components/Developer/UiLibrary/ToolbarDemo.tsx
+++ b/src/components/Developer/UiLibrary/ToolbarDemo.tsx
@@ -7,6 +7,7 @@ import {
 } from "components/styledComponents";
 import React from "react";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -26,7 +27,7 @@ const ToolbarDemo = ( ) => {
         progress={0}
         statusText=""
         stopAllUploads={noop}
-        syncIconColor="black"
+        syncIconColor={colors.darkGray}
         toggleLayout={noop}
       />
       <Heading1>Needs Upload</Heading1>

--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -16,13 +16,13 @@ import { PLACE_MODE } from "providers/ExploreContext.tsx";
 import type { Node } from "react";
 import React, { useState } from "react";
 import { Alert } from "react-native";
-import { useTheme } from "react-native-paper";
 import {
   useDebugMode,
   useStoredLayout,
   useTranslation
 } from "sharedHooks";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 import ExploreHeader from "./Header/ExploreHeader";
 import IdentifiersView from "./IdentifiersView";
@@ -95,7 +95,6 @@ const Explore = ( {
   updateTaxon,
   updateUser
 }: Props ): Node => {
-  const theme = useTheme( );
   const { t } = useTranslation( );
   const [showExploreBottomSheet, setShowExploreBottomSheet] = useState( false );
   const { layout, writeLayoutToStorage } = useStoredLayout( "exploreObservationsLayout" );
@@ -288,7 +287,7 @@ const Explore = ( {
           )}
           <INatIconButton
             icon={icon}
-            color={theme.colors.onPrimary}
+            color={colors.white}
             size={27}
             className={classnames(
               grayCircleClass,

--- a/src/components/Explore/Header/ExploreHeader.js
+++ b/src/components/Explore/Header/ExploreHeader.js
@@ -15,7 +15,7 @@ import { Pressable, View } from "components/styledComponents";
 import { useExplore } from "providers/ExploreContext.tsx";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { Surface, useTheme } from "react-native-paper";
+import { Surface } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
@@ -46,7 +46,6 @@ const Header = ( {
   updateLocation
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
   const { state, numberOfFilters } = useExplore( );
   const { taxon } = state;
   const iconicTaxonNames = state.iconic_taxa || [];
@@ -56,7 +55,7 @@ const Header = ( {
   const placeGuess = placeGuessText( state.placeMode, t, state.place_guess );
 
   const surfaceStyle = {
-    backgroundColor: theme.colors.primary,
+    backgroundColor: colors.darkGray,
     borderBottomLeftRadius: 20,
     borderBottomRightRadius: 20,
     marginBottom: -40

--- a/src/components/Explore/Header/ExploreHeaderCount.js
+++ b/src/components/Explore/Header/ExploreHeaderCount.js
@@ -8,8 +8,8 @@ import {
 import { Pressable } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 type Props = {
   count: ?number,
@@ -27,7 +27,6 @@ const ExploreHeaderCount = ( {
   onPress
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
 
   const renderText = ( ) => {
     if ( exploreView === "observations" ) {
@@ -51,7 +50,7 @@ const ExploreHeaderCount = ( {
           <INatIcon
             name={exploreViewIcon}
             size={18}
-            color={theme.colors.onPrimary}
+            color={colors.white}
           />
           <Body2 className="text-white ml-3">{renderText( )}</Body2>
         </>

--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -39,9 +39,9 @@ import {
   WILD_STATUS
 } from "providers/ExploreContext.tsx";
 import React, { useState } from "react";
-import { useTheme } from "react-native-paper";
 import { useCurrentUser, useTranslation } from "sharedHooks";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 import placeGuessText from "../helpers/placeGuessText";
 import ExploreLocationSearchModal from "./ExploreLocationSearchModal";
@@ -627,8 +627,6 @@ const FilterModal = ( {
     } );
   };
 
-  const theme = useTheme();
-
   const observedEndBeforeStart = d1 > d2;
   const uploadedEndBeforeStart = createdD1 > createdD2;
   const hasError = observedEndBeforeStart || uploadedEndBeforeStart;
@@ -987,7 +985,7 @@ const FilterModal = ( {
                     <INatIcon
                       name="triangle-exclamation"
                       size={19}
-                      color={theme.colors.error}
+                      color={colors.warningRed}
                     />
                     <List2 className="ml-3">
                       {t( "Start-must-be-before-end" )}
@@ -1086,7 +1084,7 @@ const FilterModal = ( {
                     <INatIcon
                       name="triangle-exclamation"
                       size={19}
-                      color={theme.colors.error}
+                      color={colors.warningRed}
                     />
                     <List2 className="ml-3">
                       {t( "Start-must-be-before-end" )}

--- a/src/components/LocationPicker/CrosshairCircle.js
+++ b/src/components/LocationPicker/CrosshairCircle.js
@@ -5,7 +5,6 @@ import { INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 import WarningText from "./WarningText";
@@ -29,7 +28,6 @@ type Props = {
 
 const CrosshairCircle = ( { accuracy }: Props ): Node => {
   const accuracyTest = checkAccuracy( accuracy );
-  const theme = useTheme( );
 
   return (
     <View pointerEvents="none">
@@ -55,7 +53,7 @@ const CrosshairCircle = ( { accuracy }: Props ): Node => {
           <INatIcon
             name="checkmark-circle"
             size={19}
-            color={theme.colors.secondary}
+            color={colors.inatGreen}
           />
         )}
         {accuracyTest === "fail" && (

--- a/src/components/LocationPicker/CrosshairCircle.js
+++ b/src/components/LocationPicker/CrosshairCircle.js
@@ -6,6 +6,7 @@ import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 import WarningText from "./WarningText";
 
@@ -61,7 +62,7 @@ const CrosshairCircle = ( { accuracy }: Props ): Node => {
           <INatIcon
             name="triangle-exclamation"
             size={19}
-            color={theme.colors.error}
+            color={colors.warningRed}
           />
         )}
       </View>

--- a/src/components/LocationPicker/LocationPicker.js
+++ b/src/components/LocationPicker/LocationPicker.js
@@ -60,7 +60,7 @@ const LocationPicker = ( {
         <View className="justify-center">
           <Heading4 className="self-center my-4">{t( "EDIT-LOCATION" )}</Heading4>
           <View className="absolute right-2">
-            <CloseButton black size={19} />
+            <CloseButton darkGray size={19} />
           </View>
         </View>
         <View className="flex-grow">

--- a/src/components/LocationPicker/WarningText.js
+++ b/src/components/LocationPicker/WarningText.js
@@ -44,7 +44,7 @@ const WarningText = ( { accuracyTest }: Props ): Node => {
     >
       <Body3
         className={classnames(
-          "text-black",
+          "text-darkGray",
           "text-center",
           {
             "text-white": accuracyTest === "fail"

--- a/src/components/LoginSignUp/Error.tsx
+++ b/src/components/LoginSignUp/Error.tsx
@@ -4,23 +4,19 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface Props {
   error: string;
 }
 
-const Error = ( { error }: Props ) => {
-  const theme = useTheme( );
-
-  return (
-    <View className="flex-row items-center justify-center mt-5">
-      <INatIcon name="triangle-exclamation" size={19} color={theme.colors.error} />
-      <List2 className="color-white ml-3">
-        {error}
-      </List2>
-    </View>
-  );
-};
+const Error = ( { error }: Props ) => (
+  <View className="flex-row items-center justify-center mt-5">
+    <INatIcon name="triangle-exclamation" size={19} color={colors.warningRed} />
+    <List2 className="color-white ml-3">
+      {error}
+    </List2>
+  </View>
+);
 
 export default Error;

--- a/src/components/LoginSignUp/LoginForm.js
+++ b/src/components/LoginSignUp/LoginForm.js
@@ -11,8 +11,8 @@ import { RealmContext } from "providers/contexts.ts";
 import type { Node } from "react";
 import React, { useEffect, useRef, useState } from "react";
 import { TouchableWithoutFeedback } from "react-native";
-import { useTheme } from "react-native-paper";
 import useKeyboardInfo from "sharedHooks/useKeyboardInfo";
+import colors from "styles/tailwindColors";
 
 import {
   authenticateUser
@@ -40,7 +40,6 @@ const LoginForm = ( {
   const [error, setError] = useState( null );
   const [loading, setLoading] = useState( false );
   const [isPasswordVisible, setIsPasswordVisible] = useState( false );
-  const theme = useTheme();
   const { keyboardShown } = useKeyboardInfo( );
 
   const blurFields = () => {
@@ -103,7 +102,7 @@ const LoginForm = ( {
       <View className="bg-white rounded-full">
         <INatIcon
           name="checkmark-circle"
-          color={theme.colors.secondary}
+          color={colors.inatGreen}
           size={19}
         />
       </View>

--- a/src/components/LoginSignUp/LoginSignUpInputField.js
+++ b/src/components/LoginSignUp/LoginSignUpInputField.js
@@ -6,7 +6,7 @@ import {
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { forwardRef } from "react";
-import { TextInput, useTheme } from "react-native-paper";
+import { TextInput } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 type Props = {
@@ -42,34 +42,30 @@ const LoginSignUpInputField: Function = forwardRef( ( {
   testID,
   textContentType
   // $FlowIgnore
-}: Props, ref: unknown ): Node => {
-  const theme = useTheme( );
-
-  return (
-    <View className="mx-2">
-      <Heading4 className="color-white mt-[25px] mb-[11px]">
-        {headerText}
-      </Heading4>
-      <TextInput
-        ref={ref}
-        accessibilityLabel={accessibilityLabel}
-        autoCapitalize="none"
-        autoComplete={autoComplete}
-        className="h-[45px]"
-        contentStyle={CONTENT_STYLE}
-        outlineStyle={OUTLINE_STYLE}
-        activeOutlineColor={colors.inatGreen}
-        inputMode={inputMode}
-        keyboardType={keyboardType}
-        mode="outlined"
-        onChangeText={onChangeText}
-        secureTextEntry={secureTextEntry}
-        selectionColor={theme.colors.tertiary}
-        testID={testID}
-        textContentType={textContentType}
-      />
-    </View>
-  );
-} );
+}: Props, ref: unknown ): Node => (
+  <View className="mx-2">
+    <Heading4 className="color-white mt-[25px] mb-[11px]">
+      {headerText}
+    </Heading4>
+    <TextInput
+      ref={ref}
+      accessibilityLabel={accessibilityLabel}
+      autoCapitalize="none"
+      autoComplete={autoComplete}
+      className="h-[45px]"
+      contentStyle={CONTENT_STYLE}
+      outlineStyle={OUTLINE_STYLE}
+      activeOutlineColor={colors.inatGreen}
+      inputMode={inputMode}
+      keyboardType={keyboardType}
+      mode="outlined"
+      onChangeText={onChangeText}
+      secureTextEntry={secureTextEntry}
+      selectionColor={colors.darkGray}
+      testID={testID}
+      textContentType={textContentType}
+    />
+  </View>
+) );
 
 export default LoginSignUpInputField;

--- a/src/components/LoginSignUp/LoginSignUpWrapper.js
+++ b/src/components/LoginSignUp/LoginSignUpWrapper.js
@@ -10,6 +10,7 @@ import {
   Platform,
   StatusBar
 } from "react-native";
+import colors from "styles/tailwindColors";
 
 type Props = {
   // $FlowIgnore
@@ -80,7 +81,7 @@ const LoginSignupWrapper = ( {
       >
         <StatusBar
           barStyle="light-content"
-          backgroundColor="#0000"
+          backgroundColor={colors.black}
         />
         <KeyboardAvoidingView
           keyboardVerticalOffset={keyboardVerticalOffset}

--- a/src/components/MyObservations/MyObservationsHeader.js
+++ b/src/components/MyObservations/MyObservationsHeader.js
@@ -11,7 +11,6 @@ import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
 import { Trans } from "react-i18next";
-import { useTheme } from "react-native-paper";
 import User from "realmModels/User.ts";
 import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
@@ -39,7 +38,6 @@ const MyObservationsHeader = ( {
   setHeightAboveToolbar,
   toggleLayout
 }: Props ): Node => {
-  const theme = useTheme( );
   const navigation = useNavigation( );
   const { t } = useTranslation( );
 
@@ -64,7 +62,7 @@ const MyObservationsHeader = ( {
           icon="inaturalist"
           size={41}
           color={colors.white}
-          backgroundColor={theme.colors.secondary}
+          backgroundColor={colors.inatGreen}
           accessibilityLabel="iNaturalist"
           mode="contained"
           width={67}

--- a/src/components/MyObservations/MyObservationsHeader.js
+++ b/src/components/MyObservations/MyObservationsHeader.js
@@ -14,6 +14,7 @@ import { Trans } from "react-i18next";
 import { useTheme } from "react-native-paper";
 import User from "realmModels/User.ts";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 import Onboarding from "./Onboarding";
 
@@ -62,7 +63,7 @@ const MyObservationsHeader = ( {
           className="mr-5"
           icon="inaturalist"
           size={41}
-          color={theme.colors.onSecondary}
+          color={colors.white}
           backgroundColor={theme.colors.secondary}
           accessibilityLabel="iNaturalist"
           mode="contained"

--- a/src/components/MyObservations/Toolbar.js
+++ b/src/components/MyObservations/Toolbar.js
@@ -11,8 +11,9 @@ import {
 import { Pressable, View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { ProgressBar, useTheme } from "react-native-paper";
+import { ProgressBar } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 type Props = {
   error: ?string,
@@ -47,7 +48,6 @@ const Toolbar = ( {
   syncIconColor,
   toggleLayout
 }: Props ): Node => {
-  const theme = useTheme( );
   const { t } = useTranslation( );
   // The exclamation mark should *never* appear while rotating, no matter what
   // the props say
@@ -120,7 +120,7 @@ const Toolbar = ( {
                     </Body2>
                     {showsCheckmark && (
                       <View className="ml-2">
-                        <INatIcon name="checkmark" size={11} color={theme.colors.secondary} />
+                        <INatIcon name="checkmark" size={11} color={colors.inatGreen} />
                       </View>
                     )}
                   </Pressable>
@@ -167,7 +167,7 @@ const Toolbar = ( {
       </View>
       <ProgressBar
         progress={progress}
-        color={theme.colors.secondary}
+        color={colors.inatGreen}
         // eslint-disable-next-line react-native/no-inline-styles
         style={{ backgroundColor: "transparent" }}
         visible={progress > 0}

--- a/src/components/MyObservations/ToolbarContainer.js
+++ b/src/components/MyObservations/ToolbarContainer.js
@@ -19,6 +19,7 @@ import {
   UPLOAD_PENDING
 } from "stores/createUploadObservationsSlice.ts";
 import useStore from "stores/useStore";
+import colors from "styles/tailwindColors";
 
 import Toolbar from "./Toolbar";
 
@@ -182,7 +183,7 @@ const ToolbarContainer = ( {
 
   const getSyncIconColor = useCallback( ( ) => {
     if ( showFinalUploadError ) {
-      return theme.colors.error;
+      return colors.warningRed;
     }
     if ( pendingUpload || uploadInProgress ) {
       return theme.colors.secondary;

--- a/src/components/MyObservations/ToolbarContainer.js
+++ b/src/components/MyObservations/ToolbarContainer.js
@@ -4,7 +4,6 @@ import { useNavigation } from "@react-navigation/native";
 import type { Node } from "react";
 import React, { useCallback, useMemo } from "react";
 import { Dimensions, PixelRatio } from "react-native";
-import { useTheme } from "react-native-paper";
 import {
   useCurrentUser,
   useTranslation
@@ -78,7 +77,6 @@ const ToolbarContainer = ( {
   );
 
   const { t } = useTranslation( );
-  const theme = useTheme( );
 
   const deletionsComplete = initialNumDeletionsInQueue === currentDeleteCount;
   const deletionsInProgress = initialNumDeletionsInQueue > 0 && !deletionsComplete;
@@ -186,11 +184,10 @@ const ToolbarContainer = ( {
       return colors.warningRed;
     }
     if ( pendingUpload || uploadInProgress ) {
-      return theme.colors.secondary;
+      return colors.inatGreen;
     }
-    return theme.colors.primary;
+    return colors.darkGray;
   }, [
-    theme,
     showFinalUploadError,
     pendingUpload,
     uploadInProgress

--- a/src/components/Notifications/ObsNotification.js
+++ b/src/components/Notifications/ObsNotification.js
@@ -9,9 +9,9 @@ import { View } from "components/styledComponents";
 import { RealmContext } from "providers/contexts.ts";
 import type { Node } from "react";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import { formatDifferenceForHumans } from "sharedHelpers/dateAndTime.ts";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 const { useRealm } = RealmContext;
 
@@ -25,7 +25,6 @@ const ObsNotification = ( { item }: Props ): Node => {
   const type = item?.notifier_type;
   const { user } = identification || comment;
   const realm = useRealm( );
-  const theme = useTheme();
 
   const observation = realm.objectForPrimaryKey( "Observation", item.resource_uuid );
   const photoUrl = observation?.observationPhotos[0]?.photo?.url;
@@ -55,7 +54,7 @@ const ObsNotification = ( { item }: Props ): Node => {
                 <INatIcon
                   name={renderIcon( )}
                   size={14}
-                  color={theme.colors.primary}
+                  color={colors.darkGray}
                 />
               )
           }

--- a/src/components/Notifications/ObservationIcon.js
+++ b/src/components/Notifications/ObservationIcon.js
@@ -5,7 +5,7 @@ import {
 } from "components/SharedComponents";
 import { Image, View } from "components/styledComponents";
 import * as React from "react";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 type Props = {
   photoUri: string,
@@ -15,8 +15,6 @@ type Props = {
 const ObservationIcon = ( {
   photoUri, soundUri
 }: Props ): React.Node => {
-  const theme = useTheme();
-
   if ( !photoUri && !soundUri ) {
     return (
       <View
@@ -33,7 +31,7 @@ const ObservationIcon = ( {
         <INatIcon
           name="noevidence"
           size={24}
-          color={theme.colors.primary}
+          color={colors.darkGray}
         />
       </View>
     );
@@ -55,7 +53,7 @@ const ObservationIcon = ( {
         <INatIcon
           name="sound"
           size={24}
-          color={theme.colors.primary}
+          color={colors.darkGray}
         />
       </View>
     );

--- a/src/components/ObsDetails/DQAContainer.js
+++ b/src/components/ObsDetails/DQAContainer.js
@@ -287,7 +287,7 @@ const DQAContainer = ( ): React.Node => {
         onPressClose={( ) => resetButtonsOnError( )}
       >
         <View className="px-[26px] py-[20px] flex-col space-y-[20px]">
-          <List2 className="text-black">{t( "Error-voting-in-DQA-description" )}</List2>
+          <List2 className="text-darkGray">{t( "Error-voting-in-DQA-description" )}</List2>
           <Button
             text={t( "OK" )}
             onPress={() => resetButtonsOnError( )}
@@ -301,7 +301,7 @@ const DQAContainer = ( ): React.Node => {
         onPressClose={( ) => setHideOfflineSheet( true )}
       >
         <View className="px-[26px] py-[20px] flex-col space-y-[20px]">
-          <List2 className="text-black">{t( "Offline-DQA-description" )}</List2>
+          <List2 className="text-darkGray">{t( "Offline-DQA-description" )}</List2>
           <Button
             text={t( "OK" )}
             onPress={() => setHideOfflineSheet( true )}

--- a/src/components/ObsDetails/DataQualityAssessment.js
+++ b/src/components/ObsDetails/DataQualityAssessment.js
@@ -142,9 +142,9 @@ const DataQualityAssessment = ( {
               color={theme.colors.secondary}
             />
           )}
-          <Body1 className="text-black">{titleOption( qualityGrade )}</Body1>
+          <Body1 className="text-darkGray">{titleOption( qualityGrade )}</Body1>
         </View>
-        <List2 className="text-black">{titleDescription( qualityGrade )}</List2>
+        <List2 className="text-darkGray">{titleDescription( qualityGrade )}</List2>
       </View>
       <Divider />
       <View className="mx-[15px]">

--- a/src/components/ObsDetails/DataQualityAssessment.js
+++ b/src/components/ObsDetails/DataQualityAssessment.js
@@ -18,6 +18,7 @@ import type { Node } from "react";
 import React, {
 } from "react";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 const titleOption = option => {
   switch ( option ) {
@@ -93,7 +94,7 @@ const DataQualityAssessment = ( {
       <INatIcon
         name="triangle-exclamation"
         size={19}
-        color={theme.colors.error}
+        color={colors.warningRed}
       />
     );
   };
@@ -108,7 +109,7 @@ const DataQualityAssessment = ( {
       <INatIcon
         name="triangle-exclamation"
         size={19}
-        color={theme.colors.error}
+        color={colors.warningRed}
       />
     );
   };

--- a/src/components/ObsDetails/DataQualityAssessment.js
+++ b/src/components/ObsDetails/DataQualityAssessment.js
@@ -15,9 +15,7 @@ import QualityGradeStatus from "components/SharedComponents/QualityGradeStatus/Q
 import { View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
-import React, {
-} from "react";
-import { useTheme } from "react-native-paper";
+import React from "react";
 import colors from "styles/tailwindColors";
 
 const titleOption = option => {
@@ -73,7 +71,6 @@ const DataQualityAssessment = ( {
   setNeedsIDVote
 }: Props ): Node => {
   const isResearchGrade = qualityGrade === "research";
-  const theme = useTheme( );
   const sectionClass = "flex-row my-[14px] space-x-[11px]";
   const voteClass = "flex-row mr-[15px] my-[7px] justify-between items-center";
   const listTextClass = "flex-row shrink space-x-[11px]";
@@ -86,7 +83,7 @@ const DataQualityAssessment = ( {
           testID="DQA.pass"
           name="checkmark-circle"
           size={19}
-          color={theme.colors.secondary}
+          color={colors.inatGreen}
         />
       );
     }
@@ -103,7 +100,7 @@ const DataQualityAssessment = ( {
     const ifAgree = checkTest( metric );
     if ( ifAgree || ifAgree === null ) {
       return (
-        <INatIcon name="checkmark-circle" size={19} color={theme.colors.secondary} /> );
+        <INatIcon name="checkmark-circle" size={19} color={colors.inatGreen} /> );
     }
     return (
       <INatIcon
@@ -131,8 +128,8 @@ const DataQualityAssessment = ( {
           qualityGrade={qualityGrade}
           color={
             qualityGrade === "research"
-              ? theme.colors.secondary
-              : theme.colors.primary
+              ? colors.inatGreen
+              : colors.darkGray
           }
         />
         <View className="flex-row space-x-[7px]">
@@ -140,7 +137,7 @@ const DataQualityAssessment = ( {
             <INatIcon
               name="checkmark-circle"
               size={19}
-              color={theme.colors.secondary}
+              color={colors.inatGreen}
             />
           )}
           <Body1 className="text-darkGray">{titleOption( qualityGrade )}</Body1>

--- a/src/components/ObsDetails/DetailsTab/CoordinatesCopiedNotification.js
+++ b/src/components/ObsDetails/DetailsTab/CoordinatesCopiedNotification.js
@@ -8,35 +8,32 @@ import {
 import { View } from "components/styledComponents";
 import { t } from "i18next";
 import * as React from "react";
-import { useTheme } from "react-native-paper";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
-const CoordinatesCopiedNotification = ( ): React.Node => {
-  const theme = useTheme( );
-  return (
-    <View
-      className={classnames(
-        "flex",
-        "flex-row",
-        "justify-center",
-        "items-center",
-        "bottom-1/2",
-        "bg-white",
-        "p-3",
-        "rounded-xl"
-      )}
-      style={getShadow( )}
-    >
-      <Body2 className="mr-3">
-        {t( "Coordinates-copied-to-clipboard" )}
-      </Body2>
-      <INatIcon
-        name="checkmark-circle"
-        size={19}
-        color={theme.colors.secondary}
-      />
-    </View>
+const CoordinatesCopiedNotification = ( ): React.Node => (
+  <View
+    className={classnames(
+      "flex",
+      "flex-row",
+      "justify-center",
+      "items-center",
+      "bottom-1/2",
+      "bg-white",
+      "p-3",
+      "rounded-xl"
+    )}
+    style={getShadow( )}
+  >
+    <Body2 className="mr-3">
+      {t( "Coordinates-copied-to-clipboard" )}
+    </Body2>
+    <INatIcon
+      name="checkmark-circle"
+      size={19}
+      color={colors.inatGreen}
+    />
+  </View>
 
-  );
-};
+);
 export default CoordinatesCopiedNotification;

--- a/src/components/ObsDetails/DetailsTab/DQAVoteButtons.js
+++ b/src/components/ObsDetails/DetailsTab/DQAVoteButtons.js
@@ -7,7 +7,6 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import * as React from "react";
-import { useTheme } from "react-native-paper";
 import { useCurrentUser, useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
@@ -60,7 +59,6 @@ const DQAVoteButtons = ( {
   removeVote
 }: Props ): React.Node => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
   const currentUser = useCurrentUser( );
   const userAgrees = getUserVote( currentUser, metric, votes );
   const activityIndicatorOffset = "mx-[7px]";
@@ -75,7 +73,7 @@ const DQAVoteButtons = ( {
           testID="DQAVoteButton.UserAgree"
           icon="arrow-up-bold-circle"
           size={33}
-          color={theme.colors.secondary}
+          color={colors.inatGreen}
           onPress={() => removeVote( { metric, vote: true } )}
           accessibilityLabel={t( "Add-agreement" )}
           accessibilityHint={t( "Adds-your-vote-of-agreement" )}

--- a/src/components/ObsDetails/DetailsTab/DQAVoteButtons.js
+++ b/src/components/ObsDetails/DetailsTab/DQAVoteButtons.js
@@ -9,6 +9,7 @@ import { View } from "components/styledComponents";
 import * as React from "react";
 import { useTheme } from "react-native-paper";
 import { useCurrentUser, useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 type Props = {
   metric: string,
@@ -104,7 +105,7 @@ const DQAVoteButtons = ( {
           testID="DQAVoteButton.UserDisagree"
           icon="arrow-down-bold-circle"
           size={33}
-          color={theme.colors.error}
+          color={colors.warningRed}
           onPress={() => removeVote( { metric, vote: false } )}
           accessibilityLabel={t( "Remove-disagreement" )}
           accessibilityHint={t( "Removes-your-vote-of-disagreement" )}

--- a/src/components/ObsDetails/DetailsTab/DetailsTab.js
+++ b/src/components/ObsDetails/DetailsTab/DetailsTab.js
@@ -88,7 +88,7 @@ const qualityGradeDescription = option => {
   }
 };
 
-const headingClass = "mt-[20px] mb-[11px] text-black";
+const headingClass = "mt-[20px] mb-[11px] text-darkGray";
 const sectionClass = "mx-[15px] mb-[20px]";
 
 const DetailsTab = ( { currentUser, observation }: Props ): Node => {

--- a/src/components/ObsDetails/DetailsTab/DetailsTab.js
+++ b/src/components/ObsDetails/DetailsTab/DetailsTab.js
@@ -17,8 +17,8 @@ import { t } from "i18next";
 import type { Node } from "react";
 import React from "react";
 import { Alert, Platform, Share } from "react-native";
-import { useTheme } from "react-native-paper";
 import { openExternalWebBrowser } from "sharedHelpers/util.ts";
+import colors from "styles/tailwindColors";
 
 import Attribution from "./Attribution";
 import LocationSection from "./LocationSection";
@@ -93,7 +93,6 @@ const sectionClass = "mx-[15px] mb-[20px]";
 
 const DetailsTab = ( { currentUser, observation }: Props ): Node => {
   const navigation = useNavigation( );
-  const theme = useTheme( );
   const application = observation?.application?.name;
   const qualityGrade = observation?.quality_grade;
   const observationUUID = observation?.uuid;
@@ -107,8 +106,8 @@ const DetailsTab = ( { currentUser, observation }: Props ): Node => {
       ? "1"
       : "0.5";
     const color = ( isResearchGrade )
-      ? theme.colors.secondary
-      : theme.colors.primary;
+      ? colors.inatGreen
+      : colors.darkGray;
     return (
       <View className="flex-1 flex-col space-y-[8px] items-center">
         <QualityGradeStatus qualityGrade={option} opacity={opacity} color={color} />

--- a/src/components/ObsDetails/DetailsTab/LocationSection.tsx
+++ b/src/components/ObsDetails/DetailsTab/LocationSection.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 const DETAILS_MAP_MODAL_STYLE = { margin: 0 };
 
-const headingClass = "mt-[20px] mb-[11px] text-black";
+const headingClass = "mt-[20px] mb-[11px] text-darkGray";
 const sectionClass = "mx-[15px] mb-[20px]";
 
 const LocationSection = ( { observation }: Props ): Node => {

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -222,7 +222,7 @@ const ObsDetails = ( {
       <ObsDetailsHeader
         belongsToCurrentUser={belongsToCurrentUser}
         observationId={observation?.id}
-        rightIconBlack
+        rightIconDarkGray
         uuid={observation?.uuid}
       />
     </View>

--- a/src/components/ObsDetails/ObsDetailsHeader.tsx
+++ b/src/components/ObsDetails/ObsDetailsHeader.tsx
@@ -24,14 +24,14 @@ const isTablet = DeviceInfo.isTablet( );
 interface Props {
   belongsToCurrentUser?: boolean,
   observationId: number,
-  rightIconBlack?: boolean,
+  rightIconDarkGray?: boolean,
   uuid: string
 }
 
 const ObsDetailsHeader = ( {
   belongsToCurrentUser,
   observationId,
-  rightIconBlack = false,
+  rightIconDarkGray = false,
   uuid
 }: Props ) => {
   const navigation = useNavigation( );
@@ -69,13 +69,13 @@ const ObsDetailsHeader = ( {
                   navigateToObsEdit( navigation, setMyObsOffsetToRestore );
                 }}
                 icon="pencil"
-                color={!rightIconBlack
+                color={!rightIconDarkGray
                   ? colors.white
-                  : colors.black}
+                  : colors.darkGray}
                 accessibilityLabel={t( "Edit" )}
               />
             )
-            : <HeaderKebabMenu observationId={observationId} white={!rightIconBlack} />
+            : <HeaderKebabMenu observationId={observationId} white={!rightIconDarkGray} />
         }
       />
     </LinearGradient>

--- a/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
+++ b/src/components/ObsDetails/Sheets/AgreeWithIDSheet.js
@@ -50,7 +50,7 @@ const AgreeWithIDSheet = ( {
     <View
       className="mx-[26px] space-y-[11px] my-[15px]"
     >
-      <List2 className="text-black">
+      <List2 className="text-darkGray">
         {t( "Agree-with-ID-description" )}
       </List2>
       { identification.body && (
@@ -58,7 +58,7 @@ const AgreeWithIDSheet = ( {
           className=" flex-row items-center bg-lightGray p-[15px] rounded"
         >
           <INatIcon name="add-comment-outline" size={22} />
-          <List2 className="ml-[7px] text-black">
+          <List2 className="ml-[7px] text-darkGray">
             {identification.body}
           </List2>
         </View>

--- a/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
+++ b/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
@@ -42,7 +42,7 @@ const SuggestIDSheet = ( {
           className=" flex-row items-center bg-lightGray p-[15px] rounded"
         >
           <INatIcon name="add-comment-outline" size={22} />
-          <List2 className="ml-[7px] text-black flex-1">
+          <List2 className="ml-[7px] text-darkGray flex-1">
             {identification.body}
           </List2>
         </View>

--- a/src/components/ObsDetails/SoundContainer.js
+++ b/src/components/ObsDetails/SoundContainer.js
@@ -13,11 +13,10 @@ import React, {
   useState
 } from "react";
 import AudioRecorderPlayer from "react-native-audio-recorder-player";
-import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 const SoundSlider = ( { playBackState, onSlidingComplete } ) => {
-  const theme = useTheme( );
   const sliderStyle = {
     width: "100%"
   };
@@ -30,7 +29,7 @@ const SoundSlider = ( { playBackState, onSlidingComplete } ) => {
       upperLimit={playBackState.duration}
       minimumTrackTintColor="#FFFFFF"
       maximumTrackTintColor="#FFFFFF"
-      thumbTintColor={theme.colors.inatGreen}
+      thumbTintColor={colors.inatGreen}
       tapToSeek
       value={playBackState.currentPosition}
       onSlidingComplete={onSlidingComplete}

--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -12,6 +12,7 @@ import type { Node } from "react";
 import React from "react";
 import { useTheme } from "react-native-paper";
 import useTranslation from "sharedHooks/useTranslation";
+import colors from "styles/tailwindColors";
 
 import DatePicker from "./DatePicker";
 import EvidenceList from "./EvidenceList";
@@ -103,7 +104,7 @@ const EvidenceSection = ( {
             <INatIcon name="checkmark-circle" size={19} color={theme.colors.secondary} />
           )}
           {passesEvidenceTest( ) === false && (
-            <INatIcon name="triangle-exclamation" size={19} color={theme.colors.error} />
+            <INatIcon name="triangle-exclamation" size={19} color={colors.warningRed} />
           )}
         </View>
       </View>

--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -10,7 +10,6 @@ import { MAX_SOUNDS_ALLOWED } from "components/SoundRecorder/SoundRecorder";
 import { Pressable, View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import useTranslation from "sharedHooks/useTranslation";
 import colors from "styles/tailwindColors";
 
@@ -49,7 +48,6 @@ const EvidenceSection = ( {
   updateObservationKeys
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
   // TODO fix this hack, and not with a workaround like
   // checkCamelAndSnakeCase. This component should only ever receive a local
   // Realm Observation or something that quacks like it, *not* a POJO from
@@ -101,7 +99,7 @@ const EvidenceSection = ( {
         <Heading4>{t( "EVIDENCE" )}</Heading4>
         <View className="ml-3">
           {passesEvidenceTest( ) && (
-            <INatIcon name="checkmark-circle" size={19} color={theme.colors.secondary} />
+            <INatIcon name="checkmark-circle" size={19} color={colors.inatGreen} />
           )}
           {passesEvidenceTest( ) === false && (
             <INatIcon name="triangle-exclamation" size={19} color={colors.warningRed} />

--- a/src/components/ObsEdit/IdentificationSection.js
+++ b/src/components/ObsEdit/IdentificationSection.js
@@ -14,7 +14,6 @@ import { capitalize } from "lodash";
 import { RealmContext } from "providers/contexts.ts";
 import type { Node } from "react";
 import React, { useCallback, useEffect } from "react";
-import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
@@ -34,7 +33,6 @@ const IdentificationSection = ( {
   updateObservationKeys
 }: Props ): Node => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
   const navigation = useNavigation( );
   const realm = useRealm( );
 
@@ -97,7 +95,7 @@ const IdentificationSection = ( {
                 name="sparkly-label"
                 size={24}
                 color={identTaxon
-                  ? theme.colors.primary
+                  ? colors.darkGray
                   : colors.white}
               />
             )}
@@ -135,7 +133,7 @@ const IdentificationSection = ( {
         <Heading4>{t( "IDENTIFICATION" )}</Heading4>
         {hasIdentification && (
           <View className="ml-3">
-            <INatIcon name="checkmark-circle" size={19} color={theme.colors.secondary} />
+            <INatIcon name="checkmark-circle" size={19} color={colors.inatGreen} />
           </View>
         )}
       </View>

--- a/src/components/ObsEdit/IdentificationSection.js
+++ b/src/components/ObsEdit/IdentificationSection.js
@@ -16,6 +16,7 @@ import type { Node } from "react";
 import React, { useCallback, useEffect } from "react";
 import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 const { useRealm } = RealmContext;
 
@@ -97,7 +98,7 @@ const IdentificationSection = ( {
                 size={24}
                 color={identTaxon
                   ? theme.colors.primary
-                  : theme.colors.onPrimary}
+                  : colors.white}
               />
             )}
             accessibilityLabel={t( "View-suggestions" )}

--- a/src/components/ObservationsFlashList/ObsImagePreview.js
+++ b/src/components/ObservationsFlashList/ObsImagePreview.js
@@ -6,6 +6,7 @@ import type { Node } from "react";
 import React, { useCallback } from "react";
 import { useTheme } from "react-native-paper";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 import ObsImage from "./ObsImage";
 
@@ -87,7 +88,7 @@ const ObsImagePreview = ( {
               : "bottom-1"
           )}
         >
-          <INatIcon name="photos-outline" color={theme.colors.onSecondary} size={16} />
+          <INatIcon name="photos-outline" color={colors.white} size={16} />
         </View>
       );
     }
@@ -110,8 +111,7 @@ const ObsImagePreview = ( {
   }, [
     isMultiplePhotosTop,
     isSmall,
-    obsPhotosCount,
-    theme
+    obsPhotosCount
   ] );
 
   const renderSelectable = useCallback( ( ) => {
@@ -170,7 +170,7 @@ const ObsImagePreview = ( {
           className="absolute left-1 bottom-1"
           style={ICON_DROP_SHADOW}
         >
-          <INatIcon name="sound" color={theme.colors.onSecondary} size={16} />
+          <INatIcon name="sound" color={colors.white} size={16} />
         </View>
       );
     }
@@ -182,10 +182,10 @@ const ObsImagePreview = ( {
         } )}
         style={ICON_DROP_SHADOW}
       >
-        <INatIcon name="sound" color={theme.colors.onSecondary} size={18} />
+        <INatIcon name="sound" color={colors.white} size={18} />
       </View>
     );
-  }, [hasSound, isSmall, theme] );
+  }, [hasSound, isSmall] );
 
   let content;
 

--- a/src/components/ObservationsFlashList/ObsImagePreview.js
+++ b/src/components/ObservationsFlashList/ObsImagePreview.js
@@ -4,7 +4,6 @@ import { INatIcon, PhotoCount } from "components/SharedComponents";
 import { LinearGradient, View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback } from "react";
-import { useTheme } from "react-native-paper";
 import { getShadow } from "styles/global";
 import colors from "styles/tailwindColors";
 
@@ -59,7 +58,6 @@ const ObsImagePreview = ( {
   white = false,
   width = "w-[62px]"
 }: Props ): Node => {
-  const theme = useTheme();
   const borderRadius = isSmall
     ? "rounded-lg"
     : "rounded-2xl";
@@ -131,13 +129,13 @@ const ObsImagePreview = ( {
           style={ICON_DROP_SHADOW}
         >
           {selected && (
-            <INatIcon name="checkmark" color={theme.colors.primary} size={12} />
+            <INatIcon name="checkmark" color={colors.darkGray} size={12} />
           )}
         </View>
       );
     }
     return null;
-  }, [selectable, selected, theme] );
+  }, [selectable, selected] );
 
   const renderGradient = useCallback( ( ) => {
     if ( isSmall ) return null;
@@ -199,7 +197,7 @@ const ObsImagePreview = ( {
       "justify-center",
       "items-center"
     );
-    content = <INatIcon name="sound" color={theme.colors.primary} size={24} />;
+    content = <INatIcon name="sound" color={colors.darkGray} size={24} />;
   } else {
     content = (
       <>

--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -16,7 +16,6 @@ import { Pressable, View } from "components/styledComponents";
 import { t } from "i18next";
 import type { Node } from "react";
 import React, { useCallback, useMemo, useState } from "react";
-import { useTheme } from "react-native-paper";
 import { useGridLayout } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
@@ -46,7 +45,6 @@ const GroupPhotos = ( {
   totalPhotos
 }: Props ): Node => {
   const navigation = useNavigation( );
-  const theme = useTheme();
   const {
     estimatedGridItemSize,
     flashListStyle,
@@ -156,7 +154,7 @@ const GroupPhotos = ( {
             mode="contained"
             size={20}
             color={colors.white}
-            backgroundColor={theme.colors.primary}
+            backgroundColor={colors.darkGray}
             className="m-4"
             accessibilityLabel={t( "Combine-Photos" )}
             disabled={noObsSelected || oneObsSelected}
@@ -167,7 +165,7 @@ const GroupPhotos = ( {
             mode="contained"
             size={20}
             color={colors.white}
-            backgroundColor={theme.colors.primary}
+            backgroundColor={colors.darkGray}
             className="m-4"
             accessibilityLabel={t( "Separate-Photos" )}
             disabled={!obsWithMultiplePhotosSelected}

--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -18,6 +18,7 @@ import type { Node } from "react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTheme } from "react-native-paper";
 import { useGridLayout } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 import GroupPhotoImage from "./GroupPhotoImage";
 
@@ -92,16 +93,16 @@ const GroupPhotos = ( {
           style={[gridItemStyle, {
             borderWidth: 4,
             borderStyle: "dashed",
-            borderColor: theme.colors.mediumGray
+            borderColor: colors.mediumGray
           }]}
         >
-          <INatIcon name="plus" size={50} color={theme.colors.mediumGray} />
+          <INatIcon name="plus" size={50} color={colors.mediumGray} />
         </Pressable>
       );
     }
     // $FlowIgnore
     return renderImage( item );
-  }, [gridItemStyle, renderImage, theme, addPhotos] );
+  }, [gridItemStyle, renderImage, addPhotos] );
 
   const renderHeader = ( ) => (
     <View className="m-5">
@@ -154,7 +155,7 @@ const GroupPhotos = ( {
             icon="combine"
             mode="contained"
             size={20}
-            color={theme.colors.onPrimary}
+            color={colors.white}
             backgroundColor={theme.colors.primary}
             className="m-4"
             accessibilityLabel={t( "Combine-Photos" )}
@@ -165,7 +166,7 @@ const GroupPhotos = ( {
             icon="separate"
             mode="contained"
             size={20}
-            color={theme.colors.onPrimary}
+            color={colors.white}
             backgroundColor={theme.colors.primary}
             className="m-4"
             accessibilityLabel={t( "Separate-Photos" )}
@@ -176,8 +177,8 @@ const GroupPhotos = ( {
             icon="trash-outline"
             mode="contained"
             size={20}
-            color={theme.colors.onError}
-            backgroundColor={theme.colors.error}
+            color={colors.white}
+            backgroundColor={colors.warningRed}
             className="m-4"
             accessibilityLabel={t( "Remove-Photos" )}
             disabled={noObsSelected}

--- a/src/components/SharedComponents/ActivityAnimation/ActivityAnimation.tsx
+++ b/src/components/SharedComponents/ActivityAnimation/ActivityAnimation.tsx
@@ -1,6 +1,6 @@
 import { View } from "components/styledComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 import Confetti from "./Confetti";
 import IndeterminateProgressBar from "./IndeterminateProgressBar";
@@ -8,18 +8,15 @@ import IndeterminateProgressBar from "./IndeterminateProgressBar";
 const count = 30;
 const duration = 7000;
 
-const ActivityAnimation = ( ) => {
-  const theme = useTheme();
-  return (
-    <View className="flex-1">
-      {/* A view that animates in a loop */}
-      <IndeterminateProgressBar
-        color={theme.colors.secondary}
-      />
-      {/* A view that rains confetti of random iconic taxon icons */}
-      <Confetti key="confetti" count={count} duration={duration} />
-    </View>
-  );
-};
+const ActivityAnimation = ( ) => (
+  <View className="flex-1">
+    {/* A view that animates in a loop */}
+    <IndeterminateProgressBar
+      color={colors.inatGreen}
+    />
+    {/* A view that rains confetti of random iconic taxon icons */}
+    <Confetti key="confetti" count={count} duration={duration} />
+  </View>
+);
 
 export default ActivityAnimation;

--- a/src/components/SharedComponents/ActivityAnimation/Confetti.tsx
+++ b/src/components/SharedComponents/ActivityAnimation/Confetti.tsx
@@ -6,7 +6,6 @@ import React, {
   memo, PropsWithChildren, useEffect, useState
 } from "react";
 import { StyleSheet, useWindowDimensions } from "react-native";
-import { useTheme } from "react-native-paper";
 import Animated, {
   Easing,
   interpolate,
@@ -15,6 +14,7 @@ import Animated, {
   useSharedValue,
   withTiming
 } from "react-native-reanimated";
+import colors from "styles/tailwindColors";
 
 type ConfettiProps = PropsWithChildren<{
   count: number
@@ -71,7 +71,6 @@ const AnimatedElement = memo(
 );
 
 const Confetti = ( { count, duration = 5000 }: ConfettiProps ) => {
-  const theme = useTheme();
   const animation = useSharedValue( 0 );
   const [autoDestroy, setAutoDestroy] = useState( false );
 
@@ -143,7 +142,7 @@ const Confetti = ( { count, duration = 5000 }: ConfettiProps ) => {
               <INatIcon
                 name={`iconic-${randomIconicTaxon}`}
                 size={22}
-                color={theme.colors.secondary}
+                color={colors.inatGreen}
               />
             </View>
           </AnimatedElement>

--- a/src/components/SharedComponents/ActivityCount/ActivityCount.js
+++ b/src/components/SharedComponents/ActivityCount/ActivityCount.js
@@ -8,6 +8,7 @@ import type { Node } from "react";
 import React from "react";
 import { useTheme } from "react-native-paper";
 import useTranslation from "sharedHooks/useTranslation";
+import colors from "styles/tailwindColors";
 
 type Props = {
   accessibilityLabel?: string,
@@ -40,7 +41,7 @@ const ActivityCount = ( {
       <INatIcon
         name={icon || "comments"}
         color={white
-          ? theme.colors.onPrimary
+          ? colors.white
           : theme.colors.primary}
         size={14}
       />

--- a/src/components/SharedComponents/ActivityCount/ActivityCount.js
+++ b/src/components/SharedComponents/ActivityCount/ActivityCount.js
@@ -6,7 +6,6 @@ import Body3 from "components/SharedComponents/Typography/Body3.tsx";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import useTranslation from "sharedHooks/useTranslation";
 import colors from "styles/tailwindColors";
 
@@ -27,7 +26,6 @@ const ActivityCount = ( {
   testID,
   classNameMargin
 }: Props ): Node => {
-  const theme = useTheme( );
   const { t } = useTranslation( );
 
   return (
@@ -42,7 +40,7 @@ const ActivityCount = ( {
         name={icon || "comments"}
         color={white
           ? colors.white
-          : theme.colors.primary}
+          : colors.darkGray}
         size={14}
       />
       <Body3

--- a/src/components/SharedComponents/Buttons/BackButton.js
+++ b/src/components/SharedComponents/Buttons/BackButton.js
@@ -41,7 +41,7 @@ const REACT_NAVIGATION_BACK_BUTTON_STYLES = {
 };
 
 const BackButton = ( {
-  color = colors.black,
+  color = colors.darkGray,
   onPress,
   inCustomHeader,
   customStyles,
@@ -49,7 +49,7 @@ const BackButton = ( {
 }: Props ): Node => {
   const { isRTL } = I18nManager;
   const navigation = useNavigation();
-  const tintColor = color || colors.black;
+  const tintColor = color || colors.darkGray;
   const { t } = useTranslation( );
 
   const imageStyles = [

--- a/src/components/SharedComponents/Buttons/Button.tsx
+++ b/src/components/SharedComponents/Buttons/Button.tsx
@@ -4,7 +4,6 @@ import { ActivityIndicator, Heading4, INatIcon } from "components/SharedComponen
 import { Pressable, View } from "components/styledComponents";
 import * as React from "react";
 import { AccessibilityRole, GestureResponderEvent, ViewStyle } from "react-native";
-import { MD3Theme, useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 interface ButtonProps {
@@ -127,12 +126,11 @@ const setStyles = ( {
 // };
 
 const activityIndicatorColor = ( {
-  isPrimary, isWarning, isFocus, theme
+  isPrimary, isWarning, isFocus
 }: {
   isPrimary: boolean;
   isWarning: boolean;
   isFocus: boolean;
-  theme: MD3Theme;
 } ) => {
   if ( isPrimary ) {
     return colors.white;
@@ -144,7 +142,7 @@ const activityIndicatorColor = ( {
     return colors.white;
   }
   // Default color of ActivityIndicator is primary anyways, but we need to return something
-  return theme.colors.primary;
+  return colors.darkGray;
 };
 
 const Button = ( {
@@ -187,8 +185,6 @@ const Button = ( {
   //   forceDark
   // } );
 
-  const theme = useTheme();
-
   return (
     <Pressable
       style={style}
@@ -208,7 +204,7 @@ const Button = ( {
           className="mr-2"
           color={!isNeutral
             ? activityIndicatorColor( {
-              isPrimary, isWarning, isFocus, theme
+              isPrimary, isWarning, isFocus
             } )
             : undefined}
         />

--- a/src/components/SharedComponents/Buttons/Button.tsx
+++ b/src/components/SharedComponents/Buttons/Button.tsx
@@ -5,6 +5,7 @@ import { Pressable, View } from "components/styledComponents";
 import * as React from "react";
 import { AccessibilityRole, GestureResponderEvent, ViewStyle } from "react-native";
 import { MD3Theme, useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface ButtonProps {
   accessibilityHint?: string;
@@ -134,13 +135,13 @@ const activityIndicatorColor = ( {
   theme: MD3Theme;
 } ) => {
   if ( isPrimary ) {
-    return theme.colors.onPrimary;
+    return colors.white;
   }
   if ( isFocus ) {
-    return theme.colors.onSecondary;
+    return colors.white;
   }
   if ( isWarning ) {
-    return theme.colors.onError;
+    return colors.white;
   }
   // Default color of ActivityIndicator is primary anyways, but we need to return something
   return theme.colors.primary;

--- a/src/components/SharedComponents/Buttons/CloseButton.tsx
+++ b/src/components/SharedComponents/Buttons/CloseButton.tsx
@@ -3,20 +3,21 @@ import { INatIconButton } from "components/SharedComponents";
 import { t } from "i18next";
 import React from "react";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface Props {
-  handleClose?: ( ) => void;
-  black?: boolean;
   buttonClassName?: string;
-  size?: number;
-  icon?: string;
-  width?: number;
+  darkGray?: boolean;
+  handleClose?: ( ) => void;
   height?: number;
+  icon?: string;
+  size?: number;
+  width?: number;
 }
 
 const CloseButton = ( {
-  black,
   buttonClassName,
+  darkGray,
   handleClose,
   height,
   icon,
@@ -31,8 +32,8 @@ const CloseButton = ( {
       className={buttonClassName}
       icon={icon || "close"}
       size={size}
-      color={black
-        ? theme.colors.tertiary
+      color={darkGray
+        ? colors.darkGray
         : theme.colors.background}
       onPress={( ) => {
         if ( handleClose ) {

--- a/src/components/SharedComponents/Buttons/CloseButton.tsx
+++ b/src/components/SharedComponents/Buttons/CloseButton.tsx
@@ -2,7 +2,6 @@ import { useNavigation } from "@react-navigation/native";
 import { INatIconButton } from "components/SharedComponents";
 import { t } from "i18next";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 interface Props {
@@ -25,7 +24,6 @@ const CloseButton = ( {
   width
 }: Props ) => {
   const navigation = useNavigation( );
-  const theme = useTheme( );
 
   return (
     <INatIconButton
@@ -34,7 +32,7 @@ const CloseButton = ( {
       size={size}
       color={darkGray
         ? colors.darkGray
-        : theme.colors.background}
+        : colors.white}
       onPress={( ) => {
         if ( handleClose ) {
           handleClose( navigation );

--- a/src/components/SharedComponents/Buttons/EvidenceButton.js
+++ b/src/components/SharedComponents/Buttons/EvidenceButton.js
@@ -1,7 +1,6 @@
 // @flow
 import { INatIconButton } from "components/SharedComponents";
 import * as React from "react";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 type Props = {
@@ -19,7 +18,6 @@ const EvidenceButton = ( {
   accessibilityLabel,
   accessibilityHint
 }: Props ): React.Node => {
-  const theme = useTheme( );
   if ( !accessibilityLabel ) {
     throw new Error(
       "EvidenceButton needs an accessibility label"
@@ -30,7 +28,7 @@ const EvidenceButton = ( {
       onPress={handlePress}
       backgroundColor={disabled
         ? colors.lightGray
-        : theme.colors.secondary}
+        : colors.inatGreen}
       color={colors.white}
       size={33}
       icon={icon}

--- a/src/components/SharedComponents/Buttons/EvidenceButton.js
+++ b/src/components/SharedComponents/Buttons/EvidenceButton.js
@@ -31,7 +31,7 @@ const EvidenceButton = ( {
       backgroundColor={disabled
         ? colors.lightGray
         : theme.colors.secondary}
-      color={theme.colors.onSecondary}
+      color={colors.white}
       size={33}
       icon={icon}
       accessibilityLabel={accessibilityLabel}

--- a/src/components/SharedComponents/Buttons/INatIconButton.tsx
+++ b/src/components/SharedComponents/Buttons/INatIconButton.tsx
@@ -8,7 +8,7 @@ import {
   Pressable,
   ViewStyle
 } from "react-native";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface Props {
   accessibilityHint?: string;
@@ -52,7 +52,6 @@ const INatIconButton = ( {
   backgroundColor,
   mode
 }: Props ) => {
-  const theme = useTheme( );
   // width || 0 is to placate flow. width should never be undefined because of
   // the defaultProps, but I guess flow can't figure that out.
   if ( ( width || 0 ) < MIN_ACCESSIBLE_DIM ) {
@@ -148,7 +147,7 @@ const INatIconButton = ( {
             <INatIcon
               name={icon}
               size={size}
-              color={color || theme.colors.primary}
+              color={color || colors.darkGray}
             />
           )
         }

--- a/src/components/SharedComponents/Checkbox.tsx
+++ b/src/components/SharedComponents/Checkbox.tsx
@@ -1,7 +1,6 @@
 import { Body2, INatIcon } from "components/SharedComponents";
 import React, { useMemo } from "react";
 import BouncyCheckbox from "react-native-bouncy-checkbox";
-import { useTheme } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 interface Props {
@@ -19,8 +18,6 @@ const Checkbox = ( {
   onPress,
   text
 }: Props ) => {
-  const theme = useTheme( );
-
   const renderCheckboxText = useMemo( ( ) => {
     if ( !text ) { return null; }
     return <Body2 className="ml-3 flex-shrink">{text}</Body2>;
@@ -36,10 +33,10 @@ const Checkbox = ( {
     )
     : null ), [isChecked] );
 
-  const checkedBorderColor = theme.colors.secondary;
+  const checkedBorderColor = colors.inatGreen;
   const uncheckedBorderColor = transparent
     ? colors.white
-    : theme.colors.primary;
+    : colors.darkGray;
 
   const innerIconStyle = {
     borderRadius: 6,
@@ -54,7 +51,7 @@ const Checkbox = ( {
   return (
     <BouncyCheckbox
       size={25}
-      fillColor={theme.colors.secondary}
+      fillColor={colors.inatGreen}
       unfillColor={transparent
         ? undefined
         : colors.white}

--- a/src/components/SharedComponents/Checkbox.tsx
+++ b/src/components/SharedComponents/Checkbox.tsx
@@ -2,6 +2,7 @@ import { Body2, INatIcon } from "components/SharedComponents";
 import React, { useMemo } from "react";
 import BouncyCheckbox from "react-native-bouncy-checkbox";
 import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface Props {
   transparent?: boolean;
@@ -29,15 +30,15 @@ const Checkbox = ( {
     ? (
       <INatIcon
         name="checkmark"
-        color={theme.colors.onPrimary}
+        color={colors.white}
         size={19}
       />
     )
-    : null ), [theme, isChecked] );
+    : null ), [isChecked] );
 
   const checkedBorderColor = theme.colors.secondary;
   const uncheckedBorderColor = transparent
-    ? theme.colors.onPrimary
+    ? colors.white
     : theme.colors.primary;
 
   const innerIconStyle = {
@@ -56,7 +57,7 @@ const Checkbox = ( {
       fillColor={theme.colors.secondary}
       unfillColor={transparent
         ? undefined
-        : theme.colors.onPrimary}
+        : colors.white}
       iconComponent={renderIcon}
       onPress={onPress}
       isChecked={isChecked}

--- a/src/components/SharedComponents/INatIcon/index.tsx
+++ b/src/components/SharedComponents/INatIcon/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 import Icon from "./INatIcon";
 
@@ -79,19 +79,15 @@ const ALIASES: Aliases = {
   "upvote-inactive": "arrow-up-bold-circle-outline"
 } as const;
 
+// Use default color if none is specified
 const INatIcon = ( {
   testID, name, color, size
-}: Props ) => {
-  const theme = useTheme();
-  // Use default color if none is specified
-  return (
-    <Icon
-      testID={testID}
-      name={ALIASES[name] || name}
-      color={color || theme.colors.primary}
-      size={size}
-    />
-  );
-};
-
+}: Props ) => (
+  <Icon
+    testID={testID}
+    name={ALIASES[name] || name}
+    color={color || colors.darkGray}
+    size={size}
+  />
+);
 export default INatIcon;

--- a/src/components/SharedComponents/InputField.js
+++ b/src/components/SharedComponents/InputField.js
@@ -46,7 +46,7 @@ const InputField = ( {
       keyboardType={keyboardType}
       onChangeText={handleTextChange}
       placeholder={placeholder}
-      placeholderTextColor={colors.black}
+      placeholderTextColor={colors.darkGray}
       secureTextEntry={type === "password"}
       selectTextOnFocus={Platform.OS === "android"}
       className="border border-lightGray h-8 mx-5 rounded-xl pl-3"

--- a/src/components/SharedComponents/KebabMenu.js
+++ b/src/components/SharedComponents/KebabMenu.js
@@ -50,7 +50,7 @@ const KebabMenu = ( {
       accessibilityHint={accessibilityHint || t( "Open-menu" )}
       color={white
         ? colors.white
-        : colors.black}
+        : colors.darkGray}
     />
   );
 
@@ -85,7 +85,7 @@ const KebabMenuItem = ( {
     onPress={onPress}
   >
     <Body3
-      className="m-[14px] text-black"
+      className="m-[14px] text-darkGray"
     >
       {title}
     </Body3>

--- a/src/components/SharedComponents/Map/DetailsMap.js
+++ b/src/components/SharedComponents/Map/DetailsMap.js
@@ -19,8 +19,8 @@ import { t } from "i18next";
 import type { Node } from "react";
 import React, { useState } from "react";
 import openMap from "react-native-open-maps";
-import { useTheme } from "react-native-paper";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 type Props = {
   latitude: number,
@@ -72,7 +72,6 @@ const DetailsMap = ( {
   region,
   coordinateString
 }: Props ): Node => {
-  const theme = useTheme( );
   const [showNotificationModal, setShowNotificationModal] = useState( false );
 
   const closeShowNotificationModal = () => {
@@ -97,7 +96,7 @@ const DetailsMap = ( {
       <SafeAreaView>
         <View className="bg-white w-fit flex-row py-[22px] pl-[21px] pr-[24px] items-start">
           <HeaderBackButton
-            tintColor={theme.colors.primary}
+            tintColor={colors.darkGray}
             onPress={( ) => closeModal()}
             labelVisible={false}
           />

--- a/src/components/SharedComponents/Map/LocationIndicator.tsx
+++ b/src/components/SharedComponents/Map/LocationIndicator.tsx
@@ -4,7 +4,7 @@ import {
   Circle,
   Marker
 } from "react-native-maps";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface Props {
   obsLatitude: number,
@@ -19,8 +19,6 @@ const LocationIndicator = ( {
   positionalAccuracy,
   showLocationIndicator
 }: Props ) => {
-  const theme = useTheme( );
-
   const locationIndicator = ( ) => (
     <LocationIndicatorIcon
       testID="Map.LocationIndicator"
@@ -38,7 +36,7 @@ const LocationIndicator = ( {
         }}
         radius={positionalAccuracy}
         strokeWidth={2}
-        strokeColor={theme.colors.inatGreen}
+        strokeColor={colors.inatGreen}
         fillColor="rgba( 116, 172, 0, 0.2 )"
       />
       <Marker

--- a/src/components/SharedComponents/ObsStatus.js
+++ b/src/components/SharedComponents/ObsStatus.js
@@ -12,6 +12,7 @@ import type { Node } from "react";
 import React, { useCallback } from "react";
 import { useTheme } from "react-native-paper";
 import Observation from "realmModels/Observation";
+import colors from "styles/tailwindColors";
 
 type Props = {
   observation: typeof Observation,
@@ -73,7 +74,7 @@ const ObsStatus = ( {
       ? theme.colors.secondary
       : theme.colors.primary;
     const iconColor = white
-      ? theme.colors.onPrimary
+      ? colors.white
       : iconColorResearchCheck;
     return <QualityGradeStatus qualityGrade={qualityGrade} color={iconColor} />;
   }, [observation, theme, white] );

--- a/src/components/SharedComponents/ObsStatus.js
+++ b/src/components/SharedComponents/ObsStatus.js
@@ -10,7 +10,6 @@ import {
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback } from "react";
-import { useTheme } from "react-native-paper";
 import Observation from "realmModels/Observation";
 import colors from "styles/tailwindColors";
 
@@ -29,7 +28,6 @@ const ObsStatus = ( {
   classNameMargin,
   testID
 }: Props ): Node => {
-  const theme = useTheme();
   const margin = layout === "vertical"
     ? "mb-1 ml-1"
     : "mr-2";
@@ -71,13 +69,13 @@ const ObsStatus = ( {
   const showQualityGrade = useCallback( ( ) => {
     const qualityGrade = checkCamelAndSnakeCase( observation, "qualityGrade" );
     const iconColorResearchCheck = qualityGrade === "research"
-      ? theme.colors.secondary
-      : theme.colors.primary;
+      ? colors.inatGreen
+      : colors.darkGray;
     const iconColor = white
       ? colors.white
       : iconColorResearchCheck;
     return <QualityGradeStatus qualityGrade={qualityGrade} color={iconColor} />;
-  }, [observation, theme, white] );
+  }, [observation, white] );
 
   return (
     <View

--- a/src/components/SharedComponents/OfflineNotice.tsx
+++ b/src/components/SharedComponents/OfflineNotice.tsx
@@ -38,7 +38,9 @@ const OfflineNotice = ( {
       <Body2
         className={classnames(
           "mt-[30px]",
-          color && `text-${color}`
+          color
+            ? `text-${color}`
+            : "text-darkGray"
         )}
       >
         { t( "You-are-offline-Tap-to-try-again" ) }

--- a/src/components/SharedComponents/PhotoCount.js
+++ b/src/components/SharedComponents/PhotoCount.js
@@ -10,6 +10,7 @@ import { useTheme } from "react-native-paper";
 import Svg, { Path } from "react-native-svg";
 import { useTranslation } from "sharedHooks";
 import { dropShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 const HEIGHT = 24;
 
@@ -59,12 +60,12 @@ const PhotoCount = ( { count }: Props ): Node => {
           fillRule="nonzero"
           clipRule="evenodd"
           d="M4 5.818a4 4 0 00-4 4V20a4 4 0 004 4h10.182a4 4 0 004-4V9.818a4 4 0 00-4-4z"
-          fill={theme.colors.background}
+          fill={colors.white}
         />
         <Path
         // eslint-disable-next-line max-len
           d="M15.364 3.636h-9.53A4 4 0 019.818 0H20a4 4 0 014 4v10.182a4 4 0 01-3.636 3.984v-9.53a5 5 0 00-5-5z"
-          fill={theme.colors.background}
+          fill={colors.white}
           clipRule="evenodd"
           fillRule="nonzero"
         />

--- a/src/components/SharedComponents/QualityGradeStatus/QualityGradeStatus.js
+++ b/src/components/SharedComponents/QualityGradeStatus/QualityGradeStatus.js
@@ -5,7 +5,7 @@ import CasualGrade from "images/svg/casual_grade.svg";
 import NeedsIdGrade from "images/svg/needs_id_grade.svg";
 import ResearchGrade from "images/svg/research_grade.svg";
 import * as React from "react";
-import { useTheme } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 type Props = {
   qualityGrade: ?string,
@@ -51,8 +51,7 @@ const qualityGradeSVG = ( qualityGrade, color, opacity ) => {
 };
 
 const QualityGradeStatus = ( { qualityGrade, color, opacity }: Props ): React.Node => {
-  const theme = useTheme();
-  const svgColor = color || theme.colors.primary;
+  const svgColor = color || colors.darkGray;
   const svgOpacity = opacity || 1;
   return (
     <View>{qualityGradeSVG( qualityGrade, svgColor, svgOpacity )}</View>

--- a/src/components/SharedComponents/RadioButtonRow.tsx
+++ b/src/components/SharedComponents/RadioButtonRow.tsx
@@ -51,6 +51,7 @@ const RadioButtonRow = ( {
           value={value}
           status={status}
           accessibilityLabel={label}
+          color={colors.darkGray}
         />
         <View className="ml-3 flex-row w-5/6">
           {labelComponent || <Label className="mr-2">{label}</Label>}

--- a/src/components/SharedComponents/RadioButtonRow.tsx
+++ b/src/components/SharedComponents/RadioButtonRow.tsx
@@ -7,7 +7,8 @@ import {
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
 import { GestureResponderEvent } from "react-native";
-import { RadioButton, useTheme } from "react-native-paper";
+import { RadioButton } from "react-native-paper";
+import colors from "styles/tailwindColors";
 
 interface Props {
   checked: boolean;
@@ -34,8 +35,6 @@ const RadioButtonRow = ( {
   testID,
   value
 }: Props ) => {
-  const theme = useTheme( );
-
   const status = checked
     ? "checked"
     : "unchecked";
@@ -55,7 +54,7 @@ const RadioButtonRow = ( {
         />
         <View className="ml-3 flex-row w-5/6">
           {labelComponent || <Label className="mr-2">{label}</Label>}
-          {icon && <INatIcon name={icon} size={19} color={theme.colors.secondary} />}
+          {icon && <INatIcon name={icon} size={19} color={colors.inatGreen} />}
         </View>
       </View>
       {description && (

--- a/src/components/SharedComponents/SearchBar.tsx
+++ b/src/components/SharedComponents/SearchBar.tsx
@@ -7,6 +7,7 @@ import { TextInput as RNTextInput } from "react-native";
 import { TextInput, useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 const DROP_SHADOW = getShadow( );
 
@@ -70,7 +71,7 @@ const SearchBar = ( {
       <TextInput
         ref={input}
         accessibilityLabel={t( "Search-for-a-taxon" )}
-        activeUnderlineColor={theme.colors.primary}
+        activeUnderlineColor={colors.darkGray}
         autoFocus={autoFocus}
         dense
         keyboardType="default"
@@ -81,7 +82,7 @@ const SearchBar = ( {
         style={style}
         testID={testID}
         theme={fontTheme}
-        underlineColor={theme.colors.primary}
+        underlineColor={colors.darkGray}
         value={value}
       />
       {value?.length > 0 && clearSearch

--- a/src/components/SharedComponents/SearchBar.tsx
+++ b/src/components/SharedComponents/SearchBar.tsx
@@ -79,6 +79,7 @@ const SearchBar = ( {
         onChangeText={handleTextChange}
         outlineStyle={outlineStyle}
         placeholder={placeholder}
+        selectionColor={colors.darkGray}
         style={style}
         testID={testID}
         theme={fontTheme}

--- a/src/components/SharedComponents/Sheets/TextInputSheet.js
+++ b/src/components/SharedComponents/Sheets/TextInputSheet.js
@@ -10,10 +10,10 @@ import { Pressable, View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useMemo, useRef, useState } from "react";
 import { Keyboard } from "react-native";
-import { useTheme } from "react-native-paper";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import useKeyboardInfo from "sharedHooks/useKeyboardInfo";
 import useTranslation from "sharedHooks/useTranslation";
+import colors from "styles/tailwindColors";
 
 // Optimized to maximize input size while minimizing post-render height
 // adjustments for for iPhone 13 and taller screens. Shorter screens
@@ -64,7 +64,6 @@ const TextInputSheet = ( {
   textInputStyle
 }: Props ): Node => {
   const textInputRef = useRef( );
-  const theme = useTheme( );
   const [input, setInput] = useState( initialInput );
   const { t } = useTranslation( );
   const { nonKeyboardHeight } = useKeyboardInfo( TARGET_INPUT_HEIGHT );
@@ -82,12 +81,11 @@ const TextInputSheet = ( {
     fontFamily: fontRegular,
     fontSize: 14,
     lineHeight: 17,
-    color: theme.colors.primary,
+    color: colors.darkGray,
     textAlignVertical: "top"
   } ), [
     nonKeyboardHeight,
     sheetHeight,
-    theme,
     topInset
   ] );
 

--- a/src/components/SharedComponents/SpeciesSeenCheckmark.js
+++ b/src/components/SharedComponents/SpeciesSeenCheckmark.js
@@ -5,42 +5,37 @@ import { INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import { getShadow } from "styles/global";
+import colors from "styles/tailwindColors";
 
 const DROP_SHADOW = getShadow( );
 
-const SpeciesSeenCheckmark = ( ): Node => {
-  const theme = useTheme( );
-
-  // Styling the outer element to be the white background wasn't looking right
-  // in android, so instead we insert smaller white circle behind the icon
-  return (
+// Styling the outer element to be the white background wasn't looking right
+// in android, so instead we insert smaller white circle behind the icon
+const SpeciesSeenCheckmark = ( ): Node => (
+  <View
+    className="rounded-full items-center"
+    style={DROP_SHADOW}
+    testID="SpeciesSeenCheckmark"
+  >
     <View
-      className="rounded-full items-center"
-      style={DROP_SHADOW}
-      testID="SpeciesSeenCheckmark"
-    >
-      <View
-        className={classnames(
-          "w-[16px]",
-          "h-[16px]",
-          "bg-white",
-          "absolute",
-          "rounded-full",
-          "top-1/2",
-          "mt-[-8px]"
-        )}
+      className={classnames(
+        "w-[16px]",
+        "h-[16px]",
+        "bg-white",
+        "absolute",
+        "rounded-full",
+        "top-1/2",
+        "mt-[-8px]"
+      )}
+    />
+    <View className="-mt-[0.5px]">
+      <INatIcon
+        name="checkmark-circle"
+        size={20}
+        color={colors.inatGreen}
       />
-      <View className="-mt-[0.5px]">
-        <INatIcon
-          name="checkmark-circle"
-          size={20}
-          color={theme.colors.secondary}
-        />
-      </View>
     </View>
-  );
-};
-
+  </View>
+);
 export default SpeciesSeenCheckmark;

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -7,7 +7,6 @@ import {
 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import { accessibleTaxonName } from "sharedHelpers/taxon";
 import { useCurrentUser, useTaxon, useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
@@ -70,7 +69,6 @@ const TaxonResult = ( {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
 
-  const theme = useTheme( );
   const currentUser = useCurrentUser( );
 
   // thinking about future performance, it might make more sense to batch
@@ -120,7 +118,7 @@ const TaxonResult = ( {
         color={
           clearBackground
             ? colors.white
-            : theme.colors.primary
+            : colors.darkGray
         }
         onPress={() => handleCheckmarkPress( usableTaxon )}
         accessibilityLabel={accessibilityLabel}

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { useTheme } from "react-native-paper";
 import { accessibleTaxonName } from "sharedHelpers/taxon";
 import { useCurrentUser, useTaxon, useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 import ConfidenceInterval from "./ConfidenceInterval";
 
@@ -104,7 +105,7 @@ const TaxonResult = ( {
           } )}
           icon="checkmark"
           size={21}
-          color={theme.colors.onSecondary}
+          color={colors.white}
           onPress={() => handleCheckmarkPress( usableTaxon )}
           accessibilityLabel={accessibilityLabel}
           testID={`${testID}.checkmark`}
@@ -118,7 +119,7 @@ const TaxonResult = ( {
         size={40}
         color={
           clearBackground
-            ? theme.colors.onSecondary
+            ? colors.white
             : theme.colors.primary
         }
         onPress={() => handleCheckmarkPress( usableTaxon )}
@@ -202,7 +203,7 @@ const TaxonResult = ( {
               }
               navToTaxonDetails( );
             }}
-            color={clearBackground && theme.colors.onSecondary}
+            color={clearBackground && colors.white}
             accessibilityLabel={t( "More-info" )}
             accessibilityHint={t( "Navigates-to-taxon-details" )}
           />

--- a/src/components/Suggestions/SuggestionsOffline.tsx
+++ b/src/components/Suggestions/SuggestionsOffline.tsx
@@ -5,8 +5,8 @@ import {
 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
-import { useTheme } from "react-native-paper";
 import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
 
 interface Props {
   reloadSuggestions: ( ) => void;
@@ -16,7 +16,6 @@ const SuggestionsOffline = ( {
   reloadSuggestions
 }: Props ) => {
   const { t } = useTranslation( );
-  const theme = useTheme( );
   return (
     <Pressable
       accessibilityRole="button"
@@ -28,7 +27,7 @@ const SuggestionsOffline = ( {
           <INatIcon
             name="offline"
             size={22}
-            color={theme.colors.warningYellow}
+            color={colors.warningYellow}
           />
           <Body2 className="mx-2">{t( "You-are-offline-Tap-to-reload" )}</Body2>
         </View>

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -28,7 +28,6 @@ import {
   StatusBar
 } from "react-native";
 import DeviceInfo from "react-native-device-info";
-import { useTheme } from "react-native-paper";
 import { log } from "sharedHelpers/logger";
 import saveObservation from "sharedHelpers/saveObservation.ts";
 import { fetchTaxonAndSave } from "sharedHelpers/taxon";
@@ -63,7 +62,6 @@ const TaxonDetails = ( ): Node => {
   const setExploreView = useStore( state => state.setExploreView );
   const cameraRollUris = useStore( state => state.cameraRollUris );
   const resetMyObsOffsetToRestore = useStore( state => state.resetMyObsOffsetToRestore );
-  const theme = useTheme( );
   const navigation = useNavigation( );
   const { params } = useRoute( );
   const { id, hideNavButtons } = params;
@@ -261,7 +259,7 @@ const TaxonDetails = ( ): Node => {
             accessibilityLabel={t( "See-observations-of-this-taxon-in-explore" )}
             accessibilityHint={t( "Navigates-to-explore" )}
             size={30}
-            color={theme.colors.onPrimary}
+            color={colors.white}
             className="bg-inatGreen rounded-full"
             mode="contained"
             preventTransparency
@@ -276,8 +274,7 @@ const TaxonDetails = ( ): Node => {
     navigation,
     setExploreView,
     t,
-    taxon,
-    theme.colors.onPrimary
+    taxon
   ] );
 
   const displayTaxonMedia = () => {
@@ -373,7 +370,7 @@ const TaxonDetails = ( ): Node => {
               <INatIcon
                 name="checkmark"
                 size={19}
-                color={theme.colors.onPrimary}
+                color={colors.white}
               />
             )}
             iconPosition="right"

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -40,6 +40,7 @@ import {
   useUserMe
 } from "sharedHooks";
 import useStore from "stores/useStore";
+import colors from "styles/tailwindColors";
 
 import EstablishmentMeans from "./EstablishmentMeans";
 import TaxonDetailsHeader from "./TaxonDetailsHeader";
@@ -207,7 +208,6 @@ const TaxonDetails = ( ): Node => {
               refresh();
               refetch();
             }}
-            color="black"
           />
         </View>
       );
@@ -323,7 +323,7 @@ const TaxonDetails = ( ): Node => {
           black, which reveals a dark area at the bottom of the screen on
           overscroll in iOS ~~~kueda20240228
         */}
-        <StatusBar barStyle="light-content" backgroundColor="#000000" />
+        <StatusBar barStyle="light-content" backgroundColor={colors.black} />
         <View className="flex-1 h-full bg-black">
           <View className="w-full h-[420px] shrink-1">
             {displayTaxonMedia()}

--- a/src/navigation/ContextHeader.js
+++ b/src/navigation/ContextHeader.js
@@ -53,7 +53,7 @@ const ContextHeader = ( {
 
     return (
       <BackButton
-        color={colors.black}
+        color={colors.darkGray}
         onPress={handleBackNavigation}
         inCustomHeader
         customStyles={extraPadding}

--- a/src/navigation/StackNavigators/NoBottomTabStackNavigator.js
+++ b/src/navigation/StackNavigators/NoBottomTabStackNavigator.js
@@ -116,7 +116,6 @@ const NoBottomTabStackNavigator = ( ): Node => (
   <Stack.Navigator
     screenOptions={{
       headerBackTitleVisible: false,
-      headerTintColor: "black",
       contentStyle: {
         backgroundColor: "white"
       }

--- a/src/navigation/StackNavigators/TabStackNavigator.js
+++ b/src/navigation/StackNavigators/TabStackNavigator.js
@@ -39,6 +39,7 @@ import {
 } from "navigation/navigationOptions";
 import type { Node } from "react";
 import React from "react";
+import colors from "styles/tailwindColors";
 
 import SharedStackScreens from "./SharedStackScreens";
 
@@ -93,7 +94,7 @@ const TabStackNavigator = ( ): Node => (
   <Stack.Navigator
     screenOptions={{
       headerBackTitleVisible: false,
-      headerTintColor: "black"
+      headerTintColor: colors.darkGray
     }}
   >
     {/* Screens with no header */}

--- a/src/navigation/navigationOptions.js
+++ b/src/navigation/navigationOptions.js
@@ -17,7 +17,7 @@ const baseHeaderOptions: Object = {
 
 const showHeader: Object = {
   ...baseHeaderOptions,
-  headerTintColor: colors.black,
+  headerTintColor: colors.darkGray,
   // Note: left header is not supported on iOS
   // so we would need to build a custom header for this:
   // https://reactnavigation.org/docs/native-stack-navigator#headertitlealign
@@ -29,7 +29,7 @@ const showHeader: Object = {
 
 const showLongHeader: Object = {
   ...baseHeaderOptions,
-  headerTintColor: colors.black,
+  headerTintColor: colors.darkGray,
   // Note: left header is not supported on iOS
   // so we would need to build a custom header for this:
   // https://reactnavigation.org/docs/native-stack-navigator#headertitlealign

--- a/src/providers/INatPaperProvider.js
+++ b/src/providers/INatPaperProvider.js
@@ -19,7 +19,6 @@ const theme = {
     onPrimary: colors.white,
     secondary: colors.inatGreen, // TODO: change to accessibleGreen for accessibility
     onSecondary: colors.white,
-    tertiary: colors.black,
     background: colors.white,
     onBackground: colors.darkGray,
     outline: colors.lightGray,

--- a/src/providers/INatPaperProvider.js
+++ b/src/providers/INatPaperProvider.js
@@ -9,6 +9,9 @@ import {
 } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
+// it's still possible to access colors using theme,
+// but it's more consistent to access them directly using
+// import colors from "styles/tailwindColors";
 const theme = {
   ...DefaultTheme,
   version: 3,

--- a/src/providers/INatPaperProvider.js
+++ b/src/providers/INatPaperProvider.js
@@ -17,7 +17,9 @@ const theme = {
   version: 3,
   colors: {
     ...DefaultTheme.colors,
-    ...colors
+    ...colors,
+    // keeping background here for react-native-paper TextInput
+    background: colors.white
   }
 };
 

--- a/src/providers/INatPaperProvider.js
+++ b/src/providers/INatPaperProvider.js
@@ -14,9 +14,7 @@ const theme = {
   version: 3,
   colors: {
     ...DefaultTheme.colors,
-    ...colors,
-    primary: colors.darkGray,
-    secondary: colors.inatGreen // TODO: change to accessibleGreen for accessibility
+    ...colors
   }
 };
 

--- a/src/providers/INatPaperProvider.js
+++ b/src/providers/INatPaperProvider.js
@@ -16,15 +16,7 @@ const theme = {
     ...DefaultTheme.colors,
     ...colors,
     primary: colors.darkGray,
-    onPrimary: colors.white,
-    secondary: colors.inatGreen, // TODO: change to accessibleGreen for accessibility
-    onSecondary: colors.white,
-    background: colors.white,
-    onBackground: colors.darkGray,
-    outline: colors.lightGray,
-    error: colors.warningRed,
-    onError: colors.white,
-    mediumGray: colors.mediumGray
+    secondary: colors.inatGreen // TODO: change to accessibleGreen for accessibility
   }
 };
 

--- a/tests/unit/components/QualityGradeStatus/__snapshots__/QualityGradeStatus.test.js.snap
+++ b/tests/unit/components/QualityGradeStatus/__snapshots__/QualityGradeStatus.test.js.snap
@@ -5,7 +5,7 @@ exports[`Quality Grade casual should render correctly 1`] = `
   <SvgMock
     accessibilityLabel="Quality Grade: Casual"
     accessible={true}
-    color="rgba(103, 80, 164, 1)"
+    color="#454545"
     opacity={1}
     testID="QualityGrade.casual"
   />
@@ -17,7 +17,7 @@ exports[`Quality Grade needs_id should render correctly 1`] = `
   <SvgMock
     accessibilityLabel="Quality Grade: Needs ID"
     accessible={true}
-    color="rgba(103, 80, 164, 1)"
+    color="#454545"
     opacity={1}
     testID="QualityGrade.needs_id"
   />
@@ -29,7 +29,7 @@ exports[`Quality Grade research should render correctly 1`] = `
   <SvgMock
     accessibilityLabel="Quality Grade: Research"
     accessible={true}
-    color="rgba(103, 80, 164, 1)"
+    color="#454545"
     opacity={1}
     testID="QualityGrade.research"
   />

--- a/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/ActivityCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/ActivityCount.test.js.snap
@@ -23,7 +23,7 @@ exports[`ActivityCount renders reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(103, 80, 164, 1)",
+          "color": "#454545",
           "fontSize": 14,
         },
         undefined,

--- a/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/CommentsCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/CommentsCount.test.js.snap
@@ -23,7 +23,7 @@ exports[`CommentsCount renders default reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(103, 80, 164, 1)",
+          "color": "#454545",
           "fontSize": 14,
         },
         undefined,
@@ -88,7 +88,7 @@ exports[`CommentsCount renders filled reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(103, 80, 164, 1)",
+          "color": "#454545",
           "fontSize": 14,
         },
         undefined,
@@ -153,7 +153,7 @@ exports[`CommentsCount renders white reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(255, 255, 255, 1)",
+          "color": "#ffffff",
           "fontSize": 14,
         },
         undefined,

--- a/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/IdentificationsCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/IdentificationsCount.test.js.snap
@@ -23,7 +23,7 @@ exports[`IdentificationsCount renders default reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(103, 80, 164, 1)",
+          "color": "#454545",
           "fontSize": 14,
         },
         undefined,
@@ -88,7 +88,7 @@ exports[`IdentificationsCount renders filled reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(103, 80, 164, 1)",
+          "color": "#454545",
           "fontSize": 14,
         },
         undefined,
@@ -153,7 +153,7 @@ exports[`IdentificationsCount renders white reliably 1`] = `
     style={
       [
         {
-          "color": "rgba(255, 255, 255, 1)",
+          "color": "#ffffff",
           "fontSize": 14,
         },
         undefined,

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/INatIconButton.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/INatIconButton.test.js.snap
@@ -70,7 +70,7 @@ exports[`INatIconButton renders correctly 1`] = `
       style={
         [
           {
-            "color": "rgba(103, 80, 164, 1)",
+            "color": "#454545",
             "fontSize": 18,
           },
           undefined,

--- a/tests/unit/components/SharedComponents/InlineUser/__snapshots__/InlineUser.test.js.snap
+++ b/tests/unit/components/SharedComponents/InlineUser/__snapshots__/InlineUser.test.js.snap
@@ -156,7 +156,7 @@ exports[`InlineUser when offline renders reliably 1`] = `
       style={
         [
           {
-            "color": "rgba(103, 80, 164, 1)",
+            "color": "#454545",
             "fontSize": 22,
           },
           undefined,
@@ -263,7 +263,7 @@ exports[`InlineUser when user has no icon set renders reliably 1`] = `
       style={
         [
           {
-            "color": "rgba(103, 80, 164, 1)",
+            "color": "#454545",
             "fontSize": 22,
           },
           undefined,

--- a/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/PhotoCount/__snapshots__/PhotoCount.test.js.snap
@@ -92,7 +92,7 @@ exports[`PhotoCount renders correctly 1`] = `
         d="M4 5.818a4 4 0 00-4 4V20a4 4 0 004 4h10.182a4 4 0 004-4V9.818a4 4 0 00-4-4z"
         fill={
           {
-            "payload": 4294966270,
+            "payload": 4294967295,
             "type": 0,
           }
         }
@@ -109,7 +109,7 @@ exports[`PhotoCount renders correctly 1`] = `
         d="M15.364 3.636h-9.53A4 4 0 019.818 0H20a4 4 0 014 4v10.182a4 4 0 01-3.636 3.984v-9.53a5 5 0 00-5-5z"
         fill={
           {
-            "payload": 4294966270,
+            "payload": 4294967295,
             "type": 0,
           }
         }

--- a/tests/unit/components/SharedComponents/__snapshots__/Checkbox.test.js.snap
+++ b/tests/unit/components/SharedComponents/__snapshots__/Checkbox.test.js.snap
@@ -23,7 +23,7 @@ exports[`Checkbox renders reliably 1`] = `
   accessible={true}
   collapsable={false}
   disableBuiltInState={true}
-  fillColor="rgba(98, 91, 113, 1)"
+  fillColor="#74AC00"
   focusable={true}
   iconComponent={null}
   iconStyle={
@@ -33,7 +33,7 @@ exports[`Checkbox renders reliably 1`] = `
   }
   innerIconStyle={
     {
-      "borderColor": "rgba(103, 80, 164, 1)",
+      "borderColor": "#454545",
       "borderRadius": 6,
       "borderWidth": 2,
     }
@@ -66,14 +66,14 @@ exports[`Checkbox renders reliably 1`] = `
       Checkmark text
     </ForwardRef>
   }
-  unfillColor="rgba(255, 255, 255, 1)"
+  unfillColor="#ffffff"
 >
   <View
     collapsable={false}
     style={
       {
         "alignItems": "center",
-        "backgroundColor": "rgba(255, 255, 255, 1)",
+        "backgroundColor": "#ffffff",
         "borderRadius": 6,
         "height": 25,
         "justifyContent": "center",
@@ -91,7 +91,7 @@ exports[`Checkbox renders reliably 1`] = `
         [
           {
             "alignItems": "center",
-            "borderColor": "rgba(98, 91, 113, 1)",
+            "borderColor": "#74AC00",
             "borderRadius": 12.5,
             "borderWidth": 1,
             "height": 25,
@@ -99,7 +99,7 @@ exports[`Checkbox renders reliably 1`] = `
             "width": 25,
           },
           {
-            "borderColor": "rgba(103, 80, 164, 1)",
+            "borderColor": "#454545",
             "borderRadius": 6,
             "borderWidth": 2,
           },
@@ -160,11 +160,11 @@ exports[`Checkbox renders reliably being checked 1`] = `
   accessible={true}
   collapsable={false}
   disableBuiltInState={true}
-  fillColor="rgba(98, 91, 113, 1)"
+  fillColor="#74AC00"
   focusable={true}
   iconComponent={
     <INatIcon
-      color="rgba(255, 255, 255, 1)"
+      color="#ffffff"
       name="checkmark"
       size={19}
     />
@@ -176,7 +176,7 @@ exports[`Checkbox renders reliably being checked 1`] = `
   }
   innerIconStyle={
     {
-      "borderColor": "rgba(98, 91, 113, 1)",
+      "borderColor": "#74AC00",
       "borderRadius": 6,
       "borderWidth": 2,
     }
@@ -209,14 +209,14 @@ exports[`Checkbox renders reliably being checked 1`] = `
       Checkmark text
     </ForwardRef>
   }
-  unfillColor="rgba(255, 255, 255, 1)"
+  unfillColor="#ffffff"
 >
   <View
     collapsable={false}
     style={
       {
         "alignItems": "center",
-        "backgroundColor": "rgba(98, 91, 113, 1)",
+        "backgroundColor": "#74AC00",
         "borderRadius": 6,
         "height": 25,
         "justifyContent": "center",
@@ -234,7 +234,7 @@ exports[`Checkbox renders reliably being checked 1`] = `
         [
           {
             "alignItems": "center",
-            "borderColor": "rgba(98, 91, 113, 1)",
+            "borderColor": "#74AC00",
             "borderRadius": 12.5,
             "borderWidth": 1,
             "height": 25,
@@ -242,7 +242,7 @@ exports[`Checkbox renders reliably being checked 1`] = `
             "width": 25,
           },
           {
-            "borderColor": "rgba(98, 91, 113, 1)",
+            "borderColor": "#74AC00",
             "borderRadius": 6,
             "borderWidth": 2,
           },
@@ -255,7 +255,7 @@ exports[`Checkbox renders reliably being checked 1`] = `
         style={
           [
             {
-              "color": "rgba(255, 255, 255, 1)",
+              "color": "#ffffff",
               "fontSize": 19,
             },
             undefined,

--- a/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
+++ b/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
@@ -257,7 +257,7 @@ exports[`TaxonResult should render correctly 1`] = `
                 style={
                   [
                     {
-                      "color": "rgba(103, 80, 164, 1)",
+                      "color": "#454545",
                       "fontSize": 22,
                     },
                     undefined,
@@ -479,7 +479,7 @@ exports[`TaxonResult should render correctly 1`] = `
           style={
             [
               {
-                "color": "rgba(103, 80, 164, 1)",
+                "color": "#454545",
                 "fontSize": 22,
               },
               undefined,
@@ -570,7 +570,7 @@ exports[`TaxonResult should render correctly 1`] = `
           style={
             [
               {
-                "color": "rgba(103, 80, 164, 1)",
+                "color": "#454545",
                 "fontSize": 40,
               },
               undefined,


### PR DESCRIPTION
Closes #2125

- Replaces all instances of black text with darkGray text, including back button icons

Additionally, we were mixing and matching between two ways of declaring colors throughout the app, 1) `theme.colors.X` from the `INatPaperProvider` theme, and 2) `colors.X` from `tailwind.config.js`. 

This PR removes all the instances of `theme.colors.X` and only uses `colors.X`. I picked the tailwind theme for two reasons: 1) it's easier to read and understand colors with the actual color name (i.e. `colors.white`) rather than an abstract name (i.e. `theme.colors.onPrimary`) and 2) theme required a hook to be called, which also meant we were passing theme around as props and via the `useCallback` dependency array, which seems unnecessary and less straightforward than using the tailwind color