### PR TITLE
Fix: Keep list items within screen width on ObsDetails

### DIFF
--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -133,7 +133,8 @@ const UserText = ( {
     fontSize: 16,
     lineHeight: 22,
     color: colors.darkGray,
-    ...htmlStyle
+    ...htmlStyle,
+    width: "100%"
   };
   const fonts = [fontRegular, ...defaultSystemFonts];
 


### PR DESCRIPTION
Closes MOB-348