### PR TITLE
Add location picker / gate to Match screen

### DIFF
--- a/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
+++ b/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
@@ -5,6 +5,7 @@ import {
 } from "react";
 import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
+import fetchPlaceName from "sharedHelpers/fetchPlaceName";
 import useStore from "stores/useStore";
 
 import savePhotosToCameraGallery from "../helpers/savePhotosToCameraGallery";
@@ -77,9 +78,11 @@ const usePrepareStoreAndNavigate = ( ): Function => {
     // Suggestions after the changes to permissions github issue is complete, and
     // we'll be able to updateObservationKeys on the observation there
     if ( userLocation?.latitude ) {
+      const placeName = await fetchPlaceName( userLocation.latitude, userLocation.longitude );
       newObservation.latitude = userLocation?.latitude;
       newObservation.longitude = userLocation?.longitude;
       newObservation.positional_accuracy = userLocation?.positional_accuracy;
+      newObservation.place_guess = placeName;
     }
     newObservation.observationPhotos = await ObservationPhoto
       .createObsPhotosWithPosition( uris, {

--- a/src/components/Match/EmptyMapSection.js
+++ b/src/components/Match/EmptyMapSection.js
@@ -2,24 +2,36 @@ import {
   INatIcon,
   Subheading1
 } from "components/SharedComponents";
-import { ImageBackground } from "components/styledComponents";
+import { ImageBackground, Pressable } from "components/styledComponents";
 import React from "react";
 import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
 
-const EmptyMapSection = ( ) => {
+type Props = {
+  handleLocationPickerPressed: ( ) => void
+}
+
+const EmptyMapSection = ( {
+  handleLocationPickerPressed
+}: Props ) => {
   const { t } = useTranslation( );
   return (
-    <ImageBackground
-      className="w-full h-[230px] flex items-center justify-center"
-      source={require( "images/topographic-map.png" )}
-      accessibilityIgnoresInvertColors
+    <Pressable
+      accessibilityLabel={t( "Edit-location" )}
+      accessibilityRole="link"
+      onPress={handleLocationPickerPressed}
     >
-      <INatIcon name="location" size={40} color={colors.white} />
-      <Subheading1 className="mt-3 text-white px-28 text-center">
-        {t( "Add-location-for-better-identifications" )}
-      </Subheading1>
-    </ImageBackground>
+      <ImageBackground
+        className="w-full h-[230px] flex items-center justify-center"
+        source={require( "images/topographic-map.png" )}
+        accessibilityIgnoresInvertColors
+      >
+        <INatIcon name="location" size={40} color={colors.white} />
+        <Subheading1 className="mt-3 text-white px-28 text-center">
+          {t( "Add-location-for-better-identifications" )}
+        </Subheading1>
+      </ImageBackground>
+    </Pressable>
   );
 };
 

--- a/src/components/Match/Match.js
+++ b/src/components/Match/Match.js
@@ -25,7 +25,8 @@ type Props = {
   handleSaveOrDiscardPress: ( ) => void,
   navToTaxonDetails: ( ) => void,
   taxon: Object,
-  confidence: number
+  confidence: number,
+  handleLocationPickerPressed: ( ) => void
 }
 
 const Match = ( {
@@ -33,7 +34,8 @@ const Match = ( {
   handleSaveOrDiscardPress,
   navToTaxonDetails,
   taxon,
-  confidence
+  confidence,
+  handleLocationPickerPressed
 }: Props ) => {
   const { t } = useTranslation( );
 
@@ -57,13 +59,14 @@ const Match = ( {
           navToTaxonDetails={navToTaxonDetails}
         />
         {!latitude
-          ? <EmptyMapSection />
+          ? <EmptyMapSection handleLocationPickerPressed={handleLocationPickerPressed} />
           : (
             <MapSection observation={observation} />
           )}
         <LocationSection
           belongsToCurrentUser
           observation={observation}
+          handleLocationPickerPressed={handleLocationPickerPressed}
         />
         <View className="px-5 pt-2">
           <Button
@@ -88,7 +91,8 @@ const Match = ( {
             className="mb-7"
             level="neutral"
             text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
-            onPress={navToTaxonDetails}
+            onPress={handleLocationPickerPressed}
+            accessibilityLabel={t( "Edit-location" )}
             accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
           />
         </View>

--- a/src/components/Match/Match.js
+++ b/src/components/Match/Match.js
@@ -66,7 +66,9 @@ const Match = ( {
         <LocationSection
           belongsToCurrentUser
           observation={observation}
-          handleLocationPickerPressed={handleLocationPickerPressed}
+          handleLocationPickerPressed={!latitude
+            ? handleLocationPickerPressed
+            : null}
         />
         <View className="px-5 pt-2">
           <Button
@@ -87,14 +89,16 @@ const Match = ( {
               taxon: secondTaxon
             }]}
           />
-          <Button
-            className="mb-7"
-            level="neutral"
-            text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
-            onPress={handleLocationPickerPressed}
-            accessibilityLabel={t( "Edit-location" )}
-            accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
-          />
+          {!latitude && (
+            <Button
+              className="mb-7"
+              level="neutral"
+              text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
+              onPress={handleLocationPickerPressed}
+              accessibilityLabel={t( "Edit-location" )}
+              accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
+            />
+          )}
         </View>
       </ScrollViewWrapper>
       <SaveDiscardButtons

--- a/src/components/Match/MatchContainer.js
+++ b/src/components/Match/MatchContainer.js
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import React from "react";
-import { useTaxon } from "sharedHooks";
+import { useLocationPermission, useTaxon } from "sharedHooks";
 import useStore from "stores/useStore";
 
 import Match from "./Match";
@@ -9,6 +9,7 @@ const MatchContainer = ( ) => {
   const currentObservation = useStore( state => state.currentObservation );
   const matchScreenSuggestion = useStore( state => state.matchScreenSuggestion );
   const navigation = useNavigation( );
+  const { hasPermissions, renderPermissionsGate, requestPermissions } = useLocationPermission( );
 
   const { taxon } = useTaxon( matchScreenSuggestion?.taxon );
 
@@ -21,18 +22,34 @@ const MatchContainer = ( ) => {
 
   const handleSaveOrDiscardPress = action => console.log( action, "action" );
 
+  const openLocationPicker = ( ) => {
+    navigation.navigate( "LocationPicker" );
+  };
+
+  const handleLocationPickerPressed = ( ) => {
+    if ( hasPermissions ) {
+      openLocationPicker( );
+    } else {
+      requestPermissions( );
+    }
+  };
+
   const confidence = matchScreenSuggestion
     ? Math.round( matchScreenSuggestion.score * 100 )
     : null;
 
   return (
-    <Match
-      observation={currentObservation}
-      handleSaveOrDiscardPress={handleSaveOrDiscardPress}
-      navToTaxonDetails={navToTaxonDetails}
-      taxon={taxon}
-      confidence={confidence}
-    />
+    <>
+      <Match
+        observation={currentObservation}
+        handleSaveOrDiscardPress={handleSaveOrDiscardPress}
+        navToTaxonDetails={navToTaxonDetails}
+        taxon={taxon}
+        confidence={confidence}
+        handleLocationPickerPressed={handleLocationPickerPressed}
+      />
+      {renderPermissionsGate( { onPermissionGranted: openLocationPicker } )}
+    </>
   );
 };
 

--- a/src/components/ObsDetailsDefaultMode/LocationSection/LocationSection.tsx
+++ b/src/components/ObsDetailsDefaultMode/LocationSection/LocationSection.tsx
@@ -15,10 +15,15 @@ import ObscurationExplanation from "./ObscurationExplanation";
 
 interface Props {
   belongsToCurrentUser: boolean,
-  observation: Observation
+  observation: Observation,
+  handleLocationPickerPressed?: ( ) => void
 }
 
-const LocationSection = ( { belongsToCurrentUser, observation }: Props ) => {
+const LocationSection = ( {
+  belongsToCurrentUser,
+  observation,
+  handleLocationPickerPressed
+}: Props ) => {
   const currentUser = useCurrentUser( );
   const geoprivacy = observation?.geoprivacy;
   const taxonGeoprivacy = observation?.taxon_geoprivacy;
@@ -31,7 +36,10 @@ const LocationSection = ( { belongsToCurrentUser, observation }: Props ) => {
         <Heading5 className="mb-2">
           {t( "OBSERVED-IN--label" )}
         </Heading5>
-        <SimpleObservationLocation observation={observation} />
+        <SimpleObservationLocation
+          observation={observation}
+          handleLocationPickerPressed={handleLocationPickerPressed}
+        />
         {observation.obscured && (
           <ObscurationExplanation
             textClassName="ml-[20px] mt-[10px]"

--- a/src/components/SharedComponents/SimpleObservationLocation.js
+++ b/src/components/SharedComponents/SimpleObservationLocation.js
@@ -45,8 +45,9 @@ const SimpleObservationLocation = ( {
       accessibilityValue={{
         text: displayLocation
       }}
+      disabled={displayLocation !== null}
       onPress={( ) => {
-        if ( handleLocationPickerPressed ) {
+        if ( handleLocationPickerPressed !== undefined ) {
           handleLocationPickerPressed( );
         }
       }}

--- a/src/components/SharedComponents/SimpleObservationLocation.js
+++ b/src/components/SharedComponents/SimpleObservationLocation.js
@@ -6,11 +6,13 @@ import React, { useMemo } from "react";
 import { useTranslation } from "sharedHooks";
 
 type Props = {
-  observation: Object
+  observation: Object,
+  handleLocationPickerPressed?: ( ) => void
 };
 
 const SimpleObservationLocation = ( {
-  observation
+  observation,
+  handleLocationPickerPressed
 }: Props ): Node => {
   const { t } = useTranslation( );
 
@@ -37,9 +39,16 @@ const SimpleObservationLocation = ( {
       className="text-darkGray"
       ellipsizeMode="tail"
       accessible
-      accessibilityLabel={t( "Location" )}
+      accessibilityLabel={handleLocationPickerPressed
+        ? t( "Edit-location" )
+        : t( "Location" )}
       accessibilityValue={{
         text: displayLocation
+      }}
+      onPress={( ) => {
+        if ( handleLocationPickerPressed ) {
+          handleLocationPickerPressed( );
+        }
       }}
     >
       {displayLocation}


### PR DESCRIPTION
Closes MOB-354

- When a user taps the empty map, the empty location text, or the add location button, they will see the location permission gate. If they have already given permissions, they will see the location picker.