### PR TITLE
fix: edit location without location permission

### DIFF
--- a/src/components/Explore/SearchScreens/ExploreLocationSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreLocationSearch.js
@@ -108,10 +108,10 @@ const ExploreLocationSearch = ( { closeModal, updateLocation }: Props ): Node =>
   }, [dispatch, defaultExploreLocation, closeModal] );
 
   const onNearbyPressed = () => {
-    if ( !hasPermissions ) {
-      requestPermissions( );
-    } else {
+    if ( hasPermissions ) {
       setNearbyLocation( );
+    } else {
+      requestPermissions( );
     }
   };
 

--- a/src/components/LocationPicker/LocationPickerContainer.js
+++ b/src/components/LocationPicker/LocationPickerContainer.js
@@ -19,20 +19,24 @@ const { width } = Dimensions.get( "screen" );
 const DELTA = 0.02;
 const CROSSHAIRLENGTH = 254;
 
-const setInitialRegion = currentObservation => ( {
-  // This was causing a crash when getting to the location picker before
-  // current location was fetched in the observation viewer
-  latitude:
-      currentObservation?.privateLatitude
-      || currentObservation?.latitude
-      || 0.0,
-  longitude:
-      currentObservation?.privateLongitude
-      || currentObservation?.longitude
-      || 0.0,
-  latitudeDelta: DELTA,
-  longitudeDelta: DELTA
-} );
+const setInitialRegion = currentObservation => {
+  const latitude = currentObservation?.privateLatitude
+    || currentObservation?.latitude;
+  const longitude = currentObservation?.privateLongitude
+    || currentObservation?.longitude;
+  return {
+    // This was causing a crash when getting to the location picker before
+    // current location was fetched in the observation viewer
+    latitude: latitude || 0.0,
+    longitude: longitude || 0.0,
+    latitudeDelta: latitude
+      ? DELTA
+      : 90,
+    longitudeDelta: longitude
+      ? DELTA
+      : 180
+  };
+};
 
 const initializeMap = ( state, action ) => {
   const newMap = {

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -6,7 +6,12 @@ import { View } from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
-import shouldFetchObservationLocation from "sharedHelpers/shouldFetchObservationLocation.ts";
+import shouldFetchObservationLocation, {
+  isFromCamera,
+  isFromNoEvidence,
+  isFromSoundRecorder,
+  isNew
+} from "sharedHelpers/shouldFetchObservationLocation.ts";
 import { useCurrentUser, useLocationPermission, useWatchPosition } from "sharedHooks";
 import useStore from "stores/useStore";
 import { getShadow } from "styles/global";
@@ -36,6 +41,7 @@ const ObsEdit = ( ): Node => {
   const currentUser = useCurrentUser( );
   const {
     hasPermissions: hasLocationPermission,
+    hasBlockedPermissions: hasBlockedLocationPermission,
     renderPermissionsGate: renderLocationPermissionGate,
     requestPermissions: requestLocationPermission
   } = useLocationPermission( );
@@ -66,12 +72,19 @@ const ObsEdit = ( ): Node => {
   }, [stopWatch, subscriptionId, navigation] );
 
   const onLocationPress = ( ) => {
-    // If we have location permissions, navigate to the location picker
-    if ( hasLocationPermission ) {
-      navToLocationPicker( );
-    } else {
-      // If we don't have location permissions, request them
+    if (
+      !hasLocationPermission
+      && !hasBlockedLocationPermission
+      && isNew( currentObservation )
+      && (
+        isFromCamera( currentObservation )
+        || isFromSoundRecorder( currentObservation )
+        || isFromNoEvidence( currentObservation )
+      )
+    ) {
       requestLocationPermission( );
+    } else {
+      navToLocationPicker( );
     }
   };
 

--- a/src/components/SharedComponents/Map/CurrentLocationButton.tsx
+++ b/src/components/SharedComponents/Map/CurrentLocationButton.tsx
@@ -8,28 +8,18 @@ const DROP_SHADOW = getShadow( );
 
 interface Props {
   currentLocationButtonClassName?: string;
-  handlePress: () => void;
+  onPress: () => void;
   showCurrentLocationButton?: boolean;
-  hasPermissions: boolean | undefined;
   renderPermissionsGate: () => React.JSX.Element;
-  requestPermissions: () => void;
 }
 
 const CurrentLocationButton = ( {
   currentLocationButtonClassName,
-  handlePress,
+  onPress,
   showCurrentLocationButton,
-  hasPermissions,
-  renderPermissionsGate,
-  requestPermissions
+  renderPermissionsGate
 }: Props ) => {
   const { t } = useTranslation( );
-  const onPress = ( ) => {
-    if ( !hasPermissions ) {
-      requestPermissions( );
-    }
-    handlePress( );
-  };
   return showCurrentLocationButton && (
     <>
       <INatIconButton

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -131,7 +131,6 @@ const Map = ( {
   const mapViewRef = useRef<MapView>();
   const [currentMapType, setCurrentMapType] = useState( mapType || "standard" );
   const [showsUserLocation, setShowsUserLocation] = useState( showsUserLocationProp );
-  const [currentLocationPressQueued, setCurrentLocationPressQueued] = useState( false );
 
   let defaultInitialRegion = getDefaultRegion( obsLatitude, obsLongitude );
 
@@ -205,10 +204,19 @@ const Map = ( {
     // function in an effect when we have a location
     if ( !showsUserLocation ) {
       setShowsUserLocation( true );
-      setCurrentLocationPressQueued( true );
+      requestPermissions( );
       return;
     }
-    if ( onCurrentLocationPress ) { onCurrentLocationPress( ); }
+    // If we're supposed to be showing user location but we don't have it, ask
+    // for permission again, which should result in fetching the location if
+    // we can
+    if ( !userLocation ) {
+      requestPermissions( );
+      return;
+    }
+    if ( onCurrentLocationPress ) {
+      onCurrentLocationPress( );
+    }
     if ( userLocation && mapViewRef?.current ) {
       // Zoom level based on location accuracy.
       let latitudeDelta = metersToLatitudeDelta( userLocation.accuracy, userLocation.latitude );
@@ -235,20 +243,12 @@ const Map = ( {
     }
   }, [
     onCurrentLocationPress,
+    requestPermissions,
     screenHeight,
     screenWidth,
     showsUserLocation,
     userLocation
   ] );
-
-  // If we have the user's location *and* they asked us to show it, we zoom to
-  // it
-  useEffect( ( ) => {
-    if ( userLocation && currentLocationPressQueued ) {
-      setCurrentLocationPressQueued( false );
-      handleCurrentLocationPress();
-    }
-  }, [userLocation, currentLocationPressQueued, handleCurrentLocationPress] );
 
   const mapContainerStyle = [
     mapHeight
@@ -365,7 +365,7 @@ const Map = ( {
         renderPermissionsGate={renderCurrentLocationPermissionsGate}
         requestPermissions={requestPermissions}
         onPermissionGranted={onPermissionGranted}
-        handlePress={handleCurrentLocationPress}
+        onPress={handleCurrentLocationPress}
       />
       <SwitchMapTypeButton
         currentMapType={currentMapType}

--- a/src/components/SharedComponents/PermissionGateContainer.tsx
+++ b/src/components/SharedComponents/PermissionGateContainer.tsx
@@ -204,14 +204,14 @@ const PermissionGateContainer = ( {
     ) {
       setModalShown( false );
     }
-  }, [result, children, setModalShown] );
+  }, [result, children] );
 
   useEffect( ( ) => {
     // permission already denied
     if ( result === RESULTS.BLOCKED ) {
-      setModalShown( false );
+      setModalShown( true );
     }
-  }, [result, setModalShown] );
+  }, [result] );
 
   useEffect( () => {
   // We need to handle permission changes manually on Android
@@ -240,9 +240,7 @@ const PermissionGateContainer = ( {
 
   const closeModal = useCallback( ( ) => {
     setModalShown( false );
-  }, [
-    setModalShown
-  ] );
+  }, [] );
 
   const onModalHide = useCallback( ( ) => {
     if ( onModalHideProp ) {
@@ -274,9 +272,12 @@ const PermissionGateContainer = ( {
     result
   ] );
 
-  // If permission results asked and answered, render children
+  // If permission granted and children are gated, let the children out
   if (
-    ( result === RESULTS.GRANTED || result === RESULTS.LIMITED || result === RESULTS.BLOCKED )
+    (
+      result === RESULTS.GRANTED
+      || result === RESULTS.LIMITED
+    )
     && children
   ) return children;
 

--- a/src/components/SharedComponents/PermissionGateContainer.tsx
+++ b/src/components/SharedComponents/PermissionGateContainer.tsx
@@ -180,6 +180,17 @@ const PermissionGateContainer = ( {
       setModalShown( true );
       return () => undefined;
     }
+    if (
+      ( result === RESULTS.GRANTED || result === RESULTS.LIMITED )
+      && !children
+    ) {
+      setModalShown( false );
+      return ( ) => undefined;
+    }
+    if ( result === RESULTS.BLOCKED ) {
+      setModalShown( false );
+      return ( ) => undefined;
+    }
     if ( !withoutNavigation ) {
       const unsubscribe = navigation.addListener( "focus", async () => {
         await checkPermission( );
@@ -197,6 +208,8 @@ const PermissionGateContainer = ( {
     withoutNavigation
   ] );
 
+  // If permission was granted and there are no children to render, we can
+  // just hide the modal and do nothing
   useEffect( ( ) => {
     if (
       ( result === RESULTS.GRANTED || result === RESULTS.LIMITED )
@@ -279,7 +292,9 @@ const PermissionGateContainer = ( {
       || result === RESULTS.LIMITED
     )
     && children
-  ) return children;
+  ) {
+    return children;
+  }
 
   if ( !result ) return null;
 

--- a/src/realmModels/types.d.ts
+++ b/src/realmModels/types.d.ts
@@ -1,16 +1,22 @@
+export interface RealmObservationPhoto {
+  originalPhotoUri?: string;
+}
+
 export interface RealmObservation {
-  captive_flag: boolean | null,
-  description: string | null,
-  geoprivacy: string | null,
-  latitude: number | null,
-  longitude: number | null,
-  observed_on_string: string | null,
-  observationPhotos: Array<Object>,
-  observationSounds: Array<Object>,
-  owners_identification_from_vision: boolean | null,
-  place_guess: string | null,
-  positional_accuracy: number | null,
-  species_guess: string | null,
-  taxon_id: number | null,
-  uuid: string
+  _created_at?: Date;
+  _synced_at?: Date;
+  captive_flag: boolean | null;
+  description: string | null;
+  geoprivacy: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  observationPhotos: Array<RealmObservationPhoto>;
+  observationSounds: Array<Object>;
+  observed_on_string: string | null;
+  owners_identification_from_vision: boolean | null;
+  place_guess: string | null;
+  positional_accuracy: number | null;
+  species_guess: string | null;
+  taxon_id: number | null;
+  uuid: string;
 }

--- a/src/sharedHelpers/shouldFetchObservationLocation.ts
+++ b/src/sharedHelpers/shouldFetchObservationLocation.ts
@@ -1,39 +1,65 @@
 import { galleryPhotosPath, rotatedOriginalPhotosPath } from "appConstants/paths.ts";
-import RNFS from "react-native-fs";
-import { RealmObservation } from "realmModels/types.d.ts";
+import { DocumentDirectoryPath } from "react-native-fs";
+import type { RealmObservation } from "realmModels/types.d.ts";
 import {
   TARGET_POSITIONAL_ACCURACY
 } from "sharedHooks/useWatchPosition.ts";
 
-const shouldFetchObservationLocation = ( observation: RealmObservation ) => {
+// In theory all of these functions belong in Observation.js... but we often
+// map API responses to behave like Realm records, so they don't always have
+// the methods
+
+function originalPhotoUri( observation: RealmObservation ) {
+  return observation?.observationPhotos?.[0]?.originalPhotoUri || "";
+}
+
+export function isNew( observation: RealmObservation ) {
+  return (
+    observation
+    && !observation._created_at
+    && !observation._synced_at
+  );
+}
+
+export function isFromGallery( observation: RealmObservation ) {
+  return originalPhotoUri( observation ).includes( galleryPhotosPath );
+}
+
+export function isFromSharing( observation: RealmObservation ) {
+  // Shared photo paths will look something like Shared/AppGroup/sdgsdgsdgk
+  const uri = originalPhotoUri( observation );
+  return uri && !uri.includes( DocumentDirectoryPath );
+}
+
+export function isFromCamera( observation: RealmObservation ) {
+  return originalPhotoUri( observation ).includes( rotatedOriginalPhotosPath );
+}
+
+export function isFromSoundRecorder( observation: RealmObservation ) {
+  return observation?.observationSounds?.length > 0;
+}
+
+export function isFromNoEvidence( observation: RealmObservation ) {
+  return !(
+    observation?.observationSounds?.length > 0
+    || observation?.observationPhotos?.length > 0
+  );
+}
+
+function shouldFetchObservationLocation( observation: RealmObservation ) {
   const latitude = observation?.latitude;
   const longitude = observation?.longitude;
   const hasLocation = !!( latitude && longitude );
-  const originalPhotoUri = observation?.observationPhotos
-    && observation?.observationPhotos[0]?.originalPhotoUri;
-  const isGalleryPhoto = originalPhotoUri?.includes( galleryPhotosPath );
-  // Shared photo paths will look something like Shared/AppGroup/sdgsdgsdgk
-  const isSharedPhoto = (
-    originalPhotoUri && !originalPhotoUri.includes( RNFS.DocumentDirectoryPath )
-  );
-  const isCameraPhoto = (
-    originalPhotoUri && originalPhotoUri.includes( rotatedOriginalPhotosPath )
-  );
-  const isNewObservation = (
-    observation
-    && !observation?._created_at
-    && !observation?._synced_at
-  );
   const accGoodEnough = (
     observation?.positional_accuracy
     && observation.positional_accuracy <= TARGET_POSITIONAL_ACCURACY
   );
 
   return observation
-    && isNewObservation
-    && ( !hasLocation || ( isCameraPhoto && !accGoodEnough ) )
-    && !isGalleryPhoto
-    && !isSharedPhoto;
-};
+    && isNew( observation )
+    && ( !hasLocation || ( isFromCamera( observation ) && !accGoodEnough ) )
+    && !isFromGallery( observation )
+    && !isFromSharing( observation );
+}
 
 export default shouldFetchObservationLocation;

--- a/src/sharedHooks/useLocationPermission.tsx
+++ b/src/sharedHooks/useLocationPermission.tsx
@@ -48,7 +48,7 @@ const useLocationPermission = ( ) => {
 
     return (
       <LocationPermissionGate
-        permissionNeeded={showPermissionGate}
+        permissionNeeded
         withoutNavigation
         onModalHide={( ) => {
           setShowPermissionGate( false );

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -109,7 +109,7 @@ describe( "ObsEdit offline", ( ) => {
       expect( coords ).toBeTruthy( );
       expect( screen.queryByText( "Finding location..." ) ).toBeFalsy( );
       await waitFor( ( ) => {
-        const indicator = screen.queryByTestId( "EvidenceSection.fetchingLocationIndicator" )
+        const indicator = screen.queryByTestId( "EvidenceSection.fetchingLocationIndicator" );
         expect( indicator ).toBeFalsy( );
       }, { timeout: 5_000, interval: 500 } );
     } );

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -109,9 +109,8 @@ describe( "ObsEdit offline", ( ) => {
       expect( coords ).toBeTruthy( );
       expect( screen.queryByText( "Finding location..." ) ).toBeFalsy( );
       await waitFor( ( ) => {
-        expect(
-          screen.queryByTestId( "EvidenceSection.fetchingLocationIndicator" )
-        ).toBeFalsy( );
+        const indicator = screen.queryByTestId( "EvidenceSection.fetchingLocationIndicator" )
+        expect( indicator ).toBeFalsy( );
       }, { timeout: 5_000, interval: 500 } );
     } );
   } );


### PR DESCRIPTION
* allow user to edit obs location even if location permission denied
* zoom location picker out to a global level if editing location for an obs with no coordinates
* stop showing sound recorder or any children of a permission gate if permission denied
* show permission gate if permission denied

Closes #2319