### PR TITLE
MOB-690 - Add error context to 401 errors

### DIFF
--- a/src/api/error.js
+++ b/src/api/error.js
@@ -36,6 +36,10 @@ export class INatApiUnauthorizedError extends INatApiError {
     super( errorJson, 401, context );
   }
 }
+// https://wbinnssmith.com/blog/subclassing-error-in-modern-javascript/
+Object.defineProperty( INatApiUnauthorizedError.prototype, "name", {
+  value: "INatApiUnauthorizedError"
+} );
 
 export class INatApiTooManyRequestsError extends INatApiError {
   constructor( context?: Object ) {

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -26,6 +26,17 @@ Object.defineProperty( INatApiError.prototype, "name", {
   value: "INatApiError"
 } );
 
+export class INatApiUnauthorizedError extends INatApiError {
+  constructor( context?: Object ) {
+    const errorJson = {
+      error: "Unauthorized",
+      status: 401,
+      context
+    };
+    super( errorJson, 401, context );
+  }
+}
+
 export class INatApiTooManyRequestsError extends INatApiError {
   constructor( context?: Object ) {
     const errorJson = {
@@ -81,6 +92,8 @@ async function handleError( e: Object, options: Object = {} ): Object {
   if ( e.response.status === 429 ) {
     logger.error( "429 with a response in handleError:", JSON.stringify( context ) );
     throw new INatApiTooManyRequestsError( context );
+  } else if ( e.response.status === 401 ) {
+    throw new INatApiUnauthorizedError( context );
   }
 
   // Try to parse JSON in the response if this was an HTTP error. If we can't

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -83,11 +83,16 @@ async function handleError( e: Object, options: Object = {} ): Object {
   // Get context from options if available
   const originalContext = options?.context || null;
   const context = createContext( e, options, originalContext );
-  if ( e.status === 429 ) {
-    logger.error( "429 without a response in handleError:", JSON.stringify( context ) );
+  if ( !e.response ) {
+    if ( e.status === 429 ) {
+      logger.error( "429 without a response in handleError:", JSON.stringify( context ) );
+      throw new INatApiTooManyRequestsError( context );
+    } else if ( e.status === 401 ) {
+      logger.error( "401 without a response in handleError:", JSON.stringify( context ) );
+      throw new INatApiUnauthorizedError( context );
+    }
+    throw e;
   }
-
-  if ( !e.response ) { throw e; }
 
   // 429 responses don't return JSON so the parsing that we do below will
   // fail. Info about the request that triggered the 429 response is

--- a/src/api/error.js
+++ b/src/api/error.js
@@ -97,6 +97,7 @@ async function handleError( e: Object, options: Object = {} ): Object {
     logger.error( "429 with a response in handleError:", JSON.stringify( context ) );
     throw new INatApiTooManyRequestsError( context );
   } else if ( e.response.status === 401 ) {
+    logger.error( "401 with a response in handleError:", JSON.stringify( context ) );
     throw new INatApiUnauthorizedError( context );
   }
 

--- a/src/sharedHooks/useAuthenticatedMutation.js
+++ b/src/sharedHooks/useAuthenticatedMutation.js
@@ -47,6 +47,11 @@ const useAuthenticatedMutation = (
         getJWT( true ).catch( refreshError => {
           logger.error( "Failed to refresh token in mutation after 401:", refreshError );
         } );
+
+        return handleError( error, {
+          context: errorContext,
+          throw: mutationOptions.throwOnError !== false
+        } );
       }
 
       if ( error.status === 429 || ( error.response && error.response.status === 429 ) ) {


### PR DESCRIPTION
I don't know what happened to the previous PR. This is a copy of a previous one with only the commits we want to have added. Summary of previous [PR](https://github.com/inaturalist/iNaturalistReactNative/pull/2864):

No description provided.

----------
@[albullington](https://github.com/albullington) albullington [last month](https://github.com/inaturalist/iNaturalistReactNative/pull/2864#discussion_r2054860256)
one problem we're bumping into in 429 errors is that the context is still showing up as null every time. i'm not sure what the core issue is there -- maybe we're not awaiting the  handleError function throughout the app and we need to? I don't think this will fix the core issue or help us add context, unfortunately.

----------
Have updated this PR with the results of the previous PR that worked on 429 errors. I think with these changes, this one is also good to go (@albullington ?). Have tested in production and these are two errors I see with these changes (from the two different error code paths we currently have through handleError):

`401 with a response in handleError: {"queryKey":"unknown","timestamp":"2025-05-20T12:22:48.141Z","errorType":"Error","status":401,"url":"https://api.inaturalist.org/v2/observations/updates?observations_by=owner&viewed=false&fields=viewed%2Cresource_uuid%2Ccomment_id%2Cidentification_id&per_page=50","functionName":"fetchObservationUpdates","opts":{"api_token":"xx"}}`

`401 without a response in handleError: {"queryKey":"unknown","timestamp":"2025-05-20T12:22:48.135Z","errorType":"INatApiUnauthorizedError","status":401}`

-----------
I'm not sure what happened in this PR, but there are 340 files changed that mostly have nothing to do with this issue, so this isn't ready to merge. My best recommendation here would be to create another branch for this issue from main, cherry-pick the actual desired commits, and close this PR.
