### PR TITLE
fix for infinite re-rendering in Explore map view on Android

### DIFF
--- a/src/components/Explore/MapView.tsx
+++ b/src/components/Explore/MapView.tsx
@@ -6,7 +6,6 @@ import { getMapRegion } from "components/SharedComponents/Map/helpers/mapHelpers
 import { View } from "components/styledComponents";
 import { MapBoundaries, PLACE_MODE, useExplore } from "providers/ExploreContext.tsx";
 import React, { useEffect } from "react";
-import { Platform } from "react-native";
 import { Region } from "react-native-maps";
 import { useTranslation } from "sharedHooks";
 import { getShadow } from "styles/global";
@@ -70,17 +69,6 @@ const MapView = ( {
   delete tileMapParams.order;
   delete tileMapParams.orderBy;
 
-  const handleRegionChangeComplete = async ( newRegion, boundaries ) => {
-    // Seems to be a bug in react-native-maps where
-    // onRegionChangeComplete fires once on initial load before the
-    // region actually changes, so we're just ignoring that update
-    // here
-    if ( Platform.OS === "android" && Math.round( newRegion.latitude ) === 0 ) {
-      return;
-    }
-    await updateMapBoundaries( newRegion, boundaries );
-  };
-
   return (
     <View className="flex-1 overflow-hidden h-full">
       <View className="z-10">
@@ -101,7 +89,7 @@ const MapView = ( {
       <Map
         currentLocationButtonClassName="left-5 bottom-20"
         onPanDrag={onPanDrag}
-        onRegionChangeComplete={handleRegionChangeComplete}
+        onRegionChangeComplete={updateMapBoundaries}
         region={region}
         showCurrentLocationButton
         showSwitchMapTypeButton

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -9,7 +9,7 @@ import React, {
   useRef,
   useState
 } from "react";
-import { DimensionValue, ViewStyle } from "react-native";
+import { DimensionValue, Platform, ViewStyle } from "react-native";
 import MapView, {
   BoundingBox, LatLng, MapType, Region
 } from "react-native-maps";
@@ -273,7 +273,13 @@ const Map = ( {
     setUserLocation( coordinate );
   };
 
-  const handleRegionChangeComplete = async newRegion => {
+  const handleRegionChangeComplete = async ( newRegion, gesture ) => {
+    // We are only interested in region changes due to user interaction.
+    // In Android, onRegionChangeComplete also fires for other map region
+    // changes and gesture.isGesture is available to test for user interaction.
+    if ( Platform.OS === "android" && !gesture.isGesture ) {
+      return;
+    }
     if ( onRegionChangeComplete ) {
       const boundaries = await mapViewRef?.current?.getMapBoundaries( );
       onRegionChangeComplete( newRegion, boundaries );


### PR DESCRIPTION
This is a fix for issue #2432 Explore rapidly alternates between different maps.

The underlying problem is that on Android, the Explore map view is infinitely re-rendered. The `onRegionChangeComplete` callback should only be called at the end of a pan or zoom user interaction. On Android, it is also called when the map is first displayed, before any user interaction.

This seems to be a known issue, as there is a comment and a function in the codebase to handle it:
```
  const handleRegionChangeComplete = async ( newRegion, boundaries ) => {
    // Seems to be a bug in react-native-maps where
    // onRegionChangeComplete fires once on initial load before the
    // region actually changes, so we're just ignoring that update
    // here
    if ( Platform.OS === "android" && Math.round( newRegion.latitude ) === 0 ) {
      return;
    }
    await updateMapBoundaries( newRegion, boundaries );
  };
```
This code ignores the extra call for the initial map with latitude = longitude = 0°. It does not work for issue #2432 where the map is for a place with non-zero coordinates. An unintended consequence of this code is that it interferes with the correct behavior of the app when a user gets closer than 55.5km to the equator - the latitude can also be close to zero in user interactions.

This commit replaces this function with a different approach that directly tests whether the call is due to user interaction. This is the approach suggested in the [react-native-maps documentation](https://github.com/react-native-maps/react-native-maps) near the end of the document under "onRegionChangeComplete() callback is called infinitely".