### PR TITLE
Request fewer update fields from API

### DIFF
--- a/src/components/Notifications/NotificationsList.tsx
+++ b/src/components/Notifications/NotificationsList.tsx
@@ -1,4 +1,3 @@
-import type { ApiNotification } from "api/types";
 import NotificationsListItem from "components/Notifications/NotificationsListItem.tsx";
 import {
   ActivityIndicator,
@@ -16,7 +15,7 @@ import type { Notification } from "sharedHooks/useInfiniteNotificationsScroll";
 
 type Props = {
   currentUser: RealmUser | null,
-  data: ApiNotification[],
+  data: Notification[],
   isError?: boolean,
   isFetching?: boolean,
   isInitialLoading?: boolean,
@@ -112,7 +111,7 @@ const NotificationsList = ( {
       ListFooterComponent={renderFooter}
       data={data}
       estimatedItemSize={85}
-      keyExtractor={( item: ApiNotification ) => item.id}
+      keyExtractor={( item: Notification ) => item.id}
       onEndReached={onEndReached}
       refreshing={isFetching}
       refreshControl={refreshControl}

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -28,9 +28,29 @@ interface InfiniteNotificationsScrollResponse {
   refetch: ( ) => void;
 }
 
+const UPDATE_FIELDS = {
+  comment_id: true,
+  comment: {
+    user: {
+      login: true
+    }
+  },
+  created_at: true,
+  id: true,
+  identification_id: true,
+  identification: {
+    user: {
+      login: true
+    }
+  },
+  notifier_type: true,
+  resource_uuid: true,
+  viewed: true
+};
+
 const BASE_PARAMS: ApiObservationsUpdatesParams = {
   // observations_by: "owner",
-  fields: "all", // TODO narrow this down. this has a massive response
+  fields: UPDATE_FIELDS,
   per_page: 30,
   ttl: -1,
   page: 1


### PR DESCRIPTION
This came out of a recent user problem where notifications would not load. While the actual error reason was a 500 on the server we are also requesting many more fields here than we actually need for the notifications screen to work.
So, a small cleanup, safeguard, possible speed improvement.
Closes MOB-780