### PR TITLE
Do not show loading state on Android

### DIFF
--- a/src/components/Onboarding/OnboardingCarousel.js
+++ b/src/components/Onboarding/OnboardingCarousel.js
@@ -20,6 +20,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import {
   Image,
+  Platform,
   StatusBar,
   useWindowDimensions,
   View
@@ -163,7 +164,12 @@ const OnboardingCarousel = ( ) => {
     } );
   }, [ONBOARDING_SLIDES, totalImages] );
 
-  if ( !imagesLoaded ) {
+  // TODO: On Android release build imagesLoaded never switched from false to true, and
+  // this screen was stuck in a loading state. On iOS it worked as expected.
+  // Disabling it now on Android to make a new release possible.
+  if ( Platform.OS === "android"
+    ? false
+    : !imagesLoaded ) {
     return (
       <ImageBackground
         source={require( "images/background/daniel-olah-YNUFtf4qyh0-unsplash.jpg" )}


### PR DESCRIPTION
On Android release builds, imagesLoaded never switched from false to true, and this screen was stuck in a loading state. On iOS it worked as expected. Disabling it now on Android to make a new release possible.