### PR TITLE
Update vision-plugin to prepare for cv model v2.20

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1206,7 +1206,7 @@ PODS:
   - VisionCamera/React (4.0.5):
     - React-Core
     - VisionCamera/FrameProcessors
-  - VisionCameraPluginInatVision (5.0.0):
+  - VisionCameraPluginInatVision (5.2.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -1616,7 +1616,7 @@ SPEC CHECKSUMS:
   RNVectorIcons: 102cd20472bf0d7cd15443d43cd87f9c97228ac3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   VisionCamera: f02de0b1b6b1516b327bd8215237a97e7386db8a
-  VisionCameraPluginInatVision: 54906a97413a22b55ca21ed674cb4b2b9af9ccc5
+  VisionCameraPluginInatVision: 9562479ff3360026c99b2dc2013127950ea31bbe
   Yoga: 1f93d5925ea12fb0880b21efe3566677337cf2ed
 
 PODFILE CHECKSUM: eff4b75123af5d6680139a78c055b44ad37c269b

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "sanitize-html": "^2.13.0",
         "ts-jest": "^29.1.2",
         "uuid": "^11.0.5",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#83b1e532f00e25a51e7408acbe3c5b178370013b",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#924a801b224be6243679c8237fbe0ec58ece0ac9",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -20725,9 +20725,9 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "5.0.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#83b1e532f00e25a51e7408acbe3c5b178370013b",
-      "integrity": "sha512-cdd9yCwD2eghoPSk8hPJ9EkFeWEtQucGj4M19zfi5k3E3piSc9QPOE2T+ab7e55Uo8ROD1USVxQVn8++9mBL2g==",
+      "version": "5.2.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#924a801b224be6243679c8237fbe0ec58ece0ac9",
+      "integrity": "sha512-+8ZqYFRpmsIaSR4VDGJg8lKJ8iVo8JYBFGPxoWHlzUzeComffvCDDYX/zJCiyw7Z6dCka4y0wySQMdvlNiXQ7g==",
       "license": "MIT",
       "dependencies": {
         "h3-js": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "sanitize-html": "^2.13.0",
     "ts-jest": "^29.1.2",
     "uuid": "^11.0.5",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#83b1e532f00e25a51e7408acbe3c5b178370013b",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#924a801b224be6243679c8237fbe0ec58ece0ac9",
     "zustand": "^4.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The update is required to run vision model version 2.20.
Should be fully backwards compatible though, so no actual need to update to v2.20.
Have tested with 2.13 and still works as expected.

Have also tested with 2.20 and works as expected.