### PR TITLE
Better error handling for missing or invalid jwt errors

### DIFF
--- a/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteDeletedObservations.ts
@@ -38,8 +38,8 @@ const deleteRemotelyDeletedObservations = ( deletedObservations, realm ) => {
 
 // eslint-disable-next-line no-undef
 export default syncRemoteDeletedObservations = async realm => {
-  const apiToken = await getJWT( );
   const deletedParams = setParamsWithLastSyncTime( realm );
+  const apiToken = await getJWT( );
   const response = await checkForDeletedObservations( deletedParams, { api_token: apiToken } );
   const currentSyncTime = format( new Date( ), "yyyy-MM-dd" );
   zustandStorage.setItem( "lastDeletedSyncTime", currentSyncTime );

--- a/src/components/MyObservations/helpers/syncRemoteObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteObservations.ts
@@ -4,7 +4,6 @@ import Observation from "realmModels/Observation";
 import { sleep } from "sharedHelpers/util.ts";
 
 async function syncRemoteObservations( realm, currentUserId: number, deletionsCompletedAt: Date ) {
-  const apiToken = await getJWT( );
   const searchParams = {
     user_id: currentUserId,
     per_page: 50,
@@ -23,6 +22,7 @@ async function syncRemoteObservations( realm, currentUserId: number, deletionsCo
       await sleep( naptime );
     }
   }
+  const apiToken = await getJWT( );
   const { results } = await searchObservations( searchParams, { api_token: apiToken } );
   await Observation.upsertRemoteObservations( results, realm );
 }

--- a/src/components/Settings/LanguageSetting.tsx
+++ b/src/components/Settings/LanguageSetting.tsx
@@ -1,4 +1,5 @@
 import fetchAvailableLocales from "api/translations";
+import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import {
   Button,
   Heading4,
@@ -40,7 +41,8 @@ const LanguageSetting = ( { onChange }: Props ) => {
         ? JSON.parse( currentLocales )
         : [] );
 
-      const locales = await fetchAvailableLocales();
+      const apiToken = await getJWT( );
+      const locales = await fetchAvailableLocales( {}, { api_token: apiToken } );
       zustandStorage.setItem( "availableLocales", JSON.stringify( locales ) );
       setWebLocales( locales as LocalesResponse );
     }

--- a/src/components/hooks/useLinking.js
+++ b/src/components/hooks/useLinking.js
@@ -4,6 +4,7 @@ import { useNavigation } from "@react-navigation/native";
 import {
   searchObservations
 } from "api/observations";
+import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import navigateToObsDetails from "components/ObsDetails/helpers/navigateToObsDetails";
 import { useCallback, useEffect, useState } from "react";
 import { Linking } from "react-native";
@@ -25,7 +26,11 @@ const useLinking = ( currentUser: ?Object ) => {
 
   const navigateToObservations = useCallback( async ( ) => {
     const searchParams = { id: observationId };
-    const { results } = await searchObservations( searchParams );
+    const apiToken = await getJWT( );
+    const options = {
+      api_token: apiToken
+    };
+    const { results } = await searchObservations( searchParams, options );
     const uuid = results?.[0]?.uuid;
 
     if ( uuid ) {

--- a/src/sharedHelpers/uploadObservation.js
+++ b/src/sharedHelpers/uploadObservation.js
@@ -12,7 +12,10 @@ import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
 import ObservationSound from "realmModels/ObservationSound";
 import emitUploadProgress from "sharedHelpers/emitUploadProgress.ts";
+import { log } from "sharedHelpers/logger";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+
+const logger = log.extend( "uploadObservation" );
 
 const UPLOAD_PROGRESS_INCREMENT = 1;
 
@@ -106,28 +109,43 @@ const uploadEvidence = async (
   // $FlowIgnore
 ): Promise<unknown> => {
   const uploadToServer = async currentEvidence => {
-    const params = apiSchemaMapper( observationId, currentEvidence );
-    const evidenceUUID = currentEvidence.uuid;
+    try {
+      const params = apiSchemaMapper( observationId, currentEvidence );
+      const evidenceUUID = currentEvidence.uuid;
 
-    const response = await createOrUpdateEvidence(
-      apiEndpoint,
-      params,
-      options
-    );
+      const response = await createOrUpdateEvidence(
+        apiEndpoint,
+        params,
+        options
+      );
 
-    if ( response && observationUUID ) {
+      if ( response && observationUUID ) {
       // we're emitting progress increments:
       // one when the upload of obs
       // half one when obsPhoto/obsSound is successfully uploaded
       // half one when the obsPhoto/obsSound is attached to the obs
-      emitUploadProgress( observationUUID, ( UPLOAD_PROGRESS_INCREMENT / 2 ) );
-      // TODO: can't mark records as uploaded by primary key for ObsPhotos and ObsSound anymore
-      markRecordUploaded( observationUUID, evidenceUUID, type, response, realm, {
-        record: currentEvidence
-      } );
+        emitUploadProgress( observationUUID, ( UPLOAD_PROGRESS_INCREMENT / 2 ) );
+        // TODO: can't mark records as uploaded by primary key for ObsPhotos and ObsSound anymore
+        markRecordUploaded( observationUUID, evidenceUUID, type, response, realm, {
+          record: currentEvidence
+        } );
+      }
+      return response;
+    } catch ( error ) {
+      if ( error.status === 401
+      || ( error.errors && error.errors[0]?.errorCode === "401" )
+      || JSON.stringify( error ).includes( "JWT is missing or invalid" ) ) {
+        logger.error( "JWT_ERROR in uploadEvidence", {
+          type,
+          evidenceUUID: currentEvidence.uuid,
+          observationUUID,
+          errorStatus: error.status,
+          errorMessage: error.message,
+          timestamp: new Date().toISOString()
+        } );
+      }
+      return null;
     }
-
-    return response;
   };
 
   const responses = await Promise.all( evidence.map( item => {


### PR DESCRIPTION
Error handling for Mob-445

A few things here:
- More detailed error handling overall for 401 errors at the react-query level
- Add error handling for mutations
- Audit places in the app where we're not using react-query for whatever reason -- a few of them were missing JWT tokens including `fetchAvailableLocales` and `searchObservations` (this is why it's great to standardize the way we're doing things whenever we can)
- Add error handling for `uploadEvidence`, because it's possible that our JWT tokens are expiring before a set of bulk uploads complete (say if a user leaves the MyObservations screen and comes back to ongoing bulk uploads minutes, hours, or days later). For this one, when we refactor uploadObservations we could do more decoupling and intentionally force JWTs to update at every stage of the upload process

FYI @angielt on this multi-pronged approach since I know you were looking into this too.