### PR TITLE
Downgrade react-native-screens to v4.4.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1179,7 +1179,7 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-  - RNScreens (4.10.0):
+  - RNScreens (4.4.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1610,7 +1610,7 @@ SPEC CHECKSUMS:
   RNLocalize: 080849cb8a824d9f759b8a5ae00c8321d46dbed0
   RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f
   RNReanimated: b158619f02f1384a5be9e1203b58e0e4a80407d7
-  RNScreens: e1e83715f23cb93c4eafa8839d688b79e9c64e43
+  RNScreens: e0f79783ce405f4362c29d098b19fe7e241f11a9
   RNShareMenu: e1cdfa3b9af89416afc75a80377cfd0de4f30ded
   RNStoreReview: 613c43e9132998ed41a65946e20c223c91b36464
   RNSVG: a31e321979e3001f56ba9331d10ac917f8ad1851

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "react-native-render-html": "^6.3.4",
         "react-native-restart": "^0.0.27",
         "react-native-safe-area-context": "^4.14.1",
-        "react-native-screens": "^4.10.0",
+        "react-native-screens": "4.4.0",
         "react-native-sensitive-info": "^6.0.0-alpha.9",
         "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
         "react-native-store-review": "^0.4.3",
@@ -17998,10 +17998,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.10.0.tgz",
-      "integrity": "sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==",
-      "license": "MIT",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.4.0.tgz",
+      "integrity": "sha512-c7zc7Zwjty6/pGyuuvh9gK3YBYqHPOxrhXfG1lF4gHlojQSmIx2piNbNaV+Uykj+RDTmFXK0e/hA+fucw/Qozg==",
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.27",
     "react-native-safe-area-context": "^4.14.1",
-    "react-native-screens": "^4.10.0",
+    "react-native-screens": "4.4.0",
     "react-native-sensitive-info": "^6.0.0-alpha.9",
     "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
     "react-native-store-review": "^0.4.3",


### PR DESCRIPTION
react-native-screens version 4.5.0 increases the react native version that it supports to 0.74.0+ (https://github.com/software-mansion/react-native-screens/pull/2613/files). So, by using 4.4.0 we are still able to build the app on Android as we are still on 0.73 for now (have tested and it works).
Have not seen any effect on the changes related to the latest react-navigation versions.