### PR TITLE
Fix: Show observation date in ObsEdit date picker

### DIFF
--- a/src/components/ObsEdit/DatePicker.tsx
+++ b/src/components/ObsEdit/DatePicker.tsx
@@ -22,6 +22,9 @@ const DatePicker = ( { currentObservation, updateObservationKeys }: Props ) => {
   const openModal = () => setShowModal( true );
   const closeModal = () => setShowModal( false );
 
+  const observationDate = currentObservation?.observed_on_string
+    || currentObservation?.time_observed_at;
+
   const handlePicked = ( value: Date ) => {
     const dateString = formatISONoSeconds( value );
     updateObservationKeys( {
@@ -31,14 +34,17 @@ const DatePicker = ( { currentObservation, updateObservationKeys }: Props ) => {
   };
 
   const displayDate = ( ) => formatLongDatetime(
-    currentObservation?.observed_on_string || currentObservation?.time_observed_at,
+    observationDate,
     i18n,
     { missing: null }
   );
 
+  const observationDateForPicker = new Date( observationDate );
+
   return (
     <>
       <DateTimePicker
+        date={observationDateForPicker}
         datetime
         isDateTimePickerVisible={showModal}
         onDatePicked={handlePicked}

--- a/src/components/SharedComponents/DateTimePicker.js
+++ b/src/components/SharedComponents/DateTimePicker.js
@@ -5,6 +5,7 @@ import { Appearance } from "react-native";
 import DateTimePicker from "react-native-modal-datetime-picker";
 
 type Props = {
+  date: Date,
   toggleDateTimePicker: Function,
   onDatePicked: Function,
   isDateTimePickerVisible: boolean,
@@ -16,6 +17,7 @@ type Props = {
 const EmptyHeader = ( ) => null;
 
 const DatePicker = ( {
+  date,
   datetime,
   isDateTimePickerVisible,
   onDatePicked,
@@ -34,10 +36,11 @@ const DatePicker = ( {
         ? "datetime"
         : "date"}
       onCancel={toggleDateTimePicker}
-      onConfirm={date => {
-        onDatePicked( date );
+      onConfirm={selectedDate => {
+        onDatePicked( selectedDate );
         toggleDateTimePicker( );
       }}
+      date={date || new Date( )}
     />
   );
 };


### PR DESCRIPTION
Closes MOB-347

If observation has a date, show that instead of the current date in the date picker on ObsEdit.