### PR TITLE
Fix: id text on every item

### DIFF
--- a/src/components/ObsDetailsDefaultMode/CommunitySection/ActivityItem.js
+++ b/src/components/ObsDetailsDefaultMode/CommunitySection/ActivityItem.js
@@ -118,11 +118,21 @@ const ActivityItem = ( {
             withdrawn={idWithdrawn}
           />
         )}
-        { showExplainerText && (
-          <Body4 className="py-2 font-Lato-Italic">
-            {t( "This-is-your-identification-other-people-may-help-confirm-it" )}
-          </Body4>
-        )}
+        {/*
+          Only show explainer text if we are on the user's obs, if it is an ID of this user
+          and the user has in total less than 10 obs (handled in HOC)
+        */}
+        { showExplainerText
+          && belongsToCurrentUser
+          && taxon
+          && user?.id === currentUserId
+          && (
+            <Body4 className="py-2 font-Lato-Italic">
+              {t(
+                "This-is-your-identification-other-people-may-help-confirm-it"
+              )}
+            </Body4>
+          )}
       </View>
       <Divider />
     </View>

--- a/src/components/ObsDetailsDefaultMode/CommunitySection/CommunitySection.js
+++ b/src/components/ObsDetailsDefaultMode/CommunitySection/CommunitySection.js
@@ -91,11 +91,7 @@ const ActivitySection = ( {
               geoprivacy={geoprivacy}
               taxonGeoprivacy={taxonGeoprivacy}
               belongsToCurrentUser={belongsToCurrentUser}
-              showExplainerText={
-                // Only show explainer text if we are on the user's obs,
-                // and the user has in total less than 10 obs
-                belongsToCurrentUser && currentUser?.observations_count < 10
-              }
+              showExplainerText={currentUser?.observations_count < 10}
             />
           </View>
         ) )}

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1249,6 +1249,7 @@ The-models-that-suggest-species = The models that suggest species based on visua
 #  Wild status sheet descriptions
 This-is-a-wild-organism = This is a wild organism and wasn't placed in this location by humans.
 This-is-how-taxon-names-will-be-displayed = This is how all taxon names will be displayed to you across iNaturalist:
+# Text shown only for new users on their own ID on their first few observations
 This-is-your-identification-other-people-may-help-confirm-it = This is your identification. Other people may help confirm it!
 This-may-take-a-few-seconds = This may take a few seconds.
 This-observation-has-no-comments-or-identifications-yet = This observation has no comments or identifications yet.

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1249,6 +1249,7 @@ The-models-that-suggest-species = The models that suggest species based on visua
 #  Wild status sheet descriptions
 This-is-a-wild-organism = This is a wild organism and wasn't placed in this location by humans.
 This-is-how-taxon-names-will-be-displayed = This is how all taxon names will be displayed to you across iNaturalist:
+# Text shown only for new users on their own ID on their first few observations
 This-is-your-identification-other-people-may-help-confirm-it = This is your identification. Other people may help confirm it!
 This-may-take-a-few-seconds = This may take a few seconds.
 This-observation-has-no-comments-or-identifications-yet = This observation has no comments or identifications yet.


### PR DESCRIPTION
Only show explainer text if we are on the user's obs, if it is an ID of this user and the user has in total less than 10 obs (handled in HOC).

Closes MOB-630