### PR TITLE
Prevent explore filters headers from overlapping reset button

### DIFF
--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -635,46 +635,54 @@ const FilterModal = ( {
     <ViewWrapper className="flex-1 bg-white" testID="filter-modal">
       {/* Header */}
       <View
-        className="flex-row items-center p-5 justify-between bg-white"
+        className="flex-row items-center p-5 bg-white"
         style={DROP_SHADOW}
       >
-        <View className="flex-row items-center">
-          <INatIconButton
-            icon="close"
-            onPress={
-              !differsFromSnapshot
-                ? () => {
-                  discardChanges();
-                  closeModal();
-                }
-                : () => {
-                  setOpenSheet( CONFIRMATION );
-                }
-            }
-            size={22}
-            accessibilityLabel={t( "Go-back" )}
-          />
-          <Heading1 className="ml-3">{t( "Explore-Filters" )}</Heading1>
+        <INatIconButton
+          icon="close"
+          onPress={
+            !differsFromSnapshot
+              ? () => {
+                discardChanges();
+                closeModal();
+              }
+              : () => {
+                setOpenSheet( CONFIRMATION );
+              }
+          }
+          size={22}
+          accessibilityLabel={t( "Go-back" )}
+        />
+        <View className="flex-1 items-center flex-row">
+          <Heading1 className="ml-3 wrap">{t( "Explore-Filters" )}</Heading1>
           {numberOfFilters !== 0 && (
-            <View className="ml-3">
+            <View className="w-[50px] ml-3">
               <NumberBadge number={numberOfFilters} />
             </View>
           )}
         </View>
-        {isNotInitialState
-          ? (
-            <Body3
-              accessibilityRole="button"
-              onPress={async ( ) => {
-                dispatch( { type: EXPLORE_ACTION.RESET } );
-              }}
-            >
-              {t( "Reset-verb" )}
-            </Body3>
-          )
-          : (
-            <Body3 className="opacity-50">{t( "Reset-verb" )}</Body3>
-          )}
+        <View className="w-[50px]">
+          {isNotInitialState
+            ? (
+              <Body3
+                accessibilityRole="button"
+                onPress={async ( ) => {
+                  dispatch( { type: EXPLORE_ACTION.RESET } );
+                }}
+                maxFontSizeMultiplier={1.5}
+              >
+                {t( "Reset-verb" )}
+              </Body3>
+            )
+            : (
+              <Body3
+                className="opacity-50"
+                maxFontSizeMultiplier={1.5}
+              >
+                {t( "Reset-verb" )}
+              </Body3>
+            )}
+        </View>
       </View>
 
       <ScrollView className="py-4">

--- a/src/components/Explore/SearchScreens/ExploreSearchHeader.tsx
+++ b/src/components/Explore/SearchScreens/ExploreSearchHeader.tsx
@@ -31,9 +31,9 @@ const ExploreSearchHeader = ( {
           accessibilityLabel={headerText}
         />
       </View>
-      <Heading4>{headerText}</Heading4>
+      <Heading4 className="flex-1 wrap text-center">{headerText}</Heading4>
       <View className="w-[50px] items-end">
-        <Body3 onPress={resetFilters}>
+        <Body3 onPress={resetFilters} maxFontSizeMultiplier={1.5}>
           {t( "Reset-verb" )}
         </Body3>
       </View>


### PR DESCRIPTION
Closes #2130

- When text sizes are large and screen is small, explore filters header and explore search headers wrap text into two lines
- Reset button is given a smaller maxFontSizeMultiplier value so text stays one one line (at least in English)

This prevents header text from either running off the screen and hiding the reset button (FilterModal) or overlapping the reset button so it can't be tapped (ExploreSearchHeader)
