### PR TITLE
fix: prevent maps from showing user location by default

### DIFF
--- a/src/components/Explore/MapView.tsx
+++ b/src/components/Explore/MapView.tsx
@@ -107,6 +107,7 @@ const MapView = ( {
         showSwitchMapTypeButton
         showsCompass={false}
         switchMapTypeButtonClassName="left-20 bottom-20"
+        showsUserLocation
         tileMapParams={tileMapParams}
         withPressableObsTiles={tileMapParams !== null}
       />

--- a/src/components/LocationPicker/LocationPicker.js
+++ b/src/components/LocationPicker/LocationPicker.js
@@ -108,6 +108,7 @@ const LocationPicker = ( {
             showCurrentLocationButton
             showSwitchMapTypeButton
             showsCompass={false}
+            showsUserLocation
             testID="LocationPicker.Map"
           />
         </View>


### PR DESCRIPTION
This was causing location to be fetched even in situations where there was no need, like ObsDetails and TaxonDetails, which was a bit creepy. This requires us to explicitly turn it on, which I've done for Explore and the LocationPicker.

Closes #2260