### PR TITLE
Move blur effect to CameraContainer

### DIFF
--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -1,4 +1,3 @@
-import { useNavigation } from "@react-navigation/native";
 import CameraFlip from "components/Camera/Buttons/CameraFlip.tsx";
 import Close from "components/Camera/Buttons/Close.tsx";
 import Flash from "components/Camera/Buttons/Flash.tsx";
@@ -8,11 +7,7 @@ import TakePhoto from "components/Camera/Buttons/TakePhoto.tsx";
 import Zoom from "components/Camera/Buttons/Zoom.tsx";
 import TabletButtons from "components/Camera/TabletButtons.tsx";
 import { View } from "components/styledComponents";
-import React, {
-  useEffect,
-  useRef,
-  useState
-} from "react";
+import React from "react";
 import { GestureResponderEvent, ViewStyle } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import type { CameraDeviceFormat, TakePhotoOptions } from "react-native-vision-camera";
@@ -79,28 +74,6 @@ const AICameraButtons = ( {
   toggleLocation
 }: Props ) => {
   const { isDefaultMode } = useLayoutPrefs();
-  const navigation = useNavigation();
-
-  const [isProcessing, setIsProcessing] = useState( false );
-  const onPressRef = useRef( takePhoto );
-
-  onPressRef.current = takePhoto;
-
-  const handleTakePhoto = ( event?: GestureResponderEvent ) => {
-    setIsProcessing( true );
-
-    onPressRef.current( event );
-  };
-
-  useEffect( () => {
-    const unsubscribe = navigation.addListener( "blur", () => {
-      // only reset buttons after screen blurs
-      setIsProcessing( false );
-    } );
-
-    return unsubscribe;
-  }, [navigation] );
-
   if ( isTablet ) {
     return (
       <TabletButtons
@@ -183,14 +156,14 @@ const AICameraButtons = ( {
         <View>
           <PhotoLibraryIcon
             rotatableAnimatedStyle={rotatableAnimatedStyle}
-            disabled={takingPhoto || isProcessing}
+            disabled={takingPhoto}
           />
         </View>
       </View>
       <View className="flex-row justify-center items-center w-full" pointerEvents="box-none">
         <TakePhoto
-          disabled={!modelLoaded || takingPhoto || isProcessing}
-          takePhoto={handleTakePhoto}
+          disabled={!modelLoaded || takingPhoto}
+          takePhoto={takePhoto}
           showPrediction={showPrediction}
         />
       </View>

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -79,6 +79,7 @@ const AICameraButtons = ( {
       <TabletButtons
         handleZoomButtonPress={handleZoomButtonPress}
         disabled={!modelLoaded || takingPhoto}
+        disabledPhotoLibrary={takingPhoto}
         flipCamera={flipCamera}
         hasFlash={hasFlash}
         hasPhotoLibraryButton

--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -249,13 +249,25 @@ const CameraContainer = ( ) => {
     }
     const uri = await saveRotatedPhotoToDocumentsDirectory( cameraPhoto, deviceOrientation );
     const newPhotoState = await updateTakePhotoStore( uri, options );
-    setTakingPhoto( false );
+    if ( cameraType !== "AI" ) { setTakingPhoto( false ); }
     if ( options?.navigateImmediately ) {
       await handleCheckmarkPress( newPhotoState, options?.visionResult );
     }
     setNewPhotoUris( [...newPhotoUris, uri] );
     return uri;
   };
+
+  useEffect( () => {
+    const unsubscribe = navigation.addListener( "blur", () => {
+      // This is only needed for the AI camera, since the multicapture camera is supposed to set
+      // the takingPhoto state to false for each photo. In the AI camera, we want the buttons
+      // only to reset after the user navigates away from the camera. (It doesn't hurt to also
+      // reset the multicapture camera though I think.)
+      setTakingPhoto( false );
+    } );
+
+    return unsubscribe;
+  }, [navigation] );
 
   useEffect( ( ) => {
     const fetchLocation = async ( ) => {

--- a/src/components/Camera/TabletButtons.tsx
+++ b/src/components/Camera/TabletButtons.tsx
@@ -40,6 +40,7 @@ const cameraOptionsClasses = [
 interface Props {
   handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   disabled: boolean;
+  disabledPhotoLibrary: boolean;
   flipCamera: ( _event: GestureResponderEvent ) => void;
   handleCheckmarkPress?: ( _event: GestureResponderEvent ) => void;
   handleClose?: ( _event: GestureResponderEvent ) => void;
@@ -76,6 +77,7 @@ const CameraButtonPlaceholder = ( { extraClassName }: { extraClassName?: string 
 const TabletButtons = ( {
   handleZoomButtonPress,
   disabled,
+  disabledPhotoLibrary,
   flipCamera,
   handleCheckmarkPress,
   handleClose,
@@ -163,7 +165,10 @@ const TabletButtons = ( {
       { showZoomButton && <CameraButtonPlaceholder extraClassName="mt-[25px]" /> }
       { hasPhotoLibraryButton && (
         <View className="absolute bottom-6">
-          <PhotoLibraryIcon rotatableAnimatedStyle={rotatableAnimatedStyle} />
+          <PhotoLibraryIcon
+            rotatableAnimatedStyle={rotatableAnimatedStyle}
+            disabled={disabledPhotoLibrary}
+          />
         </View>
       ) }
     </View>


### PR DESCRIPTION
I think we should reuse the already existing `takingPhoto` state to disable the camera UI until the user navigates away.
This way we can at a later point also add some error handling, and re-enable the camera if say the first photo taken errors out.