### PR TITLE
Fix: log location fetch start without infinite renders

### DIFF
--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -107,7 +107,10 @@ const CameraContainer = ( ) => {
     generateSentinelFile( );
   }, [setSentinelFileName, cameraType] );
 
-  const logFetchingLocation = !!( hasPermissions && sentinelFileName );
+  const logFetchingLocation = useMemo(
+    ( ) => !!( hasPermissions && sentinelFileName ),
+    [hasPermissions, sentinelFileName]
+  );
 
   useEffect( ( ) => {
     if ( logFetchingLocation ) {


### PR DESCRIPTION
Memoize the boolean passed into trigger this `useEffect`, which should prevent phone from overheating and potential issues with location fetching (since iOS will give up on fetching if you try to fetch too many times in quick succession)