### PR TITLE
Remove initial block function from location permission gate

### DIFF
--- a/src/components/Match/MatchContainer.js
+++ b/src/components/Match/MatchContainer.js
@@ -326,14 +326,7 @@ const MatchContainer = ( ) => {
         suggestionsLoading={suggestionsLoading}
         scrollRef={scrollRef}
       />
-      {renderPermissionsGate(
-        {
-          onPermissionGranted: getCurrentUserLocation
-        },
-        {
-          closeOnInitialBlock: true
-        }
-      )}
+      {renderPermissionsGate( { onPermissionGranted: getCurrentUserLocation } )}
     </>
   );
 };

--- a/src/sharedHooks/useLocationPermission.tsx
+++ b/src/sharedHooks/useLocationPermission.tsx
@@ -18,10 +18,6 @@ export interface LocationPermissionCallbacks {
   onModalHide?: ( ) => void;
 }
 
-export interface LocationPermissionOptions {
-  closeOnInitialBlock?: boolean;
-}
-
 /**
  * A hook to check and request location permissions.
  * @returns {boolean} hasPermissions - Undefined if permissions have not been checked yet.
@@ -34,24 +30,16 @@ const useLocationPermission = ( ) => {
   const [hasPermissions, setHasPermissions] = useState<boolean>( );
   const [showPermissionGate, setShowPermissionGate] = useState( false );
   const [hasBlockedPermissions, setHasBlockedPermissions] = useState( false );
-  const [initialBlock, setInitialBlock] = useState( false );
 
   // PermissionGate callbacks need to use useCallback, otherwise they'll
   // trigger re-renders if/when they change
-  const renderPermissionsGate = useCallback( (
-    callbacks?: LocationPermissionCallbacks,
-    options?: LocationPermissionOptions
-  ) => {
+  const renderPermissionsGate = useCallback( ( callbacks?: LocationPermissionCallbacks ) => {
     const {
       onPermissionGranted,
       onPermissionDenied,
       onPermissionBlocked,
       onModalHide
     } = callbacks || { };
-
-    const {
-      closeOnInitialBlock = false
-    } = options || { };
 
     // this prevents infinite rerenders of the LocationPermissionGate component
     if ( !showPermissionGate ) {
@@ -70,7 +58,6 @@ const useLocationPermission = ( ) => {
           setShowPermissionGate( false );
           setHasPermissions( true );
           setHasBlockedPermissions( false );
-          setInitialBlock( false );
           if ( onPermissionGranted ) onPermissionGranted( );
         }}
         onPermissionDenied={( ) => {
@@ -80,17 +67,11 @@ const useLocationPermission = ( ) => {
           setHasPermissions( false );
           setHasBlockedPermissions( true );
           setShowPermissionGate( true );
-          if ( !initialBlock ) {
-            setInitialBlock( true );
-            if ( closeOnInitialBlock ) {
-              setShowPermissionGate( false );
-            }
-          }
           if ( onPermissionBlocked ) onPermissionBlocked( );
         }}
       />
     );
-  }, [initialBlock, showPermissionGate] );
+  }, [showPermissionGate] );
 
   // This gets exported and used as a dependency, so it needs to have
   // referential stability


### PR DESCRIPTION
This was introduced because of a misunderstanding of requirements in a previous ticket. Now the permission gate behaves again the same on all screens.