### PR TITLE
Add error context to crash reporting

### DIFF
--- a/src/api/error.js
+++ b/src/api/error.js
@@ -11,10 +11,14 @@ export class INatApiError extends Error {
   // HTTP status code of the server response
   status: number;
 
-  constructor( json: Object, status?: number ) {
+  // Additional context information
+  context: ?Object;
+
+  constructor( json: Object, status?: number, context?: Object ) {
     super( JSON.stringify( json ) );
     this.json = json;
     this.status = status || json.status;
+    this.context = context || null;
   }
 }
 // https://wbinnssmith.com/blog/subclassing-error-in-modern-javascript/
@@ -23,8 +27,8 @@ Object.defineProperty( INatApiError.prototype, "name", {
 } );
 
 export class INatApiTooManyRequestsError extends INatApiError {
-  constructor() {
-    super( { error: "Too Many Requests", status: 429 } );
+  constructor( context?: Object ) {
+    super( { error: "Too Many Requests", status: 429 }, 429, context );
   }
 }
 Object.defineProperty( INatApiTooManyRequestsError, "name", {
@@ -34,12 +38,15 @@ Object.defineProperty( INatApiTooManyRequestsError, "name", {
 async function handleError( e: Object, options: Object = {} ): Object {
   if ( !e.response ) { throw e; }
 
+  // Get context from options if available
+  const context = options?.context || null;
+
   // 429 responses don't return JSON so the parsing that we do below will
   // fail. Also, info about the request that triggered the 429 response is
   // kind of irrelevant. It's the behaviors that led up to being blocked that
   // matter.
   if ( e.response.status === 429 ) {
-    throw new INatApiTooManyRequestsError( );
+    throw new INatApiTooManyRequestsError( context );
   }
 
   // Try to parse JSON in the response if this was an HTTP error. If we can't
@@ -70,7 +77,7 @@ async function handleError( e: Object, options: Object = {} ): Object {
     } );
   }
 
-  const error = new INatApiError( errorJson, e.response.status );
+  const error = new INatApiError( errorJson, e.response.status, context );
 
   // In theory code higher up in the stack will handle this error when thrown,
   // so it's probably not worth reporting at this stage. If it doesn't get
@@ -79,7 +86,10 @@ async function handleError( e: Object, options: Object = {} ): Object {
   console.error(
     `Error requesting ${e.response.url} (status: ${e.response.status}):
     ${JSON.stringify( errorJson )}`,
-    error
+    error,
+    error.context
+      ? JSON.stringify( error.context )
+      : "No context"
   );
   if ( typeof ( options.onApiError ) === "function" ) {
     options.onApiError( error );

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -28,10 +28,16 @@ Object.defineProperty( INatApiError.prototype, "name", {
 
 export class INatApiTooManyRequestsError extends INatApiError {
   constructor( context?: Object ) {
-    super( { error: "Too Many Requests", status: 429 }, 429, context );
+    const errorJson = {
+      error: "Too Many Requests",
+      status: 429,
+      context
+    };
+    super( errorJson, 429, context );
   }
 }
-Object.defineProperty( INatApiTooManyRequestsError, "name", {
+
+Object.defineProperty( INatApiTooManyRequestsError.prototype, "name", {
   value: "INatApiTooManyRequestsError"
 } );
 

--- a/src/components/Developer/Developer.js
+++ b/src/components/Developer/Developer.js
@@ -126,13 +126,25 @@ const Developer = (): Node => {
                 className="mb-5"
               />
               <Button
-                onPress={() => { throw new INatApiError( { error: "Test error", status: 422 } ); }}
+                onPress={() => {
+                  throw new INatApiError( {
+                    error: "Test error",
+                    status: 422,
+                    context: {
+                      routeName: "MyObservations",
+                      timestamp: new Date().toISOString()
+                    }
+                  } );
+                }}
                 text="TEST INATAPIERROR"
                 className="mb-5"
               />
               <Button
                 onPress={() => {
-                  throw new INatApiTooManyRequestsError( );
+                  throw new INatApiTooManyRequestsError( {
+                    routeName: "TaxonDetails",
+                    timestamp: new Date().toISOString()
+                  } );
                 }}
                 text="TEST API TOO MANY REQUESTS ERROR"
                 className="mb-5"


### PR DESCRIPTION
For better or worse we haven't gotten the 429 errors in Grafana for build 0.59.16 yet that would confirm that this is working in a production environment, but we can simulate that it's working in <Developer /> by pressing the relevant 429 error button. This is intended to help us understand what a user was doing in the app before they receive a 429 error.