### PR TITLE
Fix confidence calculation crash when accessing match screen online

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1516,9 +1516,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
+  BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FasterImage: 5215480384883bb4a4a7f5655d4d1f8354e96987
+  FasterImage: 60d0750ddbcefff0070c4c17309c2d1d6cc650f0
   FBLazyVector: b46891061bfe0a9b07f601813114c8653a72a45c
   FBReactNativeSpec: 9a01850c21d81027fa7b20b9dcc25d9bfae083da
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
@@ -1531,94 +1531,94 @@ SPEC CHECKSUMS:
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
   Mute: 20135a96076f140cc82bfc8b810e2d6150d8ec7e
-  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
+  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 415e56f7c33799a6483e41e4dce607f3daf1e69b
   RCTTypeSafety: e984a88e713281c2d8c2309a1a6d2775af0107ae
   React: ab885684e73c5f659bad63446a977312fd3d1ecb
   React-callinvoker: 50a2d1ce3594637c700401ba306373321231eb71
-  React-Codegen: 0ca856c100b98ab436c73601f9b1296a58d26b92
-  React-Core: d5166294382484f57e25dfde05ba00596703d51c
-  React-CoreModules: 459534f8112ee73e94f04f5e58276b3d236efd16
-  React-cxxreact: d5716540fd97df323792ef1d227f50515fb3e1a8
+  React-Codegen: 0b62f5a15aac03c4e04e7d62ebee702071d93660
+  React-Core: 9d66a8a953d975aee4989abccf4602e7ba7c65fa
+  React-CoreModules: e93a24aaae933d496329112cec78b681c76cdc53
+  React-cxxreact: 8f6abe06e11f79f2292c7939dc6390027e53e5ba
   React-debug: cbc88cbcffdca42184a32d073ceb7d9b11122b8d
-  React-Fabric: 0008b953afdacf3dd5ac38947a36d9c280e3a0a1
-  React-FabricImage: 51198a14587c3269e12cf823e81a6f3b642dd136
-  React-graphics: 977137c75673c2f31a1515ce48db31a076771112
-  React-hermes: 59ff965e45955d66977a23d51fe9235b44a09bd4
-  React-ImageManager: 5c8d5e6246c22613a0cb198c51044f4794e8c518
-  React-jserrorhandler: 90c29c95fb32abfdb61ab9c8eb425e6af097a0b9
-  React-jsi: 36f85df7d83197707e9fd9320d857eac616e6df3
-  React-jsiexecutor: a68ea442fd94c7ecf5d9355bde2443f0241531d9
+  React-Fabric: f22d9c367ae9536650d06d7c338383abf41daa73
+  React-FabricImage: d5b397555e58147bfbcd24c9d2cd10e566ea29ee
+  React-graphics: eb385065f994ca67550ae69df58dcbc27fdf1b07
+  React-hermes: c2877efac91c02266c66cd62ccef3fa7c36d8604
+  React-ImageManager: 99ffa733ce3406463da89bf74fd55a12c5aeb053
+  React-jserrorhandler: 5a90e88499755b6cfe263c01c208ac3782f535ad
+  React-jsi: 5da729c3787b5d58b8612fcd4308290e88af9dde
+  React-jsiexecutor: 911f565c4dcb2faf750e274a18012c88355fc33c
   React-jsinspector: a98428936fb888cc15d857226a26d9ac0a668a0e
-  React-logger: 6e4873d1f9c54cca30f6c91a6617f8c91b75ba4c
-  React-Mapbuffer: 57bf49a458398d329dad2bf8bc660e3e35b96989
-  react-native-cameraroll: 71a0dc2273bbb802bd5d4caffed9eff21fefa0d3
-  react-native-config: ea75335a7cca1d3326de1da384227e580a7c082e
-  react-native-exif-reader: d871d62023d532e33cc230ede6e2ba9cbfe220e2
-  react-native-geocoder-reborn: a3c3d8460910309e750609c373b6887ec6f67a8f
-  react-native-geolocation: 52795f4d0d1e40a42b020e6063bfaa0c33c8ed6d
-  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
-  react-native-image-picker: b64848e41db57068721d5db3cea54e32ecb92791
-  react-native-image-resizer: 24c5d06fae2176dc0caed4b6396e02befb44064a
-  react-native-keep-awake: 3c347cbcb834e5ce4b5717e9e2734b374f6fd70f
-  react-native-mail: 6e83813066984b26403d3fdfe79ac7bb31857e3c
-  react-native-maps: 85da55259d35bd50b5161d2ec0ee153d454158cc
-  react-native-mmkv: 5a8111cda779bc8789c4d09103f22e2d9cf46950
-  react-native-netinfo: 2e3c27627db7d49ba412bfab25834e679db41e21
-  react-native-orientation-locker: dbd3f6ddbe9e62389cb0807dc2af63f6c36dec36
-  react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
-  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
-  react-native-sensitive-info: ee358bf2b901ac3d04f63ff637b31daee44ea87f
-  react-native-slider: fbf693dba15ed9cf83c539f9ac6c9646bdf98752
-  react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988
-  react-native-webview: b3d56b5d601bf7f9715f41eb0914b761cc973302
-  react-native-worklets-core: f730c01db8ea3d580e322617f4a631206f1905fb
+  React-logger: 6c1170f7bc315878ef4bd3b918e09130cf632798
+  React-Mapbuffer: 41c166b84fc479afc78097cd51404109ec9edf68
+  react-native-cameraroll: 0fe31282894817a82b5991dd0d78dc04c5a6ed35
+  react-native-config: 8f7283449bbb048902f4e764affbbf24504454af
+  react-native-exif-reader: fe4678df00e36e1aba6ade9013fd1d35c78c8381
+  react-native-geocoder-reborn: c31cbc630d9307ebbceea1dea2746d0054be35c4
+  react-native-geolocation: ed9e1d132f576b9a4a503af46f9704413ea0dec1
+  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
+  react-native-image-picker: ddbbe4d226d9c82a82360f5de66bf71a657a42e6
+  react-native-image-resizer: 6260ba497fb8d1a593c1c92ccd593f570df6f5b7
+  react-native-keep-awake: 5cfb49d1b2ee4321b2ffbc651e2d6d64d6f66772
+  react-native-mail: 8fdcd3aef007c33a6877a18eb4cf7447a1d4ce4a
+  react-native-maps: fa054512735831f232e822ee6bdb0afcdd88de4a
+  react-native-mmkv: 1fdc81aa70c1aba09370718e6a63a09cbbbac8d2
+  react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
+  react-native-orientation-locker: 851f6510d8046ea2f14aa169b1e01fcd309a94ba
+  react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
+  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
+  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
+  react-native-sensitive-info: d44e909d065f9c0e15734245e5dd6a24b82e3dcd
+  react-native-slider: 09e5a8b7e766d3b5ae24ec15c5c4ec2679ca0f8c
+  react-native-volume-manager: 3c7d8047841b6831730dea7bf25250522388b4f4
+  react-native-webview: 9395e82c917d81407deb9b1fe53158dd6c8880ff
+  react-native-worklets-core: f51430dd07bf5343d4918d28a4bb00fe8f98b982
   React-nativeconfig: 8fd29a35a3e4e8c37682d976667663d834ba6165
-  React-NativeModulesApple: 83d7077877f8eda8e1b6055b3f8f16f7db8463b5
+  React-NativeModulesApple: 68eb729eaf628ba066bca5308dd4ccacaaacba97
   React-perflogger: 3887a05940ccd34a83457fd153fdeda509b31737
   React-RCTActionSheet: 2f42b4797374b53e93b65c79eaa8a0d292e255ac
-  React-RCTAnimation: 5639dcd418b798b28e9caacaed18ff5472454837
-  React-RCTAppDelegate: 37d3142bfa7cb9f2f8cd41feedc6b50c95986029
-  React-RCTBlob: e9f735bb085c6da208dd138bd4bfd294a52e3a86
-  React-RCTFabric: 8c1abd00ccb3aff18f67b39f0a37034a30f402f3
-  React-RCTImage: cc82df2b50bbdc1a0a0b19bf6fc16dd321eb8f0f
-  React-RCTLinking: 3d7900f52ecf03bb2522d7b94d8d16cce776294a
-  React-RCTNetwork: ac25c15ee52eb4aadb510afe68db0d1f949c45fa
-  React-RCTSettings: 013301fe7304ff06acca5287f6f754c9fa2b63b7
-  React-RCTText: ba6997c26241ea0b36ec8f98502a4ed45cab18e4
-  React-RCTVibration: b5ba13ed0909d2f2614ed99b067543e6ea0d7c37
-  React-rendererdebug: dda7606832e5907ecbdf2093950068a36fd5a267
+  React-RCTAnimation: 8d855a38975b065bab2528ccf158734044bcec59
+  React-RCTAppDelegate: bddf79fb86d03810269d1af5d6ad06a654479a16
+  React-RCTBlob: f4bad11cecd4ed488dcbbda1581ff8fe92746107
+  React-RCTFabric: 05fd71882ffd9733433ad4816d899f397ffd496c
+  React-RCTImage: 187d39d7f82dbddaee1c00fe5beb3fb4cd16eee2
+  React-RCTLinking: 22568a7c6d2ee51ef4d5c36e9e4d9720f74e9aed
+  React-RCTNetwork: 6453b643f665273e31fdfe21cfa5a32666d61685
+  React-RCTSettings: 237e7aa727543b5df2e0eecbfc49fc1bf21482b5
+  React-RCTText: 9a775859da5b6a1a2e4bebcd358909a77072f7c8
+  React-RCTVibration: 0167279571af233088b53ca3c67606b2a355a0f2
+  React-rendererdebug: 4023a996275f40116d7c88ae5be0b5882ca3eeb7
   React-rncore: 0dd62c0c8f8215747a9b49035410fde76a18876e
   React-runtimeexecutor: 2fd27b921f664e66d903ee274dcda55cc0b2cb2e
-  React-runtimescheduler: 398069b748d97567cc7585cc9a97284ad19d72fa
-  React-utils: e8549669b504c18929b2e9aa4d87657e530a91a4
-  ReactCommon: 9c38e8797dc2ac72edf63cd18cf450d918575666
-  ReactNativeExceptionHandler: a23922ca00122b050ae9412f960061791c232c47
-  RealmJS: d47a10c707662e9b8c2824a9f085bd0a4ada6e93
-  RNAppleAuthentication: 8d313d93fe2238d6b7ff0a39c67ebcf298d96653
-  RNAudioRecorderPlayer: fa079748b34d15cd3b7b6a5d47b286bae6d5d49b
-  RNCClipboard: 4abb037e8fe3b98a952564c9e0474f91c492df6d
-  RNCPicker: fb82ba6cfba077a80a32412bc7b5391130a4e25f
-  RNDateTimePicker: b43e41f10305dde521c0ab1370d7454979ec4287
-  RNDeviceInfo: 538b62f03991eb4a2a15cf6fec5fff6bb5edc34e
-  RNFlashList: acc8b5f413b16c09304d7bbd2fc9e51f6ee16f71
-  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNGestureHandler: e262eeb792addec0705a116456f210ee1be0dcd0
-  RNGoogleSignin: ba93c1137f8d5cebdd39b04f493fd212ddf5ecd6
-  RNLocalize: 080849cb8a824d9f759b8a5ae00c8321d46dbed0
-  RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f
-  RNReanimated: b158619f02f1384a5be9e1203b58e0e4a80407d7
-  RNScreens: cedc9bffb599d0bcd57903ef2ce0eef1df5d1065
-  RNShareMenu: e1cdfa3b9af89416afc75a80377cfd0de4f30ded
-  RNStoreReview: 613c43e9132998ed41a65946e20c223c91b36464
-  RNSVG: a31e321979e3001f56ba9331d10ac917f8ad1851
-  RNVectorIcons: 102cd20472bf0d7cd15443d43cd87f9c97228ac3
+  React-runtimescheduler: a36193fd33a0187852d54d402e170510f1300952
+  React-utils: eaaed6083fccd050a594baf1d72db5f949a3b9bb
+  ReactCommon: 1a93f1ef5c6e33bf14b9563cdb8e7621a893aa37
+  ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
+  RealmJS: bfe9a997a1f813c05c432c94405753879572a1a2
+  RNAppleAuthentication: e00c76acb03351f5544373c78fa7f359bef6d5d3
+  RNAudioRecorderPlayer: 9b34adc281800e5b19258f1b91d889b1ef3abdd6
+  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
+  RNCPicker: 82ccad5b08259dc09310082118cbb6c136d7da67
+  RNDateTimePicker: 7b38b71bcd7c4cfa1cb95f2dff9a4f1faed2dced
+  RNDeviceInfo: 4f9c7cfd6b9db1b05eb919620a001cf35b536423
+  RNFlashList: 556074dc4bc8b89e60635bd02447c3338bf88191
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
+  RNGestureHandler: bc2cdb2dc42facdf34992ae364b8a728e19a3686
+  RNGoogleSignin: 9e68b9bcc3888219357924e32ee563624745647d
+  RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
+  RNPermissions: b3d6efca086546e29a2920cd649a0ab04ca77794
+  RNReanimated: 6cfa556540186ce7ae7a0b048f369236b1d86ebb
+  RNScreens: b6b64d956af3715adbfe84808694ae82d3fec74f
+  RNShareMenu: cb9dac548c8bf147d06f0bf07296ad51ea9f5fc3
+  RNStoreReview: 31dbfd0dac2eea9675f0b84f1dd3261c2110c337
+  RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
+  RNVectorIcons: 73ab573085f65a572d3b6233e68996d4707fd505
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: f02de0b1b6b1516b327bd8215237a97e7386db8a
-  VisionCameraPluginInatVision: 54906a97413a22b55ca21ed674cb4b2b9af9ccc5
-  Yoga: 1f93d5925ea12fb0880b21efe3566677337cf2ed
+  VisionCamera: 4c1d19f1ac09f2f42f758e306fcf642536627357
+  VisionCameraPluginInatVision: 622b77af520d82f504e7611c05bc1bf723fa6859
+  Yoga: a813a6d82538ccba91c54406404e3ed80b48a692
 
 PODFILE CHECKSUM: eff4b75123af5d6680139a78c055b44ad37c269b
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1516,9 +1516,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
+  BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FasterImage: 60d0750ddbcefff0070c4c17309c2d1d6cc650f0
+  FasterImage: 5215480384883bb4a4a7f5655d4d1f8354e96987
   FBLazyVector: b46891061bfe0a9b07f601813114c8653a72a45c
   FBReactNativeSpec: 9a01850c21d81027fa7b20b9dcc25d9bfae083da
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
@@ -1531,94 +1531,94 @@ SPEC CHECKSUMS:
   MMKV: ce484c1ac40bf76d5f09a0195d2ec5b3d3840d55
   MMKVCore: 1eb661c6c498ab88e3df9ce5d8ff94d05fcc0567
   Mute: 20135a96076f140cc82bfc8b810e2d6150d8ec7e
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
   RCTRequired: 415e56f7c33799a6483e41e4dce607f3daf1e69b
   RCTTypeSafety: e984a88e713281c2d8c2309a1a6d2775af0107ae
   React: ab885684e73c5f659bad63446a977312fd3d1ecb
   React-callinvoker: 50a2d1ce3594637c700401ba306373321231eb71
-  React-Codegen: 0b62f5a15aac03c4e04e7d62ebee702071d93660
-  React-Core: 9d66a8a953d975aee4989abccf4602e7ba7c65fa
-  React-CoreModules: e93a24aaae933d496329112cec78b681c76cdc53
-  React-cxxreact: 8f6abe06e11f79f2292c7939dc6390027e53e5ba
+  React-Codegen: 0ca856c100b98ab436c73601f9b1296a58d26b92
+  React-Core: d5166294382484f57e25dfde05ba00596703d51c
+  React-CoreModules: 459534f8112ee73e94f04f5e58276b3d236efd16
+  React-cxxreact: d5716540fd97df323792ef1d227f50515fb3e1a8
   React-debug: cbc88cbcffdca42184a32d073ceb7d9b11122b8d
-  React-Fabric: f22d9c367ae9536650d06d7c338383abf41daa73
-  React-FabricImage: d5b397555e58147bfbcd24c9d2cd10e566ea29ee
-  React-graphics: eb385065f994ca67550ae69df58dcbc27fdf1b07
-  React-hermes: c2877efac91c02266c66cd62ccef3fa7c36d8604
-  React-ImageManager: 99ffa733ce3406463da89bf74fd55a12c5aeb053
-  React-jserrorhandler: 5a90e88499755b6cfe263c01c208ac3782f535ad
-  React-jsi: 5da729c3787b5d58b8612fcd4308290e88af9dde
-  React-jsiexecutor: 911f565c4dcb2faf750e274a18012c88355fc33c
+  React-Fabric: 0008b953afdacf3dd5ac38947a36d9c280e3a0a1
+  React-FabricImage: 51198a14587c3269e12cf823e81a6f3b642dd136
+  React-graphics: 977137c75673c2f31a1515ce48db31a076771112
+  React-hermes: 59ff965e45955d66977a23d51fe9235b44a09bd4
+  React-ImageManager: 5c8d5e6246c22613a0cb198c51044f4794e8c518
+  React-jserrorhandler: 90c29c95fb32abfdb61ab9c8eb425e6af097a0b9
+  React-jsi: 36f85df7d83197707e9fd9320d857eac616e6df3
+  React-jsiexecutor: a68ea442fd94c7ecf5d9355bde2443f0241531d9
   React-jsinspector: a98428936fb888cc15d857226a26d9ac0a668a0e
-  React-logger: 6c1170f7bc315878ef4bd3b918e09130cf632798
-  React-Mapbuffer: 41c166b84fc479afc78097cd51404109ec9edf68
-  react-native-cameraroll: 0fe31282894817a82b5991dd0d78dc04c5a6ed35
-  react-native-config: 8f7283449bbb048902f4e764affbbf24504454af
-  react-native-exif-reader: fe4678df00e36e1aba6ade9013fd1d35c78c8381
-  react-native-geocoder-reborn: c31cbc630d9307ebbceea1dea2746d0054be35c4
-  react-native-geolocation: ed9e1d132f576b9a4a503af46f9704413ea0dec1
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-image-picker: ddbbe4d226d9c82a82360f5de66bf71a657a42e6
-  react-native-image-resizer: 6260ba497fb8d1a593c1c92ccd593f570df6f5b7
-  react-native-keep-awake: 5cfb49d1b2ee4321b2ffbc651e2d6d64d6f66772
-  react-native-mail: 8fdcd3aef007c33a6877a18eb4cf7447a1d4ce4a
-  react-native-maps: fa054512735831f232e822ee6bdb0afcdd88de4a
-  react-native-mmkv: 1fdc81aa70c1aba09370718e6a63a09cbbbac8d2
-  react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
-  react-native-orientation-locker: 851f6510d8046ea2f14aa169b1e01fcd309a94ba
-  react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
-  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
-  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
-  react-native-sensitive-info: d44e909d065f9c0e15734245e5dd6a24b82e3dcd
-  react-native-slider: 09e5a8b7e766d3b5ae24ec15c5c4ec2679ca0f8c
-  react-native-volume-manager: 3c7d8047841b6831730dea7bf25250522388b4f4
-  react-native-webview: 9395e82c917d81407deb9b1fe53158dd6c8880ff
-  react-native-worklets-core: f51430dd07bf5343d4918d28a4bb00fe8f98b982
+  React-logger: 6e4873d1f9c54cca30f6c91a6617f8c91b75ba4c
+  React-Mapbuffer: 57bf49a458398d329dad2bf8bc660e3e35b96989
+  react-native-cameraroll: 71a0dc2273bbb802bd5d4caffed9eff21fefa0d3
+  react-native-config: ea75335a7cca1d3326de1da384227e580a7c082e
+  react-native-exif-reader: d871d62023d532e33cc230ede6e2ba9cbfe220e2
+  react-native-geocoder-reborn: a3c3d8460910309e750609c373b6887ec6f67a8f
+  react-native-geolocation: 52795f4d0d1e40a42b020e6063bfaa0c33c8ed6d
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-image-picker: b64848e41db57068721d5db3cea54e32ecb92791
+  react-native-image-resizer: 24c5d06fae2176dc0caed4b6396e02befb44064a
+  react-native-keep-awake: 3c347cbcb834e5ce4b5717e9e2734b374f6fd70f
+  react-native-mail: 6e83813066984b26403d3fdfe79ac7bb31857e3c
+  react-native-maps: 85da55259d35bd50b5161d2ec0ee153d454158cc
+  react-native-mmkv: 5a8111cda779bc8789c4d09103f22e2d9cf46950
+  react-native-netinfo: 2e3c27627db7d49ba412bfab25834e679db41e21
+  react-native-orientation-locker: dbd3f6ddbe9e62389cb0807dc2af63f6c36dec36
+  react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
+  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
+  react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
+  react-native-sensitive-info: ee358bf2b901ac3d04f63ff637b31daee44ea87f
+  react-native-slider: fbf693dba15ed9cf83c539f9ac6c9646bdf98752
+  react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988
+  react-native-webview: b3d56b5d601bf7f9715f41eb0914b761cc973302
+  react-native-worklets-core: f730c01db8ea3d580e322617f4a631206f1905fb
   React-nativeconfig: 8fd29a35a3e4e8c37682d976667663d834ba6165
-  React-NativeModulesApple: 68eb729eaf628ba066bca5308dd4ccacaaacba97
+  React-NativeModulesApple: 83d7077877f8eda8e1b6055b3f8f16f7db8463b5
   React-perflogger: 3887a05940ccd34a83457fd153fdeda509b31737
   React-RCTActionSheet: 2f42b4797374b53e93b65c79eaa8a0d292e255ac
-  React-RCTAnimation: 8d855a38975b065bab2528ccf158734044bcec59
-  React-RCTAppDelegate: bddf79fb86d03810269d1af5d6ad06a654479a16
-  React-RCTBlob: f4bad11cecd4ed488dcbbda1581ff8fe92746107
-  React-RCTFabric: 05fd71882ffd9733433ad4816d899f397ffd496c
-  React-RCTImage: 187d39d7f82dbddaee1c00fe5beb3fb4cd16eee2
-  React-RCTLinking: 22568a7c6d2ee51ef4d5c36e9e4d9720f74e9aed
-  React-RCTNetwork: 6453b643f665273e31fdfe21cfa5a32666d61685
-  React-RCTSettings: 237e7aa727543b5df2e0eecbfc49fc1bf21482b5
-  React-RCTText: 9a775859da5b6a1a2e4bebcd358909a77072f7c8
-  React-RCTVibration: 0167279571af233088b53ca3c67606b2a355a0f2
-  React-rendererdebug: 4023a996275f40116d7c88ae5be0b5882ca3eeb7
+  React-RCTAnimation: 5639dcd418b798b28e9caacaed18ff5472454837
+  React-RCTAppDelegate: 37d3142bfa7cb9f2f8cd41feedc6b50c95986029
+  React-RCTBlob: e9f735bb085c6da208dd138bd4bfd294a52e3a86
+  React-RCTFabric: 8c1abd00ccb3aff18f67b39f0a37034a30f402f3
+  React-RCTImage: cc82df2b50bbdc1a0a0b19bf6fc16dd321eb8f0f
+  React-RCTLinking: 3d7900f52ecf03bb2522d7b94d8d16cce776294a
+  React-RCTNetwork: ac25c15ee52eb4aadb510afe68db0d1f949c45fa
+  React-RCTSettings: 013301fe7304ff06acca5287f6f754c9fa2b63b7
+  React-RCTText: ba6997c26241ea0b36ec8f98502a4ed45cab18e4
+  React-RCTVibration: b5ba13ed0909d2f2614ed99b067543e6ea0d7c37
+  React-rendererdebug: dda7606832e5907ecbdf2093950068a36fd5a267
   React-rncore: 0dd62c0c8f8215747a9b49035410fde76a18876e
   React-runtimeexecutor: 2fd27b921f664e66d903ee274dcda55cc0b2cb2e
-  React-runtimescheduler: a36193fd33a0187852d54d402e170510f1300952
-  React-utils: eaaed6083fccd050a594baf1d72db5f949a3b9bb
-  ReactCommon: 1a93f1ef5c6e33bf14b9563cdb8e7621a893aa37
-  ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
-  RealmJS: bfe9a997a1f813c05c432c94405753879572a1a2
-  RNAppleAuthentication: e00c76acb03351f5544373c78fa7f359bef6d5d3
-  RNAudioRecorderPlayer: 9b34adc281800e5b19258f1b91d889b1ef3abdd6
-  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
-  RNCPicker: 82ccad5b08259dc09310082118cbb6c136d7da67
-  RNDateTimePicker: 7b38b71bcd7c4cfa1cb95f2dff9a4f1faed2dced
-  RNDeviceInfo: 4f9c7cfd6b9db1b05eb919620a001cf35b536423
-  RNFlashList: 556074dc4bc8b89e60635bd02447c3338bf88191
-  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNGestureHandler: bc2cdb2dc42facdf34992ae364b8a728e19a3686
-  RNGoogleSignin: 9e68b9bcc3888219357924e32ee563624745647d
-  RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
-  RNPermissions: b3d6efca086546e29a2920cd649a0ab04ca77794
-  RNReanimated: 6cfa556540186ce7ae7a0b048f369236b1d86ebb
-  RNScreens: b6b64d956af3715adbfe84808694ae82d3fec74f
-  RNShareMenu: cb9dac548c8bf147d06f0bf07296ad51ea9f5fc3
-  RNStoreReview: 31dbfd0dac2eea9675f0b84f1dd3261c2110c337
-  RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
-  RNVectorIcons: 73ab573085f65a572d3b6233e68996d4707fd505
+  React-runtimescheduler: 398069b748d97567cc7585cc9a97284ad19d72fa
+  React-utils: e8549669b504c18929b2e9aa4d87657e530a91a4
+  ReactCommon: 9c38e8797dc2ac72edf63cd18cf450d918575666
+  ReactNativeExceptionHandler: a23922ca00122b050ae9412f960061791c232c47
+  RealmJS: d47a10c707662e9b8c2824a9f085bd0a4ada6e93
+  RNAppleAuthentication: 8d313d93fe2238d6b7ff0a39c67ebcf298d96653
+  RNAudioRecorderPlayer: fa079748b34d15cd3b7b6a5d47b286bae6d5d49b
+  RNCClipboard: 4abb037e8fe3b98a952564c9e0474f91c492df6d
+  RNCPicker: fb82ba6cfba077a80a32412bc7b5391130a4e25f
+  RNDateTimePicker: b43e41f10305dde521c0ab1370d7454979ec4287
+  RNDeviceInfo: 538b62f03991eb4a2a15cf6fec5fff6bb5edc34e
+  RNFlashList: acc8b5f413b16c09304d7bbd2fc9e51f6ee16f71
+  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
+  RNGestureHandler: e262eeb792addec0705a116456f210ee1be0dcd0
+  RNGoogleSignin: ba93c1137f8d5cebdd39b04f493fd212ddf5ecd6
+  RNLocalize: 080849cb8a824d9f759b8a5ae00c8321d46dbed0
+  RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f
+  RNReanimated: b158619f02f1384a5be9e1203b58e0e4a80407d7
+  RNScreens: cedc9bffb599d0bcd57903ef2ce0eef1df5d1065
+  RNShareMenu: e1cdfa3b9af89416afc75a80377cfd0de4f30ded
+  RNStoreReview: 613c43e9132998ed41a65946e20c223c91b36464
+  RNSVG: a31e321979e3001f56ba9331d10ac917f8ad1851
+  RNVectorIcons: 102cd20472bf0d7cd15443d43cd87f9c97228ac3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: 4c1d19f1ac09f2f42f758e306fcf642536627357
-  VisionCameraPluginInatVision: 622b77af520d82f504e7611c05bc1bf723fa6859
-  Yoga: a813a6d82538ccba91c54406404e3ed80b48a692
+  VisionCamera: f02de0b1b6b1516b327bd8215237a97e7386db8a
+  VisionCameraPluginInatVision: 54906a97413a22b55ca21ed674cb4b2b9af9ccc5
+  Yoga: 1f93d5925ea12fb0880b21efe3566677337cf2ed
 
 PODFILE CHECKSUM: eff4b75123af5d6680139a78c055b44ad37c269b
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.14.3

--- a/src/components/Match/calculateConfidence.js
+++ b/src/components/Match/calculateConfidence.js
@@ -5,15 +5,16 @@ const calculateConfidence = suggestion => {
 
   // Note: combined_score as returned from vision-plugin >v5 as well as iNatVisionAPI
   // have values between 0 and 100.
-  // For common_ancestor from API, the score is in score field rather than combined_score
+  // For common_ancestor from API, the combined_core parameter is renamed to score by the node API
   if ( suggestion.combined_score === undefined && suggestion.score !== undefined ) {
     return parseFloat( suggestion.score.toFixed( 1 ) );
   } if ( suggestion.combined_score !== undefined ) {
     return parseFloat( suggestion.combined_score.toFixed( 1 ) );
   }
 
-  // Return default confidence if neither score exists
-  return 0;
+  // Return null confidence if neither score exists - I hope to see this as NaN and detect the
+  // problem rather than hiding it.
+  return null;
 };
 
 export default calculateConfidence;

--- a/src/components/Match/calculateConfidence.js
+++ b/src/components/Match/calculateConfidence.js
@@ -5,8 +5,15 @@ const calculateConfidence = suggestion => {
 
   // Note: combined_score as returned from vision-plugin >v5 as well as iNatVisionAPI
   // have values between 0 and 100.
-  const confidence = parseFloat( suggestion.combined_score.toFixed( 1 ) );
-  return confidence;
+  // For common_ancestor from API, the score is in score field rather than combined_score
+  if ( suggestion.combined_score === undefined && suggestion.score !== undefined ) {
+    return parseFloat( suggestion.score.toFixed( 1 ) );
+  } if ( suggestion.combined_score !== undefined ) {
+    return parseFloat( suggestion.combined_score.toFixed( 1 ) );
+  }
+
+  // Return default confidence if neither score exists
+  return 0;
 };
 
 export default calculateConfidence;


### PR DESCRIPTION
~~I'm not sure this is the right fix long term, but rather than tracing all the sources of suggestions this simple change handles current and former score properties.~~ In my testing, the old factor computation is no longer needed, as both score and combined_score are using the same 0-100 range.

Update after extensive debugging and testing: For the common ancestor property of iNatVisionAPI results, the node API layer is [renaming](https://github.com/inaturalist/iNaturalistAPI/blob/cf4503c5df13ef757e419dc5de9fcec0e029ad67/lib/controllers/v1/computervision_controller.js#L395) `combined_score` to `score`
They're scaled correctly by the vision api layer, and iNat Next doesn't need to scale anymore, as previously commented.

Fixes MOB-513