### PR TITLE
fix: scroll to activity item once

### DIFF
--- a/src/components/Notifications/NotificationsListItem.js
+++ b/src/components/Notifications/NotificationsListItem.js
@@ -9,7 +9,7 @@ import { ACTIVITY_TAB } from "stores/createLayoutSlice";
 import useStore from "stores/useStore";
 
 type Props = {
-item: Object
+  item: Object
 };
 
 const NotificationsListItem = ( { item }: Props ): Node => {
@@ -34,7 +34,7 @@ const NotificationsListItem = ( { item }: Props ): Node => {
           screen: "ObsDetails",
           params: {
             uuid: item.resource_uuid,
-            notificationId: item.identification_id || item.comment_id
+            targetActivityItemID: item.identification_id || item.comment_id
           }
         } );
       }}

--- a/src/components/ObsDetails/ActivityTab/ActivityTab.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityTab.js
@@ -13,8 +13,9 @@ type Props = {
   activityItems: Array<Object>,
   openAgreeWithIdSheet: Function,
   isConnected: boolean,
-  notificationId: number,
-  onLayoutActivityItem: ( event: any ) => void
+  targetItemID: number,
+  // TODO change to LayoutEvent from react-native if/when switching to TS
+  onLayoutTargetItem: ( event: Object ) => void
 }
 
 const ActivityTab = ( {
@@ -23,8 +24,8 @@ const ActivityTab = ( {
   activityItems,
   openAgreeWithIdSheet,
   isConnected,
-  notificationId,
-  onLayoutActivityItem
+  targetItemID,
+  onLayoutTargetItem
 }: Props ): Node => {
   const currentUser = useCurrentUser( );
   const userId = currentUser?.id;
@@ -62,9 +63,9 @@ const ActivityTab = ( {
       {stableItems.length > 0 && stableItems.map( ( item, index ) => (
         <View
           onLayout={event => {
-            if ( notificationId === item?.id ) {
+            if ( targetItemID === item?.id ) {
               // const { layout } = event.nativeEvent;
-              onLayoutActivityItem( event );
+              onLayoutTargetItem( event );
             }
           }}
           key={item.uuid}

--- a/src/components/ObsDetails/ActivityTab/ActivityTab.js
+++ b/src/components/ObsDetails/ActivityTab/ActivityTab.js
@@ -14,7 +14,7 @@ type Props = {
   openAgreeWithIdSheet: Function,
   isConnected: boolean,
   notificationId: number,
-  setScrollToY: ( number ) => void
+  onLayoutActivityItem: ( event: any ) => void
 }
 
 const ActivityTab = ( {
@@ -24,7 +24,7 @@ const ActivityTab = ( {
   openAgreeWithIdSheet,
   isConnected,
   notificationId,
-  setScrollToY
+  onLayoutActivityItem
 }: Props ): Node => {
   const currentUser = useCurrentUser( );
   const userId = currentUser?.id;
@@ -59,31 +59,30 @@ const ActivityTab = ( {
 
   return (
     <View testID="ActivityTab">
-      {stableItems.length > 0
-        && stableItems.map( ( item, index ) => (
-          <View
-            onLayout={event => {
-              if ( notificationId === item?.id ) {
-                const { layout } = event.nativeEvent;
-                setScrollToY( layout.y );
-              }
-            }}
-            key={item.uuid}
-          >
-            <ActivityItem
-              currentUserId={userId}
-              isFirstDisplay={index === indexOfFirstTaxonDisplayed( item.taxon?.id )}
-              isConnected={isConnected}
-              item={item}
-              openAgreeWithIdSheet={openAgreeWithIdSheet}
-              refetchRemoteObservation={refetchRemoteObservation}
-              userAgreedId={userAgreedToId}
-              geoprivacy={geoprivacy}
-              taxonGeoprivacy={taxonGeoprivacy}
-              belongsToCurrentUser={belongsToCurrentUser}
-            />
-          </View>
-        ) )}
+      {stableItems.length > 0 && stableItems.map( ( item, index ) => (
+        <View
+          onLayout={event => {
+            if ( notificationId === item?.id ) {
+              // const { layout } = event.nativeEvent;
+              onLayoutActivityItem( event );
+            }
+          }}
+          key={item.uuid}
+        >
+          <ActivityItem
+            currentUserId={userId}
+            isFirstDisplay={index === indexOfFirstTaxonDisplayed( item.taxon?.id )}
+            isConnected={isConnected}
+            item={item}
+            openAgreeWithIdSheet={openAgreeWithIdSheet}
+            refetchRemoteObservation={refetchRemoteObservation}
+            userAgreedId={userAgreedToId}
+            geoprivacy={geoprivacy}
+            taxonGeoprivacy={taxonGeoprivacy}
+            belongsToCurrentUser={belongsToCurrentUser}
+          />
+        </View>
+      ) )}
     </View>
   );
 };

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -155,7 +155,10 @@ const ObsDetails = ( {
         observation={observation}
         openAgreeWithIdSheet={openAgreeWithIdSheet}
         refetchRemoteObservation={refetchRemoteObservation}
-        setScrollToY={setScrollToY}
+        onLayoutActivityItem={event => {
+          const { layout } = event.nativeEvent;
+          setScrollToY( layout.y );
+        }}
       />
     </HideView>
   );

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -57,7 +57,7 @@ type Props = {
   isConnected: boolean,
   isRefetching: boolean,
   navToSuggestions: Function,
-  notificationId: number,
+  targetActivityItemID: number,
   observation: Object,
   openAddCommentSheet: Function,
   openAgreeWithIdSheet: Function,
@@ -101,7 +101,7 @@ const ObsDetails = ( {
   isConnected,
   isRefetching,
   navToSuggestions,
-  notificationId,
+  targetActivityItemID,
   observation,
   onAgree,
   openAgreeWithIdSheet,
@@ -138,6 +138,15 @@ const ObsDetails = ( {
     }
   }, [oneTimeScrollOffsetY] );
 
+  // If the user just added an activity item and we're waiting for it to load,
+  // scroll to the bottom where it will be visible. Also provides immediate
+  // feedback that the user's action had an effect
+  useEffect( ( ) => {
+    if ( addingActivityItem ) {
+      scrollViewRef?.current?.scrollToEnd( );
+    }
+  }, [addingActivityItem] );
+
   const dynamicInsets = useMemo( () => ( {
     backgroundColor: "#ffffff",
     paddingTop: insets.top,
@@ -155,11 +164,11 @@ const ObsDetails = ( {
       <ActivityTab
         activityItems={activityItems}
         isConnected={isConnected}
-        notificationId={notificationId}
+        targetItemID={targetActivityItemID}
         observation={observation}
         openAgreeWithIdSheet={openAgreeWithIdSheet}
         refetchRemoteObservation={refetchRemoteObservation}
-        onLayoutActivityItem={event => {
+        onLayoutTargetItem={event => {
           const { layout } = event.nativeEvent;
           setOneTimeScrollOffsetY( layout.y + layout.height );
         }}

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -15,7 +15,10 @@ import {
 } from "components/styledComponents";
 import type { Node } from "react";
 import React, {
-  useLayoutEffect, useMemo, useRef, useState
+  useEffect,
+  useMemo,
+  useRef,
+  useState
 } from "react";
 import { Platform } from "react-native";
 import DeviceInfo from "react-native-device-info";
@@ -124,15 +127,16 @@ const ObsDetails = ( {
   const scrollViewRef = useRef( );
   const insets = useSafeAreaInsets();
   const { t } = useTranslation( );
-  const [scrollToY, setScrollToY] = useState( 0 );
 
-  useLayoutEffect( ( ) => {
-    // we need useLayoutEffect here to make sure the ScrollView has already rendered
-    // before trying to scroll to the relevant activity item
-    if ( notificationId && scrollViewRef?.current ) {
-      scrollViewRef?.current?.scrollTo( { y: scrollToY } );
+  // Scroll the scrollview to this y position once if set, then unset it.
+  // Could be refactored into a hook if we need this logic elsewher
+  const [oneTimeScrollOffsetY, setOneTimeScrollOffsetY] = useState( 0 );
+  useEffect( ( ) => {
+    if ( oneTimeScrollOffsetY && scrollViewRef?.current ) {
+      scrollViewRef?.current?.scrollTo( { y: oneTimeScrollOffsetY } );
+      setOneTimeScrollOffsetY( 0 );
     }
-  } );
+  }, [oneTimeScrollOffsetY] );
 
   const dynamicInsets = useMemo( () => ( {
     backgroundColor: "#ffffff",
@@ -157,7 +161,7 @@ const ObsDetails = ( {
         refetchRemoteObservation={refetchRemoteObservation}
         onLayoutActivityItem={event => {
           const { layout } = event.nativeEvent;
-          setScrollToY( layout.y );
+          setOneTimeScrollOffsetY( layout.y + layout.height );
         }}
       />
     </HideView>

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -182,7 +182,7 @@ const ObsDetailsContainer = ( ): Node => {
     identAt,
     identTaxonId,
     identTaxonFromVision,
-    notificationId,
+    targetActivityItemID,
     uuid
   } = params;
   const navigation = useNavigation( );
@@ -604,7 +604,7 @@ const ObsDetailsContainer = ( ): Node => {
       isConnected={isConnected}
       isRefetching={isRefetching}
       navToSuggestions={navToSuggestions}
-      notificationId={notificationId}
+      targetActivityItemID={targetActivityItemID}
       // saving observation in state (i.e. using observationShown)
       // limits the number of rerenders to entire obs details tree
       observation={observationShown}


### PR DESCRIPTION
* prevent ObsDetail from re-scrolling to an activity item after returning from
  TaxonDetails (closes #2232)
* scroll far enough down ObsDetail to show the whole activity item the user
  wants to see, even on small screens (closes #2233)
* scroll all the way to the bottom after creating a new comment or ID
  (closes #2231)