### PR TITLE
Show empty MyObs screen after deleting last observation in account

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -26,7 +26,7 @@ type Props = {
   onScroll?: Function,
   setShowLoginSheet: Function,
   showLoginSheet: boolean,
-  status: string,
+  showNoResults: boolean,
   toggleLayout: Function
 };
 
@@ -45,7 +45,7 @@ const MyObservations = ( {
   onScroll,
   setShowLoginSheet,
   showLoginSheet,
-  status,
+  showNoResults,
   toggleLayout
 }: Props ): Node => (
   <>
@@ -78,7 +78,7 @@ const MyObservations = ( {
             onLayout={onListLayout}
             ref={listRef}
             showObservationsEmptyScreen
-            showNoResults={( status === "success" && !!( currentUser ) ) || !currentUser}
+            showNoResults={showNoResults}
             testID="MyObservationsAnimatedList"
             renderHeader={(
               <Announcements isConnected={isConnected} />

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -72,8 +72,8 @@ const MyObservationsContainer = ( ): Node => {
   const {
     fetchNextPage,
     isFetchingNextPage,
-    observations: data,
-    status
+    status,
+    firstObservationsInRealm
   } = useInfiniteObservationsScroll( {
     upsert: syncingStatus === "sync-pending",
     params: {
@@ -164,11 +164,9 @@ const MyObservationsContainer = ( ): Node => {
 
   if ( !layout ) { return null; }
 
-  // remote data is available before data is synced locally; this check
-  // prevents the empty list from rendering briefly when a user first logs in
-  const observationListStatus = data?.length > observations?.length
-    ? "loading"
-    : status;
+  // show empty screen instead of loading wheel
+  const showNoResults = !currentUser
+    || ( status === "success" && !!( currentUser ) && firstObservationsInRealm );
 
   return (
     <MyObservations
@@ -188,7 +186,7 @@ const MyObservationsContainer = ( ): Node => {
       onScroll={scrollEvent => setMyObsOffset( scrollEvent.nativeEvent.contentOffset.y )}
       setShowLoginSheet={setShowLoginSheet}
       showLoginSheet={showLoginSheet}
-      status={observationListStatus}
+      showNoResults={showNoResults}
       toggleLayout={toggleLayout}
     />
   );

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -68,14 +68,9 @@ const useSyncObservations = (
 
       if ( !hasBeenSyncedRemotely ) {
         Observation.deleteLocalObservation( realm, uuid );
+      } else {
+        handleRemoteDeletion.mutate( { uuid } );
       }
-      if ( !canSync ) {
-        // TODO: do we want to let user know their deletions can't happen
-        // when they're offline or logged out?
-        return null;
-      }
-
-      handleRemoteDeletion.mutate( { uuid } );
 
       if ( i > 0 ) {
         // this loop isn't really being used, since a user can only delete one
@@ -88,7 +83,6 @@ const useSyncObservations = (
       return null;
     } );
   }, [
-    canSync,
     completeLocalDeletions,
     deleteQueue,
     handleRemoteDeletion,

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -4,7 +4,7 @@ import {
 import { INatApiError } from "api/error";
 import { deleteRemoteObservation } from "api/observations";
 import { RealmContext } from "providers/contexts.ts";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Observation from "realmModels/Observation";
 import { useAuthenticatedMutation } from "sharedHooks";
 import {
@@ -25,7 +25,7 @@ const useSyncObservations = (
   startUploadObservations: ( ) => void
 ): void => {
   const { isConnected } = useNetInfo( );
-  const loggedIn = !!currentUserId;
+  const loggedIn = !!( currentUserId );
   const deleteQueue = useStore( state => state.deleteQueue );
   const deletionsCompletedAt = useStore( state => state.deletionsCompletedAt );
   const completeLocalDeletions = useStore( state => state.completeLocalDeletions );
@@ -37,19 +37,20 @@ const useSyncObservations = (
   const resetSyncToolbar = useStore( state => state.resetSyncToolbar );
   const removeFromDeleteQueue = useStore( state => state.removeFromDeleteQueue );
   const autoSyncAbortController = useStore( storeState => storeState.autoSyncAbortController );
+  const [currentDeletionUuid, setCurrentDeletionUuid] = useState( null );
 
-  const canSync = loggedIn && isConnected;
+  const canSync = loggedIn && isConnected === true;
 
   const realm = useRealm( );
-
-  const deleteRealmObservation = useCallback( async ( uuid: string ) => {
-    await Observation.deleteLocalObservation( realm, uuid );
-  }, [realm] );
 
   const handleRemoteDeletion = useAuthenticatedMutation(
     ( params: Object, optsWithAuth: Object ) => deleteRemoteObservation( params, optsWithAuth ),
     {
-      onSuccess: ( ) => undefined,
+      onSuccess: ( ) => {
+        Observation
+          .deleteLocalObservation( realm, currentDeletionUuid );
+        removeFromDeleteQueue( );
+      },
       onError: ( deleteObservationError: Error ) => {
         setDeletionError( deleteObservationError?.message );
         throw deleteObservationError;
@@ -61,11 +62,12 @@ const useSyncObservations = (
     if ( deleteQueue.length === 0 ) { return; }
 
     deleteQueue.forEach( async ( uuid: string, i: number ) => {
+      setCurrentDeletionUuid( uuid );
       const observation = realm.objectForPrimaryKey( "Observation", uuid );
       const hasBeenSyncedRemotely = observation?._synced_at;
 
       if ( !hasBeenSyncedRemotely ) {
-        return deleteRealmObservation( uuid );
+        Observation.deleteLocalObservation( realm, uuid );
       }
       if ( !canSync ) {
         // TODO: do we want to let user know their deletions can't happen
@@ -73,8 +75,7 @@ const useSyncObservations = (
         return null;
       }
 
-      await handleRemoteDeletion.mutate( { uuid } );
-      removeFromDeleteQueue( );
+      handleRemoteDeletion.mutate( { uuid } );
 
       if ( i > 0 ) {
         // this loop isn't really being used, since a user can only delete one
@@ -82,7 +83,7 @@ const useSyncObservations = (
         startNextDeletion( );
       }
       if ( i === deleteQueue.length - 1 ) {
-        completeLocalDeletions( );
+        await completeLocalDeletions( );
       }
       return null;
     } );
@@ -90,10 +91,8 @@ const useSyncObservations = (
     canSync,
     completeLocalDeletions,
     deleteQueue,
-    deleteRealmObservation,
     handleRemoteDeletion,
     realm,
-    removeFromDeleteQueue,
     startNextDeletion
   ] );
 

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -435,15 +435,13 @@ class Observation extends Realm.Object {
     return updatedObs;
   };
 
-  static deleteLocalObservation = async ( realm, uuidToDelete ) => {
+  static deleteLocalObservation = ( realm, uuidToDelete ) => {
     const observation = realm?.objectForPrimaryKey( "Observation", uuidToDelete );
     if ( observation ) {
-      await safeRealmWrite( realm, ( ) => {
+      safeRealmWrite( realm, ( ) => {
         realm?.delete( observation );
       }, `deleting local observation ${uuidToDelete} in deleteLocalObservation` );
-      return true;
     }
-    return false;
   };
 
   static schema = {

--- a/src/sharedHooks/useInfiniteObservationsScroll.js
+++ b/src/sharedHooks/useInfiniteObservationsScroll.js
@@ -3,7 +3,7 @@
 import { searchObservations } from "api/observations";
 import { flatten, last, noop } from "lodash";
 import { RealmContext } from "providers/contexts.ts";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Observation from "realmModels/Observation";
 import { useAuthenticatedInfiniteQuery, useCurrentUser } from "sharedHooks";
 
@@ -12,6 +12,7 @@ const { useRealm } = RealmContext;
 const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Object ): Object => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
+  const [firstObservationsInRealm, setFirstObservationsInRealm] = useState( false );
 
   const baseParams = {
     ...newInputParams,
@@ -58,6 +59,7 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
         flatten( last( observations.pages ) ),
         realm
       );
+      setFirstObservationsInRealm( true );
     }
   }, [realm, observations, upsert] );
 
@@ -66,13 +68,15 @@ const useInfiniteObservationsScroll = ( { upsert, params: newInputParams }: Obje
       isFetchingNextPage,
       fetchNextPage,
       observations: flatten( observations?.pages ),
-      status
+      status,
+      firstObservationsInRealm
     }
     : {
       isFetchingNextPage: false,
       fetchNextPage: noop,
       observations: flatten( observations?.pages ),
-      status
+      status,
+      firstObservationsInRealm
     };
 };
 

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -60,10 +60,6 @@ const useLocalObservations = ( ): Object => {
       const unsynced = Observation.filterUnsyncedObservations( realm );
       setNumUnuploadedObservations( unsynced.length );
 
-      if ( _changes?.deletions?.length > 0 ) {
-        setObservationList( stagedObservationList?.current || [] );
-      }
-
       if ( isFocused ) {
         setObservationList( stagedObservationList.current );
       }


### PR DESCRIPTION
Closes #2033 

Kinda finicky. Hopefully fixed a couple things here:

- Local deletions should now be working correctly after an observation was successfully deleted remotely
- Activity indicator should show at correct time: 1) when a user first logs in and remote observations are fetching and 2) not after the final observation has been deleted from an account
- Empty screen should show immediately after the final observation has been deleted from an account