### PR TITLE
fix: skip container to allow Ruby setup in crowdin-pull action

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
-BUNDLE_PATH: "vendor/bundle"
-BUNDLE_FORCE_RUBY_PLATFORM: 1

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -13,10 +13,10 @@ jobs:
   pull-from-crowdin:
     runs-on: ubuntu-latest
 
-    # Apparently needed to rename files, though maybe there's a better way
-    container:
-      image: ghcr.io/actions/actions-runner:latest
-      options: --user root
+    # # Apparently needed to rename files, though maybe there's a better way
+    # container:
+    #   image: ghcr.io/actions/actions-runner:latest
+    #   options: --user root
 
     steps:
       - name: Checkout
@@ -45,6 +45,11 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
+      - name: test permissions
+        run: |
+          ls -lh src/i18n/l10n/
+          echo "current user: $USER"
+          more src/i18n/l10n/tl.ftl
       # Need this for pre-commit linting of Ruby
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -83,6 +83,7 @@ jobs:
           ls -lh src/i18n/l10n/
           echo "current user: $USER"
           more src/i18n/l10n/tl.ftl
+          chown -R $USER src/i18n/l10n/
           npm run translate
 
       - name: Prepare Fastlane metadata directories

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -80,10 +80,7 @@ jobs:
       # validation failures in the PR
       - name: Normalize and validate
         run: |
-          ls -lh src/i18n/l10n/
-          echo "current user: $USER"
-          more src/i18n/l10n/tl.ftl
-          sudo chown -R $USER src/i18n/l10n/
+          sudo chown -R $USER *
           npm run translate
 
       - name: Prepare Fastlane metadata directories

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -13,11 +13,6 @@ jobs:
   pull-from-crowdin:
     runs-on: ubuntu-latest
 
-    # # Apparently needed to rename files, though maybe there's a better way
-    # container:
-    #   image: ghcr.io/actions/actions-runner:latest
-    #   options: --user root
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,14 +69,17 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      # The crowdin action adds new files owned by root. We need the default
+      # user to own them so we can move them around
+      - name: Change ownership
+        run: sudo chown -R $USER *
+
       # Move files named with crowdin locales to files named with iNat
       # locales. This will also fail if there's invalid FTL. We might want to
       # separate those things in the future if it's easier to notice
       # validation failures in the PR
       - name: Normalize and validate
-        run: |
-          sudo chown -R $USER *
-          npm run translate
+        run: npm run translate
 
       - name: Prepare Fastlane metadata directories
         run: npm run prepare-fastlane-metadata

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -83,7 +83,7 @@ jobs:
           ls -lh src/i18n/l10n/
           echo "current user: $USER"
           more src/i18n/l10n/tl.ftl
-          chown -R $USER src/i18n/l10n/
+          sudo chown -R $USER src/i18n/l10n/
           npm run translate
 
       - name: Prepare Fastlane metadata directories

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -15,7 +15,7 @@ jobs:
 
     # Apparently needed to rename files, though maybe there's a better way
     container:
-      image: node:18
+      image: ubuntu-latest
       options: --user root
 
     steps:

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -13,10 +13,10 @@ jobs:
   pull-from-crowdin:
     runs-on: ubuntu-latest
 
-    # Apparently needed to rename files, though maybe there's a better way
-    container:
-      image: ubuntu-latest
-      options: --user root
+    # # Apparently needed to rename files, though maybe there's a better way
+    # container:
+    #   image: ubuntu-latest
+    #   options: --user root
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -13,10 +13,10 @@ jobs:
   pull-from-crowdin:
     runs-on: ubuntu-latest
 
-    # # Apparently needed to rename files, though maybe there's a better way
-    # container:
-    #   image: ubuntu-latest
-    #   options: --user root
+    # Apparently needed to rename files, though maybe there's a better way
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+      options: --user root
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -45,11 +45,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
-      - name: test permissions
-        run: |
-          ls -lh src/i18n/l10n/
-          echo "current user: $USER"
-          more src/i18n/l10n/tl.ftl
       # Need this for pre-commit linting of Ruby
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
@@ -84,7 +79,12 @@ jobs:
       # separate those things in the future if it's easier to notice
       # validation failures in the PR
       - name: Normalize and validate
-        run: npm run translate
+        run: |
+          ls -lh src/i18n/l10n/
+          echo "current user: $USER"
+          more src/i18n/l10n/tl.ftl
+          npm run translate
+
       - name: Prepare Fastlane metadata directories
         run: npm run prepare-fastlane-metadata
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ npm-debug.log
 yarn-error.log
 
 # Bundle artifact
+.bundle*
 *.jsbundle
 
 # Ruby / CocoaPods


### PR DESCRIPTION
The setup-ruby action was choking on the explicit Docker container image we were using in crowdin-pull. The only reason we were doing that was to run everything as root, b/c the crowdin action adds files owned by root, leading to permissions errors when we later move things around. This PR just uses `sudo chown` (which apparently works?!) to get the same effect.