### PR TITLE
Add pull-to-refresh on MyObservations list and grid

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -17,6 +17,7 @@ type Props = {
   currentUser: Object,
   handleIndividualUploadPress: Function,
   handleSyncButtonPress: Function,
+  handlePullToRefresh: Function,
   isConnected: boolean,
   isFetchingNextPage: boolean,
   layout: "list" | "grid",
@@ -26,6 +27,7 @@ type Props = {
   onEndReached: Function,
   onListLayout?: Function,
   onScroll?: Function,
+  refreshing: boolean,
   setShowLoginSheet: Function,
   showLoginSheet: boolean,
   showNoResults: boolean,
@@ -36,6 +38,7 @@ const MyObservations = ( {
   currentUser,
   handleIndividualUploadPress,
   handleSyncButtonPress,
+  handlePullToRefresh,
   isConnected,
   isFetchingNextPage,
   layout,
@@ -45,6 +48,7 @@ const MyObservations = ( {
   onEndReached,
   onListLayout,
   onScroll,
+  refreshing,
   setShowLoginSheet,
   showLoginSheet,
   showNoResults,
@@ -77,6 +81,7 @@ const MyObservations = ( {
             <ObservationsFlashList
               dataCanBeFetched={!!currentUser}
               data={observations}
+              handlePullToRefresh={handlePullToRefresh}
               handleIndividualUploadPress={handleIndividualUploadPress}
               onScroll={animatedScrollEvent}
               hideLoadingWheel={!isFetchingNextPage || !currentUser}
@@ -87,6 +92,7 @@ const MyObservations = ( {
               onEndReached={onEndReached}
               onLayout={onListLayout}
               ref={listRef}
+              refreshing={refreshing}
               showObservationsEmptyScreen
               showNoResults={showNoResults}
               testID="MyObservationsAnimatedList"

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -53,7 +53,7 @@ const MyObservationsContainer = ( ): Node => {
   const canUpload = currentUser && isConnected;
 
   const { startUploadObservations } = useUploadObservations( canUpload );
-  useSyncObservations(
+  const { syncManually, refreshing } = useSyncObservations(
     currentUserId,
     startUploadObservations
   );
@@ -149,6 +149,10 @@ const MyObservationsContainer = ( ): Node => {
     ] )
   );
 
+  const handlePullToRefresh = useCallback( ( ) => {
+    syncManually( { skipUploads: true } );
+  }, [syncManually] );
+
   // Scroll the list to the offset we need to restore, e.g. when you are
   // scrolled way down, edit an observation, and return. Entering ObsEdit
   // takes you into a parallel stack navigator, which will destroy MyObs, so
@@ -178,6 +182,7 @@ const MyObservationsContainer = ( ): Node => {
       isConnected={isConnected}
       handleIndividualUploadPress={handleIndividualUploadPress}
       handleSyncButtonPress={handleSyncButtonPress}
+      handlePullToRefresh={handlePullToRefresh}
       layout={layout}
       listRef={listRef}
       numUnuploadedObservations={numUnuploadedObservations}
@@ -185,6 +190,7 @@ const MyObservationsContainer = ( ): Node => {
       onEndReached={fetchNextPage}
       onListLayout={restoreScrollOffset}
       onScroll={onScroll}
+      refreshing={refreshing}
       setShowLoginSheet={setShowLoginSheet}
       showLoginSheet={showLoginSheet}
       showNoResults={showNoResults}

--- a/src/components/ObservationsFlashList/CustomRefreshControl.tsx
+++ b/src/components/ObservationsFlashList/CustomRefreshControl.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { RefreshControl } from "react-native";
+
+const CustomRefreshControl = ( {
+  accessibilityLabel,
+  refreshing,
+  onRefresh,
+  ...props
+} ) => (
+  <RefreshControl
+    accessibilityLabel={accessibilityLabel}
+    onRefresh={onRefresh}
+    refreshing={refreshing}
+    // 20241121 amanda - added some opacity to try to lighten up the
+    // darkest version of the ActivityIndicator when a user is at
+    // full pull-to-refresh. if that doesn't look inatGreen enough,
+    // maybe we stick to light gray here
+    tintColor="#74AC0066"
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    {...props}
+  />
+);
+
+export default CustomRefreshControl;

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -3,7 +3,10 @@ import { useNavigation } from "@react-navigation/native";
 import MyObservationsEmpty from "components/MyObservations/MyObservationsEmpty";
 import navigateToObsEdit from "components/ObsEdit/helpers/navigateToObsEdit.ts";
 import {
-  ActivityIndicator, Body3, CustomFlashList, InfiniteScrollLoadingWheel
+  ActivityIndicator,
+  Body3,
+  CustomFlashList,
+  InfiniteScrollLoadingWheel
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { RealmContext } from "providers/contexts.ts";
@@ -20,6 +23,7 @@ import {
 } from "sharedHooks";
 import useStore from "stores/useStore";
 
+import CustomRefreshControl from "./CustomRefreshControl";
 import ObsPressable from "./ObsPressable";
 
 const { useRealm } = RealmContext;
@@ -31,6 +35,7 @@ type Props = {
   data: Array<Object>,
   dataCanBeFetched?: boolean,
   explore: boolean,
+  handlePullToRefresh: Function,
   handleIndividualUploadPress: Function,
   hideLoadingWheel: boolean,
   isConnected: boolean,
@@ -40,6 +45,7 @@ type Props = {
   onEndReached: Function,
   onLayout?: Function,
   onScroll?: Function,
+  refreshing: boolean,
   renderHeader?: Function,
   showNoResults?: boolean,
   showObservationsEmptyScreen?: boolean,
@@ -51,6 +57,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
   data,
   dataCanBeFetched,
   explore,
+  handlePullToRefresh,
   handleIndividualUploadPress,
   hideLoadingWheel,
   isConnected,
@@ -60,6 +67,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
   onEndReached,
   onLayout,
   onScroll,
+  refreshing,
   renderHeader,
   showNoResults,
   showObservationsEmptyScreen,
@@ -211,6 +219,14 @@ const ObservationsFlashList: Function = forwardRef( ( {
     }
   };
 
+  const refreshControl = (
+    <CustomRefreshControl
+      accessibilityLabel={t( "Pull-to-refresh-and-sync-observations" )}
+      refreshing={refreshing}
+      onRefresh={handlePullToRefresh}
+    />
+  );
+
   return (
     <AnimatedFlashList
       ItemSeparatorComponent={renderItemSeparator}
@@ -228,8 +244,8 @@ const ObservationsFlashList: Function = forwardRef( ( {
       onLayout={onLayout}
       onMomentumScrollEnd={onMomentumScrollEnd}
       onScroll={onScroll}
-      refreshing={isFetchingNextPage}
       renderItem={renderItem}
+      refreshControl={refreshControl}
       testID={testID}
     />
   );

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -860,6 +860,8 @@ PROJECTS = PROJECTS
 # As in iNat projects, collections of observations or observation search filters
 Projects = Projects
 PROJECTS-X = PROJECTS ({ $projectCount })
+# Accessibility label for pull-to-refresh on MyObservations list and grid view
+Pull-to-refresh-and-sync-observations = Pull to refresh and sync observations
 QUALITY-GRADE = QUALITY GRADE
 # label in project requirements
 Quality-Grade = Quality Grade

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -536,6 +536,7 @@
   "PROJECTS": "PROJECTS",
   "Projects": "Projects",
   "PROJECTS-X": "PROJECTS ({ $projectCount })",
+  "Pull-to-refresh-and-sync-observations": "Pull to refresh and sync observations",
   "QUALITY-GRADE": "QUALITY GRADE",
   "Quality-Grade": "Quality Grade",
   "Quality-Grade-Casual--label": "Quality Grade: Casual",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -860,6 +860,8 @@ PROJECTS = PROJECTS
 # As in iNat projects, collections of observations or observation search filters
 Projects = Projects
 PROJECTS-X = PROJECTS ({ $projectCount })
+# Accessibility label for pull-to-refresh on MyObservations list and grid view
+Pull-to-refresh-and-sync-observations = Pull to refresh and sync observations
 QUALITY-GRADE = QUALITY GRADE
 # label in project requirements
 Quality-Grade = Quality Grade
@@ -1427,5 +1429,3 @@ Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve 
 Zoom-to-current-location = Zoom to current location
 # Label for button that shows zoom level, e.g. on a camera
 zoom-x = { $zoom }×
-# Accessibility label for pull-to-refresh on MyObservations list and grid view
-Pull-to-refresh-and-sync-observations = Pull to refresh and sync observations

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1427,3 +1427,5 @@ Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve 
 Zoom-to-current-location = Zoom to current location
 # Label for button that shows zoom level, e.g. on a camera
 zoom-x = { $zoom }×
+# Accessibility label for pull-to-refresh on MyObservations list and grid view
+Pull-to-refresh-and-sync-observations = Pull to refresh and sync observations

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -366,6 +366,22 @@ describe( "MyObservations", ( ) => {
         } ).not.toThrow( );
       } );
 
+      it( "should trigger manual observation sync on pull-to-refresh", async ( ) => {
+        renderAppWithComponent( <MyObservationsContainer /> );
+
+        const myObsList = await screen.findByTestId( "MyObservationsAnimatedList" );
+
+        fireEvent.scroll( myObsList, {
+          nativeEvent: {
+            contentOffset: { y: -100 },
+            contentSize: { height: 1000, width: 100 },
+            layoutMeasurement: { height: 500, width: 100 }
+          }
+        } );
+
+        expect( inatjs.observations.deleted ).toHaveBeenCalled( );
+      } );
+
       describe( "on screen focus", ( ) => {
         beforeEach( ( ) => {
           zustandStorage.setItem( "lastDeletedSyncTime", "2024-05-01" );


### PR DESCRIPTION
Closes #2332

- Uses built-in React Native `RefreshControl` component to add pull-to-refresh functionality on MyObservations
- Pull-to-refresh triggers a manual sync, but skips the upload step that a manual tap of the sync button would trigger