### PR TITLE
Maintenance: break upload code into smaller modules -- error handling

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,8 @@ module.exports = {
         sharedHooks: "./src/sharedHooks",
         stores: "./src/stores",
         styles: "./src/styles",
-        tests: "./tests"
+        tests: "./tests",
+        uploaders: "./src/uploaders"
       }
     }],
     // Reanimated plugin has to be listed last https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/

--- a/src/components/MyObservations/hooks/useUploadObservations.ts
+++ b/src/components/MyObservations/hooks/useUploadObservations.ts
@@ -8,7 +8,7 @@ import type { RealmObservation } from "realmModels/types.d.ts";
 import {
   INCREMENT_SINGLE_UPLOAD_PROGRESS
 } from "sharedHelpers/emitUploadProgress.ts";
-import uploadObservation, { handleUploadError } from "sharedHelpers/uploadObservation";
+import uploadObservation from "sharedHelpers/uploadObservation";
 import {
   useTranslation
 } from "sharedHooks";
@@ -18,6 +18,7 @@ import {
   UPLOAD_IN_PROGRESS
 } from "stores/createUploadObservationsSlice.ts";
 import useStore from "stores/useStore";
+import { handleUploadError } from "uploaders";
 
 export const MS_BEFORE_TOOLBAR_RESET = 5_000;
 const MS_BEFORE_UPLOAD_TIMES_OUT = 60_000 * 5;

--- a/src/sharedHelpers/uploadObservation.js
+++ b/src/sharedHelpers/uploadObservation.js
@@ -12,87 +12,9 @@ import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
 import ObservationSound from "realmModels/ObservationSound";
 import emitUploadProgress from "sharedHelpers/emitUploadProgress.ts";
-import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { markRecordUploaded } from "uploaders";
 
 const UPLOAD_PROGRESS_INCREMENT = 1;
-
-// The reason this doesn't simply accept the record is because we're not being
-// strict about using Realm.Objects, so sometimes the thing we just uploaded
-// is a Realm.Object and sometimes it's a POJO, but in order to mark it as
-// uploaded and add a server-assigned id attribute, we need to find the
-// matching Realm.Object
-const markRecordUploaded = (
-  observationUUID: string,
-  recordUUID: string | null,
-  type: string,
-  response: {
-    results: Array<{id: number}>
-  },
-  realm: Object,
-  options?: {
-    record: Object
-  }
-) => {
-  const { id } = response.results[0];
-  if ( !realm || realm.isClosed ) return;
-  function extractRecord( obsUUID, recUUID, recordType, opts ) {
-    const observation = realm?.objectForPrimaryKey( "Observation", obsUUID );
-    let record;
-    if ( recordType === "Observation" ) {
-      record = observation;
-    } else if ( recordType === "ObservationPhoto" ) {
-      const existingObsPhoto = observation?.observationPhotos?.find( op => op.uuid === recUUID );
-      record = existingObsPhoto;
-    } else if ( recordType === "ObservationSound" ) {
-      const existingObsSound = observation?.observationSounds?.find( os => os.uuid === recUUID );
-      record = existingObsSound;
-    } else if ( recordType === "Photo" ) {
-      // Photos do not have UUIDs, so we pass the Photo itself as an option
-      record = opts?.record;
-    }
-    return record;
-  }
-  let record = extractRecord( observationUUID, recordUUID, type, options );
-
-  if ( !record ) {
-    throw new Error(
-      `Cannot find local Realm object to mark as updated (${type}), recordUUID: ${recordUUID || ""}`
-    );
-  }
-
-  try {
-    safeRealmWrite( realm, ( ) => {
-      // These flow errors don't make any sense b/c if record is undefined, we
-      // will throw an error above
-      // $FlowIgnore
-      record.id = id;
-      // $FlowIgnore
-      record._synced_at = new Date( );
-      if ( type === "Observation" ) {
-        // $FlowIgnore
-        record.needs_sync = false;
-      }
-    }, `marking record uploaded in uploadObservation.js, type: ${type}` );
-  } catch ( realmWriteError ) {
-    // Try it one more time in case it was invalidated but it's still in the
-    // database
-    if ( realmWriteError.message.match( /invalidated or deleted/ ) ) {
-      record = extractRecord( observationUUID, recordUUID, type, options );
-      safeRealmWrite( realm, ( ) => {
-        // These flow errors don't make any sense b/c if record is undefined, we
-        // will throw an error above
-        // $FlowIgnore
-        record.id = id;
-        // $FlowIgnore
-        record._synced_at = new Date( );
-        if ( type === "Observation" ) {
-          // $FlowIgnore
-          record.needs_sync = false;
-        }
-      }, `marking record uploaded in uploadObservation.js, type: ${type}` );
-    }
-  }
-};
 
 const uploadEvidence = async (
   evidence: Array<Object>,

--- a/src/sharedHelpers/uploadObservation.js
+++ b/src/sharedHelpers/uploadObservation.js
@@ -1,5 +1,5 @@
 // @flow
-import { INatApiError } from "api/error";
+
 import {
   createObservation,
   createOrUpdateEvidence,
@@ -230,33 +230,6 @@ async function uploadObservation( obs: Object, realm: Object, opts: Object = {} 
   );
   Observation.upsertRemoteObservations( [remoteObs], realm, { force: true } );
   return response;
-}
-
-export function handleUploadError( uploadError: Error | INatApiError, t: Function ): string {
-  let { message } = uploadError;
-  // uploadError might be an INatApiError but I don't know how to tell flow to
-  // shut up about the possibility that uploadError might not have this
-  // attribute... even though ?. will prevent that from being a problem.
-  // ~~~~kueda20240523
-  // $FlowIgnore
-  if ( uploadError?.json?.errors ) {
-    // TODO localize comma join
-    message = uploadError.json.errors.map( e => {
-      if ( e.message?.errors ) {
-        if ( typeof ( e.message.errors.flat ) === "function" ) {
-          return e.message.errors.flat( ).join( ", " );
-        }
-        return String( e.message.errors );
-      }
-      // 410 error for observations previously deleted uses e.message?.error format
-      return e.message?.error || e.message;
-    } ).join( ", " );
-  } else if ( uploadError.message?.match( /Network request failed/ ) ) {
-    message = t( "Connection-problem-Please-try-again-later" );
-  } else {
-    throw uploadError;
-  }
-  return message;
 }
 
 export default uploadObservation;

--- a/src/uploaders/index.ts
+++ b/src/uploaders/index.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
+export { default as handleUploadError } from "./utils/errorHandling";
 export { default as markRecordUploaded } from "./utils/realmSync";

--- a/src/uploaders/index.ts
+++ b/src/uploaders/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as markRecordUploaded } from "./utils/realmSync";

--- a/src/uploaders/utils/errorHandling.ts
+++ b/src/uploaders/utils/errorHandling.ts
@@ -1,0 +1,25 @@
+import { INatApiError } from "api/error";
+
+function handleUploadError( uploadError: Error | INatApiError, t: Function ): string {
+  let { message } = uploadError;
+  if ( uploadError?.json?.errors ) {
+    // TODO localize comma join
+    message = uploadError.json.errors.map( e => {
+      if ( e.message?.errors ) {
+        if ( typeof ( e.message.errors.flat ) === "function" ) {
+          return e.message.errors.flat( ).join( ", " );
+        }
+        return String( e.message.errors );
+      }
+      // 410 error for observations previously deleted uses e.message?.error format
+      return e.message?.error || e.message;
+    } ).join( ", " );
+  } else if ( uploadError.message?.match( /Network request failed/ ) ) {
+    message = t( "Connection-problem-Please-try-again-later" );
+  } else {
+    throw uploadError;
+  }
+  return message;
+}
+
+export default handleUploadError;

--- a/src/uploaders/utils/realmSync.ts
+++ b/src/uploaders/utils/realmSync.ts
@@ -1,5 +1,79 @@
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 
+function findRecordInRealm(
+  realm: Object,
+  observationUUID: string,
+  recordUUID: string | null,
+  type: string,
+  options?: {
+    record: Object
+  }
+): Object | null {
+  if ( !realm || realm.isClosed ) return null;
+
+  // Photos do not have UUIDs, so we pass the Photo itself as an option
+  if ( type === "Photo" && options?.record ) {
+    return options.record;
+  }
+
+  const observation = realm.objectForPrimaryKey( "Observation", observationUUID );
+  if ( !observation ) return null;
+
+  if ( type === "Observation" ) {
+    return observation;
+  } if ( type === "ObservationPhoto" ) {
+    return observation.observationPhotos?.find( op => op.uuid === recordUUID ) || null;
+  } if ( type === "ObservationSound" ) {
+    return observation.observationSounds?.find( os => os.uuid === recordUUID ) || null;
+  }
+
+  return null;
+}
+
+function updateRecordWithServerId(
+  realm: Object,
+  record: Object,
+  serverId: number,
+  type: string
+): void {
+  safeRealmWrite( realm, ( ) => {
+    record.id = serverId;
+    record._synced_at = new Date( );
+    if ( type === "Observation" ) {
+      record.needs_sync = false;
+    }
+  }, `marking record uploaded in realmSync.js, type: ${type}` );
+}
+
+function handleRecordUpdateError(
+  error: Error,
+  realm: Object,
+  observationUUID: string,
+  recordUUID: string | null,
+  type: string,
+  serverId: number,
+  options?: {
+    record: Object
+  }
+): void {
+  // Try it one more time in case it was invalidated but it's still in the
+  // database
+  if ( error.message.match( /invalidated or deleted/ ) ) {
+    const refreshedRecord
+        = findRecordInRealm( realm, observationUUID, recordUUID, type, options );
+    if ( !refreshedRecord ) {
+      throw new Error(
+        `Cannot find local Realm object on retry (${type}), recordUUID: ${recordUUID || ""}`
+      );
+    }
+    updateRecordWithServerId( realm, refreshedRecord, serverId, type );
+  } else {
+    // For other errors, just log and re-throw
+    console.error( `Error updating record in Realm: ${error.message}` );
+    throw error;
+  }
+}
+
 // The reason this doesn't simply accept the record is because we're not being
 // strict about using Realm.Objects, so sometimes the thing we just uploaded
 // is a Realm.Object and sometimes it's a POJO, but in order to mark it as
@@ -17,26 +91,11 @@ const markRecordUploaded = (
     record: Object
   }
 ) => {
-  const { id } = response.results[0];
   if ( !realm || realm.isClosed ) return;
-  function extractRecord( obsUUID, recUUID, recordType, opts ) {
-    const observation = realm?.objectForPrimaryKey( "Observation", obsUUID );
-    let record;
-    if ( recordType === "Observation" ) {
-      record = observation;
-    } else if ( recordType === "ObservationPhoto" ) {
-      const existingObsPhoto = observation?.observationPhotos?.find( op => op.uuid === recUUID );
-      record = existingObsPhoto;
-    } else if ( recordType === "ObservationSound" ) {
-      const existingObsSound = observation?.observationSounds?.find( os => os.uuid === recUUID );
-      record = existingObsSound;
-    } else if ( recordType === "Photo" ) {
-      // Photos do not have UUIDs, so we pass the Photo itself as an option
-      record = opts?.record;
-    }
-    return record;
-  }
-  let record = extractRecord( observationUUID, recordUUID, type, options );
+
+  const { id } = response.results[0];
+
+  const record = findRecordInRealm( realm, observationUUID, recordUUID, type, options );
 
   if ( !record ) {
     throw new Error(
@@ -45,36 +104,17 @@ const markRecordUploaded = (
   }
 
   try {
-    safeRealmWrite( realm, ( ) => {
-      // These flow errors don't make any sense b/c if record is undefined, we
-      // will throw an error above
-      // $FlowIgnore
-      record.id = id;
-      // $FlowIgnore
-      record._synced_at = new Date( );
-      if ( type === "Observation" ) {
-        // $FlowIgnore
-        record.needs_sync = false;
-      }
-    }, `marking record uploaded in uploadObservation.js, type: ${type}` );
+    updateRecordWithServerId( realm, record, id, type );
   } catch ( realmWriteError ) {
-    // Try it one more time in case it was invalidated but it's still in the
-    // database
-    if ( realmWriteError.message.match( /invalidated or deleted/ ) ) {
-      record = extractRecord( observationUUID, recordUUID, type, options );
-      safeRealmWrite( realm, ( ) => {
-        // These flow errors don't make any sense b/c if record is undefined, we
-        // will throw an error above
-        // $FlowIgnore
-        record.id = id;
-        // $FlowIgnore
-        record._synced_at = new Date( );
-        if ( type === "Observation" ) {
-          // $FlowIgnore
-          record.needs_sync = false;
-        }
-      }, `marking record uploaded in uploadObservation.js, type: ${type}` );
-    }
+    handleRecordUpdateError(
+      realmWriteError,
+      realm,
+      observationUUID,
+      recordUUID,
+      type,
+      id,
+      options
+    );
   }
 };
 

--- a/src/uploaders/utils/realmSync.ts
+++ b/src/uploaders/utils/realmSync.ts
@@ -1,0 +1,81 @@
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+
+// The reason this doesn't simply accept the record is because we're not being
+// strict about using Realm.Objects, so sometimes the thing we just uploaded
+// is a Realm.Object and sometimes it's a POJO, but in order to mark it as
+// uploaded and add a server-assigned id attribute, we need to find the
+// matching Realm.Object
+const markRecordUploaded = (
+  observationUUID: string,
+  recordUUID: string | null,
+  type: string,
+  response: {
+    results: Array<{id: number}>
+  },
+  realm: Object,
+  options?: {
+    record: Object
+  }
+) => {
+  const { id } = response.results[0];
+  if ( !realm || realm.isClosed ) return;
+  function extractRecord( obsUUID, recUUID, recordType, opts ) {
+    const observation = realm?.objectForPrimaryKey( "Observation", obsUUID );
+    let record;
+    if ( recordType === "Observation" ) {
+      record = observation;
+    } else if ( recordType === "ObservationPhoto" ) {
+      const existingObsPhoto = observation?.observationPhotos?.find( op => op.uuid === recUUID );
+      record = existingObsPhoto;
+    } else if ( recordType === "ObservationSound" ) {
+      const existingObsSound = observation?.observationSounds?.find( os => os.uuid === recUUID );
+      record = existingObsSound;
+    } else if ( recordType === "Photo" ) {
+      // Photos do not have UUIDs, so we pass the Photo itself as an option
+      record = opts?.record;
+    }
+    return record;
+  }
+  let record = extractRecord( observationUUID, recordUUID, type, options );
+
+  if ( !record ) {
+    throw new Error(
+      `Cannot find local Realm object to mark as updated (${type}), recordUUID: ${recordUUID || ""}`
+    );
+  }
+
+  try {
+    safeRealmWrite( realm, ( ) => {
+      // These flow errors don't make any sense b/c if record is undefined, we
+      // will throw an error above
+      // $FlowIgnore
+      record.id = id;
+      // $FlowIgnore
+      record._synced_at = new Date( );
+      if ( type === "Observation" ) {
+        // $FlowIgnore
+        record.needs_sync = false;
+      }
+    }, `marking record uploaded in uploadObservation.js, type: ${type}` );
+  } catch ( realmWriteError ) {
+    // Try it one more time in case it was invalidated but it's still in the
+    // database
+    if ( realmWriteError.message.match( /invalidated or deleted/ ) ) {
+      record = extractRecord( observationUUID, recordUUID, type, options );
+      safeRealmWrite( realm, ( ) => {
+        // These flow errors don't make any sense b/c if record is undefined, we
+        // will throw an error above
+        // $FlowIgnore
+        record.id = id;
+        // $FlowIgnore
+        record._synced_at = new Date( );
+        if ( type === "Observation" ) {
+          // $FlowIgnore
+          record.needs_sync = false;
+        }
+      }, `marking record uploaded in uploadObservation.js, type: ${type}` );
+    }
+  }
+};
+
+export default markRecordUploaded;

--- a/tests/unit/uploaders/utils/errorHandling.test.js
+++ b/tests/unit/uploaders/utils/errorHandling.test.js
@@ -1,0 +1,82 @@
+import { handleUploadError } from "uploaders";
+
+describe( "errorHandling", ( ) => {
+  // Mock translation function since we're passing that into the error handler
+  const t = jest.fn( key => key );
+
+  describe( "handleUploadError", ( ) => {
+    beforeEach( ( ) => {
+      jest.clearAllMocks( );
+    } );
+
+    test( "should throw basic errors without special handling", ( ) => {
+      const error = new Error( "Basic error" );
+
+      expect( ( ) => {
+        handleUploadError( error, t );
+      } ).toThrow( "Basic error" );
+    } );
+
+    test( "should return 'Connection problem' message for network errors", ( ) => {
+      const networkError = new Error( "Network request failed" );
+
+      const result = handleUploadError( networkError, t );
+
+      expect( result ).toBe( "Connection-problem-Please-try-again-later" );
+    } );
+
+    test( "should return a string from an array of iNaturalist API errors", ( ) => {
+      const apiError = new Error( "API Upload Error" );
+      apiError.json = {
+        errors: [
+          { message: "First error" },
+          { message: "Second error" }
+        ]
+      };
+
+      const result = handleUploadError( apiError, t );
+
+      expect( result ).toBe( "First error, Second error" );
+    } );
+
+    test( "should return a string from a nested array of iNaturalist API errors", ( ) => {
+      const apiError = new Error( "API Error" );
+      apiError.json = {
+        errors: [
+          { message: { errors: ["Error 1", "Error 2"] } }
+        ]
+      };
+
+      const result = handleUploadError( apiError, t );
+
+      expect( result ).toBe( "Error 1, Error 2" );
+    } );
+
+    test( "should return a string from a nested string "
+      + "within iNaturalist API error messages", ( ) => {
+      const apiError = new Error( "API Error" );
+      apiError.json = {
+        errors: [
+          { message: { errors: "Nested error message string" } }
+        ]
+      };
+
+      const result = handleUploadError( apiError, t );
+
+      expect( result ).toBe( "Nested error message string" );
+    } );
+
+    test( "should handle 410 errors for previously deleted observations or evidence", ( ) => {
+      const apiError = new Error( "API Error" );
+      apiError.json = {
+        errors: [
+          { message: { error: "Resource was previously deleted" } }
+        ]
+      };
+
+      const result = handleUploadError( apiError, t );
+
+      expect( result ).toBe( "Resource was previously deleted" );
+    } );
+  } );
+} );

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -1,0 +1,137 @@
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { markRecordUploaded } from "uploaders";
+
+jest.mock( "sharedHelpers/safeRealmWrite" );
+
+describe( "markRecordUploaded", () => {
+  let mockRealm;
+  let mockObservation;
+  let mockObsPhoto;
+  let mockObsSound;
+  let mockPhoto;
+  let mockResponse;
+
+  beforeEach( () => {
+    jest.clearAllMocks();
+
+    mockObsPhoto = { uuid: "photo123", id: null, _synced_at: null };
+    mockObsSound = { uuid: "sound123", id: null, _synced_at: null };
+    mockPhoto = { id: null, _synced_at: null };
+
+    mockObservation = {
+      uuid: "obs123",
+      id: null,
+      _synced_at: null,
+      needs_sync: true,
+      observationPhotos: [mockObsPhoto],
+      observationSounds: [mockObsSound]
+    };
+
+    mockResponse = {
+      results: [{ id: 12345 }]
+    };
+
+    mockRealm = {
+      isClosed: false,
+      objectForPrimaryKey: jest.fn().mockReturnValue( mockObservation )
+    };
+
+    // Mock the safeRealmWrite implementation
+    safeRealmWrite.mockImplementation( ( realm, callback ) => {
+      callback();
+    } );
+  } );
+
+  test( "should do nothing if realm is closed", () => {
+    mockRealm.isClosed = true;
+
+    markRecordUploaded( mockObservation.uuid, null, "Observation", mockResponse, mockRealm );
+
+    expect( safeRealmWrite ).not.toHaveBeenCalled();
+  } );
+
+  test( "should update an Observation record correctly", () => {
+    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockObservation.id ).toBe( 12345 );
+    expect( mockObservation._synced_at ).toBeInstanceOf( Date );
+    expect( mockObservation.needs_sync ).toBe( false );
+  } );
+
+  test( "should update an ObservationPhoto record correctly", () => {
+    markRecordUploaded( "obs123", "photo123", "ObservationPhoto", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockObsPhoto.id ).toBe( 12345 );
+    expect( mockObsPhoto._synced_at ).toBeInstanceOf( Date );
+    // needs_sync should not be modified for ObservationPhoto
+    expect( mockObsPhoto.needs_sync ).toBeUndefined();
+  } );
+
+  test( "should update an ObservationSound record correctly", () => {
+    markRecordUploaded( "obs123", "sound123", "ObservationSound", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockObsSound.id ).toBe( 12345 );
+    expect( mockObsSound._synced_at ).toBeInstanceOf( Date );
+    // needs_sync should not be modified for ObservationSound
+    expect( mockObsSound.needs_sync ).toBeUndefined();
+  } );
+
+  test( "should update a Photo record correctly with options.record", () => {
+    const options = { record: mockPhoto };
+
+    markRecordUploaded( "obs123", null, "Photo", mockResponse, mockRealm, options );
+
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockPhoto.id ).toBe( 12345 );
+    expect( mockPhoto._synced_at ).toBeInstanceOf( Date );
+  } );
+
+  test( "should throw error when record is not found", () => {
+    expect( () => {
+      markRecordUploaded( "obs123", "nonexistent", "ObservationPhoto", mockResponse, mockRealm );
+    } ).toThrow( "Cannot find local Realm object to mark as updated" );
+  } );
+
+  test( "should retry on invalidated object error", () => {
+    safeRealmWrite.mockImplementationOnce( () => {
+      throw new Error( "Object has been invalidated or deleted" );
+    } );
+
+    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledTimes( 2 );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 2 );
+
+    expect( mockObservation.id ).toBe( 12345 );
+    expect( mockObservation._synced_at ).toBeInstanceOf( Date );
+    expect( mockObservation.needs_sync ).toBe( false );
+  } );
+
+  test( "should attempt to retry on non-invalidation errors", () => {
+    // Mock safeRealmWrite to throw a non-invalidation error
+    safeRealmWrite.mockImplementationOnce( ( realm, callback, description ) => {
+      const error = new Error( "Some other error" );
+      error.message = `${description}: ${error.message}`;
+      throw error;
+    } )
+      .mockImplementationOnce( ( realm, callback ) => {
+      // Second call succeeds
+        callback( );
+      } );
+
+    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+
+    // Only called once because error doesn't match invalidated pattern
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+  } );
+} );

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -123,13 +123,11 @@ describe( "markRecordUploaded", () => {
       const error = new Error( "Some other error" );
       error.message = `${description}: ${error.message}`;
       throw error;
-    } )
-      .mockImplementationOnce( ( realm, callback ) => {
-      // Second call succeeds
-        callback( );
-      } );
+    } );
 
-    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+    expect( () => {
+      markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+    } ).toThrow( /Some other error/ );
 
     // Only called once because error doesn't match invalidated pattern
     expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
Closes Mob-736

Note: I built this off of a branch from the realm sync PR to keep the same babel aliases and `uploaders/` file directory, so that should be reviewed first.