### PR TITLE
Prevent Suggestions photo scroll from resetting scroll placement on selection

### DIFF
--- a/src/components/Suggestions/Suggestions.js
+++ b/src/components/Suggestions/Suggestions.js
@@ -78,7 +78,7 @@ const Suggestions = ( {
     />
   ), [onTaxonChosen, t, currentUser, showOfflineText] );
 
-  const renderEmptyList = useCallback( ( ) => (
+  const renderEmptyList = useMemo( ( ) => (
     <SuggestionsEmpty
       hasTopSuggestion={!!topSuggestion}
       isLoading={isLoading}
@@ -110,7 +110,7 @@ const Suggestions = ( {
     toggleLocation
   ] );
 
-  const renderHeader = useCallback( ( ) => (
+  const renderHeader = useMemo( ( ) => (
     <SuggestionsHeader
       onPressPhoto={onPressPhoto}
       photoUris={photoUris}


### PR DESCRIPTION
Closes #2272

Another `useMemo` vs. `useCallback` error, like the one originally tracked down while debugging test errors in https://github.com/inaturalist/iNaturalistReactNative/pull/2280. 

`useMemo` prevents the SuggestionsHeader from rerendering when a photo is selected, while `useCallback` likely creates a lot of extra rerenders when a photo is selected.