### PR TITLE
Fix: Add a step to rebuild *native* modules after restoring node cache

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -61,6 +61,14 @@ jobs:
       # Currently, (Detox 20) those two commands are macOS only
       run: npx detox clean-framework-cache && npx detox build-framework-cache
 
+    # supposedly our current cache includes cache includes native modules like Realm
+    # that have compiled binaries specific to the environment where they were installed
+    # which might not be the same as the github actions environment
+    # so we need to rebuild them
+    - name: Rebuild native modules
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: npm rebuild
+
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm install

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -62,6 +62,14 @@ jobs:
       if: steps.cache.outputs.cache-hit == 'true'
       run: npx detox clean-framework-cache && npx detox build-framework-cache
 
+    # supposedly our current cache includes cache includes native modules like Realm
+    # that have compiled binaries specific to the environment where they were installed
+    # which might not be the same as the github actions environment
+    # so we need to rebuild them
+    - name: Rebuild native modules
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: npm rebuild
+
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,14 @@ jobs:
         path: node_modules
         key: node-modules-${{ hashFiles('**/package-lock.json') }}
 
+    # supposedly our current cache includes cache includes native modules like Realm
+    # that have compiled binaries specific to the environment where they were installed
+    # which might not be the same as the github actions environment
+    # so we need to rebuild them
+    - name: Rebuild native modules
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: npm rebuild
+
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm install


### PR DESCRIPTION
We're seeing this error `node_modules/realm/prebuilds/node/realm.node: invalid ELF header` in our current Github Actions tests, and supposedly that means the binary Realm file doesn't have the correct format for the system that's trying to execute it. It was built in one of our local environments and cached, but now Github Actions is trying to run it in a different environment.

After we retrieve the cached `node_modules`, we can make sure binary modules are recompiled for the current environment.