### PR TITLE
Include taxon photo similarity parameter when making online vision api requests for the match screen

### DIFF
--- a/src/api/computerVision.ts
+++ b/src/api/computerVision.ts
@@ -4,6 +4,7 @@ import Taxon from "realmModels/Taxon";
 import handleError from "./error";
 
 const PARAMS = {
+  include_representative_photos: true,
   fields: {
     combined_score: true,
     vision_score: true,

--- a/src/components/Match/AdditionalSuggestions/SuggestionsResult.js
+++ b/src/components/Match/AdditionalSuggestions/SuggestionsResult.js
@@ -49,7 +49,9 @@ const SuggestionsResult = ( {
   if ( !usableTaxon ) return null;
 
   const taxonImage = {
-    uri: usableTaxon?.default_photo?.url
+    uri: taxonProp?.representativePhoto?.url
+      || taxonProp?.representative_photo?.url
+      || usableTaxon?.default_photo?.url
       || usableTaxon?.defaultPhoto?.url
   };
 

--- a/src/components/Match/AdditionalSuggestions/SuggestionsResult.js
+++ b/src/components/Match/AdditionalSuggestions/SuggestionsResult.js
@@ -48,6 +48,9 @@ const SuggestionsResult = ( {
   // useTaxon could return null, and it's at least remotely possible taxonProp is null
   if ( !usableTaxon ) return null;
 
+  // A representative photo is dependant on the actual image that was scored by computer vision
+  // and is currently not added to the taxon realm. So, if it is available directly from the
+  // suggestion, i.e. taxonProp, use it. Otherwise, use the default photo from the taxon.
   const taxonImage = {
     uri: taxonProp?.representativePhoto?.url
       || taxonProp?.representative_photo?.url

--- a/src/components/Match/Match.js
+++ b/src/components/Match/Match.js
@@ -65,6 +65,7 @@ const Match = ( {
           }
         </View>
         <PhotosSection
+          representativePhoto={topSuggestion?.taxon?.representative_photo}
           taxon={taxon}
           obsPhotos={obsPhotos}
           navToTaxonDetails={navToTaxonDetails}

--- a/src/components/Match/PhotosSection.js
+++ b/src/components/Match/PhotosSection.js
@@ -6,20 +6,24 @@ import {
 import {
   Image, Pressable, View
 } from "components/styledComponents";
-import _, { compact } from "lodash";
+import _, { compact, uniqBy } from "lodash";
 import React, { useEffect, useState } from "react";
 import Photo from "realmModels/Photo";
 import getImageDimensions from "sharedHelpers/getImageDimensions";
 import { useTaxon } from "sharedHooks";
 
 type Props = {
+  representativePhoto: Object,
   taxon: Object,
   obsPhotos: Array<Object>,
   navToTaxonDetails: ( ) => void
 }
 
 const PhotosSection = ( {
-  taxon, obsPhotos, navToTaxonDetails
+  representativePhoto,
+  taxon,
+  obsPhotos,
+  navToTaxonDetails
 }: Props ) => {
   const [displayPortraitLayout, setDisplayPortraitLayout] = useState( null );
   const [mediaViewerVisible, setMediaViewerVisible] = useState( false );
@@ -34,17 +38,21 @@ const PhotosSection = ( {
       ? localTaxonPhotos.map( taxonPhoto => taxonPhoto.photo )
       : [taxon?.defaultPhoto]
   );
+  // don't show the iconic taxon photo which is a mashup of 9 photos
+  const taxonPhotosNoIconic = localTaxon?.isIconic
+    ? taxonPhotos.slice( 1, 4 )
+    : taxonPhotos.slice( 0, 3 );
+
+  // Add the representative photo at the start of the list of taxon photos.
+  const taxonPhotosWithRepPhoto = compact( [representativePhoto, ...taxonPhotosNoIconic] );
+  // The representative photo might be already included in taxonPhotosNoIconic
+  const uniqueTaxonPhotos = uniqBy( taxonPhotosWithRepPhoto, "id" );
 
   const observationPhotos = compact(
     obsPhotos
       ? obsPhotos.map( obsPhoto => obsPhoto.photo )
       : []
   );
-
-  // don't show the iconic taxon photo which is a mashup of 9 photos
-  const taxonPhotosNoIconic = localTaxon?.isIconic
-    ? taxonPhotos.slice( 1, 4 )
-    : taxonPhotos.slice( 0, 3 );
 
   useEffect( ( ) => {
     const checkImageOrientation = async ( ) => {
@@ -99,7 +107,7 @@ const PhotosSection = ( {
       }
     )}
     >
-      {taxonPhotosNoIconic.map( photo => (
+      {uniqueTaxonPhotos.map( photo => (
         <Pressable
           accessibilityRole="button"
           onPress={navToTaxonDetails}

--- a/src/realmModels/Taxon.js
+++ b/src/realmModels/Taxon.js
@@ -25,6 +25,10 @@ class Taxon extends Realm.Object {
       id: true,
       url: true
     },
+    representative_photo: {
+      id: true,
+      url: true
+    },
     iconic_taxon_name: true,
     name: true,
     preferred_common_name: true,


### PR DESCRIPTION
Closes MOB-454

The representative photos are directly pulled from the online suggestions objects and not stored in realm as they only pertain to a certain image being scored.