### PR TITLE
Fix: limit API calls in AICamera to avoid delay in advancing navigation

### DIFF
--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -277,6 +277,10 @@ const AICamera = ( {
                 taxon={result?.taxon}
                 testID={`AICamera.taxa.${result?.taxon?.id}`}
                 white
+                // my thinking here is that we're already making this API call over and over
+                // every second when a prediction comes back, and we likely don't want to
+                // 3x that in low network conditions if every request is failing
+                retryQuery={false}
               />
             )
             : (

--- a/src/components/Camera/AICamera/hooks/usePredictions.ts
+++ b/src/components/Camera/AICamera/hooks/usePredictions.ts
@@ -1,6 +1,8 @@
+import { RealmContext } from "providers/contexts.ts";
 import { useState } from "react";
-import { useIconicTaxa } from "sharedHooks";
 import { Result } from "vision-camera-plugin-inatvision";
+
+const { useRealm } = RealmContext;
 
 interface StoredResult {
   taxon: {
@@ -14,6 +16,7 @@ interface StoredResult {
 }
 
 const usePredictions = ( ) => {
+  const realm = useRealm( );
   const [result, setResult] = useState<StoredResult | null>( null );
   const [resultTimestamp, setResultTimestamp] = useState<number | undefined>( undefined );
   const [modelLoaded, setModelLoaded] = useState( false );
@@ -21,7 +24,7 @@ const usePredictions = ( ) => {
   const [fps, setFPS] = useState( 1 );
   const [numStoredResults, setNumStoredResults] = useState( 5 );
   const [cropRatio, setCropRatio] = useState( 1 );
-  const iconicTaxa = useIconicTaxa( );
+  const iconicTaxa = realm?.objects( "Taxon" ).filtered( "isIconic = true" );
 
   const handleTaxaDetected = ( cvResult: Result ) => {
     if ( cvResult && !modelLoaded ) {

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -66,6 +66,7 @@ const TaxonResult = ( {
   hideNavButtons = false,
   lastScreen = null,
   onPressInfo,
+  retryQuery = true,
   showCheckmark = true,
   showEditButton = false,
   showRemoveButton = false,
@@ -84,7 +85,11 @@ const TaxonResult = ( {
   // network requests for useTaxon instead of making individual API calls.
   // right now, this fetches a single taxon at a time on AI camera &
   // a short list of taxa from offline Suggestions
-  const { taxon: localTaxon } = useTaxon( taxonProp, fetchRemote ) as { taxon: RealmTaxon };
+  const { taxon: localTaxon } = useTaxon(
+    taxonProp,
+    fetchRemote,
+    retryQuery
+  ) as { taxon: RealmTaxon };
   const usableTaxon = fromLocal
     ? localTaxon
     : taxonProp;

--- a/src/sharedHooks/useAuthenticatedQuery.js
+++ b/src/sharedHooks/useAuthenticatedQuery.js
@@ -45,13 +45,15 @@ const useAuthenticatedQuery = (
       };
       return queryFunction( options );
     },
-    retry: ( failureCount, error ) => reactQueryRetry( failureCount, error, {
-      queryKey,
-      routeName: route?.name,
-      routeParams: route?.params
-    } ),
-    retryDelay: ( failureCount, error ) => handleRetryDelay( failureCount, error ),
     ...queryOptions,
+    retry: queryOptions.retry !== false
+      ? ( failureCount, error ) => reactQueryRetry( failureCount, error, {
+        queryKey,
+        routeName: route?.name,
+        routeParams: route?.params
+      } )
+      : false,
+    retryDelay: ( failureCount, error ) => handleRetryDelay( failureCount, error ),
     // Authenticated queries should not run until we know whether or not the
     // user is signed in
     enabled: userLoggedIn !== LOGGED_IN_UNKNOWN && queryOptions.enabled

--- a/src/sharedHooks/useTaxon.js
+++ b/src/sharedHooks/useTaxon.js
@@ -21,7 +21,7 @@ const ONE_WEEK_MS = (
 );
 
 // $FlowIgnore
-const useTaxon = ( taxon: Object, fetchRemote = true ): Object => {
+const useTaxon = ( taxon: Object, fetchRemote = true, retryQuery = true ): Object => {
   const realm = useRealm( );
   // taxon id is returned as a string, not a number, from CV model
   const taxonId = Number( taxon?.id );
@@ -67,7 +67,8 @@ const useTaxon = ( taxon: Object, fetchRemote = true ): Object => {
     ["fetchTaxon", taxonId],
     optsWithAuth => fetchTaxon( taxonId, params, optsWithAuth ),
     {
-      enabled
+      enabled,
+      retry: retryQuery
     }
   );
 

--- a/src/sharedHooks/useTaxonSearch.ts
+++ b/src/sharedHooks/useTaxonSearch.ts
@@ -7,7 +7,7 @@ import Taxon from "realmModels/Taxon";
 import type { RealmTaxon } from "realmModels/types";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import validateRealmSearch from "sharedHelpers/validateRealmSearch.ts";
-import { useAuthenticatedQuery, useIconicTaxa } from "sharedHooks";
+import { useAuthenticatedQuery } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
@@ -28,7 +28,7 @@ function saveTaxaToRealm( taxa: Taxon[], realm: Realm ) {
 
 const useTaxonSearch = ( taxonQueryArg = "" ) => {
   const realm = useRealm( );
-  const iconicTaxa = useIconicTaxa( { reload: false } );
+  const iconicTaxa = realm?.objects( "Taxon" ).filtered( "isIconic = true" );
   // Remove leading and trailing whitespace, no need to perform new queries or
   // potentially get different results b/c of meaningless whitespace
   const taxonQuery = taxonQueryArg.trim();

--- a/src/sharedHooks/useTaxonSearch.ts
+++ b/src/sharedHooks/useTaxonSearch.ts
@@ -7,7 +7,7 @@ import Taxon from "realmModels/Taxon";
 import type { RealmTaxon } from "realmModels/types";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import validateRealmSearch from "sharedHelpers/validateRealmSearch.ts";
-import { useAuthenticatedQuery } from "sharedHooks";
+import { useAuthenticatedQuery, useIconicTaxa } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
@@ -28,7 +28,7 @@ function saveTaxaToRealm( taxa: Taxon[], realm: Realm ) {
 
 const useTaxonSearch = ( taxonQueryArg = "" ) => {
   const realm = useRealm( );
-  const iconicTaxa = realm?.objects( "Taxon" ).filtered( "isIconic = true" );
+  const iconicTaxa = useIconicTaxa( { reload: false } );
   // Remove leading and trailing whitespace, no need to perform new queries or
   // potentially get different results b/c of meaningless whitespace
   const taxonQuery = taxonQueryArg.trim();


### PR DESCRIPTION
Closes Mob-635

I wasn't able to reproduce this, so taking a multi-pronged approach to avoid lengthy network requests here:

- Make sure we're not accidentally calling the API for iconic taxon whenever there's a new prediction. We fetch that data to store in Realm on app startup, so we can get it directly from Realm instead of the API.
- Set no retries for each TaxonResult (prediction) in the AICamera, since this API is being fetched every second anyway, and it seems wise to make sure these API calls are not stacking up (3 retries each) in low connectivity conditions
- Set a 2.5 second timeout for the geocoded observation place name