### PR TITLE
Disable fetching offline suggestions for successful but empty online results

### DIFF
--- a/src/sharedHooks/useSuggestions/useSuggestions.js
+++ b/src/sharedHooks/useSuggestions/useSuggestions.js
@@ -48,9 +48,7 @@ export const useSuggestions = ( photoUri, options ) => {
   // skip to offline suggestions if internet connection is spotty
   const tryOfflineSuggestions = !urlWillCrashOffline && (
     timedOut
-    || (
-      ( !onlineSuggestions || onlineSuggestions?.results?.length === 0 )
-      && onlineSuggestionsAttempted )
+    || ( !onlineSuggestions && onlineSuggestionsAttempted )
   );
 
   const {


### PR DESCRIPTION
Close MOB-486

As discussed on the linked linear issue, we want to trust online results more than offline results. So, if the online API call was successful but resulted in zero suggestions (currently, this can happen for example if human is part of the low-confidence suggestions that are filtered out before returning).