### PR TITLE
test: wait for OTHER SUGGESTIONS in aicamera test

### DIFF
--- a/e2e/aiCamera.e2e.js
+++ b/e2e/aiCamera.e2e.js
@@ -52,9 +52,8 @@ describe( "AICamera", () => {
       await takePhotoButton.tap();
 
       // On suggestions find the first element in the suggestions list
-      await waitFor( element( by.text( /OTHER SUGGESTIONS/ ) ) )
-        .toBeVisible( )
-        .withTimeout( TIMEOUT );
+      const otherSuggestionsTitle = element( by.text( "OTHER SUGGESTIONS" ) );
+      await waitFor( otherSuggestionsTitle ).toBeVisible( ).withTimeout( 20_000 );
       const firstSuggestion = element( by.id( /SuggestionsList\.taxa\..*/ ) ).atIndex(
         0
       );

--- a/e2e/aiCamera.e2e.js
+++ b/e2e/aiCamera.e2e.js
@@ -9,6 +9,8 @@ import signIn from "./sharedFlows/signIn";
 import switchPowerMode from "./sharedFlows/switchPowerMode";
 import uploadObservation from "./sharedFlows/uploadObservation";
 
+const TIMEOUT = 10_000;
+
 describe( "AICamera", () => {
   beforeAll( async () => iNatE2eBeforeAll( device ) );
   beforeEach( async () => iNatE2eBeforeEach( device ) );
@@ -32,35 +34,40 @@ describe( "AICamera", () => {
       */
       // Tap to open AICamera
       const addObsButton = element( by.id( "add-obs-button" ) );
-      await waitFor( addObsButton ).toBeVisible().withTimeout( 10000 );
+      await waitFor( addObsButton ).toBeVisible().withTimeout( TIMEOUT );
       await addObsButton.tap();
       const aiCameraButton = element( by.id( "aicamera-button" ) );
-      await waitFor( aiCameraButton ).toBeVisible().withTimeout( 10000 );
+      await waitFor( aiCameraButton ).toBeVisible().withTimeout( TIMEOUT );
       await aiCameraButton.tap();
 
       // Check that the camera screen is visible
       const cameraContainer = element( by.id( "CameraWithDevice" ) );
-      await waitFor( cameraContainer ).toBeVisible().withTimeout( 10000 );
+      await waitFor( cameraContainer ).toBeVisible().withTimeout( TIMEOUT );
       // Check that the mocked cv suggestion is visible
       const taxonResult = element( by.id( "AICamera.taxa.51779" ) );
-      await waitFor( taxonResult ).toBeVisible().withTimeout( 10000 );
+      await waitFor( taxonResult ).toBeVisible().withTimeout( TIMEOUT );
       // Tap the take photo button
       const takePhotoButton = element( by.id( "take-photo-button" ) );
-      await waitFor( takePhotoButton ).toBeVisible().withTimeout( 10000 );
+      await waitFor( takePhotoButton ).toBeVisible().withTimeout( TIMEOUT );
       await takePhotoButton.tap();
+
       // On suggestions find the first element in the suggestions list
+      await waitFor( element( by.text( /OTHER SUGGESTIONS/ ) ) )
+        .toBeVisible( )
+        .withTimeout( TIMEOUT );
       const firstSuggestion = element( by.id( /SuggestionsList\.taxa\..*/ ) ).atIndex(
         0
       );
-      await waitFor( firstSuggestion ).toBeVisible().withTimeout( 10000 );
+      await waitFor( firstSuggestion ).toBeVisible().withTimeout( TIMEOUT );
       const suggestionAttributes = await firstSuggestion.getAttributes();
       const taxonID = suggestionAttributes.elements
         ? suggestionAttributes.elements[0].identifier.split( "." ).pop()
         : suggestionAttributes.identifier.split( "." ).pop();
       await firstSuggestion.tap();
+
       // On Taxon Detail
       const selectTaxonButon = element( by.id( "TaxonDetails.SelectButton" ) );
-      await waitFor( selectTaxonButon ).toBeVisible().withTimeout( 10000 );
+      await waitFor( selectTaxonButon ).toBeVisible().withTimeout( TIMEOUT );
       await selectTaxonButon.tap();
 
       await uploadObservation( { upload: true } );
@@ -69,14 +76,14 @@ describe( "AICamera", () => {
       const displayTaxonName = element( by.id( `display-taxon-name.${taxonID}` ) ).atIndex(
         0
       );
-      await waitFor( displayTaxonName ).toBeVisible().withTimeout( 10000 );
+      await waitFor( displayTaxonName ).toBeVisible().withTimeout( TIMEOUT );
       await displayTaxonName.tap();
 
       // Delete the observation
       await deleteObservation( { uploaded: true } );
 
       // Make sure we're back on MyObservations
-      await waitFor( username ).toBeVisible().withTimeout( 10000 );
+      await waitFor( username ).toBeVisible().withTimeout( TIMEOUT );
     }
   );
 } );

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -19,28 +19,37 @@ export async function iNatE2eBeforeEach( device ) {
   // for both, but on CI for Android it does not work. So we use reloadReactNative for Android.
   if ( device.getPlatform() === "android" ) {
     await device.reloadReactNative();
-  } else {
-    await device.launchApp( {
-      newInstance: true,
-      permissions: {
-        location: "always",
-        camera: "YES",
-        medialibrary: "YES",
-        photos: "YES"
-      }
-    } );
-    // disable password autofill
-    execSync(
-      // eslint-disable-next-line max-len
-      `plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/${device.id}/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist`
-    );
-    execSync(
-      // eslint-disable-next-line max-len
-      `plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/${device.id}/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist`
-    );
-    execSync(
-      // eslint-disable-next-line max-len
-      `plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/${device.id}/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist`
-    );
+    return;
   }
+  const launchAppOptions = {
+    newInstance: true,
+    permissions: {
+      location: "always",
+      camera: "YES",
+      medialibrary: "YES",
+      photos: "YES"
+    }
+  };
+  try {
+    await device.launchApp( launchAppOptions );
+  } catch ( launchAppError ) {
+    if ( !launchAppError.message.match( /unexpectedly disconnected/ ) ) {
+      throw launchAppError;
+    }
+    // Try it one more time
+    await device.launchApp( launchAppOptions );
+  }
+  // disable password autofill
+  execSync(
+    // eslint-disable-next-line max-len
+    `plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/${device.id}/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist`
+  );
+  execSync(
+    // eslint-disable-next-line max-len
+    `plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/${device.id}/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist`
+  );
+  execSync(
+    // eslint-disable-next-line max-len
+    `plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/${device.id}/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist`
+  );
 }


### PR DESCRIPTION
Operating under the theory that one potential reason for flakiness is that finding *a* suggestion finds the temporary one from the camera, then it disappears, then the test fails when it tries to tap on that disappeared element.