### PR TITLE
fix: load new Explore results when filters change

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -242,6 +242,7 @@ const Explore = ( {
         }}
         radioValues={values}
         selectedValue={currentExploreView}
+        testID="ExploreObsViewSheet"
       />
     );
   };

--- a/src/components/Explore/hooks/useInfiniteExploreScroll.js
+++ b/src/components/Explore/hooks/useInfiniteExploreScroll.js
@@ -16,7 +16,7 @@ const useInfiniteExploreScroll = ( { params: newInputParams, enabled }: Object )
     ttl: -1
   };
 
-  const queryKey = ["useInfiniteExploreScroll"];
+  const queryKey = ["useInfiniteExploreScroll", newInputParams];
 
   const getNextPageParam = useCallback( lastPage => {
     const lastObs = last( lastPage.results );

--- a/src/components/SharedComponents/Sheets/BottomSheet.tsx
+++ b/src/components/SharedComponents/Sheets/BottomSheet.tsx
@@ -36,6 +36,7 @@ interface Props {
   snapPoints?: Array<string>;
   insideModal?: boolean;
   keyboardShouldPersistTaps: string;
+  testID?: string;
 }
 
 const StandardBottomSheet = ( {
@@ -47,7 +48,8 @@ const StandardBottomSheet = ( {
   onPressClose,
   snapPoints,
   insideModal,
-  keyboardShouldPersistTaps = "never"
+  keyboardShouldPersistTaps = "never",
+  testID
 }: Props ): Node => {
   if ( snapPoints ) {
     throw new Error( "BottomSheet does not accept snapPoints as a prop." );
@@ -115,6 +117,9 @@ const StandardBottomSheet = ( {
               : null
           )}
           onLayout={onLayout}
+          // Not ideal, but @gorhom/bottom-sheet components don't support
+          // testID
+          testID={testID}
         >
           <View className="items-center">
             <Heading4 testID="bottom-sheet-header">{headerText}</Heading4>

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -25,6 +25,7 @@ interface Props {
     }
   },
   selectedValue?: string,
+  testID?: string,
   topDescriptionText?: React.JSX.Element,
 }
 
@@ -38,6 +39,7 @@ const RadioButtonSheet = ( {
   onPressClose,
   radioValues,
   selectedValue = "none",
+  testID,
   topDescriptionText
 }: Props ) => {
   const { t } = useTranslation( );
@@ -65,6 +67,7 @@ const RadioButtonSheet = ( {
       headerText={headerText}
       insideModal={insideModal}
       onPressClose={onPressClose}
+      testID={testID}
     >
       <View className="p-4 pt-2">
         {topDescriptionText}

--- a/src/sharedHooks/useFontScale.ts
+++ b/src/sharedHooks/useFontScale.ts
@@ -1,15 +1,20 @@
 import {
+  useEffect,
   useState
 } from "react";
 import DeviceInfo from "react-native-device-info";
 
-const useFontScale = ( ):Object => {
+const useFontScale = ( ): {
+  isLargeFontScale: boolean
+} => {
   const [isLargeFontScale, setIsLargeFontScale] = useState<boolean>( false );
 
-  DeviceInfo.getFontScale().then( fontScale => {
-    if ( fontScale > 1.3 ) setIsLargeFontScale( true );
-    else setIsLargeFontScale( false );
-  } );
+  useEffect( ( ) => {
+    DeviceInfo.getFontScale().then( fontScale => {
+      if ( fontScale > 1.3 ) setIsLargeFontScale( true );
+      else setIsLargeFontScale( false );
+    } );
+  }, [] );
 
   return {
     isLargeFontScale


### PR DESCRIPTION
URL params got removed from the query key as a part of pull-to-refresh, but that's how changes to filters were triggering a new request. This restores that behavior, adds a test to ensure changes to filters call the API again, and fixes the prior test of pull to refresh which was not testing the equivalent behavior when pulling to refresh (API on first load, so the mock needed to be cleared).