### PR TITLE
feat: use full-text index on new _searchableName field

### DIFF
--- a/src/components/Suggestions/hooks/useOnlineSuggestions.ts
+++ b/src/components/Suggestions/hooks/useOnlineSuggestions.ts
@@ -106,7 +106,7 @@ const useOnlineSuggestions = (
       mappedTaxa.forEach( remoteTaxon => {
         realm.create(
           "Taxon",
-          { ...remoteTaxon, _synced_at: new Date( ) },
+          Taxon.forUpdate( remoteTaxon ),
           "modified"
         );
       } );

--- a/src/components/hooks/useTaxonCommonNames.ts
+++ b/src/components/hooks/useTaxonCommonNames.ts
@@ -90,7 +90,7 @@ const useTaxonCommonNames = ( ) => {
           safeRealmWrite( realm, ( ) => {
             realm.create(
               "Taxon",
-              { ...mappedTaxon, _synced_at: new Date( ) },
+              Taxon.forUpdate( mappedTaxon ),
               "modified"
             );
           }, "saving taxon in useTaxonCommonNames" );

--- a/src/realmModels/Taxon.js
+++ b/src/realmModels/Taxon.js
@@ -109,6 +109,24 @@ class Taxon extends Realm.Object {
     };
   }
 
+  static compileSearchableName( taxon ) {
+    const names = [
+      taxon.name,
+      taxon.preferred_common_name,
+      taxon.preferredCommonName
+    ];
+    return [...new Set( names )].filter( Boolean ).join( "; " );
+  }
+
+  static forUpdate( taxon, extra = {} ) {
+    return {
+      ...taxon,
+      ...extra,
+      _searchableName: Taxon.compileSearchableName( taxon ),
+      _synced_at: new Date( )
+    };
+  }
+
   static mapApiToRealm( taxon, _realm = null ) {
     return {
       ...taxon,
@@ -139,6 +157,11 @@ class Taxon extends Realm.Object {
         type: "string",
         // indexed: "full-text",
         mapTo: "preferredCommonName",
+        optional: true
+      },
+      _searchableName: {
+        type: "string",
+        indexed: "full-text",
         optional: true
       },
       rank: "string?",

--- a/src/realmModels/index.ts
+++ b/src/realmModels/index.ts
@@ -1,4 +1,5 @@
 import RNFS from "react-native-fs";
+import Realm from "realm";
 
 import Application from "./Application";
 import Comment from "./Comment";
@@ -30,14 +31,23 @@ export default {
     User,
     Vote
   ],
-  schemaVersion: 58,
+  schemaVersion: 59,
   path: `${RNFS.DocumentDirectoryPath}/db.realm`,
   // https://github.com/realm/realm-js/pull/6076 embedded constraints
   migrationOptions: {
     resolveEmbeddedConstraints: true
   },
   // TODO: type?
-  migration: ( oldRealm, newRealm ) => {
+  migration: ( oldRealm: Realm, newRealm: Realm ) => {
+    if ( oldRealm.schemaVersion < 59 ) {
+      const oldTaxa = oldRealm.objects( "Taxon" );
+      const newTaxa = newRealm.objects( "Taxon" );
+      newTaxa.keys( ).forEach( ( objectIndex: number ) => {
+        const newTaxon = newTaxa[objectIndex];
+        const oldTaxon = oldTaxa[objectIndex];
+        newTaxon._searchableName = Taxon.compileSearchableName( oldTaxon );
+      } );
+    }
     if ( oldRealm.schemaVersion < 55 ) {
       const newObservations = newRealm.objects( "Observation" );
       newObservations.keys( ).forEach( objectIndex => {

--- a/src/sharedHelpers/taxon.js
+++ b/src/sharedHelpers/taxon.js
@@ -168,10 +168,7 @@ export async function fetchTaxonAndSave( id, realm, params = {}, opts = {} ) {
   safeRealmWrite( realm, ( ) => {
     realm.create(
       "Taxon",
-      {
-        ...mappedRemoteTaxon,
-        _synced_at: new Date( )
-      },
+      Taxon.forUpdate( mappedRemoteTaxon ),
       "modified"
     );
   }, "saving remote taxon in ObsDetails" );

--- a/src/sharedHooks/useIconicTaxa.ts
+++ b/src/sharedHooks/useIconicTaxa.ts
@@ -2,6 +2,7 @@ import { searchTaxa } from "api/taxa";
 import { RealmContext } from "providers/contexts.ts";
 import { useEffect, useState } from "react";
 import { UpdateMode } from "realm";
+import Taxon from "realmModels/Taxon";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { useAuthenticatedQuery } from "sharedHooks";
 
@@ -27,11 +28,11 @@ const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ) => {
       setIsUpdatingRealm( true );
       safeRealmWrite( realm, ( ) => {
         iconicTaxa.forEach( taxon => {
-          realm.create( "Taxon", {
-            ...taxon,
-            isIconic: true,
-            _synced_at: new Date( )
-          }, UpdateMode.Modified );
+          realm.create(
+            "Taxon",
+            Taxon.forUpdate( taxon, { isIconic: true } ),
+            UpdateMode.Modified
+          );
         } );
       }, "modifying iconic taxa in useIconicTaxa" );
     }

--- a/src/sharedHooks/useTaxon.js
+++ b/src/sharedHooks/useTaxon.js
@@ -65,7 +65,7 @@ const useTaxon = ( taxon: Object, fetchRemote = true ): Object => {
     safeRealmWrite( realm, ( ) => {
       realm.create(
         "Taxon",
-        { ...mappedRemoteTaxon, _synced_at: new Date( ) },
+        Taxon.forUpdate( mappedRemoteTaxon ),
         "modified"
       );
     }, "saving remote taxon in useTaxon" );

--- a/src/sharedHooks/useTaxonSearch.ts
+++ b/src/sharedHooks/useTaxonSearch.ts
@@ -17,7 +17,7 @@ function saveTaxaToRealm( taxa: Taxon[], realm: Realm ) {
     taxa.forEach( remoteTaxon => {
       realm.create(
         "Taxon",
-        { ...remoteTaxon, _synced_at: new Date( ) },
+        Taxon.forUpdate( remoteTaxon ),
         UpdateMode.Modified
       );
     } );
@@ -73,8 +73,12 @@ const useTaxonSearch = ( taxonQuery = "" ) => {
       // "name TEXT $0"
       // + " || preferredCommonName TEXT $0"
       // + " || name CONTAINS[c] $0"
-      "name CONTAINS[c] $0"
-      + " || preferredCommonName CONTAINS[c] $0"
+
+      // "name CONTAINS[c] $0"
+      // + " || preferredCommonName CONTAINS[c] $0"
+
+      "_searchableName TEXT $0 || _searchableName CONTAINS[c] $0"
+
       + " LIMIT(50)",
       taxonQuery
     );


### PR DESCRIPTION
Trying again with a migration and a totally separate field. Locally it worked for me, but I also wasn't able to replicate the prior release-only bug, so I'm curious if you can still see that here, @jtklein. If so, I think we just have to abandon the full-text index.