### PR TITLE
Add tracking for Pressable and INatIconButton taps

### DIFF
--- a/src/components/MyObservations/MyObservationsEmptySimple.js
+++ b/src/components/MyObservations/MyObservationsEmptySimple.js
@@ -8,11 +8,12 @@ import {
 } from "components/SharedComponents";
 import GradientButton from "components/SharedComponents/Buttons/GradientButton.tsx";
 import Modal from "components/SharedComponents/Modal.tsx";
-import { View } from "components/styledComponents";
+import {
+  Pressable, View
+} from "components/styledComponents";
 import Arrow from "images/svg/curved_arrow_down.svg";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { Pressable } from "react-native";
 import { useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
 

--- a/src/components/SharedComponents/Buttons/Button.tsx
+++ b/src/components/SharedComponents/Buttons/Button.tsx
@@ -2,13 +2,9 @@ import { tailwindFontBold } from "appConstants/fontFamilies.ts";
 import classnames from "classnames";
 import { ActivityIndicator, Heading4, INatIcon } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
-import { getCurrentRoute } from "navigation/navigationUtils.ts";
 import React, { useEffect, useRef, useState } from "react";
 import { AccessibilityRole, GestureResponderEvent, ViewStyle } from "react-native";
-import { log } from "sharedHelpers/logger";
 import colors from "styles/tailwindColors";
-
-const logger = log.extend( "Button" );
 
 interface ButtonProps {
   accessibilityHint?: string;
@@ -212,17 +208,7 @@ const Button = ( {
   //   forceDark
   // } );
 
-  const handlePress = async ( event?: GestureResponderEvent ) => {
-    const currentRoute = getCurrentRoute();
-    const buttonInfo = {
-      accessibilityHint: accessibilityHint || null,
-      accessibilityLabel: accessibilityLabel || null,
-      testID: testID || null,
-      text: text || null,
-      routeName: currentRoute?.name || null
-    };
-
-    logger.info( "Button tap:", JSON.stringify( buttonInfo ) );
+  const handlePress = ( event?: GestureResponderEvent ) => {
     if ( !preventMultipleTaps ) {
       onPressRef.current( event );
       return;

--- a/src/components/SharedComponents/Buttons/Button.tsx
+++ b/src/components/SharedComponents/Buttons/Button.tsx
@@ -2,9 +2,13 @@ import { tailwindFontBold } from "appConstants/fontFamilies.ts";
 import classnames from "classnames";
 import { ActivityIndicator, Heading4, INatIcon } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
+import { getCurrentRoute } from "navigation/navigationUtils.ts";
 import React, { useEffect, useRef, useState } from "react";
 import { AccessibilityRole, GestureResponderEvent, ViewStyle } from "react-native";
+import { log } from "sharedHelpers/logger";
 import colors from "styles/tailwindColors";
+
+const logger = log.extend( "Button" );
 
 interface ButtonProps {
   accessibilityHint?: string;
@@ -208,7 +212,17 @@ const Button = ( {
   //   forceDark
   // } );
 
-  const handlePress = ( event?: GestureResponderEvent ) => {
+  const handlePress = async ( event?: GestureResponderEvent ) => {
+    const currentRoute = getCurrentRoute();
+    const buttonInfo = {
+      accessibilityHint: accessibilityHint || null,
+      accessibilityLabel: accessibilityLabel || null,
+      testID: testID || null,
+      text: text || null,
+      routeName: currentRoute?.name || null
+    };
+
+    logger.info( "Button tap:", JSON.stringify( buttonInfo ) );
     if ( !preventMultipleTaps ) {
       onPressRef.current( event );
       return;

--- a/src/components/SharedComponents/Buttons/INatIconButton.tsx
+++ b/src/components/SharedComponents/Buttons/INatIconButton.tsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import { INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
+import { getCurrentRoute } from "navigation/navigationUtils.ts";
 import React, { PropsWithChildren } from "react";
 import {
   GestureResponderEvent,
@@ -8,7 +9,10 @@ import {
   Pressable,
   ViewStyle
 } from "react-native";
+import { log } from "sharedHelpers/logger";
 import colors from "styles/tailwindColors";
+
+const logger = log.extend( "INatIconButton" );
 
 interface Props extends PropsWithChildren {
   accessibilityHint?: string;
@@ -171,6 +175,17 @@ const INatIconButton = ( {
     );
   }
 
+  const handlePressWithTracking = ( event?: GestureResponderEvent ) => {
+    if ( testID ) {
+      const currentRoute = getCurrentRoute( );
+      logger.info( `Button tap: ${testID}-${currentRoute?.name || "undefined"}` );
+    }
+
+    if ( onPress ) {
+      onPress( event );
+    }
+  };
+
   return (
     <Pressable
       accessibilityHint={accessibilityHint}
@@ -178,7 +193,7 @@ const INatIconButton = ( {
       accessibilityRole="button"
       accessibilityState={{ disabled }}
       disabled={disabled}
-      onPress={onPress}
+      onPress={handlePressWithTracking}
       style={( { pressed } ) => [
         ...wrapperStyle,
         { opacity: getOpacity( pressed ) }

--- a/src/components/SharedComponents/Buttons/PressableWithTracking.tsx
+++ b/src/components/SharedComponents/Buttons/PressableWithTracking.tsx
@@ -1,0 +1,26 @@
+import { getCurrentRoute } from "navigation/navigationUtils.ts";
+import React from "react";
+import { GestureResponderEvent, Pressable } from "react-native";
+import { log } from "sharedHelpers/logger";
+
+const logger = log.extend( "PressableWithTracking" );
+
+const PressableWithTracking = React.forwardRef( ( props, ref ) => {
+  const { onPress, ...otherProps } = props;
+
+  const handlePressWithTracking = ( event?: GestureResponderEvent ) => {
+    if ( otherProps?.testID ) {
+      const currentRoute = getCurrentRoute( );
+      logger.info( `Button tap: ${otherProps?.testID}-${currentRoute?.name || "undefined"}` );
+    }
+
+    if ( onPress ) {
+      onPress( event );
+    }
+  };
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <Pressable {...otherProps} onPress={handlePressWithTracking} ref={ref} />;
+} );
+
+export default PressableWithTracking;

--- a/src/components/SharedComponents/IconicTaxonChooser.tsx
+++ b/src/components/SharedComponents/IconicTaxonChooser.tsx
@@ -78,6 +78,7 @@ const IconicTaxonChooser = ( {
           accessibilityHint={
             t( "Selects-iconic-taxon-X-for-identification", { iconicTaxon: iconicTaxonName } )
           }
+          testID={`INatIconButton.IconicTaxonButton.${iconicTaxonName}`}
         />
       </View>
     );

--- a/src/components/styledComponents.js
+++ b/src/components/styledComponents.js
@@ -4,6 +4,8 @@ import { FasterImageView as UnstyledFasterImageView } from "@candlefinance/faste
 import {
   BottomSheetTextInput as StyledBottomSheetTextInput
 } from "@gorhom/bottom-sheet";
+import PressableWithTracking
+  from "components/SharedComponents/Buttons/PressableWithTracking.tsx";
 import { styled } from "nativewind";
 import {
   Image as UnstyledImage,
@@ -11,7 +13,6 @@ import {
   KeyboardAvoidingView as UnstyledKeyboardAvoidingView,
   Modal as UnstyledModal,
   Platform,
-  Pressable as StyledPressable,
   SafeAreaView as UnstyledSafeAreaView,
   ScrollView as UnstyledScrollView,
   Text as UnstyledText,
@@ -37,7 +38,7 @@ const Text = styled( UnstyledText );
 // $FlowIgnore
 const TextInput = styled( UntyledTextInput );
 // $FlowIgnore
-const Pressable = styled( StyledPressable );
+const Pressable = styled( PressableWithTracking );
 // $FlowIgnore
 const Image = styled( UnstyledImage );
 // $FlowIgnore

--- a/src/components/styledComponents.js
+++ b/src/components/styledComponents.js
@@ -4,7 +4,7 @@ import { FasterImageView as UnstyledFasterImageView } from "@candlefinance/faste
 import {
   BottomSheetTextInput as StyledBottomSheetTextInput
 } from "@gorhom/bottom-sheet";
-import PressableWithTracking
+import UnstyledPressableWithTracking
   from "components/SharedComponents/Buttons/PressableWithTracking.tsx";
 import { styled } from "nativewind";
 import {
@@ -38,7 +38,7 @@ const Text = styled( UnstyledText );
 // $FlowIgnore
 const TextInput = styled( UntyledTextInput );
 // $FlowIgnore
-const Pressable = styled( PressableWithTracking );
+const Pressable = styled( UnstyledPressableWithTracking );
 // $FlowIgnore
 const Image = styled( UnstyledImage );
 // $FlowIgnore


### PR DESCRIPTION
REVISED: see comments below.

ORIGINAL:
Trying out a simple approach to analytics by logging `Button` taps. If we like this approach, the next step would be to extend this to the rest of our tappable components such as `INatIconButton`.

This currently shows up in the logs as something like what's shown below, which also alerts me to one problem with this approach -- we're translating strings before passing them to the Button, which means we'll be logging text in all languages and making it hard to aggregate any data:

`{"level":"info","message":"Button tap: {\"accessibilityHint\":null,\"accessibilityLabel\":\"APP-SPRACHE ÄNDERN\",\"testID\":null,\"text\":\"APP-SPRACHE ÄNDERN\",\"routeName\":\"Settings\"}","context":"Button","timestamp":"2025-04-14T21:36:42.246Z"}`

I'm blanking on the right way to handle finding the original, non-translated version of an i18next string once the Button component receives an already translated version as props, but I'm sure there's a way to do this...