### PR TITLE
Prevent multiple taps on all Button components

### DIFF
--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -153,3 +153,11 @@ jest.mock( "sharedHelpers/installData", ( ) => ( {
   useOnboardingShown: jest.fn( ( ) => [true, jest.fn()] ),
   getInstallID: jest.fn( ( ) => "fake-installation-id" )
 } ) );
+
+jest.mock( "components/SharedComponents/Buttons/Button.tsx", () => {
+  const actualButton = jest
+    .requireActual( "components/SharedComponents/Buttons/Button.tsx" ).default;
+  // Use a very short debounce time (10ms) in tests to simulate the 300ms
+  // debounce time in the actual Button component
+  return jest.fn( props => actualButton( { ...props, debounceTime: 10 } ) );
+} );


### PR DESCRIPTION
Adds a brief debounce to `<Button />` to make sure the user cannot press the button in rapid succession and thereby get lost in a navigational time warp. (Like needing to navigate back through multiple stacked versions of Suggestions.)