### PR TITLE
fix: allow faving on tablets

### DIFF
--- a/src/components/ObsDetails/FaveButton.js
+++ b/src/components/ObsDetails/FaveButton.js
@@ -8,6 +8,9 @@ import {
   ActivityIndicator,
   INatIconButton
 } from "components/SharedComponents";
+import {
+  View
+} from "components/styledComponents";
 import type { Node } from "react";
 import React, { useCallback, useMemo, useState } from "react";
 import { Alert } from "react-native";
@@ -115,32 +118,31 @@ const FaveButton = ( {
     return null;
   }
 
-  if ( loading ) {
-    return (
-      <ActivityIndicator
-        className={classNames( "absolute bottom-5 right-5", {
-          "top-0": top
-        } )}
-        size={25}
-      />
-    );
-  }
-
   return (
-    <INatIconButton
-      icon={isFaved
-        ? "star"
-        : "star-bold-outline"}
-      size={25}
-      onPress={toggleFave}
-      color={colors.white}
-      className={classNames( "absolute bottom-3 right-3", {
-        "top-0": top
+    <View
+      className={classNames( "absolute right-3 w-[44px] h-[44px] justify-center", {
+        "top-0": top,
+        "bottom-3": !top
       } )}
-      accessibilityLabel={isFaved
-        ? t( "Remove-favorite" )
-        : t( "Add-favorite" )}
-    />
+    >
+      {
+        loading
+          ? <ActivityIndicator size={25} />
+          : (
+            <INatIconButton
+              icon={isFaved
+                ? "star"
+                : "star-bold-outline"}
+              size={25}
+              onPress={toggleFave}
+              color={colors.white}
+              accessibilityLabel={isFaved
+                ? t( "Remove-favorite" )
+                : t( "Add-favorite" )}
+            />
+          )
+      }
+    </View>
   );
 };
 

--- a/src/components/ObsDetails/ObsDetailsHeader.tsx
+++ b/src/components/ObsDetails/ObsDetailsHeader.tsx
@@ -56,6 +56,7 @@ const ObsDetailsHeader = ( {
           : "rgba(0,0,0,0.6)",
         "transparent"
       ]}
+      pointerEvents="box-none"
     >
       <OverlayHeader
         testID="ObsDetails.BackButton"

--- a/src/components/SharedComponents/OverlayHeader.tsx
+++ b/src/components/SharedComponents/OverlayHeader.tsx
@@ -15,7 +15,10 @@ const OverlayHeader = ( {
   rightHeaderButton,
   testID
 }: Props ) => (
-  <View className="w-full justify-between flex-row px-[13px] h-100">
+  <View
+    className="w-full justify-between flex-row px-[13px] h-100"
+    pointerEvents="box-none"
+  >
     <View className="pt-[21px]">
       <BackButton color="white" inCustomHeader testID={testID} />
     </View>


### PR DESCRIPTION
* Allow taps to pass through the obs details header to the fave button
* Stop rendering a full-height fave button on tablets

Closes #2177