### PR TITLE
fix: bug fixes for map view in Android

### DIFF
--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -148,8 +148,7 @@ const Map = ( {
     }
   }
 
-  const [defaultInitialRegionState,
-    setDefaultInitialRegionState] = useState( defaultInitialRegion );
+  const [observationRegion, setObservationRegion] = useState( defaultInitialRegion );
 
   useEffect( ( ) => {
     // in LocationPicker we're setting initialRegion to eliminate jitteriness
@@ -202,7 +201,7 @@ const Map = ( {
     if ( region?.latitude ) {
       return region;
     }
-    return defaultInitialRegionState;
+    return observationRegion;
   };
 
   const handleCurrentLocationPress = useCallback( ( ) => {
@@ -310,7 +309,7 @@ const Map = ( {
         const boundaries = await mapViewRef?.current?.getMapBoundaries( );
         onRegionChangeComplete( newRegion, boundaries );
       } else if ( Platform.OS === "android" ) {
-        setDefaultInitialRegionState( newRegion );
+        setObservationRegion( newRegion );
       }
     }
     setCurrentZoom( calculateZoom( screenWidth, newRegion.longitudeDelta ) );

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -148,6 +148,9 @@ const Map = ( {
     }
   }
 
+  const [defaultInitialRegionState,
+    setDefaultInitialRegionState] = useState( defaultInitialRegion );
+
   useEffect( ( ) => {
     // in LocationPicker we're setting initialRegion to eliminate jitteriness
     // when scrolling, which means we also must use this method to reset the map
@@ -199,7 +202,7 @@ const Map = ( {
     if ( region?.latitude ) {
       return region;
     }
-    return defaultInitialRegion;
+    return defaultInitialRegionState;
   };
 
   const handleCurrentLocationPress = useCallback( ( ) => {
@@ -302,9 +305,13 @@ const Map = ( {
       }
       shouldSkipRegionUpdate = true;
     }
-    if ( onRegionChangeComplete && !shouldSkipRegionUpdate ) {
-      const boundaries = await mapViewRef?.current?.getMapBoundaries( );
-      onRegionChangeComplete( newRegion, boundaries );
+    if ( !shouldSkipRegionUpdate ) {
+      if ( onRegionChangeComplete ) {
+        const boundaries = await mapViewRef?.current?.getMapBoundaries( );
+        onRegionChangeComplete( newRegion, boundaries );
+      } else if ( Platform.OS === "android" ) {
+        setDefaultInitialRegionState( newRegion );
+      }
     }
     setCurrentZoom( calculateZoom( screenWidth, newRegion.longitudeDelta ) );
   };


### PR DESCRIPTION
+ From ObsDetails the map is called with an observation and neither a region nor a mathod to update the region are provided. Zooming works fine as long as we keep at least one finger on the screen. When the last finger is removed, the map reverts to the initial map computed for the observation.
A region called `defaultInitialRegion` is computed from the observation for the map view. This region is not updated after zooming. This does not seem to be a problem in iOS, but in Android the map is re-rendered after each gesture and it then reverts to the one computed from the observation.
This fix introduces a state `observationRegion` for `defaultInitialRegion` that is updated after each gesture.
+ The fix for the Current Location button consists in explicitly invoking a callback after animateToRegion() is called.
 
Closes #2529
Closes #2555