### PR TITLE
Speed up precommits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ artifacts/
 
 # GitGuardian cache file
 .cache_ggshield
+
+# Eslint cache
+.eslintcache

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ artifacts/
 
 # Eslint cache
 .eslintcache
+
+# Rubocop cache
+**/tmp/rubocop_cache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,8 +13,8 @@ else
   echo
 fi
 
-# Run lint and flow
-npm run lint:fix
+# Run lint on staged files and run flow
+npm run lint:staged:fix
 
 # Generate translations from strings.ftl
 npm run translate

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 AllCops:
   NewCops: enable
+  UseCache: true
+  CacheRootDirectory: tmp/rubocop_cache
+  MaxFilesInCache: 5000
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "npm run lint:eslint && npm run lint:flow && npm run lint:rubocop",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:flow && npm run lint:rubocop:fix",
     "lint:eslint": "eslint .",
-    "lint:eslint:fix": "eslint . --fix",
+    "lint:eslint:fix": "npx lint-staged",
     "lint:flow": "flow check",
     "lint:rubocop": "bundle exec rubocop",
     "lint:rubocop:fix": "bundle exec rubocop -A",
@@ -203,5 +203,10 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "yarn@3.6.4"
+  "packageManager": "yarn@3.6.4",
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "test:memory": "jest --runInBand --logHeapUsage",
     "lint": "npm run lint:eslint && npm run lint:flow && npm run lint:rubocop",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:flow && npm run lint:rubocop:fix",
+    "lint:staged:fix": "npx lint-staged && npm run lint:flow",
     "lint:eslint": "eslint .",
-    "lint:eslint:fix": "npx lint-staged",
+    "lint:eslint:fix": "eslint . --fix",
     "lint:flow": "flow check",
     "lint:rubocop": "bundle exec rubocop",
     "lint:rubocop:fix": "bundle exec rubocop -A",
@@ -207,6 +208,9 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache"
+    ],
+    "*.rb": [
+      "bundle exec rubocop --force-exclusion --parallel"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:memory": "jest --runInBand --logHeapUsage",
     "lint": "npm run lint:eslint && npm run lint:flow && npm run lint:rubocop",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:flow && npm run lint:rubocop:fix",
-    "lint:staged:fix": "npx lint-staged && npm run lint:flow",
+    "lint:staged:fix": "npx lint-staged",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
     "lint:flow": "flow check",
@@ -207,7 +207,8 @@
   "packageManager": "yarn@3.6.4",
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache"
+      "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache",
+      "flow check --temp-dir=/tmp/flow --max-workers 4"
     ],
     "*.rb": [
       "bundle exec rubocop --force-exclusion --parallel"


### PR DESCRIPTION
We're running a lot of checks on each commit and each commit was starting to feel pretty slow. Trying to make it feel snappier by only linting JavaScript, TypeScript, and Ruby files we actually staged in the latest commit, instead of linting everything. 

Also added caches for eslint and rubocop.

Our Flow check is theoretically also only running on staged files, but it's still slow and apparently why the industry is slowly moving towards TypeScript. If nothing else, this makes it a little easier to visually see that Flow is the slowest part of our precommit.