### PR TITLE
Do not access taxon in SuggestionsResult if none

### DIFF
--- a/src/components/Match/AdditionalSuggestions/SuggestionsResult.js
+++ b/src/components/Match/AdditionalSuggestions/SuggestionsResult.js
@@ -44,6 +44,10 @@ const SuggestionsResult = ( {
     }
   }, [forcedHeight] );
 
+  if ( !taxon ) {
+    return null;
+  }
+
   const accessibleName = accessibleTaxonName( taxon, currentUser, t );
 
   // A representative photo is dependant on the actual image that was scored by computer vision


### PR DESCRIPTION
MOB-692 related. Unsure if this is a fix for this issue.
This is the best I could come up with for now. I could not replicate this error locally.
It would be good to get detailed replication steps.
From experience not accessing any properties of the RealmObject is a good way to avoid this error message. `taxon` is the only RealmObject used in this component so maybe this change addresses it.
It's a bit weird because in the CustomFlashList higher in the stack we already access taxon.id which when I am testing with removing taxon directly from the suggestion error out. So, I am unsure how we can access something lower in the tree when not having it higher already should give a different error.
Anyways, I also checked Kibana to gauge what user actions happen before this error appears but couldn't see a pattern. Maybe good idea to release this PR and add a navigation breadcrumbs logging to errors as well.