### PR TITLE
Fixes for Map in Android

### DIFF
--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -148,12 +148,36 @@ const Map = ( {
     }
   }
 
+  // In Android, we maintain a state for defaultInitialRegion and initialRegion
+  // that is updated on gestures like pan and zoom. This state is always null in iOS.
+  const [localRegion, setLocalRegion] = useState<Region|null>( Platform.OS === "android"
+    ? initialRegion || defaultInitialRegion
+    : null );
+
+  // In Android, onMapReady does not fire when we pass parameter region instead
+  // of parameter initialRegion. This state allows us to fire onMapReady and
+  // fire it only once. This state is always false in iOS.
+  const [onMapReadyHasFired, setOnMapReadyHasFired] = useState( false );
+
+  // In Android, animateToRegion animates to the given region but the map then
+  // immediately returns to the previous region. We fake a gesture to the
+  // desired region to make it stick. This state stores the region for this
+  // gesture. This state is always null in iOS.
+  const [animateRegion, setAnimateRegion] = useState<Region|null>( null );
+
+  const animateToRegion = ( newRegion: Region ) => {
+    mapViewRef.current?.animateToRegion( newRegion );
+    if ( Platform.OS === "android" ) {
+      setAnimateRegion( newRegion );
+    }
+  };
+
   useEffect( ( ) => {
     // in LocationPicker we're setting initialRegion to eliminate jitteriness
     // when scrolling, which means we also must use this method to reset the map
     // when searching for a location by typing a place name and selecting place coordinates
-    if ( !regionToAnimate ) { return; }
-    mapViewRef.current?.animateToRegion( {
+    if ( !regionToAnimate || !mapViewRef.current ) { return; }
+    animateToRegion( {
       latitude: regionToAnimate.latitude,
       longitude: regionToAnimate.longitude
     } );
@@ -179,7 +203,7 @@ const Map = ( {
   const onPermissionGranted = async ( ) => {
     const currentLocation = await fetchUserLocation( );
     if ( currentLocation && mapViewRef?.current ) {
-      mapViewRef.current?.animateToRegion( {
+      animateToRegion( {
         latitude: currentLocation.latitude,
         longitude: currentLocation.longitude,
         latitudeDelta: metersToLatitudeDelta( NEARBY_DIM_M, currentLocation.latitude ),
@@ -192,14 +216,17 @@ const Map = ( {
     onPermissionGranted
   } );
 
+  // In Android, we always return a state, either region or localRegion.
   const setRegion = ( ) => {
-    if ( initialRegion ) {
+    if ( Platform.OS !== "android" && initialRegion ) {
       return null;
     }
     if ( region?.latitude ) {
       return region;
     }
-    return defaultInitialRegion;
+    return Platform.OS === "android"
+      ? localRegion
+      : defaultInitialRegion;
   };
 
   const handleCurrentLocationPress = useCallback( ( ) => {
@@ -238,7 +265,7 @@ const Map = ( {
       latitudeDelta = Math.max( latitudeDelta, configuredLatitudeDelta );
       longitudeDelta = Math.max( longitudeDelta, configuredLongitudeDelta );
 
-      mapViewRef.current?.animateToRegion( {
+      animateToRegion( {
         latitude: userLocation.latitude,
         longitude: userLocation.longitude,
         latitudeDelta,
@@ -291,7 +318,7 @@ const Map = ( {
 
   const [previousTileUrl, setPreviousTileUrl] = useState( tileUrlTemplate );
 
-  const handleRegionChangeComplete = async ( newRegion, gesture ) => {
+  const handleRegionChangeComplete = useCallback( async ( newRegion, gesture ) => {
     // We are only interested in region changes due to user interaction.
     // In Android, onRegionChangeComplete also fires for other map region
     // changes and gesture.isGesture is available to test for user interaction.
@@ -300,14 +327,56 @@ const Map = ( {
       if ( previousTileUrl !== tileUrlTemplate ) {
         setPreviousTileUrl( tileUrlTemplate );
       }
+      if ( !onMapReadyHasFired && onMapReady ) {
+        setOnMapReadyHasFired( true );
+        onMapReady();
+      }
       shouldSkipRegionUpdate = true;
     }
-    if ( onRegionChangeComplete && !shouldSkipRegionUpdate ) {
-      const boundaries = await mapViewRef?.current?.getMapBoundaries( );
-      onRegionChangeComplete( newRegion, boundaries );
+    if ( !shouldSkipRegionUpdate ) {
+      if ( onRegionChangeComplete ) {
+        const boundaries = await mapViewRef?.current?.getMapBoundaries( );
+        onRegionChangeComplete( newRegion, boundaries );
+      }
+      if ( localRegion ) {
+        setLocalRegion( newRegion );
+      }
     }
     setCurrentZoom( calculateZoom( screenWidth, newRegion.longitudeDelta ) );
-  };
+  }, [
+    previousTileUrl,
+    tileUrlTemplate,
+    onMapReadyHasFired,
+    onMapReady,
+    onRegionChangeComplete,
+    localRegion,
+    screenWidth
+  ] );
+
+  // In Android, animateToRegion animates to the given region but the map then
+  // immediately returns to the previous region. We fake a gesture to the
+  // desired region to make it stick.
+  useEffect(
+    ( ) => {
+      if ( Platform.OS === "android" && animateRegion ) {
+        const curRegion = localRegion || region;
+        const newRegion = {
+          ...curRegion, // provides defaults for latitudeDelta and longitudeDelta
+          ...animateRegion
+        };
+        setTimeout(
+          ( ) => handleRegionChangeComplete( newRegion, { isGesture: true } )
+        );
+        setAnimateRegion( null );
+      }
+    },
+    [
+      animateRegion,
+      localRegion,
+      region,
+      handleRegionChangeComplete
+    ]
+  );
 
   const handleMapPress = e => {
     if ( withPressableObsTiles ) onMapPressForObsLyr( e.nativeEvent.coordinate );
@@ -340,8 +409,11 @@ const Map = ( {
   const mapRegion = shouldFuzzRegion( unfuzzedMapRegion )
     ? fuzzRegion( unfuzzedMapRegion )
     : unfuzzedMapRegion;
-  const mapInitialRegion = shouldFuzzRegion( initialRegion )
-    ? fuzzRegion( initialRegion )
+
+  // In Android, we maintain initialRegion as state localRegion and
+  // pass null to parameter initialRegion.
+  const mapInitialRegion = Platform.OS === "android"
+    ? null
     : initialRegion;
 
   const renderDebugZoomLevel = ( ) => {


### PR DESCRIPTION
+ The map from ObsDetails does not reset after each zoom anymore. A state for the region needed to be introduced and updated after each gesture.
+ The current location button now centers the map on the current location. A callback needed to be called explicitly after `animateToRegion()`.
+ A search in LocationPicker now centers the map on the selected location.  A state for the region needed to be introduced and a callback needed to be called explicitly after `animateToRegion()`.

Closes #2529
Closes #2555
Closes #2593