### PR TITLE
Use existing MMKV instance to check for fresh install

### DIFF
--- a/src/components/StartupService.js
+++ b/src/components/StartupService.js
@@ -6,10 +6,10 @@ import { RealmContext } from "providers/contexts.ts";
 import { useEffect } from "react";
 import { LogBox } from "react-native";
 import DeviceInfo from "react-native-device-info";
-import { MMKV } from "react-native-mmkv";
 import Orientation from "react-native-orientation-locker";
 import Realm from "realm";
 import clearCaches from "sharedHelpers/clearCaches.ts";
+import { IS_FRESH_INSTALL, store } from "sharedHelpers/installData.ts";
 import { log } from "sharedHelpers/logger";
 import { addARCameraFiles } from "sharedHelpers/mlModel.ts";
 import { findAndLogSentinelFiles } from "sharedHelpers/sentinelFiles.ts";
@@ -33,16 +33,6 @@ NetInfo.configure( {
   reachabilityUrl: "https://www.inaturalist.org/ping"
 } );
 
-// it's not recommended to have multiple instances of MMKV in an app, but
-// we can't use the zustand one here since it hasn't been initialized yet,
-// and I don't think we can move storage creation into App.js without creating
-// a dependency cycle
-const installStatus = new MMKV( {
-  id: "install-status"
-} );
-
-const INSTALL_STATUS = "alreadyLaunched";
-
 const isTablet = DeviceInfo.isTablet( );
 
 const { useRealm } = RealmContext;
@@ -51,6 +41,18 @@ const logger = log.extend( "StartupService" );
 
 const geolocationConfig = {
   skipPermissionRequests: true
+};
+
+const checkForPreviousCrash = async ( ) => {
+  try {
+    const crashData = zustandStorage.getItem( "LAST_CRASH_DATA" );
+    if ( crashData ) {
+      logger.error( `Last Crash Data: ${JSON.parse( crashData )}` );
+      zustandStorage.removeItem( "LAST_CRASH_DATA" );
+    }
+  } catch ( e ) {
+    logger.error( "Failed to process previous crash data", e );
+  }
 };
 
 const StartupService = ( ) => {
@@ -70,35 +72,27 @@ const StartupService = ( ) => {
       // if it is, delete realm file when we sign the user out of the app
       // this handles the case where a user deletes the app, then reinstalls
       // and expects to be signed out with no previously saved data
-        const alreadyLaunched = installStatus.getBoolean( INSTALL_STATUS );
-        if ( !alreadyLaunched ) {
-          installStatus.set( INSTALL_STATUS, true );
+        const isFreshInstall = store.getBoolean( IS_FRESH_INSTALL );
+        if ( isFreshInstall ) {
+          store.set( IS_FRESH_INSTALL, false );
           if ( !currentUser ) {
             await signOut( { clearRealm: true } );
           }
+        } else {
+          // make sure the MMKV store has been created on a previous installation
+          // before trying to query it
+          // though we really should only have one store
+          await checkForPreviousCrash( );
+          // also don't bother looking for sentinel files if user has a fresh installation
+          await findAndLogSentinelFiles( );
         }
       };
       // don't remove this logger.info statement: it's used for internal metrics
       logger.info( "pickup" );
 
-      const checkForPreviousCrash = async ( ) => {
-        try {
-          const crashData = zustandStorage.getItem( "LAST_CRASH_DATA" );
-          if ( crashData ) {
-            logger.error( `Last Crash Data: ${JSON.parse( crashData )}` );
-            zustandStorage.removeItem( "LAST_CRASH_DATA" );
-          }
-        } catch ( e ) {
-          logger.error( "Failed to process previous crash data", e );
-        }
-      };
-
       try {
         await checkForSignedInUser( );
-        await checkForPreviousCrash( );
-
         await addARCameraFiles( );
-        await findAndLogSentinelFiles( );
 
         // this ensures that React Query has the most accurate depiction of whether the
         // app is online or offline. since queries only run when the app is online, this

--- a/src/sharedHelpers/installData.ts
+++ b/src/sharedHelpers/installData.ts
@@ -5,10 +5,11 @@ import * as uuid from "uuid";
 const MMKV_ID = "install-data";
 const INSTALL_ID = "installID";
 const ONBOARDING_SHOWN = "onboardingShown";
+export const IS_FRESH_INSTALL = "isFreshInstall";
 
 // This store is separate from the zustand store b/c it needs to survive sign
 // out, i.e these values should remain untill the app is uninstalled
-const store = new MMKV( { id: MMKV_ID } );
+export const store = new MMKV( { id: MMKV_ID } );
 
 // Migrate old MMKV data if it exists. This data is explicitly *not*
 // linked to a user
@@ -34,6 +35,7 @@ export function getInstallID( ) {
   if ( id ) return id;
   const newID: string = uuid.v4( ).toString( );
   store.set( INSTALL_ID, newID );
+  store.set( IS_FRESH_INSTALL, true );
   return newID;
 }
 

--- a/src/sharedHelpers/installData.ts
+++ b/src/sharedHelpers/installData.ts
@@ -14,7 +14,7 @@ export const store = new MMKV( { id: MMKV_ID } );
 // Migrate old MMKV data if it exists. This data is explicitly *not*
 // linked to a user
 const LEGACY_MMKV_ID = "user-data";
-const legacyStore = new MMKV( { id: LEGACY_MMKV_ID } );
+let legacyStore;
 if ( legacyStore.getAllKeys().length > 0 ) {
   // Migrate data if present
   legacyStore.getAllKeys().forEach( key => {
@@ -22,11 +22,15 @@ if ( legacyStore.getAllKeys().length > 0 ) {
   } );
   // Delete the old data on disk so we never have to do this again
   RNFS.readDir( `${RNFS.DocumentDirectoryPath}/mmkv` ).then( contents => {
-    contents.forEach( item => {
+    const hasLegacyFiles = contents.forEach( item => {
       if ( item.path.match( new RegExp( `/${LEGACY_MMKV_ID}` ) ) ) {
         RNFS.unlink( item.path );
       }
     } );
+
+    if ( hasLegacyFiles ) {
+      legacyStore = new MMKV( { id: LEGACY_MMKV_ID } );
+    }
   } );
 }
 

--- a/src/sharedHelpers/installData.ts
+++ b/src/sharedHelpers/installData.ts
@@ -14,7 +14,7 @@ export const store = new MMKV( { id: MMKV_ID } );
 // Migrate old MMKV data if it exists. This data is explicitly *not*
 // linked to a user
 const LEGACY_MMKV_ID = "user-data";
-let legacyStore;
+const legacyStore = new MMKV( { id: LEGACY_MMKV_ID } );
 if ( legacyStore.getAllKeys().length > 0 ) {
   // Migrate data if present
   legacyStore.getAllKeys().forEach( key => {
@@ -22,15 +22,11 @@ if ( legacyStore.getAllKeys().length > 0 ) {
   } );
   // Delete the old data on disk so we never have to do this again
   RNFS.readDir( `${RNFS.DocumentDirectoryPath}/mmkv` ).then( contents => {
-    const hasLegacyFiles = contents.forEach( item => {
+    contents.forEach( item => {
       if ( item.path.match( new RegExp( `/${LEGACY_MMKV_ID}` ) ) ) {
         RNFS.unlink( item.path );
       }
     } );
-
-    if ( hasLegacyFiles ) {
-      legacyStore = new MMKV( { id: LEGACY_MMKV_ID } );
-    }
   } );
 }
 


### PR DESCRIPTION
According to the docs, we really shouldn't be creating more than one MMKV instance. It turns out this is exactly the kind of thing that can cause a Signal 11 error, because of excessive memory usage or improper initialization.

I discovered this because I wanted to work on screen transitions and moving the onboarding screens into a react-navigation modal, but when I tried to access the `onboardingShown` data from MMKV in our `rootDrawerNavigator` I could no longer build a release build due to MMKV errors... maybe that instance of MMKV hadn't been initialized yet or was competing for resources?

Anyway, this is a partial fix since we're still creating three MMKV instances, but maybe creating only one new instance for fresh install instead of two instances is helpful.