### PR TITLE
fix: only show onboarding once per install

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ import { setJSExceptionHandler, setNativeExceptionHandler } from "react-native-e
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { startNetworkLogging } from "react-native-network-logger";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { getInstallID } from "sharedHelpers/installData.ts";
 import { reactQueryRetry } from "sharedHelpers/logging";
-import { installID } from "sharedHelpers/persistedInstallationId.ts";
 
 import { name as appName } from "./app.json";
 import { log } from "./react-native-logs.config";
@@ -106,7 +106,7 @@ inatjs.setConfig( {
   writeApiURL: Config.API_URL,
   userAgent: getUserAgent(),
   headers: {
-    "X-Installation-ID": installID( )
+    "X-Installation-ID": getInstallID( )
   }
 } );
 

--- a/src/api/log.ts
+++ b/src/api/log.ts
@@ -4,7 +4,7 @@ import { create } from "apisauce";
 import { getAnonymousJWT, getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import Config from "react-native-config";
 import { transportFunctionType } from "react-native-logs";
-import { installID } from "sharedHelpers/persistedInstallationId.ts";
+import { getInstallID } from "sharedHelpers/installData.ts";
 
 const API_HOST: string
     = Config.API_URL || process.env.API_URL || "https://api.inaturalist.org/v2";
@@ -13,7 +13,7 @@ const api = create( {
   baseURL: API_HOST,
   headers: {
     "User-Agent": getUserAgent( ),
-    "X-Installation-ID": installID( )
+    "X-Installation-ID": getInstallID( )
   }
 } );
 

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -20,8 +20,8 @@ import RNSInfo from "react-native-sensitive-info";
 import Realm, { UpdateMode } from "realm";
 import realmConfig from "realmModels/index";
 import changeLanguage from "sharedHelpers/changeLanguage.ts";
+import { getInstallID } from "sharedHelpers/installData.ts";
 import { log, logFilePath, logWithoutRemote } from "sharedHelpers/logger";
-import { installID } from "sharedHelpers/persistedInstallationId.ts";
 import removeAllFilesFromDirectory from "sharedHelpers/removeAllFilesFromDirectory.ts";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { sleep, unlink } from "sharedHelpers/util.ts";
@@ -108,7 +108,7 @@ const createAPI = ( additionalHeaders?: { [header: string]: string } ) => create
   baseURL: API_HOST,
   headers: {
     "User-Agent": getUserAgent(),
-    "X-Installation-ID": installID( ),
+    "X-Installation-ID": getInstallID( ),
     ...additionalHeaders
   }
 } );

--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -7,8 +7,8 @@ import {
   ViewWrapper
 } from "components/SharedComponents";
 import type { Node } from "react";
-import React, { useState } from "react";
-import { storage } from "stores/useStore";
+import React from "react";
+import { useOnboardingShown } from "sharedHelpers/installData.ts";
 
 import Announcements from "./Announcements";
 import LoginSheet from "./LoginSheet";
@@ -32,8 +32,6 @@ type Props = {
   toggleLayout: Function
 };
 
-const ONBOARDING_SHOWN = "onBoardingShown";
-
 const MyObservations = ( {
   currentUser,
   handleIndividualUploadPress,
@@ -52,17 +50,14 @@ const MyObservations = ( {
   showNoResults,
   toggleLayout
 }: Props ): Node => {
-  const [showOnboarding, setShowOnboarding] = useState( !storage.getBoolean( ONBOARDING_SHOWN ) );
+  const [onboardingShown, setOnboardingShown] = useOnboardingShown( );
 
   return (
     <>
       <ViewWrapper>
         <OnboardingCarouselModal
-          showModal={showOnboarding}
-          closeModal={() => {
-            setShowOnboarding( false );
-            storage.set( ONBOARDING_SHOWN, true );
-          }}
+          showModal={!onboardingShown}
+          closeModal={() => setOnboardingShown( true )}
         />
         <ScrollableWithStickyHeader
           onScroll={onScroll}

--- a/src/sharedHelpers/installData.ts
+++ b/src/sharedHelpers/installData.ts
@@ -3,7 +3,6 @@ import { MMKV } from "react-native-mmkv";
 import uuid from "react-native-uuid";
 
 const MMKV_ID = "install-data";
-
 const INSTALL_ID = "installID";
 
 // This store is separate from the zustand store b/c it needs to survive sign
@@ -30,7 +29,7 @@ if ( legacyStore.getAllKeys().length > 0 ) {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export function installID( ) {
+export function getInstallID( ) {
   const id = store.getString( INSTALL_ID );
   if ( id ) return id;
   const newID: string = uuid.v4( ).toString( );

--- a/src/sharedHelpers/installData.ts
+++ b/src/sharedHelpers/installData.ts
@@ -1,9 +1,10 @@
 import RNFS from "react-native-fs";
-import { MMKV } from "react-native-mmkv";
+import { MMKV, useMMKVBoolean } from "react-native-mmkv";
 import uuid from "react-native-uuid";
 
 const MMKV_ID = "install-data";
 const INSTALL_ID = "installID";
+const ONBOARDING_SHOWN = "onboardingShown";
 
 // This store is separate from the zustand store b/c it needs to survive sign
 // out, i.e these values should remain untill the app is uninstalled
@@ -28,11 +29,17 @@ if ( legacyStore.getAllKeys().length > 0 ) {
   } );
 }
 
-// eslint-disable-next-line import/prefer-default-export
 export function getInstallID( ) {
   const id = store.getString( INSTALL_ID );
   if ( id ) return id;
   const newID: string = uuid.v4( ).toString( );
   store.set( INSTALL_ID, newID );
   return newID;
+}
+
+// Hook to see if this *installation* has seen the onboarding. If the user
+// signs out, we don't want them to see the onboarding again. This only gets
+// used in a component, so no need to expose any other getters/setters
+export function useOnboardingShown() {
+  return useMMKVBoolean( ONBOARDING_SHOWN, store );
 }

--- a/src/sharedHelpers/persistedInstallationId.ts
+++ b/src/sharedHelpers/persistedInstallationId.ts
@@ -1,21 +1,39 @@
+import RNFS from "react-native-fs";
 import { MMKV } from "react-native-mmkv";
 import uuid from "react-native-uuid";
 
+const MMKV_ID = "install-data";
+
 const INSTALL_ID = "installID";
 
-// 20240729 amanda - we're keeping this MMKV instance separate from the
-// one wrapping zustand because we want to be able to persist the installation ID
-// even if a user logs out of the app. this means on signout, we're clearing
-// the storage for the MMKV instance wrapping zustand but leaving this one untouched
-const persistedInstallationId = new MMKV( {
-  id: "user-data"
-} );
-export default persistedInstallationId;
+// This store is separate from the zustand store b/c it needs to survive sign
+// out, i.e these values should remain untill the app is uninstalled
+const store = new MMKV( { id: MMKV_ID } );
 
+// Migrate old MMKV data if it exists. This data is explicitly *not*
+// linked to a user
+const LEGACY_MMKV_ID = "user-data";
+const legacyStore = new MMKV( { id: LEGACY_MMKV_ID } );
+if ( legacyStore.getAllKeys().length > 0 ) {
+  // Migrate data if present
+  legacyStore.getAllKeys().forEach( key => {
+    store.set( key, legacyStore.getString( key ) );
+  } );
+  // Delete the old data on disk so we never have to do this again
+  RNFS.readDir( `${RNFS.DocumentDirectoryPath}/mmkv` ).then( contents => {
+    contents.forEach( item => {
+      if ( item.path.match( new RegExp( `/${LEGACY_MMKV_ID}` ) ) ) {
+        RNFS.unlink( item.path );
+      }
+    } );
+  } );
+}
+
+// eslint-disable-next-line import/prefer-default-export
 export function installID( ) {
-  const id = persistedInstallationId.getString( INSTALL_ID );
+  const id = store.getString( INSTALL_ID );
   if ( id ) return id;
   const newID: string = uuid.v4( ).toString( );
-  persistedInstallationId.set( INSTALL_ID, newID );
+  store.set( INSTALL_ID, newID );
   return newID;
 }


### PR DESCRIPTION
* Rename the separate MMKV store we were using to store the installation ID to
  indicate that it stores data related to the installation, not the user
* Use that MMKV to store whether or not this installation has shown the
  onboarding. We don't want to re-show the onboarding to people after they
  sign out