### PR TITLE
Do not upload observations that have missing location or date when in default mode

### DIFF
--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -127,7 +127,7 @@ const MyObservationsContainer = ( ): Node => {
     return currentUser;
   }, [currentUser] );
 
-  const handleSyncButtonPress = useCallback( unuploadedObsMissingBasicsIDs => {
+  const handleSyncButtonPress = useCallback( ( { unuploadedObsMissingBasicsIDs } ) => {
     if ( !confirmLoggedIn( ) ) { return; }
     if ( !confirmInternetConnection( ) ) { return; }
 

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -127,7 +127,8 @@ const MyObservationsContainer = ( ): Node => {
     return currentUser;
   }, [currentUser] );
 
-  const handleSyncButtonPress = useCallback( ( { unuploadedObsMissingBasicsIDs } ) => {
+  const handleSyncButtonPress = useCallback( options => {
+    const { unuploadedObsMissingBasicsIDs } = options || { };
     if ( !confirmLoggedIn( ) ) { return; }
     if ( !confirmInternetConnection( ) ) { return; }
 

--- a/src/components/MyObservations/MyObservationsContainer.js
+++ b/src/components/MyObservations/MyObservationsContainer.js
@@ -127,13 +127,15 @@ const MyObservationsContainer = ( ): Node => {
     return currentUser;
   }, [currentUser] );
 
-  const handleSyncButtonPress = useCallback( ( ) => {
+  const handleSyncButtonPress = useCallback( unuploadedObsMissingBasicsIDs => {
     if ( !confirmLoggedIn( ) ) { return; }
     if ( !confirmInternetConnection( ) ) { return; }
 
     startManualSync( );
+    syncManually( { skipSomeUploads: unuploadedObsMissingBasicsIDs } );
   }, [
     startManualSync,
+    syncManually,
     confirmInternetConnection,
     confirmLoggedIn
   ] );

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -185,14 +185,16 @@ const MyObservationsSimple = ( {
     taxa?.length
   ] );
 
-  const unuploadedObservationsWithMissingBasics = useMemo( () => (
+  const unuploadedObsMissingBasics = useMemo( () => (
     observations.filter( o => o.needsSync() && o.missingBasics() )
   ), [observations] );
 
-  const numUnuploadedObservationsWithMissingBasics = unuploadedObservationsWithMissingBasics.length;
+  const numUnuploadedObsMissingBasics = unuploadedObsMissingBasics.length;
   const obsMissingBasicsExist = useMemo( ( ) => (
-    numUnuploadedObservations > 0 && numUnuploadedObservationsWithMissingBasics > 0
-  ), [numUnuploadedObservations, numUnuploadedObservationsWithMissingBasics] );
+    numUnuploadedObservations > 0 && numUnuploadedObsMissingBasics > 0
+  ), [numUnuploadedObservations, numUnuploadedObsMissingBasics] );
+
+  const numUploadableObservations = numUnuploadedObservations - numUnuploadedObsMissingBasics;
 
   const renderTabComponent = ( { id } ) => (
     <StatTab
@@ -235,7 +237,7 @@ const MyObservationsSimple = ( {
         <MyObservationsSimpleHeader
           currentUser={currentUser}
           isConnected={isConnected}
-          numUnuploadedObservations={numUnuploadedObservations}
+          numUploadableObservations={numUploadableObservations}
           handleSyncButtonPress={handleSyncButtonPress}
         />
         <Tabs

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -185,9 +185,14 @@ const MyObservationsSimple = ( {
     taxa?.length
   ] );
 
+  const unuploadedObservationsWithMissingBasics = useMemo( () => (
+    observations.filter( o => o.needsSync() && o.missingBasics() )
+  ), [observations] );
+
+  const numUnuploadedObservationsWithMissingBasics = unuploadedObservationsWithMissingBasics.length;
   const obsMissingBasicsExist = useMemo( ( ) => (
-    numUnuploadedObservations > 0 && !!observations.find( o => o.needsSync() && o.missingBasics( ) )
-  ), [numUnuploadedObservations, observations] );
+    numUnuploadedObservations > 0 && numUnuploadedObservationsWithMissingBasics > 0
+  ), [numUnuploadedObservations, numUnuploadedObservationsWithMissingBasics] );
 
   const renderTabComponent = ( { id } ) => (
     <StatTab

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -185,11 +185,13 @@ const MyObservationsSimple = ( {
     taxa?.length
   ] );
 
-  const unuploadedObsMissingBasics = useMemo( () => (
-    observations.filter( o => o.needsSync() && o.missingBasics() )
+  const unuploadedObsMissingBasicsIDs = useMemo( () => (
+    observations
+      .filter( o => o.needsSync() && o.missingBasics() )
+      .map( o => o.uuid )
   ), [observations] );
 
-  const numUnuploadedObsMissingBasics = unuploadedObsMissingBasics.length;
+  const numUnuploadedObsMissingBasics = unuploadedObsMissingBasicsIDs.length;
   const obsMissingBasicsExist = useMemo( ( ) => (
     numUnuploadedObservations > 0 && numUnuploadedObsMissingBasics > 0
   ), [numUnuploadedObservations, numUnuploadedObsMissingBasics] );
@@ -238,7 +240,9 @@ const MyObservationsSimple = ( {
           currentUser={currentUser}
           isConnected={isConnected}
           numUploadableObservations={numUploadableObservations}
-          handleSyncButtonPress={handleSyncButtonPress}
+          handleSyncButtonPress={() => {
+            handleSyncButtonPress( unuploadedObsMissingBasicsIDs );
+          }}
         />
         <Tabs
           activeColor={String( colors?.inatGreen )}

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -41,7 +41,7 @@ export interface Props {
   currentUser?: RealmUser;
   handleIndividualUploadPress: ( uuid: string ) => void;
   handlePullToRefresh: ( ) => void;
-  handleSyncButtonPress: ( ) => void;
+  handleSyncButtonPress: ( _p: { unuploadedObsMissingBasicsIDs: string[] } ) => void;
   isConnected: boolean;
   isFetchingNextPage: boolean;
   layout: "list" | "grid";
@@ -241,7 +241,7 @@ const MyObservationsSimple = ( {
           isConnected={isConnected}
           numUploadableObservations={numUploadableObservations}
           handleSyncButtonPress={() => {
-            handleSyncButtonPress( unuploadedObsMissingBasicsIDs );
+            handleSyncButtonPress( { unuploadedObsMissingBasicsIDs } );
           }}
         />
         <Tabs

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -230,6 +230,7 @@ const MyObservationsSimple = ( {
         <MyObservationsSimpleHeader
           currentUser={currentUser}
           isConnected={isConnected}
+          numUnuploadedObservations={numUnuploadedObservations}
           handleSyncButtonPress={handleSyncButtonPress}
         />
         <Tabs

--- a/src/components/MyObservations/MyObservationsSimpleHeader.tsx
+++ b/src/components/MyObservations/MyObservationsSimpleHeader.tsx
@@ -25,6 +25,7 @@ import SimpleUploadBannerContainer from "./SimpleUploadBannerContainer";
 
 export interface Props {
   currentUser?: RealmUser;
+  numUnuploadedObservations: number;
   handleSyncButtonPress: ( ) => void;
   isConnected: boolean;
 }
@@ -32,7 +33,8 @@ export interface Props {
 const MyObservationsSimpleHeader = ( {
   currentUser,
   handleSyncButtonPress,
-  isConnected
+  isConnected,
+  numUnuploadedObservations
 }: Props ) => {
   const { t } = useTranslation( );
 
@@ -42,7 +44,6 @@ const MyObservationsSimpleHeader = ( {
   const currentDeleteCount = useStore( state => state.currentDeleteCount );
   const uploadErrorsByUuid = useStore( state => state.errorsByUuid );
   const initialNumObservationsInQueue = useStore( state => state.initialNumObservationsInQueue );
-  const numUnuploadedObservations = useStore( state => state.numUnuploadedObservations );
   const uploadStatus = useStore( state => state.uploadStatus );
   const syncingStatus = useStore( state => state.syncingStatus );
   const initialNumDeletionsInQueue = useStore( state => state.initialNumDeletionsInQueue );

--- a/src/components/MyObservations/MyObservationsSimpleHeader.tsx
+++ b/src/components/MyObservations/MyObservationsSimpleHeader.tsx
@@ -70,7 +70,10 @@ const MyObservationsSimpleHeader = ( {
 
   return (
     <>
-      <SimpleUploadBannerContainer handleSyncButtonPress={handleSyncButtonPress} />
+      <SimpleUploadBannerContainer
+        handleSyncButtonPress={handleSyncButtonPress}
+        numUnuploadedObservations={numUnuploadedObservations}
+      />
       <View className="flex-row justify-between items-center px-5 py-1">
         {currentUser
           ? <HeaderUser user={currentUser} isConnected={isConnected} />

--- a/src/components/MyObservations/MyObservationsSimpleHeader.tsx
+++ b/src/components/MyObservations/MyObservationsSimpleHeader.tsx
@@ -25,7 +25,7 @@ import SimpleUploadBannerContainer from "./SimpleUploadBannerContainer";
 
 export interface Props {
   currentUser?: RealmUser;
-  numUnuploadedObservations: number;
+  numUploadableObservations: number;
   handleSyncButtonPress: ( ) => void;
   isConnected: boolean;
 }
@@ -34,7 +34,7 @@ const MyObservationsSimpleHeader = ( {
   currentUser,
   handleSyncButtonPress,
   isConnected,
-  numUnuploadedObservations
+  numUploadableObservations
 }: Props ) => {
   const { t } = useTranslation( );
 
@@ -53,7 +53,7 @@ const MyObservationsSimpleHeader = ( {
   const deletionsInProgress = initialNumDeletionsInQueue > 0 && !deletionsComplete;
 
   const manualSyncInProgress = syncingStatus === MANUAL_SYNC_IN_PROGRESS;
-  const pendingUpload = uploadStatus === UPLOAD_PENDING && numUnuploadedObservations > 0;
+  const pendingUpload = uploadStatus === UPLOAD_PENDING && numUploadableObservations > 0;
   const uploadInProgress = uploadStatus === UPLOAD_IN_PROGRESS && numUploadsAttempted > 0;
   const uploadsComplete = uploadStatus === UPLOAD_COMPLETE && initialNumObservationsInQueue > 0;
   const totalUploadErrors = Object.keys( uploadErrorsByUuid ).length;
@@ -73,7 +73,7 @@ const MyObservationsSimpleHeader = ( {
     <>
       <SimpleUploadBannerContainer
         handleSyncButtonPress={handleSyncButtonPress}
-        numUnuploadedObservations={numUnuploadedObservations}
+        numUploadableObservations={numUploadableObservations}
       />
       <View className="flex-row justify-between items-center px-5 py-1">
         {currentUser
@@ -88,7 +88,7 @@ const MyObservationsSimpleHeader = ( {
             }
             onPress={handleSyncButtonPress}
             color={String(
-              numUnuploadedObservations > 0
+              numUploadableObservations > 0
                 ? colors?.inatGreen
                 : colors?.darkGray
             )}

--- a/src/components/MyObservations/SimpleUploadBannerContainer.js
+++ b/src/components/MyObservations/SimpleUploadBannerContainer.js
@@ -24,11 +24,13 @@ const screenWidth = Dimensions.get( "window" ).width * PixelRatio.get( );
 const DELETION_STARTED_PROGRESS = 0.25;
 
 type Props = {
+  numUnuploadedObservations: number,
   handleSyncButtonPress: Function
 }
 
 const SimpleUploadBannerContainer = ( {
-  handleSyncButtonPress
+  handleSyncButtonPress,
+  numUnuploadedObservations
 }: Props ): Node => {
   const numOfUserObservations = zustandStorage.getItem( "numOfUserObservations" );
   const currentDeleteCount = useStore( state => state.currentDeleteCount );
@@ -36,7 +38,6 @@ const SimpleUploadBannerContainer = ( {
   const uploadMultiError = useStore( state => state.multiError );
   const uploadErrorsByUuid = useStore( state => state.errorsByUuid );
   const initialNumObservationsInQueue = useStore( state => state.initialNumObservationsInQueue );
-  const numUnuploadedObservations = useStore( state => state.numUnuploadedObservations );
   const totalToolbarProgress = useStore( state => state.totalToolbarProgress );
   const uploadStatus = useStore( state => state.uploadStatus );
   const syncingStatus = useStore( state => state.syncingStatus );

--- a/src/components/MyObservations/SimpleUploadBannerContainer.js
+++ b/src/components/MyObservations/SimpleUploadBannerContainer.js
@@ -24,13 +24,13 @@ const screenWidth = Dimensions.get( "window" ).width * PixelRatio.get( );
 const DELETION_STARTED_PROGRESS = 0.25;
 
 type Props = {
-  numUnuploadedObservations: number,
+  numUploadableObservations: number,
   handleSyncButtonPress: Function
 }
 
 const SimpleUploadBannerContainer = ( {
   handleSyncButtonPress,
-  numUnuploadedObservations
+  numUploadableObservations
 }: Props ): Node => {
   const numOfUserObservations = zustandStorage.getItem( "numOfUserObservations" );
   const currentDeleteCount = useStore( state => state.currentDeleteCount );
@@ -64,7 +64,7 @@ const SimpleUploadBannerContainer = ( {
 
   const automaticSyncInProgress = syncingStatus === AUTOMATIC_SYNC_IN_PROGRESS;
   const manualSyncInProgress = syncingStatus === MANUAL_SYNC_IN_PROGRESS;
-  const pendingUpload = uploadStatus === UPLOAD_PENDING && numUnuploadedObservations > 0;
+  const pendingUpload = uploadStatus === UPLOAD_PENDING && numUploadableObservations > 0;
   const uploadInProgress = uploadStatus === UPLOAD_IN_PROGRESS && numUploadsAttempted > 0;
   const uploadsComplete = uploadStatus === UPLOAD_COMPLETE && initialNumObservationsInQueue > 0;
   const totalUploadErrors = Object.keys( uploadErrorsByUuid ).length;
@@ -105,7 +105,7 @@ const SimpleUploadBannerContainer = ( {
     }
 
     if ( pendingUpload ) {
-      return t( "Upload-x-observations", { count: numUnuploadedObservations } );
+      return t( "Upload-x-observations", { count: numUploadableObservations } );
     }
 
     if ( uploadInProgress ) {
@@ -125,7 +125,7 @@ const SimpleUploadBannerContainer = ( {
     deletionsComplete,
     initialNumDeletionsInQueue,
     numUploadsAttempted,
-    numUnuploadedObservations,
+    numUploadableObservations,
     pendingUpload,
     manualSyncInProgress,
     t,

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -206,7 +206,6 @@ const useSyncObservations = (
   useEffect( ( ) => {
     if ( syncingStatus !== BEGIN_MANUAL_SYNC ) { return; }
     setSyncingStatus( MANUAL_SYNC_IN_PROGRESS );
-    syncManually( );
   }, [syncingStatus, syncManually, setSyncingStatus] );
 
   return {

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -22,8 +22,8 @@ const { useRealm } = RealmContext;
 
 const useSyncObservations = (
   currentUserId: number,
-  startUploadObservations: ( ) => void
-): void => {
+  startUploadObservations: ( _skipSomeUuids: string[] | undefined ) => void
+) => {
   const { isConnected } = useNetInfo( );
   const loggedIn = !!( currentUserId );
   const deleteQueue = useStore( state => state.deleteQueue );
@@ -159,7 +159,12 @@ const useSyncObservations = (
     signalAborted
   ] );
 
-  const syncManually = useCallback( async options => {
+  interface Options {
+    skipUploads?: boolean;
+    // uuids of observations to skip uploading
+    skipSomeUploads?: string[];
+  }
+  const syncManually = useCallback( async ( options: Options ) => {
     const skipUploads = options?.skipUploads || false;
     // we abort the automatic sync process when a user taps the manual sync button
     // on the toolbar, per #1730
@@ -182,7 +187,7 @@ const useSyncObservations = (
     // being offline, so we're not checking internet connectivity here
     if ( loggedIn && !skipUploads ) {
       // In theory completeSync will get called when the upload process finishes
-      return startUploadObservations( );
+      return startUploadObservations( options?.skipSomeUploads );
     }
     return Promise.resolve();
   }, [

--- a/src/components/MyObservations/hooks/useUploadObservations.ts
+++ b/src/components/MyObservations/hooks/useUploadObservations.ts
@@ -178,13 +178,18 @@ export default ( canUpload: boolean ) => {
     uploadStatus
   ] );
 
-  const createUploadQueueAllUnsynced = useCallback( ( ) => {
-    const uuidsQuery = unsyncedUuids
+  const createUploadQueueAllUnsynced = useCallback( ( skipSomeUuids: string[] | undefined ) => {
+    const uploadsUuids = unsyncedUuids
+      .filter( ( uuid: string ) => !skipSomeUuids?.includes( uuid ) );
+    if ( uploadsUuids.length === 0 ) {
+      return;
+    }
+    const uuidsQuery = uploadsUuids
       .map( ( uploadUuid: string ) => `'${uploadUuid}'` ).join( ", " );
     const uploads = realm.objects( "Observation" )
       .filtered( `uuid IN { ${uuidsQuery} }` );
     setTotalToolbarIncrements( uploads );
-    addToUploadQueue( unsyncedUuids );
+    addToUploadQueue( uploadsUuids );
     if ( canUpload ) {
       setStartUploadObservations( );
     } else {
@@ -200,8 +205,8 @@ export default ( canUpload: boolean ) => {
     unsyncedUuids
   ] );
 
-  const startUploadObservations = useCallback( async ( ) => {
-    createUploadQueueAllUnsynced( );
+  const startUploadObservations = useCallback( async ( skipSomeUuids: string[] | undefined ) => {
+    createUploadQueueAllUnsynced( skipSomeUuids );
   }, [
     createUploadQueueAllUnsynced
   ] );

--- a/tests/unit/components/MyObservations/useSyncObservations.test.js
+++ b/tests/unit/components/MyObservations/useSyncObservations.test.js
@@ -3,8 +3,7 @@ import useSyncObservations from "components/MyObservations/hooks/useSyncObservat
 import inatjs from "inaturalistjs";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import {
-  BEGIN_AUTOMATIC_SYNC,
-  BEGIN_MANUAL_SYNC
+  BEGIN_AUTOMATIC_SYNC
 } from "stores/createSyncObservationsSlice.ts";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
@@ -220,19 +219,6 @@ describe( "automatic sync while user is logged in", ( ) => {
     renderHook( ( ) => useSyncObservations( currentUserId, mockUpload ) );
     await waitFor( ( ) => {
       expect( mockUpload ).not.toHaveBeenCalled( );
-    } );
-  } );
-} );
-
-describe( "manual sync while user is logged in", ( ) => {
-  it( "should begin uploading unsynced observations", async ( ) => {
-    useStore.setState( {
-      ...syncingStore,
-      syncingStatus: BEGIN_MANUAL_SYNC
-    } );
-    renderHook( ( ) => useSyncObservations( currentUserId, mockUpload ) );
-    await waitFor( ( ) => {
-      expect( mockUpload ).toHaveBeenCalled( );
     } );
   } );
 } );


### PR DESCRIPTION
Closes MOB-550

This is the quickest solution I could come up with.
Two components to this solution:
- The UI state is calculated based on number of unuploaded observations minus number of observations that have some missing information.
- When the sync button is pressed the uuids of the observations with missing basics are sent along and skipped for the upload process.