### PR TITLE
Show date ranges as subtitle for collection/umbrella projects

### DIFF
--- a/src/components/ProjectDetails/ProjectDetails.js
+++ b/src/components/ProjectDetails/ProjectDetails.js
@@ -15,6 +15,7 @@ import React, { useCallback } from "react";
 import { useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
 
+import formatProjectDate from "../Projects/helpers/displayDates";
 import AboutProjectType from "./AboutProjectType";
 
 type Props = {
@@ -29,7 +30,7 @@ const ProjectDetails = ( {
 }: Props ): Node => {
   const setExploreView = useStore( state => state.setExploreView );
 
-  const { t } = useTranslation( );
+  const { t, i18n } = useTranslation( );
   const navigation = useNavigation( );
 
   const onObservationPressed = useCallback(
@@ -70,6 +71,8 @@ const ProjectDetails = ( {
 
   const userTextStyle = { lineHeight: 26 };
 
+  const { projectDate, shouldDisplayDateRange } = formatProjectDate( project, t, i18n );
+
   return (
     <ScrollViewWrapper testID="project-details">
       <View className="h-[24px]" />
@@ -87,7 +90,11 @@ const ProjectDetails = ( {
       </ImageBackground>
       <View className="mx-4 pb-8">
         <Heading1 className="shrink mt-4">{project.title}</Heading1>
-        <Heading3>{displayProjectType( project.project_type, t )}</Heading3>
+        <Heading3>
+          {shouldDisplayDateRange
+            ? projectDate
+            : displayProjectType( project.project_type, t )}
+        </Heading3>
         <OverviewCounts
           counts={{
             observations_count: project.observations_count,

--- a/src/components/ProjectDetails/ProjectDetailsContainer.js
+++ b/src/components/ProjectDetails/ProjectDetailsContainer.js
@@ -17,22 +17,6 @@ import ProjectDetails from "./ProjectDetails";
 
 const logger = log.extend( "ProjectDetailsContainer" );
 
-const DETAIL_FIELDS = {
-  title: true,
-  icon: true,
-  project_type: true,
-  icon_file_name: true,
-  header_image_url: true,
-  description: true,
-  place_id: true,
-  observation_count: true,
-  species_count: true
-};
-
-const DETAIL_PARAMS = {
-  fields: DETAIL_FIELDS
-};
-
 const ProjectDetailsContainer = ( ): Node => {
   const navigation = useNavigation( );
   const { params } = useRoute( );
@@ -44,7 +28,9 @@ const ProjectDetailsContainer = ( ): Node => {
 
   const { data: project } = useAuthenticatedQuery(
     fetchProjectsQueryKey,
-    optsWithAuth => fetchProjects( id, { ...DETAIL_PARAMS }, optsWithAuth )
+    optsWithAuth => fetchProjects( id, {
+      fields: "all"
+    }, optsWithAuth )
   );
 
   const { data: projectMembers } = useAuthenticatedQuery(

--- a/src/components/ProjectDetails/ProjectRequirements.tsx
+++ b/src/components/ProjectDetails/ProjectRequirements.tsx
@@ -7,9 +7,9 @@ import { ActivityIndicator, ScrollViewWrapper } from "components/SharedComponent
 import { View } from "components/styledComponents";
 import _ from "lodash";
 import React from "react";
-import { formatProjectsApiDatetimeLong } from "sharedHelpers/dateAndTime.ts";
 import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
 
+import formatProjectDate from "../Projects/helpers/displayDates";
 import AboutProjectType from "./AboutProjectType";
 import ProjectRuleItem from "./ProjectRuleItem";
 
@@ -22,57 +22,6 @@ const ProjectRequirements = ( ) => {
   const { params } = useRoute( );
   const { id } = params;
   const { t, i18n } = useTranslation( );
-
-  const monthValues = {
-    1: {
-      label: t( "January" ),
-      value: 1
-    },
-    2: {
-      label: t( "February" ),
-      value: 2
-    },
-    3: {
-      label: t( "March" ),
-      value: 3
-    },
-    4: {
-      label: t( "April" ),
-      value: 4
-    },
-    5: {
-      label: t( "May" ),
-      value: 5
-    },
-    6: {
-      label: t( "June" ),
-      value: 6
-    },
-    7: {
-      label: t( "July" ),
-      value: 7
-    },
-    8: {
-      label: t( "August" ),
-      value: 8
-    },
-    9: {
-      label: t( "September" ),
-      value: 9
-    },
-    10: {
-      label: t( "October" ),
-      value: 10
-    },
-    11: {
-      label: t( "November" ),
-      value: 11
-    },
-    12: {
-      label: t( "December" ),
-      value: 12
-    }
-  };
 
   const qualityGradeOption = option => {
     switch ( option ) {
@@ -267,48 +216,15 @@ const ProjectRequirements = ( ) => {
     mediaRule.inclusions = mediaList;
   }
 
-  // TODO: follow date formatting
-  // https://github.com/inaturalist/inaturalist/blob/0994c85e2b87661042289ff080d3fc29ed8e70b3/app/webpack/projects/show/components/requirements.jsx#L100C3-L114C4
-  const createDateObject = ( ) => {
-    // Date Requirements
-    const projectStartDate = getFieldValue( project?.rule_preferences
-      ?.filter( pref => pref.field === "d1" ) );
-    const projectEndDate = getFieldValue( project?.rule_preferences
-      ?.filter( pref => pref.field === "d2" ) );
-    const observedOnDate = getFieldValue( project?.rule_preferences
-      ?.filter( pref => pref.field === "observed_on" ) );
-    const months = getFieldValue( project?.rule_preferences
-      ?.filter( pref => pref.field === "month" ) );
-
-    if ( projectStartDate && !projectEndDate ) {
-      return t( "project-start-time-datetime", {
-        datetime: formatProjectsApiDatetimeLong( projectStartDate, i18n )
-      } );
-    }
-    if ( projectStartDate && projectEndDate ) {
-      return t( "date-to-date", {
-        d1: formatProjectsApiDatetimeLong( projectStartDate, i18n ),
-        d2: formatProjectsApiDatetimeLong( projectEndDate, i18n )
-      } );
-    }
-    if ( observedOnDate ) {
-      return formatProjectsApiDatetimeLong( observedOnDate, i18n );
-    }
-    if ( months ) {
-      const monthList = months.split( "," );
-      return monthList.map( numberOfMonth => monthValues[numberOfMonth].label ).join( ", " );
-    }
-    return null;
-  };
-
   const dateRule = RULES.find( r => r.name === t( "Date" ) );
-  if ( createDateObject( ) !== null ) {
+  const { projectDate } = formatProjectDate( project, t, i18n );
+  if ( projectDate !== null ) {
     dateRule.inclusions = [
     // TODO: dates need internationalized formatting
     // from 2023-03-22 07:42 -06:00 to something readable
     // https://github.com/inaturalist/inaturalist/blob/0994c85e2b87661042289ff080d3fc29ed8e70b3/app/webpack/projects/shared/util.js#L4
       {
-        text: createDateObject( )
+        text: projectDate
       }
     ];
   }
@@ -347,7 +263,7 @@ const ProjectRequirements = ( ) => {
         : (
           <>
             <View className="my-4 px-4">
-              <ProjectListItem item={project} />
+              <ProjectListItem item={project} isHeader />
             </View>
             {renderItemSeparator( )}
             {RULES.map( rule => (

--- a/src/components/ProjectList/ProjectListItem.tsx
+++ b/src/components/ProjectList/ProjectListItem.tsx
@@ -9,6 +9,8 @@ import React from "react";
 import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
+import formatProjectDate from "../Projects/helpers/displayDates";
+
 type Props = {
   item: {
     id: string;
@@ -16,10 +18,14 @@ type Props = {
     title: string;
     project_type: string;
   } | undefined | null;
+  isHeader?: boolean;
 };
 
-const ProjectListItem = ( { item }: Props ) => {
-  const { t } = useTranslation( );
+const ProjectListItem = ( { item, isHeader = false }: Props ) => {
+  const { t, i18n } = useTranslation( );
+
+  const { projectDate, shouldDisplayDateRange } = formatProjectDate( item, t, i18n );
+  const displayDateRange = shouldDisplayDateRange && !isHeader;
 
   if ( !item ) { return null; }
   return (
@@ -49,7 +55,9 @@ const ProjectListItem = ( { item }: Props ) => {
       <View className="shrink ml-3">
         <Body1>{item.title}</Body1>
         <List2 className="mt-2">
-          {displayProjectType( item.project_type, t )}
+          {displayDateRange
+            ? projectDate
+            : displayProjectType( item.project_type, t )}
         </List2>
       </View>
     </View>

--- a/src/components/Projects/helpers/displayDates.ts
+++ b/src/components/Projects/helpers/displayDates.ts
@@ -1,0 +1,94 @@
+import { formatProjectsApiDatetimeLong } from "sharedHelpers/dateAndTime.ts";
+
+const getFieldValue = item => item?.[0]?.value;
+
+// https://github.com/inaturalist/inaturalist/blob/0994c85e2b87661042289ff080d3fc29ed8e70b3/app/webpack/projects/show/components/requirements.jsx#L100C3-L114C4
+const formatProjectDate = ( project, t, i18n ) => {
+  const monthValues = {
+    1: {
+      label: t( "January" ),
+      value: 1
+    },
+    2: {
+      label: t( "February" ),
+      value: 2
+    },
+    3: {
+      label: t( "March" ),
+      value: 3
+    },
+    4: {
+      label: t( "April" ),
+      value: 4
+    },
+    5: {
+      label: t( "May" ),
+      value: 5
+    },
+    6: {
+      label: t( "June" ),
+      value: 6
+    },
+    7: {
+      label: t( "July" ),
+      value: 7
+    },
+    8: {
+      label: t( "August" ),
+      value: 8
+    },
+    9: {
+      label: t( "September" ),
+      value: 9
+    },
+    10: {
+      label: t( "October" ),
+      value: 10
+    },
+    11: {
+      label: t( "November" ),
+      value: 11
+    },
+    12: {
+      label: t( "December" ),
+      value: 12
+    }
+  };
+
+  let projectDate = null;
+
+  const projectStartDate = getFieldValue( project?.rule_preferences
+    ?.filter( pref => pref.field === "d1" ) );
+  const projectEndDate = getFieldValue( project?.rule_preferences
+    ?.filter( pref => pref.field === "d2" ) );
+  const observedOnDate = getFieldValue( project?.rule_preferences
+    ?.filter( pref => pref.field === "observed_on" ) );
+  const months = getFieldValue( project?.rule_preferences
+    ?.filter( pref => pref.field === "month" ) );
+
+  if ( projectStartDate && !projectEndDate ) {
+    projectDate = t( "project-start-time-datetime", {
+      datetime: formatProjectsApiDatetimeLong( projectStartDate, i18n )
+    } );
+  }
+  if ( projectStartDate && projectEndDate ) {
+    projectDate = t( "date-to-date", {
+      d1: formatProjectsApiDatetimeLong( projectStartDate, i18n ),
+      d2: formatProjectsApiDatetimeLong( projectEndDate, i18n )
+    } );
+  }
+  if ( observedOnDate ) {
+    projectDate = formatProjectsApiDatetimeLong( observedOnDate, i18n );
+  }
+  if ( months ) {
+    const monthList = months.split( "," );
+    projectDate = monthList.map( numberOfMonth => monthValues[numberOfMonth].label ).join( ", " );
+  }
+  return {
+    projectDate,
+    shouldDisplayDateRange: projectStartDate && projectEndDate
+      && project?.project_type !== "traditional"
+  };
+};
+
+export default formatProjectDate;

--- a/src/components/Projects/hooks/useInfiniteProjectsScroll.ts
+++ b/src/components/Projects/hooks/useInfiniteProjectsScroll.ts
@@ -8,10 +8,12 @@ const useInfiniteProjectsScroll = ( { params: newInputParams, enabled }: Object 
   const baseParams = {
     ...newInputParams,
     per_page: 50,
-    ttl: -1
+    ttl: -1,
+    rule_details: true,
+    fields: "all"
   };
 
-  const { fields, ...queryKeyParams } = baseParams;
+  const { ...queryKeyParams } = baseParams;
 
   const queryKey = ["useInfiniteProjectsScroll", "searchProjects", queryKeyParams];
 

--- a/tests/unit/components/ProjectDetails/ProjectDetails.test.js
+++ b/tests/unit/components/ProjectDetails/ProjectDetails.test.js
@@ -10,7 +10,23 @@ const mockProject = factory( "RemoteProject", {
   title: faker.lorem.sentence( ),
   icon: faker.image.url( ),
   header_image_url: faker.image.url( ),
-  description: faker.lorem.paragraph( )
+  description: faker.lorem.paragraph( ),
+  project_type: "collection"
+} );
+
+const mockProjectWithDateRange = factory( "RemoteProject", {
+  ...mockProject,
+
+  rule_preferences: [
+    {
+      field: "d1",
+      value: "2024-03-07 07:42 -06:00"
+    },
+    {
+      field: "d2",
+      value: "2024-03-14 08:41 -07:00"
+    }
+  ]
 } );
 
 jest.mock( "sharedHooks/useAuthenticatedQuery", ( ) => ( {
@@ -76,5 +92,43 @@ describe( "ProjectDetails", ( ) => {
       />
     );
     expect( screen.getByText( mockProject.title ) ).toBeTruthy( );
+  } );
+
+  test( "should display date range if collection project has date range", async ( ) => {
+    renderComponent( <ProjectDetails
+      project={mockProjectWithDateRange}
+    /> );
+    const dateRange = await screen.findByText( "Mar 7, 2024 - Mar 14, 2024" );
+    expect( dateRange ).toBeTruthy( );
+  } );
+
+  test( "should display date range if collection project has no date range", async ( ) => {
+    renderComponent( <ProjectDetails
+      project={mockProject}
+    /> );
+    const projectTypeText = await screen.findByText( /Collection Project/ );
+    expect( projectTypeText ).toBeTruthy( );
+  } );
+
+  test( "should display project type if project is traditional project", async ( ) => {
+    renderComponent( <ProjectDetails
+      project={{
+        ...mockProjectWithDateRange,
+        project_type: "traditional"
+      }}
+    /> );
+    const projectTypeText = await screen.findByText( /Traditional Project/ );
+    expect( projectTypeText ).toBeTruthy( );
+  } );
+
+  test( "should display date range if umbrella project has date range", async ( ) => {
+    renderComponent( <ProjectDetails
+      project={{
+        ...mockProjectWithDateRange,
+        project_type: "umbrella"
+      }}
+    /> );
+    const dateRange = await screen.findByText( "Mar 7, 2024 - Mar 14, 2024" );
+    expect( dateRange ).toBeTruthy( );
   } );
 } );

--- a/tests/unit/components/Projects/Projects.test.js
+++ b/tests/unit/components/Projects/Projects.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react-native";
 import ProjectsContainer from "components/Projects/ProjectsContainer.tsx";
 import React from "react";
+import { useAuthenticatedInfiniteQuery } from "sharedHooks";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
@@ -8,18 +9,35 @@ import { renderComponent } from "tests/helpers/render";
 const mockedNavigate = jest.fn( );
 const mockProject = factory( "RemoteProject", {
   icon: faker.image.url( ),
-  title: faker.lorem.sentence( )
+  title: faker.lorem.sentence( ),
+  project_type: "collection"
+} );
+
+const mockProjectWithDateRange = factory( "RemoteProject", {
+  ...mockProject,
+  rule_preferences: [
+    {
+      field: "d1",
+      value: "2024-03-07 07:42 -06:00"
+    },
+    {
+      field: "d2",
+      value: "2024-03-14 08:41 -07:00"
+    }
+  ]
+} );
+
+const infiniteScrollResults = results => ( {
+  data: {
+    pages: [{
+      results
+    }]
+  }
 } );
 
 jest.mock( "sharedHooks/useAuthenticatedInfiniteQuery", ( ) => ( {
   __esModule: true,
-  default: ( ) => ( {
-    data: {
-      pages: [{
-        results: [mockProject]
-      }]
-    }
-  } )
+  default: jest.fn( ( ) => infiniteScrollResults( [mockProject] ) )
 } ) );
 
 jest.mock( "@react-navigation/native", ( ) => {
@@ -64,7 +82,10 @@ describe( "Projects", ( ) => {
   //   expect( projects ).toBeAccessible( );
   // } );
 
-  it( "should display project search results", ( ) => {
+  test( "should display project search results", ( ) => {
+    useAuthenticatedInfiniteQuery.mockImplementation( ( ) => infiniteScrollResults(
+      [mockProject]
+    ) );
     renderComponent( <ProjectsContainer /> );
 
     const input = screen.getByTestId( "ProjectSearch.input" );
@@ -77,5 +98,51 @@ describe( "Projects", ( ) => {
     expect( mockedNavigate ).toHaveBeenCalledWith( "ProjectDetails", {
       id: mockProject.id
     } );
+  } );
+
+  test( "should display date range if collection project has date range", async ( ) => {
+    useAuthenticatedInfiniteQuery.mockImplementation( ( ) => infiniteScrollResults(
+      [mockProjectWithDateRange]
+    ) );
+    renderComponent( <ProjectsContainer /> );
+    const input = screen.getByTestId( "ProjectSearch.input" );
+    fireEvent.changeText( input, "" );
+    const dateRange = await screen.findByText( "Mar 7, 2024 - Mar 14, 2024" );
+    expect( dateRange ).toBeTruthy( );
+  } );
+
+  test( "should display project type if collection project has no date range", async ( ) => {
+    useAuthenticatedInfiniteQuery.mockImplementation( ( ) => infiniteScrollResults(
+      [mockProject]
+    ) );
+    renderComponent( <ProjectsContainer /> );
+    const projectTypeText = await screen.findByText( /Collection Project/ );
+    expect( projectTypeText ).toBeTruthy( );
+  } );
+
+  test( "should display project type if project is traditional project", async ( ) => {
+    useAuthenticatedInfiniteQuery.mockImplementation( ( ) => infiniteScrollResults(
+      [{
+        ...mockProjectWithDateRange,
+        project_type: "traditional"
+      }]
+    ) );
+    renderComponent( <ProjectsContainer /> );
+    const projectTypeText = await screen.findByText( /Traditional Project/ );
+    expect( projectTypeText ).toBeTruthy( );
+  } );
+
+  test( "should display date range if umbrella project has date range", async ( ) => {
+    useAuthenticatedInfiniteQuery.mockImplementation( ( ) => infiniteScrollResults(
+      [{
+        ...mockProjectWithDateRange,
+        project_type: "umbrella"
+      }]
+    ) );
+    renderComponent( <ProjectsContainer /> );
+    const input = screen.getByTestId( "ProjectSearch.input" );
+    fireEvent.changeText( input, "" );
+    const dateRange = await screen.findByText( "Mar 7, 2024 - Mar 14, 2024" );
+    expect( dateRange ).toBeTruthy( );
   } );
 } );


### PR DESCRIPTION
Closes #2117 

- On Projects and Project Details, show date ranges instead of project type when project is an umbrella or collection project and has date ranges in the project rules