### PR TITLE
Fix: revert upload code

### DIFF
--- a/src/realmModels/ObservationPhoto.js
+++ b/src/realmModels/ObservationPhoto.js
@@ -1,11 +1,8 @@
 import { Realm } from "@realm/react";
 import inatjs, { FileUpload } from "inaturalistjs";
-import { log } from "sharedHelpers/logger";
 import * as uuid from "uuid";
 
 import Photo from "./Photo";
-
-const logger = log.extend( "Realm ObservationPhoto" );
 
 class ObservationPhoto extends Realm.Object {
   static OBSERVATION_PHOTOS_FIELDS = {
@@ -43,14 +40,6 @@ class ObservationPhoto extends Realm.Object {
   }
 
   static mapPhotoForAttachingToObs( observationID, observationPhoto ) {
-    // when the app is backgrounded, we don't always have the observationPhoto id
-    // available. instead, we need that upload to fail so a user
-    // can upload again later without their photo disappearing (being marked as
-    // completed in realm)
-    if ( !observationPhoto.photo || !observationPhoto.photo.id ) {
-      logger.info( `Skipping attachment of photo without ID: ${observationPhoto.uuid}` );
-      return null;
-    }
     return {
       observation_photo: {
         uuid: observationPhoto.uuid,

--- a/src/realmModels/ObservationSound.js
+++ b/src/realmModels/ObservationSound.js
@@ -1,13 +1,10 @@
 import { Realm } from "@realm/react";
 import { FileUpload } from "inaturalistjs";
 import { Platform } from "react-native";
-import { log } from "sharedHelpers/logger";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import * as uuid from "uuid";
 
 import Sound from "./Sound";
-
-const logger = log.extend( "Realm ObservationSound" );
 
 class ObservationSound extends Realm.Object {
   static OBSERVATION_SOUNDS_FIELDS = {
@@ -56,14 +53,6 @@ class ObservationSound extends Realm.Object {
   }
 
   static mapSoundForAttachingToObs( id, observationSound ) {
-    // when the app is backgrounded, we don't always have the observationPhoto id
-    // available. instead, we need that upload to fail so a user
-    // can upload again later without their photo disappearing (being marked as
-    // completed in realm)
-    if ( !observationSound || !observationSound.id ) {
-      logger.info( `Skipping attachment of sound without ID: ${observationSound.uuid}` );
-      return null;
-    }
     return {
       "observation_sound[observation_id]": id,
       "observation_sound[sound_id]": observationSound.id,


### PR DESCRIPTION
Another attempt to close MOB-639.

After a lot of looking at our upload code, I realized I didn't take my own advice a few weeks ago to not touch the upload code. I'm now suspicious that [this PR](https://github.com/inaturalist/iNaturalistReactNative/pull/2783) to try to handle jwt errors is actually what recently made bulk uploads spotty. Before that, we hadn't touched that code since November, so I put this upload code back to the state it was in before.

With this reversion, I made a local release build. Unlike the current build from `main` (or in TestFlight) I can now background the app, come back, and see my uploads continue as expected with no photos dropped.

Would be great to review & merge this if it's working for others before the next public release.