### PR TITLE
Adding some more info to errors thrown from camera

### DIFF
--- a/src/components/Camera/AICamera/FrameProcessorCamera.js
+++ b/src/components/Camera/AICamera/FrameProcessorCamera.js
@@ -219,21 +219,21 @@ const FrameProcessorCamera = ( {
       cameraRef={cameraRef}
       device={device}
       frameProcessor={frameProcessor}
-      onCameraError={async ( ) => {
+      onCameraError={async error => {
+        onCameraError( error );
         await logStage( sentinelFileName, "fallback_camera_error" );
-        onCameraError( );
       }}
-      onCaptureError={async ( ) => {
+      onCaptureError={async error => {
+        onCaptureError( error );
         await logStage( sentinelFileName, "camera_capture_error" );
-        onCaptureError( );
       }}
-      onClassifierError={async ( ) => {
+      onClassifierError={async error => {
+        onClassifierError( error );
         await logStage( sentinelFileName, "camera_classifier_error" );
-        onClassifierError( );
       }}
-      onDeviceNotSupported={async ( ) => {
+      onDeviceNotSupported={async error => {
+        onDeviceNotSupported( error );
         await logStage( sentinelFileName, "camera_device_not_supported_error" );
-        onDeviceNotSupported( );
       }}
       pinchToZoom={pinchToZoom}
       inactive={inactive}

--- a/src/components/Camera/CameraView.tsx
+++ b/src/components/Camera/CameraView.tsx
@@ -30,10 +30,10 @@ interface Props {
   cameraRef: React.RefObject<Camera>,
   device: CameraDevice,
   frameProcessor?: Function,
-  onCameraError?: Function,
-  onCaptureError?: Function,
-  onClassifierError?: Function,
-  onDeviceNotSupported?: Function,
+  onCameraError: ( error: CameraRuntimeError ) => void,
+  onCaptureError: ( error: CameraRuntimeError ) => void,
+  onClassifierError: ( error: CameraRuntimeError ) => void,
+  onDeviceNotSupported: ( error: CameraRuntimeError ) => void,
   pinchToZoom?: Function,
   resizeMode?: "cover" | "contain",
   inactive?: boolean
@@ -92,13 +92,13 @@ const CameraView = ( {
       // If it is a "device/" error, return the error code
       if ( error.code.includes( "device/" ) ) {
         console.log( "error :>> ", error );
-        onDeviceNotSupported( error.code );
+        onDeviceNotSupported( error );
         return;
       }
 
       if ( error.code.includes( "capture/" ) ) {
         console.log( "error :>> ", error );
-        onCaptureError( error.code );
+        onCaptureError( error );
         return;
       }
 
@@ -119,7 +119,7 @@ const CameraView = ( {
           return;
         }
       }
-      onCameraError( error.code );
+      onCameraError( error );
     },
     [
       onClassifierError,

--- a/src/components/Camera/helpers/index.ts
+++ b/src/components/Camera/helpers/index.ts
@@ -1,38 +1,35 @@
 import { Alert } from "react-native";
+import { CameraRuntimeError } from "react-native-vision-camera";
 
 import { log } from "../../../../react-native-logs.config";
 
 const logger = log.extend( "CameraView" );
 
-type Error = {
-  message: string;
-}
-
 type Event = {
   log: string;
 }
 
-const handleClassifierError = ( error: Error ) => {
+const handleClassifierError = ( error: CameraRuntimeError ) => {
   // When we hit this error, there is an error with the classifier.
-  logger.error( "handleClassifierError: ", error );
-  Alert.alert( "error", error.message );
+  logger.error( "handleClassifierError: ", JSON.stringify( error ) );
+  Alert.alert( "error", JSON.stringify( error ) );
 };
 
-const handleDeviceNotSupported = ( error: Error ) => {
+const handleDeviceNotSupported = ( error: CameraRuntimeError ) => {
   // When we hit this error, something with the current device is not supported.
-  Alert.alert( "error", error.message );
+  Alert.alert( "error", JSON.stringify( error ) );
 };
 
-const handleCaptureError = ( error: Error ) => {
+const handleCaptureError = ( error: CameraRuntimeError ) => {
   // When we hit this error, taking a photo did not work correctly
-  logger.error( "handleCaptureError: ", error );
-  Alert.alert( "error", error.message );
+  logger.error( "handleCaptureError: ", JSON.stringify( error ) );
+  Alert.alert( "error", JSON.stringify( error ) );
 };
 
-const handleCameraError = ( error: Error ) => {
+const handleCameraError = ( error: CameraRuntimeError ) => {
   // This error is thrown when it does not fit in any of the above categories.
-  logger.error( "handleCameraError ", error );
-  Alert.alert( "error", error.message );
+  logger.error( "handleCameraError ", JSON.stringify( error ) );
+  Alert.alert( "error", JSON.stringify( error ) );
 };
 
 const handleLog = ( event: Event ) => {


### PR DESCRIPTION
Closes MOB-230: The error logged in this issue for the classifier is potentially outdated. If not this PR here changes the logs to serialize the error object as outlined in the issue. So if the error appears again we shall have more info.
Closes MOB-228: If this error appears again there should be more info what kind of error this is. "unknown/unknown" is a real error though that is thrown from the camera library we are using.
Closes MOB-478 by no longer accessing the message property.