### PR TITLE
Fix: Fetch data on infinite scroll using last observation id

### DIFF
--- a/src/components/MyObservations/MyObservationsContainer.tsx
+++ b/src/components/MyObservations/MyObservationsContainer.tsx
@@ -99,6 +99,7 @@ const MyObservationsContainer = ( ): React.FC => {
   useObservationsUpdates( !!currentUser );
 
   const {
+    fetchFromLastObservation,
     fetchNextPage,
     isFetchingNextPage,
     status,
@@ -360,6 +361,7 @@ const MyObservationsContainer = ( ): React.FC => {
       activeTab={activeTab}
       currentUser={currentUser}
       fetchMoreTaxa={fetchMoreTaxa}
+      fetchFromLastObservation={fetchFromLastObservation}
       handleIndividualUploadPress={handleIndividualUploadPress}
       handlePullToRefresh={handlePullToRefresh}
       handleSyncButtonPress={handleSyncButtonPress}

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -46,6 +46,7 @@ interface SpeciesCount {
 export interface Props {
   activeTab: string;
   currentUser?: RealmUser;
+  fetchFromLastObservation: ( id: number ) => void;
   handleIndividualUploadPress: ( uuid: string ) => void;
   handlePullToRefresh: ( ) => void;
   handleSyncButtonPress: ( _p: { unuploadedObsMissingBasicsIDs: string[] } ) => void;
@@ -85,6 +86,7 @@ export const TAXA_TAB = "taxa";
 const MyObservationsSimple = ( {
   activeTab,
   currentUser,
+  fetchFromLastObservation,
   handleIndividualUploadPress,
   handlePullToRefresh,
   handleSyncButtonPress,
@@ -220,7 +222,8 @@ const MyObservationsSimple = ( {
   const dataFilledWithEmptyBoxes = useMemo( ( ) => {
     const data = observations.filter( o => o.isValid() );
     // In grid layout fill up to 8 items to make sure the grid is filled
-    if ( layout === "grid" ) {
+    // but don't add the empty boxes at the end of a long existing list
+    if ( layout === "grid" && data.length < 8 ) {
     // Fill up to 8 items to make sure the grid is filled
       const emptyBoxes = new Array( 8 - ( data.length % 8 ) ).fill( { empty: true } );
       // Add random id to empty boxes to ensure they are unique
@@ -286,6 +289,7 @@ const MyObservationsSimple = ( {
             <ObservationsFlashList
               data={dataFilledWithEmptyBoxes}
               dataCanBeFetched={!!currentUser}
+              fetchFromLastObservation={fetchFromLastObservation}
               handlePullToRefresh={handlePullToRefresh}
               handleIndividualUploadPress={handleIndividualUploadPress}
               hideLoadingWheel={!isFetchingNextPage}

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -37,6 +37,7 @@ type Props = {
   contentContainerStyle?: Object,
   data: Array<Object>,
   dataCanBeFetched?: boolean,
+  fetchFromLastObservation?: Function,
   explore: boolean,
   handlePullToRefresh: Function,
   handleIndividualUploadPress: Function,
@@ -63,6 +64,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
   data,
   dataCanBeFetched,
   explore,
+  fetchFromLastObservation,
   handlePullToRefresh,
   handleIndividualUploadPress,
   hideLoadingWheel,
@@ -255,11 +257,26 @@ const ObservationsFlashList: Function = forwardRef( ( {
   // react thinks we've rendered a second item w/ a duplicate key
   const keyExtractor = item => item.uuid || item.id;
 
-  const onMomentumScrollEnd = ( ) => {
-    if ( dataCanBeFetched ) {
+  const onMomentumScrollEnd = useCallback( ( ) => {
+    if ( dataCanBeFetched && !fetchFromLastObservation ) {
       onEndReached( );
     }
-  };
+  }, [dataCanBeFetched, onEndReached, fetchFromLastObservation] );
+
+  const handleEndReached = useCallback( ( ) => {
+    if ( !dataCanBeFetched || explore ) return;
+
+    if ( fetchFromLastObservation && data.length > 0 ) {
+      const lastObservation = data[data.length - 1];
+      const lastId = lastObservation?.id;
+      if ( lastId ) {
+        fetchFromLastObservation( lastId );
+        return;
+      }
+    }
+
+    onEndReached( );
+  }, [dataCanBeFetched, fetchFromLastObservation, data, onEndReached, explore] );
 
   const refreshControl = (
     <CustomRefreshControl
@@ -284,6 +301,7 @@ const ObservationsFlashList: Function = forwardRef( ( {
       keyExtractor={keyExtractor}
       numColumns={numColumns}
       onLayout={onLayout}
+      onEndReached={handleEndReached}
       onMomentumScrollEnd={onMomentumScrollEnd}
       onScroll={onScroll}
       renderItem={renderItem}

--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -258,10 +258,10 @@ const ObservationsFlashList: Function = forwardRef( ( {
   const keyExtractor = item => item.uuid || item.id;
 
   const onMomentumScrollEnd = useCallback( ( ) => {
-    if ( dataCanBeFetched && !fetchFromLastObservation ) {
+    if ( dataCanBeFetched ) {
       onEndReached( );
     }
-  }, [dataCanBeFetched, onEndReached, fetchFromLastObservation] );
+  }, [dataCanBeFetched, onEndReached] );
 
   const handleEndReached = useCallback( ( ) => {
     if ( !dataCanBeFetched || explore ) return;

--- a/src/components/SharedComponents/FlashList/CustomFlashList.tsx
+++ b/src/components/SharedComponents/FlashList/CustomFlashList.tsx
@@ -104,6 +104,19 @@ const CustomFlashList: Function = forwardRef( ( props, ref ) => {
     }
   }, [onMomentumScrollEnd] );
 
+  const handleEndReached = useCallback( ( ) => {
+    if ( ignoreInitialEvents.current ) return;
+
+    if ( !fetchInProgress.current ) {
+      fetchInProgress.current = true;
+      flashListTracker.beginDataFetch( );
+    }
+
+    if ( onEndReached ) {
+      onEndReached( );
+    }
+  }, [onEndReached] );
+
   // To be called when new data is received
   // This needs to be exposed so it can be called from parent component
   React.useImperativeHandle( ref, ( ) => {
@@ -140,6 +153,7 @@ const CustomFlashList: Function = forwardRef( ( props, ref ) => {
       ref={ref}
       disableAutoLayout
       initialNumToRender={5}
+      onEndReached={handleEndReached}
       onEndReachedThreshold={0.2}
       onViewableItemsChanged={handleViewableItemsChanged}
       onScroll={handleScroll}


### PR DESCRIPTION
Closes Mob-799

This issue became apparent due to the performance improvements in https://github.com/inaturalist/iNaturalistReactNative/pull/2919 and https://github.com/inaturalist/iNaturalistReactNative/pull/2922. When the FlashList is performant enough for a user to scroll quickly, a user can reach the bottom of the list before API pagination has caught up. The result -- it might take an infinite number of scrolls before new data loads.

To solve this, this PR adds an `onEndReached` handler which fetches observations using the `id_below` parameter. When a user reaches the bottom of the list, we pass the very last observation ID to the API and begin new fetches from there.

**Note for developers**
- We'll likely want to merge this into https://github.com/inaturalist/iNaturalistReactNative/pull/2919 before merging into main since this is a small add-on to that PR.