### PR TITLE
Only show no  suggestions match screen UI without additional suggestions

### DIFF
--- a/src/components/Match/Match.js
+++ b/src/components/Match/Match.js
@@ -58,7 +58,7 @@ const Match = ( {
   const taxon = topSuggestion?.taxon;
 
   // In case the photo could not be identified
-  if ( !topSuggestion ) {
+  if ( !topSuggestion && otherSuggestions.length === 0 ) {
     return (
       <>
         <ScrollViewWrapper scrollRef={scrollRef}>


### PR DESCRIPTION
So, in a case of having no top suggestion but low confidence additional suggestions we show all UI available for the match screen, so that a user can potentially also improve them by giving location permission.

Tested with the first photo here: 
https://linear.app/inaturalist/issue/MOB-600/match-screen-special-handling-of-potential-dual-species-situations