### PR TITLE
show wild status by default when wildcaptive bottom sheet is open and…

### DIFF
--- a/src/components/ObsEdit/OtherDataSection.js
+++ b/src/components/ObsEdit/OtherDataSection.js
@@ -67,7 +67,7 @@ const OtherDataSection = ( {
       )}
       {showWildStatusSheet && (
         <WildStatusSheet
-          selectedValue={currentObservation?.captive_flag}
+          selectedValue={currentObservation?.captive_flag || false}
           onPressClose={( ) => setShowWildStatusSheet( false )}
           updateCaptiveStatus={value => updateObservationKeys( {
             captive_flag: value


### PR DESCRIPTION
… no value is assigned. Closes #2500 