### PR TITLE
Fix: display canceled upload UI correctly

### DIFF
--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -21,6 +21,9 @@ import {
   useStoredLayout,
   useTranslation
 } from "sharedHooks";
+import {
+  UPLOAD_PENDING
+} from "stores/createUploadObservationsSlice.ts";
 import useStore from "stores/useStore";
 
 import useSyncObservations from "./hooks/useSyncObservations";
@@ -43,6 +46,7 @@ const MyObservationsContainer = ( ): Node => {
   const numUnuploadedObservations = useStore( state => state.numUnuploadedObservations );
   const myObsOffsetToRestore = useStore( state => state.myObsOffsetToRestore );
   const setMyObsOffset = useStore( state => state.setMyObsOffset );
+  const uploadStatus = useStore( state => state.uploadStatus );
 
   const { observationList: observations } = useLocalObservations( );
   const { layout, writeLayoutToStorage } = useStoredLayout( "myObservationsLayout" );
@@ -114,7 +118,9 @@ const MyObservationsContainer = ( ): Node => {
     const observation = realm.objectForPrimaryKey( "Observation", uuid );
     addTotalToolbarIncrements( observation );
     addToUploadQueue( uuid );
-    setStartUploadObservations( );
+    if ( uploadStatus === UPLOAD_PENDING ) {
+      setStartUploadObservations( );
+    }
   }, [
     confirmLoggedIn,
     uploadQueue,
@@ -122,7 +128,8 @@ const MyObservationsContainer = ( ): Node => {
     realm,
     addTotalToolbarIncrements,
     addToUploadQueue,
-    setStartUploadObservations
+    setStartUploadObservations,
+    uploadStatus
   ] );
 
   // 20241107 amanda - this seems to be a culprit for the tab bar being less

--- a/src/stores/createUploadObservationsSlice.ts
+++ b/src/stores/createUploadObservationsSlice.ts
@@ -102,7 +102,22 @@ const createUploadObservationsSlice: StateCreator<UploadObservationsSlice> = ( s
   resetUploadObservationsSlice: ( ) => {
     // Preserve the abortController just in case something might try and use it
     const { abortController } = get( );
-    return set( { ...DEFAULT_STATE, abortController } );
+    const defaultStateWithController = {
+      abortController,
+      currentUpload: null,
+      errorsByUuid: {},
+      multiError: null,
+      initialNumObservationsInQueue: 0,
+      numUnuploadedObservations: 0,
+      numUploadsAttempted: 0,
+      totalToolbarIncrements: 0,
+      totalToolbarProgress: 0,
+      totalUploadProgress: [],
+      uploadQueue: [],
+      uploadStatus: UPLOAD_PENDING
+    };
+
+    return set( defaultStateWithController );
   },
   addUploadError: ( error, obsUUID ) => set( state => ( {
     errorsByUuid: {
@@ -118,13 +133,25 @@ const createUploadObservationsSlice: StateCreator<UploadObservationsSlice> = ( s
     deactivateKeepAwake( );
     const { abortController } = get( );
     abortController?.abort();
-    return set( {
-      ...DEFAULT_STATE,
+
+    const cancelledStateWithController = {
       // Preserve the abort controller in case in might still get used. It
       // should only get regenerated when the uploads start
       abortController,
+      currentUpload: null,
+      errorsByUuid: {},
+      multiError: null,
+      initialNumObservationsInQueue: 0,
+      numUnuploadedObservations: 0,
+      numUploadsAttempted: 0,
+      totalToolbarIncrements: 0,
+      totalToolbarProgress: 0,
+      totalUploadProgress: [],
+      uploadQueue: [],
       uploadStatus: UPLOAD_CANCELLED
-    } );
+    };
+
+    return set( cancelledStateWithController );
   },
   // Sets state to indicate that upload is needed without necessarily
   // resetting the state, as there might still be observations to upload


### PR DESCRIPTION
Closes #2445 

The main issue here was that spreading `...DEFAULT_STATE` to reset the upload state or update the canceled upload state wasn't doing what we thought it was... instead of updating with the actual original, empty state (i.e. `uploadQueue: []`), the existing state was being set again (i.e. `uploadQueue: [upload1, upload2, upload3]`).

So canceling an upload would still have an uploadQueue with all the previous uploads, which would make the animations on individual uploads continue to rotate.

TLDR: be careful to make sure the original state is actually being reset in zustand, particularly when spreading objects.