### PR TITLE
Update react-native-safe-area-context-to >4.10.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -955,7 +955,7 @@ PODS:
     - React-Core
   - react-native-restart (0.0.27):
     - React-Core
-  - react-native-safe-area-context (4.9.0):
+  - react-native-safe-area-context (4.14.1):
     - React-Core
   - react-native-sensitive-info (6.0.0-alpha.9):
     - React-Core
@@ -1568,12 +1568,12 @@ SPEC CHECKSUMS:
   react-native-orientation-locker: dbd3f6ddbe9e62389cb0807dc2af63f6c36dec36
   react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
   react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
   react-native-sensitive-info: ee358bf2b901ac3d04f63ff637b31daee44ea87f
   react-native-slider: fbf693dba15ed9cf83c539f9ac6c9646bdf98752
   react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988
   react-native-webview: b3d56b5d601bf7f9715f41eb0914b761cc973302
   react-native-worklets-core: f730c01db8ea3d580e322617f4a631206f1905fb
+  react-native-safe-area-context: 141eca0fd4e4191288dfc8b96a7c7e1c2983447a
   React-nativeconfig: 8fd29a35a3e4e8c37682d976667663d834ba6165
   React-NativeModulesApple: 83d7077877f8eda8e1b6055b3f8f16f7db8463b5
   React-perflogger: 3887a05940ccd34a83457fd153fdeda509b31737

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "react-native-reanimated-carousel": "^3.5.1",
         "react-native-render-html": "^6.3.4",
         "react-native-restart": "^0.0.27",
-        "react-native-safe-area-context": "^4.9.0",
+        "react-native-safe-area-context": "^4.14.1",
         "react-native-screens": "^3.30.1",
         "react-native-sensitive-info": "^6.0.0-alpha.9",
         "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
@@ -17927,9 +17927,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.9.0.tgz",
-      "integrity": "sha512-/OJD9Pb8IURyvn+1tWTszWPJqsbZ4hyHBU9P0xhOmk7h5owSuqL0zkfagU0pg7Vh0G2NKQkaPpUKUMMCUMDh/w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.14.1.tgz",
+      "integrity": "sha512-+tUhT5WBl8nh5+P+chYhAjR470iCByf9z5EYdCEbPaAK3Yfzw+o8VRPnUgmPAKlSccOgQBxx3NOl/Wzckn9ujg==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-native-reanimated-carousel": "^3.5.1",
     "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.27",
-    "react-native-safe-area-context": "^4.9.0",
+    "react-native-safe-area-context": "^4.14.1",
     "react-native-screens": "^3.30.1",
     "react-native-sensitive-info": "^6.0.0-alpha.9",
     "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -94,6 +94,14 @@ describe( "CustomTabBar with advanced user layout", () => {
   beforeEach( ( ) => {
     jest.resetAllMocks();
     useNetInfo.mockImplementation( ( ) => ( { isConnected: true } ) );
+    // Re-establish the safe area context mock after resetAllMocks
+    const safeAreaContext = require( "react-native-safe-area-context" );
+    safeAreaContext.useSafeAreaInsets.mockImplementation( () => ( {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0
+    } ) );
   } );
 
   it( "should render correctly", async () => {


### PR DESCRIPTION
Closes MOB-789
Version 4.10.1 adds support for react native 0.74. Upgrading RN to 0.74 without updating this library is breaking compilation on Android for me. I have tested with the latest available version 4.x and everything seems to be in order for it as well. The changes in v4 seem backwards compatible so we can already merge it in as a standalone PR because it is also working on RN 0.73.

