### PR TITLE
Add tracking for any Pressable or INatIconButton with a testID

### DIFF
--- a/src/components/MyObservations/MyObservationsEmptySimple.js
+++ b/src/components/MyObservations/MyObservationsEmptySimple.js
@@ -8,11 +8,12 @@ import {
 } from "components/SharedComponents";
 import GradientButton from "components/SharedComponents/Buttons/GradientButton.tsx";
 import Modal from "components/SharedComponents/Modal.tsx";
-import { View } from "components/styledComponents";
+import {
+  Pressable, View
+} from "components/styledComponents";
 import Arrow from "images/svg/curved_arrow_down.svg";
 import type { Node } from "react";
 import React, { useState } from "react";
-import { Pressable } from "react-native";
 import { useTranslation } from "sharedHooks";
 import useStore from "stores/useStore";
 

--- a/src/components/SharedComponents/Buttons/INatIconButton.tsx
+++ b/src/components/SharedComponents/Buttons/INatIconButton.tsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import { INatIcon } from "components/SharedComponents";
 import { View } from "components/styledComponents";
+import { getCurrentRoute } from "navigation/navigationUtils.ts";
 import React, { PropsWithChildren } from "react";
 import {
   GestureResponderEvent,
@@ -8,7 +9,10 @@ import {
   Pressable,
   ViewStyle
 } from "react-native";
+import { log } from "sharedHelpers/logger";
 import colors from "styles/tailwindColors";
+
+const logger = log.extend( "INatIconButton" );
 
 interface Props extends PropsWithChildren {
   accessibilityHint?: string;
@@ -171,6 +175,17 @@ const INatIconButton = ( {
     );
   }
 
+  const handlePressWithTracking = ( event?: GestureResponderEvent ) => {
+    if ( testID ) {
+      const currentRoute = getCurrentRoute( );
+      logger.info( `Button tap: ${testID}-${currentRoute?.name || "undefined"}` );
+    }
+
+    if ( onPress ) {
+      onPress( event );
+    }
+  };
+
   return (
     <Pressable
       accessibilityHint={accessibilityHint}
@@ -178,7 +193,7 @@ const INatIconButton = ( {
       accessibilityRole="button"
       accessibilityState={{ disabled }}
       disabled={disabled}
-      onPress={onPress}
+      onPress={handlePressWithTracking}
       style={( { pressed } ) => [
         ...wrapperStyle,
         { opacity: getOpacity( pressed ) }

--- a/src/components/SharedComponents/Buttons/PressableWithTracking.tsx
+++ b/src/components/SharedComponents/Buttons/PressableWithTracking.tsx
@@ -1,0 +1,26 @@
+import { getCurrentRoute } from "navigation/navigationUtils.ts";
+import React from "react";
+import { GestureResponderEvent, Pressable } from "react-native";
+import { log } from "sharedHelpers/logger";
+
+const logger = log.extend( "PressableWithTracking" );
+
+const PressableWithTracking = React.forwardRef( ( props, ref ) => {
+  const { onPress, ...otherProps } = props;
+
+  const handlePressWithTracking = ( event?: GestureResponderEvent ) => {
+    if ( otherProps?.testID ) {
+      const currentRoute = getCurrentRoute( );
+      logger.info( `Button tap: ${otherProps?.testID}-${currentRoute?.name || "undefined"}` );
+    }
+
+    if ( onPress ) {
+      onPress( event );
+    }
+  };
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <Pressable {...otherProps} onPress={handlePressWithTracking} ref={ref} />;
+} );
+
+export default PressableWithTracking;

--- a/src/components/SharedComponents/IconicTaxonChooser.tsx
+++ b/src/components/SharedComponents/IconicTaxonChooser.tsx
@@ -78,6 +78,7 @@ const IconicTaxonChooser = ( {
           accessibilityHint={
             t( "Selects-iconic-taxon-X-for-identification", { iconicTaxon: iconicTaxonName } )
           }
+          testID={`INatIconButton.IconicTaxonButton.${iconicTaxonName}`}
         />
       </View>
     );

--- a/src/components/styledComponents.js
+++ b/src/components/styledComponents.js
@@ -4,6 +4,8 @@ import { FasterImageView as UnstyledFasterImageView } from "@candlefinance/faste
 import {
   BottomSheetTextInput as StyledBottomSheetTextInput
 } from "@gorhom/bottom-sheet";
+import UnstyledPressableWithTracking
+  from "components/SharedComponents/Buttons/PressableWithTracking.tsx";
 import { styled } from "nativewind";
 import {
   Image as UnstyledImage,
@@ -11,7 +13,6 @@ import {
   KeyboardAvoidingView as UnstyledKeyboardAvoidingView,
   Modal as UnstyledModal,
   Platform,
-  Pressable as StyledPressable,
   SafeAreaView as UnstyledSafeAreaView,
   ScrollView as UnstyledScrollView,
   Text as UnstyledText,
@@ -37,7 +38,7 @@ const Text = styled( UnstyledText );
 // $FlowIgnore
 const TextInput = styled( UntyledTextInput );
 // $FlowIgnore
-const Pressable = styled( StyledPressable );
+const Pressable = styled( UnstyledPressableWithTracking );
 // $FlowIgnore
 const Image = styled( UnstyledImage );
 // $FlowIgnore


### PR DESCRIPTION
This came out of a Creative Day discussion, where the engagement team wanted to understand whether or not anyone uses the iconic taxon buttons in ObsEdit. This is a first step to understanding that, as it records individual taps to our `/log` endpoint for those buttons as well as every button in the app with a `testID`. My goal here was to see how much data we can collect with a very minimal amount of code changes.

I'm not *quite* sure what we'll end up doing with this data, but I'm picturing a new Grafana dashboard that can help us make sense of these logs. TBD.