### PR TITLE
Fix: hrank/lrank 422 api error

### DIFF
--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -188,9 +188,9 @@ const FilterModal = ( {
   };
 
   const taxonomicRankValues = {
-    [TAXONOMIC_RANK.none]: {
-      label: t( "NONE--ranks" ),
-      value: TAXONOMIC_RANK.none
+    [TAXONOMIC_RANK.all]: {
+      label: t( "ALL" ),
+      value: TAXONOMIC_RANK.all
     },
     [TAXONOMIC_RANK.kingdom]: {
       label: t( "Ranks-KINGDOM" ),

--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -188,9 +188,9 @@ const FilterModal = ( {
   };
 
   const taxonomicRankValues = {
-    [TAXONOMIC_RANK.all]: {
-      label: t( "ALL" ),
-      value: TAXONOMIC_RANK.all
+    [TAXONOMIC_RANK.none]: {
+      label: t( "NONE--ranks" ),
+      value: TAXONOMIC_RANK.none
     },
     [TAXONOMIC_RANK.kingdom]: {
       label: t( "Ranks-KINGDOM" ),

--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -196,10 +196,6 @@ const FilterModal = ( {
       label: t( "Ranks-KINGDOM" ),
       value: TAXONOMIC_RANK.kingdom
     },
-    [TAXONOMIC_RANK.subkingdom]: {
-      label: t( "Ranks-SUBKINGDOM" ),
-      value: TAXONOMIC_RANK.subkingdom
-    },
     [TAXONOMIC_RANK.phylum]: {
       label: t( "Ranks-PHYLUM" ),
       value: TAXONOMIC_RANK.phylum

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1007,7 +1007,6 @@ Ranks-SUBFAMILY = SUBFAMILY
 Ranks-Subfamily = Subfamily
 Ranks-SUBGENUS = SUBGENUS
 Ranks-Subgenus = Subgenus
-Ranks-SUBKINGDOM = SUBKINGDOM
 Ranks-Subkingdom = Subkingdom
 Ranks-SUBORDER = SUBORDER
 Ranks-Suborder = Suborder

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -807,8 +807,6 @@ No-results-found-try-different-search = No results found. Try a different search
 no-rights-reserved-cc0 = no rights reserved (CC0)
 # Displayed in place of positional accuracy when that value is missing
 none--accuracy = none
-# Option when selecting taxonomic ranks that indicates no rank was selected
-NONE--ranks = NONE
 # Button in explore filters to search for species or observations NOT by the signed in user
 NOT-BY-ME = NOT BY ME
 # Error message title when not enough storage space on device, e.g. when the

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -807,6 +807,8 @@ No-results-found-try-different-search = No results found. Try a different search
 no-rights-reserved-cc0 = no rights reserved (CC0)
 # Displayed in place of positional accuracy when that value is missing
 none--accuracy = none
+# Option when selecting taxonomic ranks that indicates no rank was selected
+NONE--ranks = NONE
 # Button in explore filters to search for species or observations NOT by the signed in user
 NOT-BY-ME = NOT BY ME
 # Error message title when not enough storage space on device, e.g. when the

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -477,6 +477,7 @@
   "No-results-found-try-different-search": "No results found. Try a different search or adjust your filters.",
   "no-rights-reserved-cc0": "no rights reserved (CC0)",
   "none--accuracy": "none",
+  "NONE--ranks": "NONE",
   "NOT-BY-ME": "NOT BY ME",
   "Not-enough-space-left-on-device": "Not enough space left on device",
   "Not-enough-space-left-on-device-try-again": "There is not enough storage space left on your device to do that. Please free up some space and try again.",

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -616,7 +616,6 @@
   "Ranks-Subfamily": "Subfamily",
   "Ranks-SUBGENUS": "SUBGENUS",
   "Ranks-Subgenus": "Subgenus",
-  "Ranks-SUBKINGDOM": "SUBKINGDOM",
   "Ranks-Subkingdom": "Subkingdom",
   "Ranks-SUBORDER": "SUBORDER",
   "Ranks-Suborder": "Suborder",

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -477,7 +477,6 @@
   "No-results-found-try-different-search": "No results found. Try a different search or adjust your filters.",
   "no-rights-reserved-cc0": "no rights reserved (CC0)",
   "none--accuracy": "none",
-  "NONE--ranks": "NONE",
   "NOT-BY-ME": "NOT BY ME",
   "Not-enough-space-left-on-device": "Not enough space left on device",
   "Not-enough-space-left-on-device-try-again": "There is not enough storage space left on your device to do that. Please free up some space and try again.",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1007,7 +1007,6 @@ Ranks-SUBFAMILY = SUBFAMILY
 Ranks-Subfamily = Subfamily
 Ranks-SUBGENUS = SUBGENUS
 Ranks-Subgenus = Subgenus
-Ranks-SUBKINGDOM = SUBKINGDOM
 Ranks-Subkingdom = Subkingdom
 Ranks-SUBORDER = SUBORDER
 Ranks-Suborder = Suborder

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -807,8 +807,6 @@ No-results-found-try-different-search = No results found. Try a different search
 no-rights-reserved-cc0 = no rights reserved (CC0)
 # Displayed in place of positional accuracy when that value is missing
 none--accuracy = none
-# Option when selecting taxonomic ranks that indicates no rank was selected
-NONE--ranks = NONE
 # Button in explore filters to search for species or observations NOT by the signed in user
 NOT-BY-ME = NOT BY ME
 # Error message title when not enough storage space on device, e.g. when the

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -807,6 +807,8 @@ No-results-found-try-different-search = No results found. Try a different search
 no-rights-reserved-cc0 = no rights reserved (CC0)
 # Displayed in place of positional accuracy when that value is missing
 none--accuracy = none
+# Option when selecting taxonomic ranks that indicates no rank was selected
+NONE--ranks = NONE
 # Button in explore filters to search for species or observations NOT by the signed in user
 NOT-BY-ME = NOT BY ME
 # Error message title when not enough storage space on device, e.g. when the

--- a/src/providers/ExploreContext.tsx
+++ b/src/providers/ExploreContext.tsx
@@ -54,7 +54,7 @@ export enum SORT_BY {
 }
 
 export enum TAXONOMIC_RANK {
-  none = null,
+  none = "none",
   kingdom = "kingdom",
   phylum = "phylum",
   subphylum = "subphylum",
@@ -513,12 +513,16 @@ function exploreReducer( state: State, action: Action ) {
     case EXPLORE_ACTION.SET_HIGHEST_TAXONOMIC_RANK:
       return {
         ...state,
-        hrank: action.hrank
+        hrank: action.hrank === TAXONOMIC_RANK.none
+          ? null
+          : action.hrank
       };
     case EXPLORE_ACTION.SET_LOWEST_TAXONOMIC_RANK:
       return {
         ...state,
-        lrank: action.lrank
+        lrank: action.lrank === TAXONOMIC_RANK.none
+          ? null
+          : action.lrank
       };
     case EXPLORE_ACTION.SET_DATE_OBSERVED_ALL:
       return {

--- a/src/providers/ExploreContext.tsx
+++ b/src/providers/ExploreContext.tsx
@@ -54,7 +54,7 @@ export enum SORT_BY {
 }
 
 export enum TAXONOMIC_RANK {
-  all = "all",
+  none = "none",
   kingdom = "kingdom",
   phylum = "phylum",
   subphylum = "subphylum",
@@ -513,14 +513,14 @@ function exploreReducer( state: State, action: Action ) {
     case EXPLORE_ACTION.SET_HIGHEST_TAXONOMIC_RANK:
       return {
         ...state,
-        hrank: action.hrank === TAXONOMIC_RANK.all
+        hrank: action.hrank === TAXONOMIC_RANK.none
           ? null
           : action.hrank
       };
     case EXPLORE_ACTION.SET_LOWEST_TAXONOMIC_RANK:
       return {
         ...state,
-        lrank: action.lrank === TAXONOMIC_RANK.all
+        lrank: action.lrank === TAXONOMIC_RANK.none
           ? null
           : action.lrank
       };

--- a/src/providers/ExploreContext.tsx
+++ b/src/providers/ExploreContext.tsx
@@ -54,7 +54,7 @@ export enum SORT_BY {
 }
 
 export enum TAXONOMIC_RANK {
-  none = "none",
+  all = "all",
   kingdom = "kingdom",
   phylum = "phylum",
   subphylum = "subphylum",
@@ -513,14 +513,14 @@ function exploreReducer( state: State, action: Action ) {
     case EXPLORE_ACTION.SET_HIGHEST_TAXONOMIC_RANK:
       return {
         ...state,
-        hrank: action.hrank === TAXONOMIC_RANK.none
+        hrank: action.hrank === TAXONOMIC_RANK.all
           ? null
           : action.hrank
       };
     case EXPLORE_ACTION.SET_LOWEST_TAXONOMIC_RANK:
       return {
         ...state,
-        lrank: action.lrank === TAXONOMIC_RANK.none
+        lrank: action.lrank === TAXONOMIC_RANK.all
           ? null
           : action.lrank
       };

--- a/src/providers/ExploreContext.tsx
+++ b/src/providers/ExploreContext.tsx
@@ -56,7 +56,6 @@ export enum SORT_BY {
 export enum TAXONOMIC_RANK {
   none = null,
   kingdom = "kingdom",
-  subkingdom = "subkingdom",
   phylum = "phylum",
   subphylum = "subphylum",
   superclass = "superclass",


### PR DESCRIPTION
Closes MOB-479
Removing the hrank or lrank filter, by selecting "NONE" in the UI did not set it back to a state of `null` but instead set it to a state of `"null"` (= string) which was rejected by the API.
So, now when "NONE" is selected we revert back to null (which means the explore param is not added to the query params). Reverting the UI back to "ALL" when "NONE" is selected in the dropdown menu is wanted behaviour (https://inaturalist.slack.com/archives/C02G5AATVGA/p1743290324244789?thread_ts=1743174700.224619&cid=C02G5AATVGA).
There was also one taxonomic rank that is actually not supported by the API.