### PR TITLE
Optional computer vision speedup using a taxonomy cutoff threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20530,7 +20530,7 @@
     },
     "node_modules/vision-camera-plugin-inatvision": {
       "version": "4.0.5",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#e6cf8b0f4fa444cc64e492545d9792f362b3f662",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#b307483a5817c2f809a8e0ea665fefe59183f97c",
       "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "realm": "^12.6.2",
         "sanitize-html": "^2.13.0",
         "ts-jest": "^29.1.2",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#taxonomy-rollup-cutoff-2",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -20530,7 +20530,7 @@
     },
     "node_modules/vision-camera-plugin-inatvision": {
       "version": "4.0.5",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#12358f6b85c059704b3abb891ebb45c14d84837a",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#e6cf8b0f4fa444cc64e492545d9792f362b3f662",
       "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "realm": "^12.6.2",
     "sanitize-html": "^2.13.0",
     "ts-jest": "^29.1.2",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#taxonomy-rollup-cutoff-2",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -69,6 +69,7 @@ const AICamera = ( {
   } = useRotation( );
   const {
     confidenceThreshold,
+    taxonomyRollupCutoff,
     fps,
     handleTaxaDetected,
     modelLoaded,
@@ -77,6 +78,7 @@ const AICamera = ( {
     setResult,
     cropRatio,
     setConfidenceThreshold,
+    setTaxonomyRollupCutoff,
     setFPS,
     setNumStoredResults,
     setCropRatio
@@ -138,6 +140,7 @@ const AICamera = ( {
           <FrameProcessorCamera
             cameraRef={camera}
             confidenceThreshold={confidenceThreshold}
+            taxonomyRollupCutoff={taxonomyRollupCutoff}
             device={device}
             fps={fps}
             numStoredResults={numStoredResults}
@@ -215,6 +218,7 @@ const AICamera = ( {
       <AICameraButtons
         handleZoomButtonPress={handleZoomButtonPress}
         confidenceThreshold={confidenceThreshold}
+        taxonomyRollupCutoff={taxonomyRollupCutoff}
         cropRatio={cropRatio}
         flipCamera={onFlipCamera}
         fps={fps}
@@ -223,6 +227,7 @@ const AICamera = ( {
         numStoredResults={numStoredResults}
         rotatableAnimatedStyle={rotatableAnimatedStyle}
         setConfidenceThreshold={setConfidenceThreshold}
+        setTaxonomyRollupCutoff={setTaxonomyRollupCutoff}
         setCropRatio={setCropRatio}
         setFPS={setFPS}
         setNumStoredResults={setNumStoredResults}

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -18,6 +18,7 @@ const isTablet = DeviceInfo.isTablet();
 interface Props {
   handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   confidenceThreshold?: number;
+  taxonomyRollupCutoff?: number;
   cropRatio?: string;
   flipCamera: ( _event: GestureResponderEvent ) => void;
   fps?: number;
@@ -27,6 +28,7 @@ interface Props {
   rotatableAnimatedStyle: ViewStyle;
   // Those four are debug only so I don't bother with types
   setConfidenceThreshold?: Function;
+  setTaxonomyRollupCutoff?: Function;
   setCropRatio?: Function,
   setFPS?: Function,
   setNumStoredResults?: Function,
@@ -42,6 +44,7 @@ interface Props {
 const AICameraButtons = ( {
   handleZoomButtonPress,
   confidenceThreshold,
+  taxonomyRollupCutoff,
   cropRatio,
   flipCamera,
   fps,
@@ -50,6 +53,7 @@ const AICameraButtons = ( {
   numStoredResults,
   rotatableAnimatedStyle,
   setConfidenceThreshold,
+  setTaxonomyRollupCutoff,
   setCropRatio,
   setFPS,
   setNumStoredResults,
@@ -94,6 +98,8 @@ const AICameraButtons = ( {
         <AIDebugButton
           confidenceThreshold={confidenceThreshold}
           setConfidenceThreshold={setConfidenceThreshold}
+          taxonomyRollupCutoff={taxonomyRollupCutoff}
+          setTaxonomyRollupCutoff={setTaxonomyRollupCutoff}
           fps={fps}
           setFPS={setFPS}
           numStoredResults={numStoredResults}

--- a/src/components/Camera/AICamera/AIDebugButton.js
+++ b/src/components/Camera/AICamera/AIDebugButton.js
@@ -1,16 +1,11 @@
-import Slider from "@react-native-community/slider";
 import classnames from "classnames";
 import {
-  Body1,
-  Heading4,
-  INatIconButton,
-  P
+  INatIconButton
 } from "components/SharedComponents";
 import {
   CIRCLE_SIZE
 } from "components/SharedComponents/Buttons/TransparentCircleButton.tsx";
 import { View } from "components/styledComponents";
-import { round } from "lodash";
 import React, { useState } from "react";
 import {
   Modal,
@@ -19,37 +14,7 @@ import {
 import { useDebugMode } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
-const SLIDER_STYLE = { display: "flex", flexGrow: 1, height: 44 };
-
-const SliderControl = ( {
-  name,
-  value,
-  setValue,
-  min,
-  max,
-  precision = 0,
-  step = 1
-} ) => (
-  <P>
-    {/* eslint-disable-next-line i18next/no-literal-string */}
-    <Heading4 className="text-white">{ `${name} (${min}-${max})` }</Heading4>
-    <View className="flex-row items-center h-fit">
-      <Body1 className="w-10 m-3 text-white">{round( value, precision )}</Body1>
-      <Slider
-        style={SLIDER_STYLE}
-        minimumValue={min}
-        maximumValue={max}
-        minimumTrackTintColor="#FFFFFF"
-        maximumTrackTintColor={colors.black}
-        renderStepNumber
-        tapToSeek
-        step={step}
-        value={value}
-        onValueChange={changedValue => setValue( changedValue )}
-      />
-    </View>
-  </P>
-);
+import SliderControl from "./SliderControl";
 
 const AIDebugButton = ( {
   confidenceThreshold,

--- a/src/components/Camera/AICamera/AIDebugButton.js
+++ b/src/components/Camera/AICamera/AIDebugButton.js
@@ -84,11 +84,11 @@ const AIDebugButton = ( {
             <SliderControl
               name="Taxonomy Rollup Cutoff"
               min={0}
-              max={0.1}
+              max={0.0001}
               value={taxonomyRollupCutoff}
               setValue={setTaxonomyRollupCutoff}
-              precision={3}
-              step={0.001}
+              precision={5}
+              step={0.00001}
             />
             <SliderControl
               name="Center Crop Ratio (Android only)"

--- a/src/components/Camera/AICamera/AIDebugButton.js
+++ b/src/components/Camera/AICamera/AIDebugButton.js
@@ -19,6 +19,8 @@ import SliderControl from "./SliderControl";
 const AIDebugButton = ( {
   confidenceThreshold,
   setConfidenceThreshold,
+  taxonomyRollupCutoff,
+  setTaxonomyRollupCutoff,
   fps,
   setFPS,
   numStoredResults,
@@ -78,6 +80,15 @@ const AIDebugButton = ( {
               setValue={setConfidenceThreshold}
               precision={2}
               step={0.05}
+            />
+            <SliderControl
+              name="Taxonomy Rollup Cutoff"
+              min={0}
+              max={0.1}
+              value={taxonomyRollupCutoff}
+              setValue={setTaxonomyRollupCutoff}
+              precision={3}
+              step={0.001}
             />
             <SliderControl
               name="Center Crop Ratio (Android only)"

--- a/src/components/Camera/AICamera/FrameProcessorCamera.js
+++ b/src/components/Camera/AICamera/FrameProcessorCamera.js
@@ -36,11 +36,13 @@ type Props = {
   onTaxaDetected: Function,
   pinchToZoom?: Function,
   takingPhoto: boolean,
+  taxonomyRollupCutoff?: number,
   inactive?: boolean
 };
 
 const DEFAULT_FPS = 1;
 const DEFAULT_CONFIDENCE_THRESHOLD = 0.5;
+const DEFAULT_TAXONOMY_CUTOFF_THRESHOLD = 0.0;
 const DEFAULT_NUM_STORED_RESULTS = 4;
 const DEFAULT_CROP_RATIO = 1.0;
 
@@ -62,6 +64,7 @@ const FrameProcessorCamera = ( {
   onTaxaDetected,
   pinchToZoom,
   takingPhoto,
+  taxonomyRollupCutoff = DEFAULT_TAXONOMY_CUTOFF_THRESHOLD,
   inactive
 }: Props ): Node => {
   const { deviceOrientation } = useDeviceOrientation();
@@ -142,6 +145,7 @@ const FrameProcessorCamera = ( {
             modelPath,
             taxonomyPath,
             confidenceThreshold,
+            taxonomyRollupCutoff,
             numStoredResults,
             cropRatio,
             patchedOrientationAndroid
@@ -160,6 +164,7 @@ const FrameProcessorCamera = ( {
       modelVersion,
       confidenceThreshold,
       takingPhoto,
+      taxonomyRollupCutoff,
       patchedOrientationAndroid,
       numStoredResults,
       cropRatio,

--- a/src/components/Camera/AICamera/SliderControl.tsx
+++ b/src/components/Camera/AICamera/SliderControl.tsx
@@ -1,0 +1,54 @@
+import Slider from "@react-native-community/slider";
+import {
+  Body1,
+  Heading4,
+  P
+} from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import { round } from "lodash";
+import React from "react";
+import colors from "styles/tailwindColors";
+
+const SLIDER_STYLE = { display: "flex", flexGrow: 1, height: 44 } as const;
+
+interface SliderControlProps {
+  name: string;
+  value: number;
+  setValue: ( value: number ) => void;
+  min: number;
+  max: number;
+  precision?: number;
+  step?: number;
+}
+
+const SliderControl = ( {
+  name,
+  value,
+  setValue,
+  min,
+  max,
+  precision = 0,
+  step = 1
+}: SliderControlProps ) => (
+  <P>
+    {/* eslint-disable-next-line i18next/no-literal-string */}
+    <Heading4 className="text-white">{ `${name} (${min}-${max})` }</Heading4>
+    <View className="flex-row items-center h-fit">
+      <Body1 className="w-10 m-3 text-white">{round( value, precision )}</Body1>
+      <Slider
+        style={SLIDER_STYLE}
+        minimumValue={min}
+        maximumValue={max}
+        minimumTrackTintColor="#FFFFFF"
+        maximumTrackTintColor={colors.black}
+        renderStepNumber
+        tapToSeek
+        step={step}
+        value={value}
+        onValueChange={changedValue => setValue( changedValue )}
+      />
+    </View>
+  </P>
+);
+
+export default SliderControl;

--- a/src/components/Camera/AICamera/hooks/usePredictions.ts
+++ b/src/components/Camera/AICamera/hooks/usePredictions.ts
@@ -18,6 +18,7 @@ const usePredictions = ( ) => {
   const [resultTimestamp, setResultTimestamp] = useState<number | undefined>( undefined );
   const [modelLoaded, setModelLoaded] = useState( false );
   const [confidenceThreshold, setConfidenceThreshold] = useState( 0.5 );
+  const [taxonomyRollupCutoff, setTaxonomyRollupCutoff] = useState( 0.0 );
   const [fps, setFPS] = useState( 1 );
   const [numStoredResults, setNumStoredResults] = useState( 4 );
   const [cropRatio, setCropRatio] = useState( 1 );
@@ -68,6 +69,7 @@ const usePredictions = ( ) => {
 
   return {
     confidenceThreshold,
+    taxonomyRollupCutoff,
     fps,
     handleTaxaDetected,
     modelLoaded,
@@ -77,6 +79,7 @@ const usePredictions = ( ) => {
     resultTimestamp,
     setResult,
     setConfidenceThreshold,
+    setTaxonomyRollupCutoff,
     setFPS,
     setNumStoredResults,
     setCropRatio


### PR DESCRIPTION
This adds an update to the computer vision plugin allowing to exclude lower scores during the taxonomy rollup phase. The threshold number is customizable as an option to the frame processor. A number of 0.01 means all nodes with a cv score lower than that are excluded from calculating the top predictions. Thereby saving resources on computing those.

Currently, the threshold defaults to 0.0, i.e. no nodes are filtered out, and so, this PR should introduce no visible changes outside debug mode. In debug mode you can change the taxonomy cutoff threshold value around a bit for exploration of this feature.
