### PR TITLE
Add error handling for 429 to React Query, including mutations

### DIFF
--- a/src/sharedHooks/index.js
+++ b/src/sharedHooks/index.js
@@ -25,6 +25,7 @@ export { default as useObservationUpdatesWhenFocused } from "./useObservationUpd
 export { default as usePerformance } from "./usePerformance";
 export { default as useQuery } from "./useQuery";
 export { default as useRemoteObservation } from "./useRemoteObservation";
+export { default as useSafeRoute } from "./useSafeRoute";
 export { default as useScrollToOffset } from "./useScrollToOffset";
 export { default as useShare } from "./useShare";
 export { default as useStoredLayout } from "./useStoredLayout";

--- a/src/sharedHooks/useAuthenticatedInfiniteQuery.ts
+++ b/src/sharedHooks/useAuthenticatedInfiniteQuery.ts
@@ -1,3 +1,4 @@
+import { useRoute } from "@react-navigation/native";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import { reactQueryRetry } from "sharedHelpers/logging";
@@ -8,23 +9,29 @@ const useAuthenticatedInfiniteQuery = (
   queryKey: Array<string>,
   queryFunction: Function,
   queryOptions: Object = {}
-): Object => useInfiniteQuery( {
-  queryKey: [...queryKey, queryOptions.allowAnonymousJWT],
-  queryFn: async params => {
+): Object => {
+  const route = useRoute( );
+
+  return useInfiniteQuery( {
+    queryKey: [...queryKey, queryOptions.allowAnonymousJWT],
+    queryFn: async params => {
     // logger.info( queryKey, "queryKey in useAuthenticatedInfiniteQuery" );
     // Note, getJWT() takes care of fetching a new token if the existing
     // one is expired. We *could* store the token in state with useState if
     // fetching from RNSInfo becomes a performance issue
-    const apiToken = await getJWT( queryOptions.allowAnonymousJWT );
-    const options = {
-      api_token: apiToken
-    };
-    return queryFunction( params, options );
-  },
-  retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
-    queryKey
-  } ),
-  ...queryOptions
-} );
+      const apiToken = await getJWT( queryOptions.allowAnonymousJWT );
+      const options = {
+        api_token: apiToken
+      };
+      return queryFunction( params, options );
+    },
+    retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
+      queryKey,
+      routeName: route?.name,
+      routeParams: route?.params
+    } ),
+    ...queryOptions
+  } );
+};
 
 export default useAuthenticatedInfiniteQuery;

--- a/src/sharedHooks/useAuthenticatedInfiniteQuery.ts
+++ b/src/sharedHooks/useAuthenticatedInfiniteQuery.ts
@@ -1,7 +1,7 @@
 import { useRoute } from "@react-navigation/native";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
-import { reactQueryRetry } from "sharedHelpers/logging";
+import { handleRetryDelay, reactQueryRetry } from "sharedHelpers/logging";
 
 // Should work like React Query's useInfiniteQuery with our custom reactQueryRetry
 // and authentication
@@ -30,6 +30,7 @@ const useAuthenticatedInfiniteQuery = (
       routeName: route?.name,
       routeParams: route?.params
     } ),
+    retryDelay: ( failureCount, error ) => handleRetryDelay( failureCount, error ),
     ...queryOptions
   } );
 };

--- a/src/sharedHooks/useAuthenticatedMutation.js
+++ b/src/sharedHooks/useAuthenticatedMutation.js
@@ -1,27 +1,57 @@
 // @flow
 
+import { useRoute } from "@react-navigation/native";
 import { useMutation } from "@tanstack/react-query";
 import handleError from "api/error";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
+
+import { log } from "../../react-native-logs.config";
+
+const logger = log.extend( "useAuthenticatedMutation" );
 
 // Should work like React Query's useMutation except it calls the queryFunction
 // with an object that includes the JWT
 const useAuthenticatedMutation = (
   mutationFunction: Function,
   mutationOptions: Object = {}
-): Object => useMutation( {
-  mutationFn: async params => {
+): Object => {
+  const route = useRoute( );
+
+  return useMutation( {
+    mutationFn: async params => {
     // Note, getJWTToken() takes care of fetching a new token if the existing
     // one is expired. We *could* store the token in state with useState if
     // fetching from RNSInfo becomes a performance issue
-    const apiToken = await getJWT( );
-    const options = {
-      api_token: apiToken
-    };
-    return mutationFunction( params, options );
-  },
-  onError: handleError,
-  ...mutationOptions
-} );
+      const apiToken = await getJWT( );
+      const options = {
+        api_token: apiToken
+      };
+      return mutationFunction( params, options );
+    },
+    onError: error => {
+    // Capture context for 429 errors
+      if ( error.status === 429 || ( error.response && error.response.status === 429 ) ) {
+        const errorContext = {
+          routeName: route?.name,
+          routeParams: route?.params,
+          mutationName: mutationOptions.mutationKey || "unknown",
+          timestamp: new Date().toISOString()
+        };
+
+        logger.error( "429 in mutation:", errorContext );
+
+        // Pass context to handleError
+        return handleError( error, {
+          context: errorContext,
+          throw: mutationOptions.throwOnError !== false
+        } );
+      }
+
+      // Call original handleError for non-429 errors
+      return handleError( error );
+    },
+    ...mutationOptions
+  } );
+};
 
 export default useAuthenticatedMutation;

--- a/src/sharedHooks/useAuthenticatedMutation.js
+++ b/src/sharedHooks/useAuthenticatedMutation.js
@@ -1,9 +1,9 @@
 // @flow
 
-import { useRoute } from "@react-navigation/native";
 import { useMutation } from "@tanstack/react-query";
 import handleError from "api/error";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
+import { useSafeRoute } from "sharedHooks";
 
 import { log } from "../../react-native-logs.config";
 
@@ -15,7 +15,7 @@ const useAuthenticatedMutation = (
   mutationFunction: Function,
   mutationOptions: Object = {}
 ): Object => {
-  const route = useRoute( );
+  const route = useSafeRoute( );
 
   return useMutation( {
     mutationFn: async params => {

--- a/src/sharedHooks/useAuthenticatedQuery.js
+++ b/src/sharedHooks/useAuthenticatedQuery.js
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getJWT, isLoggedIn } from "components/LoginSignUp/AuthenticationService.ts";
 import { useEffect, useState } from "react";
-import { reactQueryRetry } from "sharedHelpers/logging";
+import { handleRetryDelay, reactQueryRetry } from "sharedHelpers/logging";
 import { useSafeRoute } from "sharedHooks";
 
 const LOGGED_IN_UNKNOWN = null;
@@ -50,6 +50,7 @@ const useAuthenticatedQuery = (
       routeName: route?.name,
       routeParams: route?.params
     } ),
+    retryDelay: ( failureCount, error ) => handleRetryDelay( failureCount, error ),
     ...queryOptions,
     // Authenticated queries should not run until we know whether or not the
     // user is signed in

--- a/src/sharedHooks/useAuthenticatedQuery.js
+++ b/src/sharedHooks/useAuthenticatedQuery.js
@@ -1,3 +1,4 @@
+import { useRoute } from "@react-navigation/native";
 import { useQuery } from "@tanstack/react-query";
 import { getJWT, isLoggedIn } from "components/LoginSignUp/AuthenticationService.ts";
 import { useEffect, useState } from "react";
@@ -13,6 +14,7 @@ const useAuthenticatedQuery = (
   queryOptions = {}
 ) => {
   const [userLoggedIn, setUserLoggedIn] = useState( LOGGED_IN_UNKNOWN );
+  const route = useRoute( );
 
   // Whether we perform this query and whether we need to re-perform it
   // depends on whether the user is signed in. The possible vulnerability
@@ -44,7 +46,9 @@ const useAuthenticatedQuery = (
       return queryFunction( options );
     },
     retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
-      queryKey
+      queryKey,
+      routeName: route?.name,
+      routeParams: route?.params
     } ),
     ...queryOptions,
     // Authenticated queries should not run until we know whether or not the

--- a/src/sharedHooks/useAuthenticatedQuery.js
+++ b/src/sharedHooks/useAuthenticatedQuery.js
@@ -1,8 +1,8 @@
-import { useRoute } from "@react-navigation/native";
 import { useQuery } from "@tanstack/react-query";
 import { getJWT, isLoggedIn } from "components/LoginSignUp/AuthenticationService.ts";
 import { useEffect, useState } from "react";
 import { reactQueryRetry } from "sharedHelpers/logging";
+import { useSafeRoute } from "sharedHooks";
 
 const LOGGED_IN_UNKNOWN = null;
 
@@ -14,7 +14,7 @@ const useAuthenticatedQuery = (
   queryOptions = {}
 ) => {
   const [userLoggedIn, setUserLoggedIn] = useState( LOGGED_IN_UNKNOWN );
-  const route = useRoute( );
+  const route = useSafeRoute( );
 
   // Whether we perform this query and whether we need to re-perform it
   // depends on whether the user is signed in. The possible vulnerability

--- a/src/sharedHooks/useQuery.ts
+++ b/src/sharedHooks/useQuery.ts
@@ -1,6 +1,6 @@
-import { useRoute } from "@react-navigation/native";
 import { useQuery } from "@tanstack/react-query";
 import { reactQueryRetry } from "sharedHelpers/logging";
+import { useSafeRoute } from "sharedHooks";
 
 // Should work like React Query's useQuery with our custom reactQueryRetry
 const useNonAuthenticatedQuery = (
@@ -8,7 +8,7 @@ const useNonAuthenticatedQuery = (
   queryFunction: Function,
   queryOptions: Object = {}
 ): Object => {
-  const route = useRoute( );
+  const route = useSafeRoute( );
 
   return useQuery( {
     queryKey: [...queryKey, queryOptions.allowAnonymousJWT],

--- a/src/sharedHooks/useQuery.ts
+++ b/src/sharedHooks/useQuery.ts
@@ -1,3 +1,4 @@
+import { useRoute } from "@react-navigation/native";
 import { useQuery } from "@tanstack/react-query";
 import { reactQueryRetry } from "sharedHelpers/logging";
 
@@ -6,13 +7,19 @@ const useNonAuthenticatedQuery = (
   queryKey: Array<string>,
   queryFunction: Function,
   queryOptions: Object = {}
-): Object => useQuery( {
-  queryKey: [...queryKey, queryOptions.allowAnonymousJWT],
-  queryFn: queryFunction,
-  retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
-    queryKey
-  } ),
-  ...queryOptions
-} );
+): Object => {
+  const route = useRoute( );
+
+  return useQuery( {
+    queryKey: [...queryKey, queryOptions.allowAnonymousJWT],
+    queryFn: queryFunction,
+    retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
+      queryKey,
+      routeName: route?.name,
+      routeParams: route?.params
+    } ),
+    ...queryOptions
+  } );
+};
 
 export default useNonAuthenticatedQuery;

--- a/src/sharedHooks/useQuery.ts
+++ b/src/sharedHooks/useQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { reactQueryRetry } from "sharedHelpers/logging";
+import { handleRetryDelay, reactQueryRetry } from "sharedHelpers/logging";
 import { useSafeRoute } from "sharedHooks";
 
 // Should work like React Query's useQuery with our custom reactQueryRetry
@@ -18,6 +18,7 @@ const useNonAuthenticatedQuery = (
       routeName: route?.name,
       routeParams: route?.params
     } ),
+    retryDelay: ( failureCount, error ) => handleRetryDelay( failureCount, error ),
     ...queryOptions
   } );
 };

--- a/src/sharedHooks/useSafeRoute.js
+++ b/src/sharedHooks/useSafeRoute.js
@@ -1,0 +1,28 @@
+import { useRoute } from "@react-navigation/native";
+
+// import { log } from "../../react-native-logs.config";
+
+// const logger = log.extend( "useSafeRoute" );
+
+/**
+ * Safely attempts to get the current route info, without crashing if not
+ * inside a navigation context
+ * @returns {Object} Route information or empty object if no route available
+ */
+const useSafeRoute = () => {
+  try {
+    const route = useRoute( );
+    if ( route ) {
+      return {
+        routeName: route.name,
+        routeParams: route.params
+      };
+    }
+  } catch ( e ) {
+    // console.log( "Route not available from useSafeRoute" );
+  }
+
+  return {};
+};
+
+export default useSafeRoute;


### PR DESCRIPTION
Related to Mob-207

We have very little information about what's happening when a 429 error gets logged currently, so this should add some context and add a progressive retry for any 429 errors being handled by React Query