### PR TITLE
MOB-665 - group photos - add white background to import observations button (#2834)

### DIFF
--- a/src/components/PhotoImporter/GroupPhotos.js
+++ b/src/components/PhotoImporter/GroupPhotos.js
@@ -186,7 +186,7 @@ const GroupPhotos = ( {
       </FloatingActionBar>
       <ButtonBar
         sticky
-        containerClass="items-center z-50"
+        containerClass="items-center z-50 bg-white"
         onLayout={onLayout}
       >
         <Button


### PR DESCRIPTION
Minor fix to add a white background to the button bar on the GroupPhotos screen.