### PR TITLE
Fix precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:memory": "jest --runInBand --logHeapUsage",
     "lint": "npm run lint:eslint && npm run lint:flow && npm run lint:rubocop",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:flow && npm run lint:rubocop:fix",
-    "lint:staged:fix": "npx lint-staged lint:flow",
+    "lint:staged:fix": "npx lint-staged npm run lint:flow",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
     "lint:flow": "flow check",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:memory": "jest --runInBand --logHeapUsage",
     "lint": "npm run lint:eslint && npm run lint:flow && npm run lint:rubocop",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:flow && npm run lint:rubocop:fix",
-    "lint:staged:fix": "npx lint-staged npm run lint:flow",
+    "lint:staged:fix": "npx lint-staged && npm run lint:flow",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
     "lint:flow": "flow check",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:memory": "jest --runInBand --logHeapUsage",
     "lint": "npm run lint:eslint && npm run lint:flow && npm run lint:rubocop",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:flow && npm run lint:rubocop:fix",
-    "lint:staged:fix": "npx lint-staged",
+    "lint:staged:fix": "npx lint-staged lint:flow",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
     "lint:flow": "flow check",
@@ -207,8 +207,7 @@
   "packageManager": "yarn@3.6.4",
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache",
-      "flow check --temp-dir=/tmp/flow --max-workers 4"
+      "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache"
     ],
     "*.rb": [
       "bundle exec rubocop --force-exclusion --parallel"


### PR DESCRIPTION
Flow bumps into errors in lint-staging because it's expecting to run on the whole project directory, turns out.