### PR TITLE
For image similarity spread online suggestion's taxon into existing offline info

### DIFF
--- a/src/components/Match/helpers/tryToReplaceWithLocalTaxon.js
+++ b/src/components/Match/helpers/tryToReplaceWithLocalTaxon.js
@@ -4,7 +4,10 @@ const tryToReplaceWithLocalTaxon = ( localTaxa, suggestion ) => {
   if ( localTaxon ) {
     return {
       ...suggestion,
-      taxon: localTaxon
+      taxon: {
+        ...suggestion?.taxon,
+        ...localTaxon
+      }
     };
   }
 


### PR DESCRIPTION
Closes MOB-634
This is necessary because the representative_photo returned by the image similarity search from API is fleeting only (e.g. from useOnlineSuggestions -> useSuggestions -> suggestions.topSuggestion). The key is not saved to realm with the taxon because it only is relevant to the current photo scored on the API. Therefore when overriding the taxon info with offline data we need to keep it.