### PR TITLE
Optional access of optional property

### DIFF
--- a/src/components/ObsDetailsDefaultMode/LocationSection/LocationSection.tsx
+++ b/src/components/ObsDetailsDefaultMode/LocationSection/LocationSection.tsx
@@ -66,13 +66,13 @@ const LocationSection = ( {
             />
           </View>
         )}
-        {observation.obscured && (
+        {observation?.obscured && (
           <ObscurationExplanation
             textClassName="mt-[10px]"
             observation={observation}
             currentUser={currentUser}
           />
-        ) }
+        )}
       </View>
     </View>
   );


### PR DESCRIPTION
Possible fix for sharing into app crashing based on the crash report's stack trace.