### PR TITLE
Mob 720: Make loading indicator smaller and transparent

### DIFF
--- a/src/components/Explore/MapView.tsx
+++ b/src/components/Explore/MapView.tsx
@@ -31,13 +31,16 @@ const DROP_SHADOW = getShadow( {
   elevation: 6
 } );
 
+const activityIndicatorSize = 50;
 const centeredLoadingWheel = {
   position: "absolute",
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  backgroundColor: "rgba(0,0,0,0.3)",
+  top: "50%",
+  left: "50%",
+  transform: [
+    { translateX: -( activityIndicatorSize / 2 ) },
+    { translateY: -( activityIndicatorSize / 2 ) }
+  ],
+  backgroundColor: "rgba(0,0,0,0)",
   alignItems: "center",
   justifyContent: "center",
   zIndex: 20
@@ -216,7 +219,7 @@ const MapView = ( {
       />
       {isLoading && (
         <View style={centeredLoadingWheel} testID="activity-indicator">
-          <ActivityIndicator size={50} />
+          <ActivityIndicator size={activityIndicatorSize} />
         </View>
       )}
       {renderLocationPermissionsGate( { onPermissionGranted: handleCurrentLocationPress } )}


### PR DESCRIPTION
So that the map can still be interacted with while the loading indicator is shown.