### PR TITLE
Prevent cell recycling in FlashList

### DIFF
--- a/src/components/Explore/SpeciesView.js
+++ b/src/components/Explore/SpeciesView.js
@@ -122,15 +122,25 @@ const SpeciesView = ( {
     }
   }, [pageObservedTaxonIds, observedTaxonIds] );
 
-  const renderItem = ( { item } ) => (
-    <ExploreTaxonGridItem
-      setCurrentExploreView={setCurrentExploreView}
-      count={item?.count}
-      style={gridItemStyle}
-      taxon={item?.taxon}
-      showSpeciesSeenCheckmark={observedTaxonIds.has( item?.taxon.id )}
-    />
-  );
+  const renderItem = ( { item } ) => {
+    const taxon = item?.taxon;
+    const taxonId = taxon.id;
+    // Add a unique key to ensure component recreation
+    // so images don't get recycled and show on the wrong taxon
+    const itemKey = `taxon-${taxonId}-${taxon?.default_photo?.url}`;
+
+    return (
+      <ExploreTaxonGridItem
+        setCurrentExploreView={setCurrentExploreView}
+        key={itemKey}
+        count={item?.count}
+        style={gridItemStyle}
+        taxon={taxon}
+        showSpeciesSeenCheckmark={observedTaxonIds.has( taxonId )}
+      />
+    );
+  };
+
   useEffect( ( ) => {
     handleUpdateCount( "species", totalResults );
   }, [handleUpdateCount, totalResults] );
@@ -150,7 +160,7 @@ const SpeciesView = ( {
       hideLoadingWheel={!isFetchingNextPage}
       isFetchingNextPage={isFetchingNextPage}
       isConnected={isConnected}
-      keyExtractor={item => item?.taxon?.id || item}
+      keyExtractor={item => `${item.taxon.id}-${item?.taxon?.default_photo?.url || "no-photo"}`}
       layout="grid"
       numColumns={numColumns}
       renderItem={renderItem}

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -162,6 +162,7 @@ const MyObservationsSimple = ( {
     };
 
     // Add a unique key to ensure component recreation
+    // so images don't get recycled and show on the wrong taxon
     const itemKey = `taxon-${taxonId}-${source.uri}`;
 
     return (
@@ -348,14 +349,6 @@ const MyObservationsSimple = ( {
             }
             refreshing={isFetchingTaxa}
             ListFooterComponent={renderTaxaFooter}
-            disableScrollViewPanResponder
-            overrideItemLayout={( ) => {
-              layout.size = estimatedGridItemSize;
-              layout.span = 1;
-            }}
-            maintainVisibleContentPosition={{
-              minIndexForVisible: 0
-            }}
           />
         ) }
       </ViewWrapper>

--- a/src/components/MyObservations/SimpleTaxonGridItem.tsx
+++ b/src/components/MyObservations/SimpleTaxonGridItem.tsx
@@ -1,0 +1,66 @@
+import type { ApiTaxon } from "api/types";
+import classNames from "classnames";
+import { DisplayTaxonName } from "components/SharedComponents";
+import SpeciesSeenCheckmark from "components/SharedComponents/SpeciesSeenCheckmark";
+import { Image, Pressable, View } from "components/styledComponents";
+import React, { memo } from "react";
+
+const imageClassNames = [
+  "max-h-[210px]",
+  "overflow-hidden",
+  "relative",
+  "w-[62px]",
+  "h-[62px]",
+  "rounded-2xl"
+];
+
+export interface Props {
+  accessibleName: string;
+  navToTaxonDetails: ( ) => void;
+  source: {
+    uri: string
+  };
+  style?: Object;
+  taxon: ApiTaxon;
+}
+
+const SimpleTaxonGridItem = memo( ( {
+  accessibleName,
+  navToTaxonDetails,
+  source,
+  style,
+  taxon
+}: Props ) => (
+  <Pressable
+    accessibilityRole="button"
+    onPress={navToTaxonDetails}
+    accessibilityLabel={accessibleName}
+    testID="SimpleTaxonGridItem"
+    className={classNames( imageClassNames )}
+    style={style}
+  >
+    <Image
+      source={source}
+      className="grow aspect-square"
+      testID="ObsList.photo"
+      accessibilityIgnoresInvertColors
+      loading="eager"
+      fadeDuration={0}
+    />
+    <View className="absolute top-3 left-3">
+      <SpeciesSeenCheckmark />
+    </View>
+    <View className="absolute bottom-0 flex p-2 w-full">
+      <DisplayTaxonName
+        keyBase={`TaxonGridItem-DisplayTaxonName-${taxon?.id}`}
+        taxon={taxon}
+        layout="vertical"
+        color="text-white"
+        showOneNameOnly={false}
+      />
+    </View>
+  </Pressable>
+), ( prevProps, nextProps ) => prevProps.taxon.id === nextProps.taxon.id
+  && prevProps.source.uri === nextProps.source.uri );
+
+export default SimpleTaxonGridItem;

--- a/src/components/MyObservations/SimpleTaxonGridItem.tsx
+++ b/src/components/MyObservations/SimpleTaxonGridItem.tsx
@@ -1,9 +1,8 @@
 import type { ApiTaxon } from "api/types";
 import classNames from "classnames";
 import { DisplayTaxonName } from "components/SharedComponents";
-import SpeciesSeenCheckmark from "components/SharedComponents/SpeciesSeenCheckmark";
 import { Image, Pressable, View } from "components/styledComponents";
-import React, { memo } from "react";
+import React from "react";
 
 const imageClassNames = [
   "max-h-[210px]",
@@ -24,7 +23,7 @@ export interface Props {
   taxon: ApiTaxon;
 }
 
-const SimpleTaxonGridItem = memo( ( {
+const SimpleTaxonGridItem = ( {
   accessibleName,
   navToTaxonDetails,
   source,
@@ -44,23 +43,18 @@ const SimpleTaxonGridItem = memo( ( {
       className="grow aspect-square"
       testID="ObsList.photo"
       accessibilityIgnoresInvertColors
-      loading="eager"
       fadeDuration={0}
     />
-    <View className="absolute top-3 left-3">
-      <SpeciesSeenCheckmark />
-    </View>
     <View className="absolute bottom-0 flex p-2 w-full">
       <DisplayTaxonName
         keyBase={`TaxonGridItem-DisplayTaxonName-${taxon?.id}`}
         taxon={taxon}
         layout="vertical"
         color="text-white"
-        showOneNameOnly={false}
+        showOneNameOnly
       />
     </View>
   </Pressable>
-), ( prevProps, nextProps ) => prevProps.taxon.id === nextProps.taxon.id
-  && prevProps.source.uri === nextProps.source.uri );
+);
 
 export default SimpleTaxonGridItem;

--- a/src/components/ObservationsFlashList/ObsImage.js
+++ b/src/components/ObservationsFlashList/ObsImage.js
@@ -57,6 +57,7 @@ const ObsImage = ( {
         className={classNames( CLASS_NAMES )}
         testID="ObsList.photo"
         accessibilityIgnoresInvertColors
+        fadeDuration={0}
       />
     ) }
     { opaque && (

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -231,7 +231,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
 
   // only used id as a fallback key because after upload
   // react thinks we've rendered a second item w/ a duplicate key
-  const keyExtractor = item => `${item.id}-${item?.default_photo?.url || "no-photo"}`;
+  const keyExtractor = item => item.uuid || item.id;
 
   const onMomentumScrollEnd = ( ) => {
     if ( dataCanBeFetched ) {

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -127,6 +127,10 @@ const ObservationsFlashList: Function = forwardRef( ( {
       }
     };
 
+    // Add a unique key to ensure component recreation
+    // so images don't get recycled and show on the wrong taxon
+    const itemKey = `uuid-${uuid}`;
+
     return (
       <ObsPressable
         currentUser={currentUser}
@@ -135,6 +139,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
         hideMetadata={hideMetadata}
         isLargeFontScale={isLargeFontScale}
         layout={layout}
+        key={itemKey}
         observation={observation}
         onItemPress={onItemPress}
         onUploadButtonPress={onUploadButtonPress}
@@ -226,7 +231,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
 
   // only used id as a fallback key because after upload
   // react thinks we've rendered a second item w/ a duplicate key
-  const keyExtractor = item => item.uuid || item.id;
+  const keyExtractor = item => `${item.id}-${item?.default_photo?.url || "no-photo"}`;
 
   const onMomentumScrollEnd = ( ) => {
     if ( dataCanBeFetched ) {

--- a/tests/unit/components/SharedComponents/ObservationsFlashList/__snapshots__/ObsGridItem.test.js.snap
+++ b/tests/unit/components/SharedComponents/ObservationsFlashList/__snapshots__/ObsGridItem.test.js.snap
@@ -123,6 +123,7 @@ exports[`ObsGridItem for an observation with a photo should render 1`] = `
     </View>
     <Image
       accessibilityIgnoresInvertColors={true}
+      fadeDuration={0}
       source={
         {
           "uri": "https://inaturalist-open-data.s3.amazonaws.com/photos/1/large.jpeg",


### PR DESCRIPTION
Closes MOB-116

Anywhere we're using a grid view image (species view, observations grid view on Explore and MyObservations), the images were being recycled and displayed alongside the wrong observation/species.

For future reference, I believe we need three things in place to prevent recycling behavior:

1. An `Image` nested anywhere within the `renderItem` function should have `fadeDuration=0`
2. Items in the `renderItem` function should be given a unique `key` prop
3. The key extractor on the FlashList also needs to have a unique key

This PR also creates a `SimpleTaxonGridItem` for the `ObservationsSimple` species view. I started there because it was a lot easier than trying to figure out what was happening to cause recycling in our very, very nested `ObsImage` component, and because we don't need most of the props or UI options from the more complex component.