### PR TITLE
Fix: show pull-to-refresh UI only during a pull-to-refresh

### DIFF
--- a/src/components/MyObservations/MyObservations.js
+++ b/src/components/MyObservations/MyObservations.js
@@ -27,7 +27,6 @@ type Props = {
   onEndReached: Function,
   onListLayout?: Function,
   onScroll?: Function,
-  refreshing: boolean,
   setShowLoginSheet: Function,
   showLoginSheet: boolean,
   showNoResults: boolean,
@@ -48,7 +47,6 @@ const MyObservations = ( {
   onEndReached,
   onListLayout,
   onScroll,
-  refreshing,
   setShowLoginSheet,
   showLoginSheet,
   showNoResults,
@@ -92,7 +90,6 @@ const MyObservations = ( {
               onEndReached={onEndReached}
               onLayout={onListLayout}
               ref={listRef}
-              refreshing={refreshing}
               showObservationsEmptyScreen
               showNoResults={showNoResults}
               testID="MyObservationsAnimatedList"

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -53,7 +53,7 @@ const MyObservationsContainer = ( ): Node => {
   const canUpload = currentUser && isConnected;
 
   const { startUploadObservations } = useUploadObservations( canUpload );
-  const { syncManually, refreshing } = useSyncObservations(
+  const { syncManually } = useSyncObservations(
     currentUserId,
     startUploadObservations
   );
@@ -149,8 +149,8 @@ const MyObservationsContainer = ( ): Node => {
     ] )
   );
 
-  const handlePullToRefresh = useCallback( ( ) => {
-    syncManually( { skipUploads: true } );
+  const handlePullToRefresh = useCallback( async ( ) => {
+    await syncManually( { skipUploads: true } );
   }, [syncManually] );
 
   // Scroll the list to the offset we need to restore, e.g. when you are
@@ -190,7 +190,6 @@ const MyObservationsContainer = ( ): Node => {
       onEndReached={fetchNextPage}
       onListLayout={restoreScrollOffset}
       onScroll={onScroll}
-      refreshing={refreshing}
       setShowLoginSheet={setShowLoginSheet}
       showLoginSheet={showLoginSheet}
       showNoResults={showNoResults}

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -11,8 +11,7 @@ import {
   AUTOMATIC_SYNC_IN_PROGRESS,
   BEGIN_AUTOMATIC_SYNC,
   BEGIN_MANUAL_SYNC,
-  MANUAL_SYNC_IN_PROGRESS,
-  SYNC_PENDING
+  MANUAL_SYNC_IN_PROGRESS
 } from "stores/createSyncObservationsSlice.ts";
 import useStore from "stores/useStore";
 
@@ -39,8 +38,6 @@ const useSyncObservations = (
   const removeFromDeleteQueue = useStore( state => state.removeFromDeleteQueue );
   const autoSyncAbortController = useStore( storeState => storeState.autoSyncAbortController );
   const [currentDeletionUuid, setCurrentDeletionUuid] = useState( null );
-
-  const refreshing = syncingStatus !== SYNC_PENDING;
 
   const canSync = loggedIn && isConnected === true;
 
@@ -206,8 +203,7 @@ const useSyncObservations = (
   }, [syncingStatus, syncManually, setSyncingStatus] );
 
   return {
-    syncManually,
-    refreshing
+    syncManually
   };
 };
 

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -14,7 +14,8 @@ import type { Node } from "react";
 import React, {
   forwardRef,
   useCallback,
-  useMemo
+  useMemo,
+  useState
 } from "react";
 import { Animated } from "react-native";
 import RealmObservation from "realmModels/Observation";
@@ -45,7 +46,6 @@ type Props = {
   onEndReached: Function,
   onLayout?: Function,
   onScroll?: Function,
-  refreshing: boolean,
   renderHeader?: Function,
   showNoResults?: boolean,
   showObservationsEmptyScreen?: boolean,
@@ -67,7 +67,6 @@ const ObservationsFlashList: Function = forwardRef( ( {
   onEndReached,
   onLayout,
   onScroll,
-  refreshing,
   renderHeader,
   showNoResults,
   showObservationsEmptyScreen,
@@ -81,6 +80,13 @@ const ObservationsFlashList: Function = forwardRef( ( {
   const totalUploadProgress = useStore( state => state.totalUploadProgress );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
   const setMyObsOffsetToRestore = useStore( state => state.setMyObsOffsetToRestore );
+  const [refreshing, setRefreshing] = useState( false );
+
+  const onRefresh = async ( ) => {
+    setRefreshing( true );
+    await handlePullToRefresh( );
+    setRefreshing( false );
+  };
 
   const {
     estimatedGridItemSize,
@@ -223,7 +229,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
     <CustomRefreshControl
       accessibilityLabel={t( "Pull-to-refresh-and-sync-observations" )}
       refreshing={refreshing}
-      onRefresh={handlePullToRefresh}
+      onRefresh={onRefresh}
     />
   );
 


### PR DESCRIPTION
Original code was also showing pull-to-refresh when a user tapped the sync button to upload. This fix shows the refreshing UI when a user pulls down, and it hides the refreshing UI when the manual sync has completed.