### PR TITLE
fix: confidence off by factor 100 for offline results

### DIFF
--- a/src/components/Match/calculateConfidence.js
+++ b/src/components/Match/calculateConfidence.js
@@ -1,7 +1,11 @@
 const calculateConfidence = suggestion => {
-  if ( !suggestion ) { return null; }
+  if ( !suggestion ) {
+    return null;
+  }
+  // Note: combined_score have values between 0 and 100,
+  // compared with vision-plugin v4.2.2 model results that have scores between 0 and 1
   const score = suggestion?.score
-    ? suggestion.score
+    ? ( suggestion.score * 100 )
     : suggestion.combined_score;
   const confidence = parseFloat( score.toFixed( 1 ) );
   return confidence;


### PR DESCRIPTION
Fixes an undiscovered bug that the confidence values shown are off by 100 for offline results.
Offline meaning results coming from the vision-plugin, i.e. prediction from file and frame processor.