### PR TITLE
Copy of: Maintenance: break upload code into smaller modules -- realm syncing functions

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,8 @@ module.exports = {
         sharedHooks: "./src/sharedHooks",
         stores: "./src/stores",
         styles: "./src/styles",
-        tests: "./tests"
+        tests: "./tests",
+        uploaders: "./src/uploaders"
       }
     }],
     // Reanimated plugin has to be listed last https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/

--- a/src/sharedHelpers/uploadObservation.js
+++ b/src/sharedHelpers/uploadObservation.js
@@ -12,87 +12,9 @@ import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
 import ObservationSound from "realmModels/ObservationSound";
 import emitUploadProgress from "sharedHelpers/emitUploadProgress.ts";
-import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { markRecordUploaded } from "uploaders";
 
 const UPLOAD_PROGRESS_INCREMENT = 1;
-
-// The reason this doesn't simply accept the record is because we're not being
-// strict about using Realm.Objects, so sometimes the thing we just uploaded
-// is a Realm.Object and sometimes it's a POJO, but in order to mark it as
-// uploaded and add a server-assigned id attribute, we need to find the
-// matching Realm.Object
-const markRecordUploaded = (
-  observationUUID: string,
-  recordUUID: string | null,
-  type: string,
-  response: {
-    results: Array<{id: number}>
-  },
-  realm: Object,
-  options?: {
-    record: Object
-  }
-) => {
-  const { id } = response.results[0];
-  if ( !realm || realm.isClosed ) return;
-  function extractRecord( obsUUID, recUUID, recordType, opts ) {
-    const observation = realm?.objectForPrimaryKey( "Observation", obsUUID );
-    let record;
-    if ( recordType === "Observation" ) {
-      record = observation;
-    } else if ( recordType === "ObservationPhoto" ) {
-      const existingObsPhoto = observation?.observationPhotos?.find( op => op.uuid === recUUID );
-      record = existingObsPhoto;
-    } else if ( recordType === "ObservationSound" ) {
-      const existingObsSound = observation?.observationSounds?.find( os => os.uuid === recUUID );
-      record = existingObsSound;
-    } else if ( recordType === "Photo" ) {
-      // Photos do not have UUIDs, so we pass the Photo itself as an option
-      record = opts?.record;
-    }
-    return record;
-  }
-  let record = extractRecord( observationUUID, recordUUID, type, options );
-
-  if ( !record ) {
-    throw new Error(
-      `Cannot find local Realm object to mark as updated (${type}), recordUUID: ${recordUUID || ""}`
-    );
-  }
-
-  try {
-    safeRealmWrite( realm, ( ) => {
-      // These flow errors don't make any sense b/c if record is undefined, we
-      // will throw an error above
-      // $FlowIgnore
-      record.id = id;
-      // $FlowIgnore
-      record._synced_at = new Date( );
-      if ( type === "Observation" ) {
-        // $FlowIgnore
-        record.needs_sync = false;
-      }
-    }, `marking record uploaded in uploadObservation.js, type: ${type}` );
-  } catch ( realmWriteError ) {
-    // Try it one more time in case it was invalidated but it's still in the
-    // database
-    if ( realmWriteError.message.match( /invalidated or deleted/ ) ) {
-      record = extractRecord( observationUUID, recordUUID, type, options );
-      safeRealmWrite( realm, ( ) => {
-        // These flow errors don't make any sense b/c if record is undefined, we
-        // will throw an error above
-        // $FlowIgnore
-        record.id = id;
-        // $FlowIgnore
-        record._synced_at = new Date( );
-        if ( type === "Observation" ) {
-          // $FlowIgnore
-          record.needs_sync = false;
-        }
-      }, `marking record uploaded in uploadObservation.js, type: ${type}` );
-    }
-  }
-};
 
 const uploadEvidence = async (
   evidence: Array<Object>,

--- a/src/uploaders/index.ts
+++ b/src/uploaders/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as markRecordUploaded } from "./utils/realmSync";

--- a/src/uploaders/utils/realmSync.ts
+++ b/src/uploaders/utils/realmSync.ts
@@ -1,5 +1,79 @@
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 
+function findRecordInRealm(
+  realm: Object,
+  observationUUID: string,
+  recordUUID: string | null,
+  type: string,
+  options?: {
+    record: Object
+  }
+): Object | null {
+  if ( !realm || realm.isClosed ) return null;
+
+  // Photos do not have UUIDs, so we pass the Photo itself as an option
+  if ( type === "Photo" && options?.record ) {
+    return options.record;
+  }
+
+  const observation = realm.objectForPrimaryKey( "Observation", observationUUID );
+  if ( !observation ) return null;
+
+  if ( type === "Observation" ) {
+    return observation;
+  } if ( type === "ObservationPhoto" ) {
+    return observation.observationPhotos?.find( op => op.uuid === recordUUID ) || null;
+  } if ( type === "ObservationSound" ) {
+    return observation.observationSounds?.find( os => os.uuid === recordUUID ) || null;
+  }
+
+  return null;
+}
+
+function updateRecordWithServerId(
+  realm: Object,
+  record: Object,
+  serverId: number,
+  type: string
+): void {
+  safeRealmWrite( realm, ( ) => {
+    record.id = serverId;
+    record._synced_at = new Date( );
+    if ( type === "Observation" ) {
+      record.needs_sync = false;
+    }
+  }, `marking record uploaded in realmSync.js, type: ${type}` );
+}
+
+function handleRecordUpdateError(
+  error: Error,
+  realm: Object,
+  observationUUID: string,
+  recordUUID: string | null,
+  type: string,
+  serverId: number,
+  options?: {
+    record: Object
+  }
+): void {
+  // Try it one more time in case it was invalidated but it's still in the
+  // database
+  if ( error.message.match( /invalidated or deleted/ ) ) {
+    const refreshedRecord
+        = findRecordInRealm( realm, observationUUID, recordUUID, type, options );
+    if ( !refreshedRecord ) {
+      throw new Error(
+        `Cannot find local Realm object on retry (${type}), recordUUID: ${recordUUID || ""}`
+      );
+    }
+    updateRecordWithServerId( realm, refreshedRecord, serverId, type );
+  } else {
+    // For other errors, just log and re-throw
+    console.error( `Error updating record in Realm: ${error.message}` );
+    throw error;
+  }
+}
+
 // The reason this doesn't simply accept the record is because we're not being
 // strict about using Realm.Objects, so sometimes the thing we just uploaded
 // is a Realm.Object and sometimes it's a POJO, but in order to mark it as
@@ -17,26 +91,11 @@ const markRecordUploaded = (
     record: Object
   }
 ) => {
-  const { id } = response.results[0];
   if ( !realm || realm.isClosed ) return;
-  function extractRecord( obsUUID, recUUID, recordType, opts ) {
-    const observation = realm?.objectForPrimaryKey( "Observation", obsUUID );
-    let record;
-    if ( recordType === "Observation" ) {
-      record = observation;
-    } else if ( recordType === "ObservationPhoto" ) {
-      const existingObsPhoto = observation?.observationPhotos?.find( op => op.uuid === recUUID );
-      record = existingObsPhoto;
-    } else if ( recordType === "ObservationSound" ) {
-      const existingObsSound = observation?.observationSounds?.find( os => os.uuid === recUUID );
-      record = existingObsSound;
-    } else if ( recordType === "Photo" ) {
-      // Photos do not have UUIDs, so we pass the Photo itself as an option
-      record = opts?.record;
-    }
-    return record;
-  }
-  let record = extractRecord( observationUUID, recordUUID, type, options );
+
+  const { id } = response.results[0];
+
+  const record = findRecordInRealm( realm, observationUUID, recordUUID, type, options );
 
   if ( !record ) {
     throw new Error(
@@ -45,36 +104,17 @@ const markRecordUploaded = (
   }
 
   try {
-    safeRealmWrite( realm, ( ) => {
-      // These flow errors don't make any sense b/c if record is undefined, we
-      // will throw an error above
-      // $FlowIgnore
-      record.id = id;
-      // $FlowIgnore
-      record._synced_at = new Date( );
-      if ( type === "Observation" ) {
-        // $FlowIgnore
-        record.needs_sync = false;
-      }
-    }, `marking record uploaded in uploadObservation.js, type: ${type}` );
+    updateRecordWithServerId( realm, record, id, type );
   } catch ( realmWriteError ) {
-    // Try it one more time in case it was invalidated but it's still in the
-    // database
-    if ( realmWriteError.message.match( /invalidated or deleted/ ) ) {
-      record = extractRecord( observationUUID, recordUUID, type, options );
-      safeRealmWrite( realm, ( ) => {
-        // These flow errors don't make any sense b/c if record is undefined, we
-        // will throw an error above
-        // $FlowIgnore
-        record.id = id;
-        // $FlowIgnore
-        record._synced_at = new Date( );
-        if ( type === "Observation" ) {
-          // $FlowIgnore
-          record.needs_sync = false;
-        }
-      }, `marking record uploaded in uploadObservation.js, type: ${type}` );
-    }
+    handleRecordUpdateError(
+      realmWriteError,
+      realm,
+      observationUUID,
+      recordUUID,
+      type,
+      id,
+      options
+    );
   }
 };
 

--- a/src/uploaders/utils/realmSync.ts
+++ b/src/uploaders/utils/realmSync.ts
@@ -1,0 +1,81 @@
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+
+// The reason this doesn't simply accept the record is because we're not being
+// strict about using Realm.Objects, so sometimes the thing we just uploaded
+// is a Realm.Object and sometimes it's a POJO, but in order to mark it as
+// uploaded and add a server-assigned id attribute, we need to find the
+// matching Realm.Object
+const markRecordUploaded = (
+  observationUUID: string,
+  recordUUID: string | null,
+  type: string,
+  response: {
+    results: Array<{id: number}>
+  },
+  realm: Object,
+  options?: {
+    record: Object
+  }
+) => {
+  const { id } = response.results[0];
+  if ( !realm || realm.isClosed ) return;
+  function extractRecord( obsUUID, recUUID, recordType, opts ) {
+    const observation = realm?.objectForPrimaryKey( "Observation", obsUUID );
+    let record;
+    if ( recordType === "Observation" ) {
+      record = observation;
+    } else if ( recordType === "ObservationPhoto" ) {
+      const existingObsPhoto = observation?.observationPhotos?.find( op => op.uuid === recUUID );
+      record = existingObsPhoto;
+    } else if ( recordType === "ObservationSound" ) {
+      const existingObsSound = observation?.observationSounds?.find( os => os.uuid === recUUID );
+      record = existingObsSound;
+    } else if ( recordType === "Photo" ) {
+      // Photos do not have UUIDs, so we pass the Photo itself as an option
+      record = opts?.record;
+    }
+    return record;
+  }
+  let record = extractRecord( observationUUID, recordUUID, type, options );
+
+  if ( !record ) {
+    throw new Error(
+      `Cannot find local Realm object to mark as updated (${type}), recordUUID: ${recordUUID || ""}`
+    );
+  }
+
+  try {
+    safeRealmWrite( realm, ( ) => {
+      // These flow errors don't make any sense b/c if record is undefined, we
+      // will throw an error above
+      // $FlowIgnore
+      record.id = id;
+      // $FlowIgnore
+      record._synced_at = new Date( );
+      if ( type === "Observation" ) {
+        // $FlowIgnore
+        record.needs_sync = false;
+      }
+    }, `marking record uploaded in uploadObservation.js, type: ${type}` );
+  } catch ( realmWriteError ) {
+    // Try it one more time in case it was invalidated but it's still in the
+    // database
+    if ( realmWriteError.message.match( /invalidated or deleted/ ) ) {
+      record = extractRecord( observationUUID, recordUUID, type, options );
+      safeRealmWrite( realm, ( ) => {
+        // These flow errors don't make any sense b/c if record is undefined, we
+        // will throw an error above
+        // $FlowIgnore
+        record.id = id;
+        // $FlowIgnore
+        record._synced_at = new Date( );
+        if ( type === "Observation" ) {
+          // $FlowIgnore
+          record.needs_sync = false;
+        }
+      }, `marking record uploaded in uploadObservation.js, type: ${type}` );
+    }
+  }
+};
+
+export default markRecordUploaded;

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -1,0 +1,137 @@
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import { markRecordUploaded } from "uploaders";
+
+jest.mock( "sharedHelpers/safeRealmWrite" );
+
+describe( "markRecordUploaded", () => {
+  let mockRealm;
+  let mockObservation;
+  let mockObsPhoto;
+  let mockObsSound;
+  let mockPhoto;
+  let mockResponse;
+
+  beforeEach( () => {
+    jest.clearAllMocks();
+
+    mockObsPhoto = { uuid: "photo123", id: null, _synced_at: null };
+    mockObsSound = { uuid: "sound123", id: null, _synced_at: null };
+    mockPhoto = { id: null, _synced_at: null };
+
+    mockObservation = {
+      uuid: "obs123",
+      id: null,
+      _synced_at: null,
+      needs_sync: true,
+      observationPhotos: [mockObsPhoto],
+      observationSounds: [mockObsSound]
+    };
+
+    mockResponse = {
+      results: [{ id: 12345 }]
+    };
+
+    mockRealm = {
+      isClosed: false,
+      objectForPrimaryKey: jest.fn().mockReturnValue( mockObservation )
+    };
+
+    // Mock the safeRealmWrite implementation
+    safeRealmWrite.mockImplementation( ( realm, callback ) => {
+      callback();
+    } );
+  } );
+
+  test( "should do nothing if realm is closed", () => {
+    mockRealm.isClosed = true;
+
+    markRecordUploaded( mockObservation.uuid, null, "Observation", mockResponse, mockRealm );
+
+    expect( safeRealmWrite ).not.toHaveBeenCalled();
+  } );
+
+  test( "should update an Observation record correctly", () => {
+    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockObservation.id ).toBe( 12345 );
+    expect( mockObservation._synced_at ).toBeInstanceOf( Date );
+    expect( mockObservation.needs_sync ).toBe( false );
+  } );
+
+  test( "should update an ObservationPhoto record correctly", () => {
+    markRecordUploaded( "obs123", "photo123", "ObservationPhoto", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockObsPhoto.id ).toBe( 12345 );
+    expect( mockObsPhoto._synced_at ).toBeInstanceOf( Date );
+    // needs_sync should not be modified for ObservationPhoto
+    expect( mockObsPhoto.needs_sync ).toBeUndefined();
+  } );
+
+  test( "should update an ObservationSound record correctly", () => {
+    markRecordUploaded( "obs123", "sound123", "ObservationSound", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockObsSound.id ).toBe( 12345 );
+    expect( mockObsSound._synced_at ).toBeInstanceOf( Date );
+    // needs_sync should not be modified for ObservationSound
+    expect( mockObsSound.needs_sync ).toBeUndefined();
+  } );
+
+  test( "should update a Photo record correctly with options.record", () => {
+    const options = { record: mockPhoto };
+
+    markRecordUploaded( "obs123", null, "Photo", mockResponse, mockRealm, options );
+
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
+    expect( mockPhoto.id ).toBe( 12345 );
+    expect( mockPhoto._synced_at ).toBeInstanceOf( Date );
+  } );
+
+  test( "should throw error when record is not found", () => {
+    expect( () => {
+      markRecordUploaded( "obs123", "nonexistent", "ObservationPhoto", mockResponse, mockRealm );
+    } ).toThrow( "Cannot find local Realm object to mark as updated" );
+  } );
+
+  test( "should retry on invalidated object error", () => {
+    safeRealmWrite.mockImplementationOnce( () => {
+      throw new Error( "Object has been invalidated or deleted" );
+    } );
+
+    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledTimes( 2 );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 2 );
+
+    expect( mockObservation.id ).toBe( 12345 );
+    expect( mockObservation._synced_at ).toBeInstanceOf( Date );
+    expect( mockObservation.needs_sync ).toBe( false );
+  } );
+
+  test( "should attempt to retry on non-invalidation errors", () => {
+    // Mock safeRealmWrite to throw a non-invalidation error
+    safeRealmWrite.mockImplementationOnce( ( realm, callback, description ) => {
+      const error = new Error( "Some other error" );
+      error.message = `${description}: ${error.message}`;
+      throw error;
+    } )
+      .mockImplementationOnce( ( realm, callback ) => {
+      // Second call succeeds
+        callback( );
+      } );
+
+    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+
+    // Only called once because error doesn't match invalidated pattern
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+  } );
+} );

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -123,13 +123,11 @@ describe( "markRecordUploaded", () => {
       const error = new Error( "Some other error" );
       error.message = `${description}: ${error.message}`;
       throw error;
-    } )
-      .mockImplementationOnce( ( realm, callback ) => {
-      // Second call succeeds
-        callback( );
-      } );
+    } );
 
-    markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+    expect( () => {
+      markRecordUploaded( "obs123", null, "Observation", mockResponse, mockRealm );
+    } ).toThrow( /Some other error/ );
 
     // Only called once because error doesn't match invalidated pattern
     expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
Sorry, I messed up the original PR this is a copy of the two commits.
[albullington](https://github.com/albullington) commented [last week](https://github.com/inaturalist/iNaturalistReactNative/pull/2872#issue-3015479987)
Closes [Mob-734](https://linear.app/inaturalist/issue/MOB-734)

This is a sub-issue of a larger issue to start making our upload code easier to maintain. Realm syncing functionality was the most modular and easiest part of the code to break out.

Unit tests were added to make sure functionality didn't change while refactoring. The one exception to this is the very last test, which highlighted that we were swallowing any non-invalidation errors instead of throwing them. I believe throwing these errors is the desired behavior, so made this change & changed the unit test to reflect it.