### PR TITLE
fix: prevent multiple obs details from opening

### DIFF
--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -94,6 +94,7 @@ const ObservationsView = ( {
         isFetchingNextPage={isFetchingNextPage}
         isConnected={isConnected}
         layout={layout}
+        obsListKey="ExploreObservations"
         onEndReached={fetchNextPage}
         showNoResults={!canFetch || totalResults === 0}
         testID="ExploreObservationsAnimatedList"

--- a/src/components/Identify/Identify.js
+++ b/src/components/Identify/Identify.js
@@ -44,6 +44,7 @@ const Identify = (): Node => {
         isFetchingNextPage={isFetchingNextPage}
         isConnected={isConnected}
         layout="list"
+        obsListKey="IdentifyObservations"
         onEndReached={fetchNextPage}
         showObservationsEmptyScreen
         status={status}

--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -73,6 +73,7 @@ const MyObservations = ( {
             hideLoadingWheel={!isFetchingNextPage || !currentUser}
             isFetchingNextPage={isFetchingNextPage}
             isConnected={isConnected}
+            obsListKey="MyObservations"
             layout={layout}
             onEndReached={onEndReached}
             onLayout={onListLayout}

--- a/src/components/ObservationsFlashList/ObsItem.js
+++ b/src/components/ObservationsFlashList/ObsItem.js
@@ -4,9 +4,9 @@ import type { Node } from "react";
 import React from "react";
 import Observation from "realmModels/Observation";
 
-import MyObservationsPressable from "./MyObservationsPressable";
 import ObsGridItem from "./ObsGridItem";
 import ObsListItem from "./ObsListItem";
+import ObsPressable from "./ObsPressable";
 
 const { useRealm } = RealmContext;
 
@@ -32,9 +32,9 @@ const ObsItem = ( {
   const showUploadStatus = needsSync.length > 0;
 
   return (
-    <MyObservationsPressable
+    <ObsPressable
       observation={observation}
-      testID={`MyObservationsPressable.${observation.uuid}`}
+      testID={`ObsPressable.${observation.uuid}`}
     >
       {
         layout === "grid"
@@ -59,7 +59,7 @@ const ObsItem = ( {
             />
           )
       }
-    </MyObservationsPressable>
+    </ObsPressable>
   );
 };
 

--- a/src/components/ObservationsFlashList/ObsItem.js
+++ b/src/components/ObservationsFlashList/ObsItem.js
@@ -15,7 +15,8 @@ type Props = {
   handleIndividualUploadPress: Function,
   gridItemStyle: Object,
   layout: "list" | "grid",
-  observation: Object
+  observation: Object,
+  obsListKey: String
 };
 
 const ObsItem = ( {
@@ -23,7 +24,8 @@ const ObsItem = ( {
   handleIndividualUploadPress,
   gridItemStyle,
   layout,
-  observation
+  observation,
+  obsListKey
 }: Props ): Node => {
   const realm = useRealm( );
   const allUnsyncedObservations = Observation.filterUnsyncedObservations( realm );
@@ -34,6 +36,7 @@ const ObsItem = ( {
   return (
     <ObsPressable
       observation={observation}
+      obsListKey={obsListKey}
       testID={`ObsPressable.${observation.uuid}`}
     >
       {

--- a/src/components/ObservationsFlashList/ObsPressable.tsx
+++ b/src/components/ObservationsFlashList/ObsPressable.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
 import navigateToObsEdit from "components/ObsEdit/helpers/navigateToObsEdit.ts";
-import { getCurrentRoute } from "navigation/navigationUtils.ts";
 import React, { PropsWithChildren } from "react";
 import { Pressable } from "react-native";
 import RealmObservation from "realmModels/Observation";
@@ -15,10 +14,18 @@ interface Observation extends RealmObservation {
 
 interface Props extends PropsWithChildren {
   observation: Observation;
+  // Uniquely identify the list this observation appears in so we can ensure
+  // ObsDetails doesn't get pushed onto the stack twice after multiple taps
+  obsListKey: string;
   testID?: string;
 }
 
-const ObsPressable = ( { observation, testID, children }: Props ) => {
+const ObsPressable = ( {
+  children,
+  observation,
+  obsListKey = "unknown",
+  testID
+}: Props ) => {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
@@ -32,10 +39,8 @@ const ObsPressable = ( { observation, testID, children }: Props ) => {
       prepareObsEdit( observation );
       navigateToObsEdit( navigation, setMyObsOffsetToRestore );
     } else {
-      const currentRoute = getCurrentRoute();
-      const uniqueKey = currentRoute?.key || "key-default";
       navigation.navigate( {
-        key: `Obs-${uniqueKey}-${uuid}`,
+        key: `Obs-${obsListKey}-${uuid}`,
         name: "ObsDetails",
         params: { uuid }
       } );

--- a/src/components/ObservationsFlashList/ObsPressable.tsx
+++ b/src/components/ObservationsFlashList/ObsPressable.tsx
@@ -1,22 +1,24 @@
-// @flow
-
 import { useNavigation } from "@react-navigation/native";
 import navigateToObsEdit from "components/ObsEdit/helpers/navigateToObsEdit.ts";
 import { getCurrentRoute } from "navigation/navigationUtils.ts";
-import type { Node } from "react";
-import React from "react";
+import React, { PropsWithChildren } from "react";
 import { Pressable } from "react-native";
+import RealmObservation from "realmModels/Observation";
 import { useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
 
-type Props = {
-  observation: Object,
-  testID?: string,
-  // $FlowIgnore
-  children: unknown
+// TODO remove when we figure out how to type the Realm models
+interface Observation extends RealmObservation {
+  species_guess?: string;
+  uuid: string;
 }
 
-const MyObservationsPressable = ( { observation, testID, children }: Props ): Node => {
+interface Props extends PropsWithChildren {
+  observation: Observation;
+  testID?: string;
+}
+
+const ObsPressable = ( { observation, testID, children }: Props ) => {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
@@ -58,4 +60,4 @@ const MyObservationsPressable = ( { observation, testID, children }: Props ): No
   );
 };
 
-export default MyObservationsPressable;
+export default ObsPressable;

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -23,13 +23,14 @@ type Props = {
   dataCanBeFetched?: boolean,
   explore: boolean,
   handleIndividualUploadPress: Function,
-  onScroll?: Function,
   hideLoadingWheel: boolean,
   isConnected: boolean,
   isFetchingNextPage?: boolean,
   layout: "list" | "grid",
+  obsListKey: String,
   onEndReached: Function,
   onLayout?: Function,
+  onScroll?: Function,
   renderHeader?: Function,
   showNoResults?: boolean,
   showObservationsEmptyScreen?: boolean,
@@ -42,13 +43,14 @@ const ObservationsFlashList: Function = forwardRef( ( {
   dataCanBeFetched,
   explore,
   handleIndividualUploadPress,
-  onScroll,
   hideLoadingWheel,
   isConnected,
   isFetchingNextPage,
   layout,
+  obsListKey,
   onEndReached,
   onLayout,
+  onScroll,
   renderHeader,
   showNoResults,
   showObservationsEmptyScreen,
@@ -70,8 +72,15 @@ const ObservationsFlashList: Function = forwardRef( ( {
       handleIndividualUploadPress={handleIndividualUploadPress}
       layout={layout}
       observation={item}
+      obsListKey={obsListKey}
     />
-  ), [explore, layout, gridItemStyle, handleIndividualUploadPress] );
+  ), [
+    explore,
+    gridItemStyle,
+    handleIndividualUploadPress,
+    obsListKey,
+    layout
+  ] );
 
   const renderItemSeparator = useCallback( ( ) => {
     if ( layout === "grid" ) {

--- a/tests/integration/navigation/Explore.test.js
+++ b/tests/integration/navigation/Explore.test.js
@@ -91,7 +91,7 @@ async function navigateToObsDetails( ) {
   global.timeTravel( );
   expect( await screen.findByText( /Welcome back/ ) ).toBeVisible( );
   const firstObservation = await screen.findByTestId(
-    `MyObservationsPressable.${mockObservations[0].uuid}`
+    `ObsPressable.${mockObservations[0].uuid}`
   );
   await actor.press( firstObservation );
 }
@@ -283,7 +283,7 @@ describe( "logged in", ( ) => {
         const gridView = await screen.findByTestId( "SegmentedButton.grid" );
         await actor.press( gridView );
         const firstObservation = screen.queryByTestId(
-          `MyObservationsPressable.${mockObservations[0].uuid}`
+          `ObsPressable.${mockObservations[0].uuid}`
         );
         await waitFor( ( ) => {
           expect( firstObservation ).toBeVisible( );


### PR DESCRIPTION
Rapid taps on an observation could open ObsDetails multiple times for the same observation. This uses a key that is unique to the observation *and* the obs list that contains it to prevent this from happening.

Closes #2204
Closes #2216