### PR TITLE
Remove refetching loading wheel on ObsDetails

### DIFF
--- a/src/components/ObsDetails/ObsDetails.js
+++ b/src/components/ObsDetails/ObsDetails.js
@@ -55,7 +55,6 @@ type Props = {
   editIdentBody: Function,
   hideAddCommentSheet: Function,
   isConnected: boolean,
-  isRefetching: boolean,
   navToSuggestions: Function,
   targetActivityItemID: number,
   observation: Object,
@@ -99,7 +98,6 @@ const ObsDetails = ( {
   editIdentBody,
   hideAddCommentSheet,
   isConnected,
-  isRefetching,
   navToSuggestions,
   targetActivityItemID,
   observation,
@@ -212,7 +210,6 @@ const ObsDetails = ( {
           <ObsDetailsOverview
             belongsToCurrentUser={belongsToCurrentUser}
             isConnected={isConnected}
-            isRefetching={isRefetching}
             observation={observation}
           />
         </View>
@@ -284,7 +281,6 @@ const ObsDetails = ( {
         <ObsDetailsOverview
           belongsToCurrentUser={belongsToCurrentUser}
           isConnected={isConnected}
-          isRefetching={isRefetching}
           observation={observation}
         />
         <View className="bg-white">

--- a/src/components/ObsDetails/ObsDetailsContainer.js
+++ b/src/components/ObsDetails/ObsDetailsContainer.js
@@ -602,7 +602,6 @@ const ObsDetailsContainer = ( ): Node => {
       onPotentialDisagreePressed={onPotentialDisagreePressed}
       hideAddCommentSheet={hideAddCommentSheet}
       isConnected={isConnected}
-      isRefetching={isRefetching}
       navToSuggestions={navToSuggestions}
       targetActivityItemID={targetActivityItemID}
       // saving observation in state (i.e. using observationShown)

--- a/src/components/ObsDetails/ObsDetailsOverview.js
+++ b/src/components/ObsDetails/ObsDetailsOverview.js
@@ -1,8 +1,6 @@
 // @flow
 import { useNavigation, useRoute } from "@react-navigation/native";
-import classnames from "classnames";
 import {
-  ActivityIndicator,
   Body1,
   Body4,
   DateDisplay,
@@ -21,14 +19,12 @@ import {
 type Props = {
   belongsToCurrentUser: boolean,
   isConnected: boolean,
-  isRefetching: boolean,
   observation: Object,
 }
 
 const ObsDetailsOverview = ( {
   belongsToCurrentUser,
   isConnected,
-  isRefetching,
   observation
 }: Props ): Node => {
   const navigation = useNavigation( );
@@ -38,15 +34,6 @@ const ObsDetailsOverview = ( {
   const taxonGeoprivacy = observation?.taxon_geoprivacy;
 
   const communityTaxon = observation?.taxon;
-
-  const loadingIndicator = (
-    <ActivityIndicator
-      className={classnames(
-        "absolute w-full"
-      )}
-      size={25}
-    />
-  );
 
   const showCommunityTaxon = ( ) => {
     if ( !communityTaxon ) {
@@ -76,7 +63,6 @@ const ObsDetailsOverview = ( {
   return (
     <View className="bg-white">
       <View className="flex-row justify-between mx-[15px] mt-[13px]">
-        {( !observation || isRefetching ) && loadingIndicator}
         <InlineUser user={observation?.user} isConnected={isConnected} />
         {observation && (
           <DateDisplay


### PR DESCRIPTION
Closes #2410 

Removes the spinner that should never ever appear on ObsDetails