### PR TITLE
Add logging to uploads & validate jwts at each upload step

### DIFF
--- a/src/uploaders/mediaUploader.ts
+++ b/src/uploaders/mediaUploader.ts
@@ -7,11 +7,8 @@ import {
   RealmObservationSound,
   RealmPhoto
 } from "realmModels/types.d.ts";
-import { log } from "sharedHelpers/logger";
 import { markRecordUploaded, prepareMediaForUpload } from "uploaders";
 import { trackEvidenceUpload } from "uploaders/utils/progressTracker.ts";
-
-const logger = log.extend( "mediaUploader" );
 
 type EvidenceType = "Photo" | "ObservationPhoto" | "ObservationSound";
 type ActionType = "upload" | "attach" | "update";
@@ -119,7 +116,6 @@ const uploadSingleEvidence = async (
   );
 
   if ( !response ) {
-    logger.error( `Evidence: No response for ${action} ${type} ${evidenceUUID}` );
     throw new Error( `Failed to upload ${type} ${evidenceUUID}: no response from server` );
   }
 
@@ -315,15 +311,7 @@ async function uploadObservationMedia(
   const operations = createMediaOperations( mediaItems, null, true );
 
   if ( operations.length > 0 ) {
-    try {
-      await processMediaOperations( operations, options, observation.uuid, realm );
-      logger.info(
-        `MediaUpload: Uploaded ${operations.length} items for ${observation.uuid}`
-      );
-    } catch ( error ) {
-      logger.error( `MediaUpload: Failed upload for ${observation.uuid}`, error );
-      throw error;
-    }
+    await processMediaOperations( operations, options, observation.uuid, realm );
   }
 
   return {
@@ -353,15 +341,7 @@ async function attachMediaToObservation(
 
   // Process all operations in a single Promise.all
   if ( operations.length > 0 ) {
-    try {
-      await processMediaOperations( operations, options, observationUUID, realm );
-      logger.info(
-        `MediaUpload: Attached ${operations.length} items for ${observationUUID}`
-      );
-    } catch ( error ) {
-      logger.error( `MediaUpload: Failed attachment for ${observationUUID}`, error );
-      throw error;
-    }
+    await processMediaOperations( operations, options, observationUUID, realm );
   }
 }
 

--- a/src/uploaders/mediaUploader.ts
+++ b/src/uploaders/mediaUploader.ts
@@ -7,8 +7,11 @@ import {
   RealmObservationSound,
   RealmPhoto
 } from "realmModels/types.d.ts";
+import { log } from "sharedHelpers/logger";
 import { markRecordUploaded, prepareMediaForUpload } from "uploaders";
 import { trackEvidenceUpload } from "uploaders/utils/progressTracker.ts";
+
+const logger = log.extend( "mediaUploader" );
 
 type EvidenceType = "Photo" | "ObservationPhoto" | "ObservationSound";
 type ActionType = "upload" | "attach" | "update";
@@ -115,7 +118,10 @@ const uploadSingleEvidence = async (
     options
   );
 
-  console.log( params, "params" );
+  if ( !response ) {
+    logger.error( `Evidence: No response for ${action} ${type} ${evidenceUUID}` );
+    throw new Error( `Failed to upload ${type} ${evidenceUUID}: no response from server` );
+  }
 
   if ( response && observationUUID ) {
     // TODO: can't mark records as uploaded by primary key for ObsPhotos and ObsSound anymore
@@ -309,7 +315,15 @@ async function uploadObservationMedia(
   const operations = createMediaOperations( mediaItems, null, true );
 
   if ( operations.length > 0 ) {
-    await processMediaOperations( operations, options, observation.uuid, realm );
+    try {
+      await processMediaOperations( operations, options, observation.uuid, realm );
+      logger.info(
+        `MediaUpload: Uploaded ${operations.length} items for ${observation.uuid}`
+      );
+    } catch ( error ) {
+      logger.error( `MediaUpload: Failed upload for ${observation.uuid}`, error );
+      throw error;
+    }
   }
 
   return {
@@ -339,7 +353,15 @@ async function attachMediaToObservation(
 
   // Process all operations in a single Promise.all
   if ( operations.length > 0 ) {
-    await processMediaOperations( operations, options, observationUUID, realm );
+    try {
+      await processMediaOperations( operations, options, observationUUID, realm );
+      logger.info(
+        `MediaUpload: Attached ${operations.length} items for ${observationUUID}`
+      );
+    } catch ( error ) {
+      logger.error( `MediaUpload: Failed attachment for ${observationUUID}`, error );
+      throw error;
+    }
   }
 }
 

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -5,6 +5,7 @@ import {
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import Realm from "realm";
 import { RealmObservation, RealmObservationPojo } from "realmModels/types.d.ts";
+import { log } from "sharedHelpers/logger";
 import {
   markRecordUploaded,
   prepareObservationForUpload
@@ -14,6 +15,8 @@ import {
   uploadObservationMedia
 } from "uploaders/mediaUploader.ts";
 import { trackObservationUpload } from "uploaders/utils/progressTracker.ts";
+
+const logger = log.extend( "observationUploader" );
 
 interface UploadOptions {
   api_token?: string;
@@ -40,7 +43,7 @@ interface ObservationApiResponse {
 }
 
 async function validateAndGetToken( ): Promise<string> {
-  const apiToken = await getJWT( );
+  const apiToken = await getJWT( false, "upload" );
   if ( !apiToken ) {
     throw new Error( "Gack, tried to upload an observation without API token!" );
   }
@@ -73,48 +76,69 @@ async function uploadObservation(
   realm: Realm,
   opts: UploadOptions
 ): Promise<ObservationApiResponse | null> {
+  const uploadStartTime = Date.now( );
   const obsProgress = trackObservationUpload( observation.uuid );
   obsProgress.start( );
 
   const newObs = prepareObservationForUpload( observation );
-
+  try {
   // Step 1: upload the photos/sounds (before uploading the observation itself)
-  let apiToken = await validateAndGetToken( );
-  const mediaItems = await uploadObservationMedia(
-    observation,
-    { ...opts, api_token: apiToken },
-    realm
-  );
+    let apiToken = await validateAndGetToken( );
 
-  // Step 2: upload or modify observation with revalidated token
-  apiToken = await validateAndGetToken( );
-  const response = await createOrUpdateObservation(
-    observation,
-    newObs,
-    { ...opts, api_token: apiToken }
-  );
+    const mediaStartTime = Date.now( );
+    const mediaItems = await uploadObservationMedia(
+      observation,
+      { ...opts, api_token: apiToken },
+      realm
+    );
+    const mediaDuration = Date.now( ) - mediaStartTime;
 
-  obsProgress.complete( );
-  if ( !response ) {
+    // Step 2: upload or modify observation with revalidated token
+    apiToken = await validateAndGetToken( );
+    const obsStartTime = Date.now( );
+    const response = await createOrUpdateObservation(
+      observation,
+      newObs,
+      { ...opts, api_token: apiToken }
+    );
+    const obsDuration = Date.now( ) - obsStartTime;
+
+    obsProgress.complete( );
+    if ( !response ) {
+      logger.error( `Upload: No response for observation ${observation.uuid}` );
+      return response;
+    }
+
+    const { uuid: obsUUID } = response.results[0];
+
+    // Step 3: attach media to observation with revalidated token
+    apiToken = await validateAndGetToken( );
+    const attachStartTime = Date.now( );
+    await attachMediaToObservation(
+      obsUUID,
+      mediaItems,
+      { ...opts, api_token: apiToken },
+      realm
+    );
+    const attachDuration = Date.now( ) - attachStartTime;
+
+    // Step 4: mark observation as uploaded in realm
+    markRecordUploaded( observation.uuid, null, "Observation", response, realm );
+
+    const totalDuration = Date.now( ) - uploadStartTime;
+    logger.info(
+      `Upload: Completed ${observation.uuid} - total: ${totalDuration}ms`
+      + `media: ${mediaDuration}ms, obs: ${obsDuration}ms, attach: ${attachDuration}ms`
+    );
+
+    // note: removed observation fetch at the end of the upload, because we don't actually
+    // need this operation here
     return response;
+  } catch ( error ) {
+    const totalDuration = Date.now( ) - uploadStartTime;
+    logger.error( `Upload: Failed ${observation.uuid} after ${totalDuration}ms`, error );
+    throw error;
   }
-
-  const { uuid: obsUUID } = response.results[0];
-
-  // Step 3: attach media to observation with revalidated token
-  apiToken = await validateAndGetToken( );
-  await attachMediaToObservation(
-    obsUUID,
-    mediaItems,
-    { ...opts, api_token: apiToken },
-    realm
-  );
-
-  // Step 4: mark observation as uploaded in realm
-  markRecordUploaded( observation.uuid, null, "Observation", response, realm );
-  // note: removed observation fetch at the end of the upload, because we don't actually
-  // need this operation here
-  return response;
 }
 
 export default uploadObservation;

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -3,6 +3,7 @@ import {
   updateObservation
 } from "api/observations";
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
+import { AppState } from "react-native";
 import Realm from "realm";
 import { RealmObservation, RealmObservationPojo } from "realmModels/types.d.ts";
 import { log } from "sharedHelpers/logger";
@@ -71,6 +72,18 @@ async function createOrUpdateObservation(
   return createObservation( uploadParams, options );
 }
 
+function createErrorContext( stage: string, startTime: number ) {
+  const totalDuration = Date.now() - startTime;
+  const appState = AppState.currentState;
+
+  let errorContext = `stage: ${stage}`;
+  if ( appState === "background" || appState === "inactive" ) {
+    errorContext += `, app backgrounded (${appState})`;
+  }
+
+  return { errorContext, totalDuration };
+}
+
 async function uploadObservation(
   observation: RealmObservation,
   realm: Realm,
@@ -81,38 +94,66 @@ async function uploadObservation(
   obsProgress.start( );
 
   const newObs = prepareObservationForUpload( observation );
-  try {
-  // Step 1: upload the photos/sounds (before uploading the observation itself)
-    let apiToken = await validateAndGetToken( );
 
+  // Step 1: upload the photos/sounds (before uploading the observation itself)
+  let mediaItems;
+  let mediaDuration = 0;
+  try {
+    const apiToken = await validateAndGetToken( );
     const mediaStartTime = Date.now( );
-    const mediaItems = await uploadObservationMedia(
+    mediaItems = await uploadObservationMedia(
       observation,
       { ...opts, api_token: apiToken },
       realm
     );
-    const mediaDuration = Date.now( ) - mediaStartTime;
+    mediaDuration = Date.now( ) - mediaStartTime;
+  } catch ( error ) {
+    const {
+      errorContext, totalDuration
+    } = createErrorContext( "media_upload", uploadStartTime, observation.uuid );
+    logger.error(
+      `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
+      + ": Media upload failed",
+      error
+    );
+    throw new Error( `Media upload failed: ${error.message}` );
+  }
 
-    // Step 2: upload or modify observation with revalidated token
-    apiToken = await validateAndGetToken( );
+  // Step 2: upload or modify observation with revalidated token
+  let response;
+  let obsDuration = 0;
+  try {
+    const apiToken = await validateAndGetToken( );
     const obsStartTime = Date.now( );
-    const response = await createOrUpdateObservation(
+    response = await createOrUpdateObservation(
       observation,
       newObs,
       { ...opts, api_token: apiToken }
     );
-    const obsDuration = Date.now( ) - obsStartTime;
+    obsDuration = Date.now( ) - obsStartTime;
 
     obsProgress.complete( );
     if ( !response ) {
-      logger.error( `Upload: No response for observation ${observation.uuid}` );
-      return response;
+      throw new Error( "No response from observation upload" );
     }
+  } catch ( error ) {
+    const {
+      errorContext, totalDuration
+    } = createErrorContext( "observation_upload", uploadStartTime, observation.uuid );
+    logger.error(
+      `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
+      + ": Observation upload failed",
+      error
+    );
+    throw new Error( `Observation upload failed: ${error.message}` );
+  }
 
-    const { uuid: obsUUID } = response.results[0];
+  const { uuid: obsUUID } = response.results[0];
 
-    // Step 3: attach media to observation with revalidated token
-    apiToken = await validateAndGetToken( );
+  // Step 3: attach media to observation with revalidated token
+  let attachDuration = 0;
+  try {
+    const apiToken = await validateAndGetToken( );
     const attachStartTime = Date.now( );
     await attachMediaToObservation(
       obsUUID,
@@ -120,25 +161,43 @@ async function uploadObservation(
       { ...opts, api_token: apiToken },
       realm
     );
-    const attachDuration = Date.now( ) - attachStartTime;
-
-    // Step 4: mark observation as uploaded in realm
-    markRecordUploaded( observation.uuid, null, "Observation", response, realm );
-
-    const totalDuration = Date.now( ) - uploadStartTime;
-    logger.info(
-      `Upload: Completed ${observation.uuid} - total: ${totalDuration}ms`
-      + `media: ${mediaDuration}ms, obs: ${obsDuration}ms, attach: ${attachDuration}ms`
-    );
-
-    // note: removed observation fetch at the end of the upload, because we don't actually
-    // need this operation here
-    return response;
+    attachDuration = Date.now( ) - attachStartTime;
   } catch ( error ) {
-    const totalDuration = Date.now( ) - uploadStartTime;
-    logger.error( `Upload: Failed ${observation.uuid} after ${totalDuration}ms`, error );
-    throw error;
+    const {
+      errorContext, totalDuration
+    } = createErrorContext( "media_attachment", uploadStartTime, observation.uuid );
+    logger.error(
+      `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
+      + ": Media attachment failed",
+      error
+    );
+    throw new Error( `Media attachment failed: ${error.message}` );
   }
+
+  // Step 4: mark observation as uploaded in realm
+  try {
+    markRecordUploaded( observation.uuid, null, "Observation", response, realm );
+  } catch ( error ) {
+    const {
+      errorContext, totalDuration
+    } = createErrorContext( "realm_update", uploadStartTime, observation.uuid );
+    logger.error(
+      `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
+      + ": Realm update failed",
+      error
+    );
+    throw new Error( `Realm update failed: ${error.message}` );
+  }
+
+  const totalDuration = Date.now( ) - uploadStartTime;
+  logger.info(
+    `Upload: Completed ${observation.uuid} - total: ${totalDuration}ms`
+      + `, media: ${mediaDuration}ms, obs: ${obsDuration}ms, attach: ${attachDuration}ms`
+  );
+
+  // note: removed observation fetch at the end of the upload, because we don't actually
+  // need this operation here
+  return response;
 }
 
 export default uploadObservation;

--- a/tests/integration/ObsEditOnline.test.js
+++ b/tests/integration/ObsEditOnline.test.js
@@ -72,14 +72,17 @@ const mockObservation = factory( "RemoteObservation", {
 
 const mockObservations = [mockObservation];
 
-const mockMultipleObservations = [
-  mockObservation,
-  mockObservation,
-  mockObservation,
-  mockObservation,
-  mockObservation,
-  mockObservation
-];
+const mockMultipleObservations = Array.from(
+  { length: 6 },
+  () => factory( "RemoteObservation", {
+    latitude: 37.99,
+    longitude: -142.88,
+    user: mockCurrentUser,
+    place_guess: mockLocationName,
+    taxon: mockTaxon,
+    observationPhotos: []
+  } )
+);
 
 describe( "basic rendering", ( ) => {
   beforeAll( async () => {
@@ -203,6 +206,12 @@ describe( "multiple observation upload/save progress", ( ) => {
   } );
 
   test( "should show upload status when upload button pressed", async ( ) => {
+    inatjs.observations.create.mockImplementation(
+      ( params, _opts ) => Promise.resolve( makeResponse( [{
+        id: faker.number.int(),
+        uuid: params.observation.uuid
+      }] ) )
+    );
     renderObsEdit( );
     const uploadButton = await screen.findByText( /UPLOAD/ );
     fireEvent.press( uploadButton );
@@ -224,6 +233,12 @@ describe( "multiple observation upload/save progress", ( ) => {
 
   test( "should show both saved and uploading status when saved and upload"
     + " button pressed", async ( ) => {
+    inatjs.observations.create.mockImplementation(
+      ( params, _opts ) => Promise.resolve( makeResponse( [{
+        id: faker.number.int(),
+        uuid: params.observation.uuid
+      }] ) )
+    );
     renderObsEdit( );
     const saveButton = await screen.findByText( /SAVE/ );
     fireEvent.press( saveButton );
@@ -241,17 +256,12 @@ describe( "multiple observation upload/save progress", ( ) => {
 
   test( "should show uploaded status when 1 observation is uploaded"
     + " in multi-observation upload flow", async ( ) => {
-    // Mock inatjs endpoints so they return the right responses for the right test data
-    inatjs.observations.create.mockImplementation( ( params, _opts ) => {
-      const mockObs = mockObservations.find( o => o.uuid === params.observation.uuid );
-      return Promise.resolve( makeResponse( [{ id: faker.number.int( ), uuid: mockObs.uuid }] ) );
-    } );
-    inatjs.observations.fetch.mockImplementation( ( uuid, _params, _opts ) => {
-      const mockObs = mockObservations.find( o => o.uuid === uuid );
-      // It would be a lot better if this returned something that looks like
-      // a remote obs, but this works
-      return Promise.resolve( makeResponse( [mockObs] ) );
-    } );
+    inatjs.observations.create.mockImplementation(
+      ( params, _opts ) => Promise.resolve( makeResponse( [{
+        id: faker.number.int(),
+        uuid: params.observation.uuid
+      }] ) )
+    );
     renderObsEdit( );
     const uploadButton = await screen.findByText( /UPLOAD/ );
     fireEvent.press( uploadButton );

--- a/tests/integration/navigation/ObsEdit.test.js
+++ b/tests/integration/navigation/ObsEdit.test.js
@@ -4,13 +4,14 @@ import {
   waitFor,
   within
 } from "@testing-library/react-native";
+import inatjs from "inaturalistjs";
 import * as rnImagePicker from "react-native-image-picker";
 import useStore from "stores/useStore";
 // import os from "os";
 // import path from "path";
 // import Realm from "realm";
 // import realmConfig from "realmModels/index";
-import factory from "tests/factory";
+import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import {
   renderAppWithObservations
@@ -219,6 +220,22 @@ describe( "ObsEdit", ( ) => {
 
       it( "should show uploading status after user starts one upload"
         + " in the multi-observation flow", async ( ) => {
+        inatjs.photos.create.mockImplementation(
+          ( ) => Promise.resolve( makeResponse( [{
+            id: faker.number.int()
+          }] ) )
+        );
+        inatjs.observations.create.mockImplementation(
+          ( params, _opts ) => Promise.resolve( makeResponse( [{
+            id: faker.number.int(),
+            uuid: params.observation.uuid
+          }] ) )
+        );
+        inatjs.observation_photos.create.mockImplementation(
+          ( ) => Promise.resolve( makeResponse( [{
+            id: faker.number.int()
+          }] ) )
+        );
         await renderAppWithObservations( mockObservations, __filename );
         await navigateToObsEditViaGroupPhotos( );
         await uploadObsEditObservation( );

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -200,12 +200,12 @@ describe( "uploadObservation", () => {
     expect( mockProgressTracker.complete ).not.toHaveBeenCalled();
   } );
 
-  it( "should handle null response from observation creation", async () => {
+  it( "should throw an error when observation creation returns null response", async () => {
     apiObservations.createObservation.mockResolvedValue( null );
 
-    const result = await uploadObservation( mockObservation, mockRealm );
+    await expect( uploadObservation( mockObservation, mockRealm ) )
+      .rejects.toThrow( "No response from observation upload" );
 
-    expect( result ).toBeNull();
     // Should not attempt to attach media or mark as uploaded
     expect( mediaUploader.attachMediaToObservation ).not.toHaveBeenCalled();
     expect( uploaders.markRecordUploaded ).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes Mob-777

- Adds logging to the upload process to help debug what's happening when a batch upload fails. Aiming for the right amount of data to be useful without making logs noisy
- Validates jwt token at each stage of the upload process, to address our hypothesis that a token could expire between the time the user starts the upload process and the time media gets attached to an observation (this would make sense if the user backgrounded the app and came back midway through an upload, or if they had a large batch of uploads and were close to the expiry time when they started uploads)
- Throws errors at each stage of the upload process so we can see where an upload is failing and any errors that bubble up