### PR TITLE
fix: explore nearby after permission granted in Settings

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -44,21 +44,21 @@ const exploreViewIcon = {
 };
 
 type Props = {
-  // TODO: change to PLACE_MODE in Typescript
-  canFetch?: boolean,
+  canFetch?: boolean, // TODO: change to PLACE_MODE in Typescript
   closeFiltersModal: Function,
   count: Object,
   currentExploreView: string,
+  currentMapRegion: Object,
   filterByIconicTaxonUnknown: Function,
   handleUpdateCount: Function,
-  hasLocationPermissions: ?boolean,
+  hasLocationPermissions?: boolean,
   hideBackButton: boolean,
   isConnected: boolean,
   isFetchingHeaderCount: boolean,
-  currentMapRegion: Object,
   openFiltersModal: Function,
   placeMode: string,
   queryParams: Object,
+  renderLocationPermissionsGate: Function,
   requestLocationPermissions: Function,
   setCurrentExploreView: Function,
   setCurrentMapRegion: Function,
@@ -67,7 +67,7 @@ type Props = {
   updateLocation: Function,
   updateProject: Function,
   updateTaxon: Function,
-  updateUser: Function,
+  updateUser: Function
 }
 
 const Explore = ( {
@@ -75,16 +75,17 @@ const Explore = ( {
   closeFiltersModal,
   count,
   currentExploreView,
+  currentMapRegion,
   filterByIconicTaxonUnknown,
   handleUpdateCount,
   hasLocationPermissions,
   hideBackButton,
   isConnected,
   isFetchingHeaderCount,
-  currentMapRegion,
   openFiltersModal,
   placeMode,
   queryParams,
+  renderLocationPermissionsGate,
   requestLocationPermissions,
   setCurrentExploreView,
   setCurrentMapRegion,
@@ -116,12 +117,15 @@ const Explore = ( {
       count={headerCount}
       exploreView={currentExploreView}
       exploreViewIcon={icon}
+      hasLocationPermissions={hasLocationPermissions}
       hideBackButton={hideBackButton}
       isFetchingHeaderCount={isFetchingHeaderCount}
-      openFiltersModal={openFiltersModal}
-      updateTaxon={updateTaxon}
-      updateLocation={updateLocation}
       onPressCount={( ) => setShowExploreBottomSheet( true )}
+      openFiltersModal={openFiltersModal}
+      renderLocationPermissionsGate={renderLocationPermissionsGate}
+      requestLocationPermissions={requestLocationPermissions}
+      updateLocation={updateLocation}
+      updateTaxon={updateTaxon}
     />
   );
 

--- a/src/components/Explore/ExploreContainer.js
+++ b/src/components/Explore/ExploreContainer.js
@@ -150,6 +150,7 @@ const ExploreContainerWithContext = ( ): Node => {
         updateProject={updateProject}
         placeMode={state.placeMode}
         hasLocationPermissions={hasLocationPermissions}
+        renderLocationPermissionsGate={renderPermissionsGate}
         requestLocationPermissions={requestLocationPermissions}
         startFetching={startFetching}
         currentMapRegion={mapRegion}

--- a/src/components/Explore/Header/ExploreHeader.js
+++ b/src/components/Explore/Header/ExploreHeader.js
@@ -26,24 +26,30 @@ type Props = {
   count: ?number,
   exploreView: string,
   exploreViewIcon: string,
+  hasLocationPermissions?: boolean,
   hideBackButton: boolean,
   isFetchingHeaderCount: boolean,
   onPressCount?: Function,
   openFiltersModal: Function,
-  updateTaxon: Function,
-  updateLocation: Function
+  renderLocationPermissionsGate: Function,
+  requestLocationPermissions: Function,
+  updateLocation: Function,
+  updateTaxon: Function
 }
 
 const Header = ( {
   count,
   exploreView,
   exploreViewIcon,
+  hasLocationPermissions,
   hideBackButton,
   isFetchingHeaderCount,
   onPressCount,
   openFiltersModal,
-  updateTaxon,
-  updateLocation
+  renderLocationPermissionsGate,
+  requestLocationPermissions,
+  updateLocation,
+  updateTaxon
 }: Props ): Node => {
   const { t } = useTranslation( );
   const { state, numberOfFilters } = useExplore( );
@@ -143,8 +149,11 @@ const Header = ( {
         updateTaxon={updateTaxon}
       />
       <ExploreLocationSearchModal
-        showModal={showLocationSearch}
         closeModal={() => { setShowLocationSearch( false ); }}
+        hasPermissions={hasLocationPermissions}
+        renderPermissionsGate={renderLocationPermissionsGate}
+        requestPermissions={requestLocationPermissions}
+        showModal={showLocationSearch}
         updateLocation={updateLocation}
       />
     </View>

--- a/src/components/Explore/Modals/ExploreLocationSearchModal.tsx
+++ b/src/components/Explore/Modals/ExploreLocationSearchModal.tsx
@@ -1,17 +1,23 @@
 import ExploreLocationSearch from "components/Explore/SearchScreens/ExploreLocationSearch";
 import Modal from "components/SharedComponents/Modal.tsx";
 import React from "react";
+import type { LocationPermissionCallbacks } from "sharedHooks/useLocationPermission.tsx";
 
 interface Props {
-  showModal: boolean;
   closeModal: () => void;
-  // TODO: Param not typed yet, because ExploreLocationSearch is not typed yet
+  hasPermissions?: boolean;
+  renderPermissionsGate: ( options: LocationPermissionCallbacks ) => React.FC;
+  requestPermissions: ( ) => void;
+  showModal: boolean;
   updateLocation: ( location: "worldwide" | { name: string } ) => void;
 }
 
 const ExploreLocationSearchModal = ( {
-  showModal,
   closeModal,
+  hasPermissions,
+  renderPermissionsGate,
+  requestPermissions,
+  showModal,
   updateLocation
 }: Props ) => (
   <Modal
@@ -22,6 +28,9 @@ const ExploreLocationSearchModal = ( {
     modal={(
       <ExploreLocationSearch
         closeModal={closeModal}
+        hasPermissions={hasPermissions}
+        renderPermissionsGate={renderPermissionsGate}
+        requestPermissions={requestPermissions}
         updateLocation={updateLocation}
       />
     )}

--- a/src/components/Explore/RootExploreContainer.js
+++ b/src/components/Explore/RootExploreContainer.js
@@ -226,6 +226,7 @@ const RootExploreContainerWithContext = ( ): Node => {
         startFetching={startFetching}
         currentMapRegion={rootMapRegion}
         setCurrentMapRegion={setRootMapRegion}
+        renderLocationPermissionsGate={renderPermissionsGate}
       />
       {renderPermissionsGate( {
         onPermissionGranted: async ( ) => {

--- a/src/components/Explore/SearchScreens/ExploreLocationSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreLocationSearch.js
@@ -21,7 +21,6 @@ import React, {
 } from "react";
 import { FlatList } from "react-native";
 import { useAuthenticatedQuery, useTranslation } from "sharedHooks";
-import useLocationPermission from "sharedHooks/useLocationPermission.tsx";
 import { getShadow } from "styles/global";
 
 import EmptySearchResults from "./EmptySearchResults";
@@ -33,16 +32,23 @@ const DROP_SHADOW = getShadow( {
 
 type Props = {
   closeModal: Function,
+  hasPermissions?: boolean,
+  renderPermissionsGate: Function,
+  requestPermissions: Function,
   updateLocation: Function
 };
 
-const ExploreLocationSearch = ( { closeModal, updateLocation }: Props ): Node => {
+const ExploreLocationSearch = ( {
+  closeModal,
+  hasPermissions,
+  renderPermissionsGate,
+  requestPermissions,
+  updateLocation
+}: Props ): Node => {
   const { t } = useTranslation( );
   const { dispatch, defaultExploreLocation } = useExplore( );
 
   const [locationName, setLocationName] = useState( "" );
-
-  const { hasPermissions, renderPermissionsGate, requestPermissions } = useLocationPermission( );
 
   const resetPlace = useCallback(
     ( ) => {
@@ -69,13 +75,10 @@ const ExploreLocationSearch = ( { closeModal, updateLocation }: Props ): Node =>
     }
   );
 
-  const onPlaceSelected = useCallback(
-    place => {
-      updateLocation( place );
-      closeModal();
-    },
-    [updateLocation, closeModal]
-  );
+  const onPlaceSelected = useCallback( place => {
+    updateLocation( place );
+    closeModal();
+  }, [updateLocation, closeModal] );
 
   const renderItem = useCallback(
     ( { item: place } ) => (

--- a/src/sharedHooks/useLocationPermission.tsx
+++ b/src/sharedHooks/useLocationPermission.tsx
@@ -11,7 +11,7 @@ import {
 
 // PermissionGate callbacks need to use useCallback, otherwise they'll
 // trigger re-renders if/when they change
-interface LocationPermissionCallbacks {
+export interface LocationPermissionCallbacks {
   onPermissionGranted?: ( ) => void;
   onPermissionDenied?: ( ) => void;
   onPermissionBlocked?: ( ) => void;
@@ -57,6 +57,7 @@ const useLocationPermission = ( ) => {
         onPermissionGranted={( ) => {
           setShowPermissionGate( false );
           setHasPermissions( true );
+          setHasBlockedPermissions( false );
           if ( onPermissionGranted ) onPermissionGranted( );
         }}
         onPermissionDenied={( ) => {


### PR DESCRIPTION
Much of the problem described in #2318 was handled in #2418 (mostly the part about nothing happening), but there remained a problem after the user went to Settings and granted permission: when they returned, the permission gate was still visible, and closing it did nothing. This PR makes it so the permission gate closes if the app is foregrounded and the permission gate detects that permission was granted. In iOS, this also results in Explore filtering by nearby as the user intended. In Android that might happen sometimes, but usually the user needs to tap NEARBY again.

Closes #2318