### PR TITLE
Use fixed headers on ObsDetails/TaxonDetails which invert colors on scroll

### DIFF
--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -262,8 +262,6 @@ const ObsDetails = ( {
         testID={`ObsDetails.${uuid}`}
         stickyHeaderIndices={[0, 3]}
         scrollEventThrottle={16}
-        className="flex-1 flex-column"
-        stickyHeaderHiddenOnScroll
         endFillColor="white"
         onScroll={handleScroll}
       >
@@ -273,7 +271,7 @@ const ObsDetails = ( {
           observationId={observation?.id}
           uuid={observation?.uuid}
         />
-        <View>
+        <View className="-mt-[64px]">
           <ObsMediaDisplayContainer observation={observation} />
           { currentUser && (
             <FaveButton

--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -127,6 +127,7 @@ const ObsDetails = ( {
   const scrollViewRef = useRef( );
   const insets = useSafeAreaInsets();
   const { t } = useTranslation( );
+  const [invertToWhiteBackground, setInvertToWhiteBackground] = useState( false );
 
   // Scroll the scrollview to this y position once if set, then unset it.
   // Could be refactored into a hook if we need this logic elsewher
@@ -146,6 +147,14 @@ const ObsDetails = ( {
       scrollViewRef?.current?.scrollToEnd( );
     }
   }, [addingActivityItem] );
+
+  const handleScroll = e => {
+    const scrollY = e.nativeEvent.contentOffset.y;
+    const shouldInvert = !!( scrollY > 150 );
+    if ( shouldInvert !== invertToWhiteBackground ) {
+      setInvertToWhiteBackground( shouldInvert );
+    }
+  };
 
   const dynamicInsets = useMemo( () => ( {
     backgroundColor: "#ffffff",
@@ -216,6 +225,7 @@ const ObsDetails = ( {
           className="flex-1 flex-column"
           stickyHeaderHiddenOnScroll
           endFillColor="white"
+          onScroll={handleScroll}
         >
           <View className="bg-white h-full">
             {renderActivityTab( )}
@@ -237,6 +247,7 @@ const ObsDetails = ( {
       </View>
       <ObsDetailsHeader
         belongsToCurrentUser={belongsToCurrentUser}
+        invertToWhiteBackground={invertToWhiteBackground}
         observationId={observation?.id}
         rightIconDarkGray
         uuid={observation?.uuid}
@@ -254,9 +265,11 @@ const ObsDetails = ( {
         className="flex-1 flex-column"
         stickyHeaderHiddenOnScroll
         endFillColor="white"
+        onScroll={handleScroll}
       >
         <ObsDetailsHeader
           belongsToCurrentUser={belongsToCurrentUser}
+          invertToWhiteBackground={invertToWhiteBackground}
           observationId={observation?.id}
           uuid={observation?.uuid}
         />

--- a/src/components/ObsDetails/ObsDetailsHeader.tsx
+++ b/src/components/ObsDetails/ObsDetailsHeader.tsx
@@ -47,12 +47,7 @@ const ObsDetailsHeader = ( {
   return (
     <LinearGradient
       className={classnames(
-        "absolute",
-        "top-0",
-        "w-full",
-        "flex-row",
-        "justify-between",
-        "h-16"
+        "h-16 transparent"
       )}
       colors={[
         isTablet

--- a/src/components/ObsDetails/ObsDetailsHeader.tsx
+++ b/src/components/ObsDetails/ObsDetailsHeader.tsx
@@ -23,6 +23,7 @@ const isTablet = DeviceInfo.isTablet( );
 
 interface Props {
   belongsToCurrentUser?: boolean,
+  invertToWhiteBackground: boolean,
   observationId: number,
   rightIconDarkGray?: boolean,
   uuid: string
@@ -30,6 +31,7 @@ interface Props {
 
 const ObsDetailsHeader = ( {
   belongsToCurrentUser,
+  invertToWhiteBackground,
   observationId,
   rightIconDarkGray = false,
   uuid
@@ -40,6 +42,8 @@ const ObsDetailsHeader = ( {
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
   const setMyObsOffsetToRestore = useStore( state => state.setMyObsOffsetToRestore );
 
+  const whiteIcon = !rightIconDarkGray && !invertToWhiteBackground;
+
   return (
     <LinearGradient
       className={classnames(
@@ -48,7 +52,7 @@ const ObsDetailsHeader = ( {
         "w-full",
         "flex-row",
         "justify-between",
-        "h-12"
+        "h-16"
       )}
       colors={[
         isTablet
@@ -59,6 +63,7 @@ const ObsDetailsHeader = ( {
     >
       <OverlayHeader
         testID="ObsDetails.BackButton"
+        invertToWhiteBackground={invertToWhiteBackground}
         rightHeaderButton={
           belongsToCurrentUser
             ? (
@@ -69,13 +74,13 @@ const ObsDetailsHeader = ( {
                   navigateToObsEdit( navigation, setMyObsOffsetToRestore );
                 }}
                 icon="pencil"
-                color={!rightIconDarkGray
+                color={whiteIcon
                   ? colors.white
                   : colors.darkGray}
                 accessibilityLabel={t( "Edit" )}
               />
             )
-            : <HeaderKebabMenu observationId={observationId} white={!rightIconDarkGray} />
+            : <HeaderKebabMenu observationId={observationId} white={whiteIcon} />
         }
       />
     </LinearGradient>

--- a/src/components/SharedComponents/OverlayHeader.tsx
+++ b/src/components/SharedComponents/OverlayHeader.tsx
@@ -1,3 +1,4 @@
+import classnames from "classnames";
 import {
   BackButton
 } from "components/SharedComponents";
@@ -5,21 +6,38 @@ import {
   View
 } from "components/styledComponents";
 import React from "react";
+import colors from "styles/tailwindColors";
 
 interface Props {
+  invertToWhiteBackground: boolean
   rightHeaderButton: React.JSX.Element;
-  testID: string
+  testID: string,
 }
 
 const OverlayHeader = ( {
+  invertToWhiteBackground,
   rightHeaderButton,
   testID
 }: Props ) => (
-  <View className="w-full justify-between flex-row px-[13px] h-100">
-    <View className="pt-[21px]">
-      <BackButton color="white" inCustomHeader testID={testID} />
+  <View className={
+    classnames(
+      "w-full justify-between flex-row px-[13px]",
+      {
+        "bg-white": invertToWhiteBackground
+      }
+    )
+  }
+  >
+    <View className="py-[21px]">
+      <BackButton
+        color={invertToWhiteBackground
+          ? colors.darkGray
+          : colors.white}
+        inCustomHeader
+        testID={testID}
+      />
     </View>
-    <View className="pt-[7px]">
+    <View className="py-[7px]">
       {rightHeaderButton}
     </View>
   </View>

--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -14,10 +14,10 @@ import {
   INatIcon,
   INatIconButton,
   List2,
-  OfflineNotice,
-  ScrollViewWrapper
+  OfflineNotice
 } from "components/SharedComponents";
 import {
+  SafeAreaView,
   View
 } from "components/styledComponents";
 import _, { compact } from "lodash";
@@ -25,6 +25,7 @@ import { RealmContext } from "providers/contexts.ts";
 import type { Node } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 import {
+  ScrollView,
   StatusBar
 } from "react-native";
 import DeviceInfo from "react-native-device-info";
@@ -54,6 +55,10 @@ import TaxonMedia from "./TaxonMedia";
 import Taxonomy from "./Taxonomy";
 import Wikipedia from "./Wikipedia";
 
+const SCROLL_VIEW_STYLE = {
+  backgroundColor: colors.white
+};
+
 const logger = log.extend( "TaxonDetails" );
 
 const { useRealm } = RealmContext;
@@ -61,6 +66,7 @@ const { useRealm } = RealmContext;
 const isTablet = DeviceInfo.isTablet();
 
 const TaxonDetails = ( ): Node => {
+  const [invertToWhiteBackground, setInvertToWhiteBackground] = useState( false );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );
   const currentEditingObservation = useStore( state => state.currentObservation );
   const getCurrentObservation = useStore( state => state.getCurrentObservation );
@@ -337,24 +343,38 @@ const TaxonDetails = ( ): Node => {
     t( "Share-your-observation-where-it-can-help-scientists" )
   ];
 
+  const handleScroll = e => {
+    const scrollY = e.nativeEvent.contentOffset.y;
+    const shouldInvert = !!( scrollY > 150 );
+    if ( shouldInvert !== invertToWhiteBackground ) {
+      setInvertToWhiteBackground( shouldInvert );
+    }
+  };
+
   return (
-    <>
-      <ScrollViewWrapper
-        testID={`TaxonDetails.${taxon?.id}`}
-        className="bg-black"
-      >
-        <TaxonDetailsHeader
-          hideNavButtons={hideNavButtons}
-          taxonId={taxon?.id}
-        />
-        {/*
+    <SafeAreaView
+      className="flex-1 bg-black"
+    >
+      {/*
           Making the bar dark here seems like the right thing, but I haven't
           figured a way to do that *and* not making the bg of the scrollview
           black, which reveals a dark area at the bottom of the screen on
           overscroll in iOS ~~~kueda20240228
         */}
-        <StatusBar barStyle="light-content" backgroundColor={colors.black} />
-        <View className="flex-1 h-full bg-black">
+      <StatusBar barStyle="light-content" backgroundColor={colors.black} />
+      <ScrollView
+        testID={`TaxonDetails.${taxon?.id}`}
+        onScroll={handleScroll}
+        contentContainerStyle={SCROLL_VIEW_STYLE}
+        scrollEventThrottle={16}
+        stickyHeaderIndices={[0]}
+      >
+        <TaxonDetailsHeader
+          invertToWhiteBackground={invertToWhiteBackground}
+          hideNavButtons={hideNavButtons}
+          taxonId={taxon?.id}
+        />
+        <View className="flex-1 h-full bg-black -mt-[64px]">
           <View className="w-full h-[420px] shrink-1">
             {displayTaxonMedia()}
             <View
@@ -375,7 +395,7 @@ const TaxonDetails = ( ): Node => {
           photos={photos}
           header={renderHeader}
         />
-      </ScrollViewWrapper>
+      </ScrollView>
       {showSelectButton && (
         <ButtonBar containerClass="items-center z-50">
           <Button
@@ -446,7 +466,7 @@ const TaxonDetails = ( ): Node => {
           />
         </View>
       </BottomSheet>
-    </>
+    </SafeAreaView>
   );
 };
 

--- a/src/components/TaxonDetails/TaxonDetailsHeader.tsx
+++ b/src/components/TaxonDetails/TaxonDetailsHeader.tsx
@@ -22,11 +22,13 @@ import {
 const TAXON_URL = "https://www.inaturalist.org/taxa";
 
 interface Props {
+  invertToWhiteBackground: boolean
   taxonId: string
   hideNavButtons: boolean
 }
 
 const TaxonDetailsHeader = ( {
+  invertToWhiteBackground,
   taxonId,
   hideNavButtons
 }: Props ): Node => {
@@ -37,20 +39,17 @@ const TaxonDetailsHeader = ( {
 
   return (
     <View
-      className={classnames(
-        "absolute",
-        "z-10",
-        "h-12"
-      )}
+      className={classnames( "h-16 transparent z-10" )}
     >
       <OverlayHeader
         testID="TaxonDetails.BackButton"
+        invertToWhiteBackground={invertToWhiteBackground}
         rightHeaderButton={!hideNavButtons && (
           <KebabMenu
             visible={kebabMenuVisible}
             setVisible={setKebabMenuVisible}
             large
-            white
+            white={!invertToWhiteBackground}
           >
             <KebabMenu.Item
               testID="MenuItem.OpenInBrowser"


### PR DESCRIPTION
Addresses part of #2331

- This uses fixed headers on ObsDetails and TaxonDetails, and it inverts the colors of the header when a user scrolls down to a certain y value on the screen

I spent about a day looking into ways that we can make both the fixed header and the tab bar stick to the top of the screen in ObsDetails, but the furthest I got was a hacky solution that worked on iPhone 15 Pro but not an iPhone SE. React Native components are designed to only allow for one sticky header at a time, so we'll need some custom code here. I'm going to unassign myself in case someone else wants to pick up the rest of this issue.