### PR TITLE
Fix: integration tests store setup when changing layout slice

### DIFF
--- a/tests/helpers/setStoreStateLayout.js
+++ b/tests/helpers/setStoreStateLayout.js
@@ -1,0 +1,11 @@
+import useStore from "stores/useStore";
+
+export default function setStoreStateLayout( stateToMerge ) {
+  const initialState = useStore.getInitialState();
+  useStore.setState( {
+    layout: {
+      ...initialState.layout,
+      ...stateToMerge
+    }
+  } );
+}

--- a/tests/helpers/uniqueRealm.js
+++ b/tests/helpers/uniqueRealm.js
@@ -26,7 +26,6 @@ export default function setupUniqueRealm( realmIdentifier ) {
   const uniqueRealmBeforeAll = async ( ) => {
     global.mockRealms = global.mockRealms || {};
     global.mockRealms[realmIdentifier] = await Realm.open( mockRealmConfig );
-    // useStore.setState( initialStoreState, true );
   };
 
   // Ensure the realm connection gets closed

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -358,12 +358,6 @@ describe( "MyObservations", ( ) => {
       } );
 
       it( "displays observation status in list view in advanced mode", async () => {
-        useStore.setState( {
-          layout: {
-            isDefaultMode: false,
-            isAllAddObsOptionsMode: true
-          }
-        } );
         const realm = global.mockRealms[__filename];
         expect( realm.objects( "Observation" ).length ).toBeGreaterThan( 0 );
         renderAppWithComponent( <MyObservationsContainer /> );

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -10,10 +10,11 @@ import { flatten } from "lodash";
 import React from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { sleep } from "sharedHelpers/util.ts";
-import useStore, { zustandStorage } from "stores/useStore";
+import { zustandStorage } from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderAppWithComponent } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 
@@ -136,13 +137,9 @@ const displayItemByText = text => {
 };
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true
   } );
 } );
 

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -136,7 +136,9 @@ const displayItemByText = text => {
 };
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
+    ...initialState,
     layout: {
       isDefaultMode: false,
       isAllAddObsOptionsMode: true

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -138,8 +138,8 @@ const displayItemByText = text => {
 beforeEach( ( ) => {
   const initialState = useStore.getInitialState( );
   useStore.setState( {
-    ...initialState,
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true
     }

--- a/tests/integration/MyObservationsLocalization.test.js
+++ b/tests/integration/MyObservationsLocalization.test.js
@@ -45,7 +45,9 @@ const mockUser = factory( "LocalUser", {
 // } );
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState();
   useStore.setState( {
+    ...initialState,
     layout: {
       isDefaultMode: false,
       isAllAddObsOptionsMode: true

--- a/tests/integration/MyObservationsLocalization.test.js
+++ b/tests/integration/MyObservationsLocalization.test.js
@@ -2,11 +2,11 @@ import { screen, waitFor } from "@testing-library/react-native";
 import MyObservationsContainer from "components/MyObservations/MyObservationsContainer.tsx";
 // import inatjs from "inaturalistjs";
 import React from "react";
-import useStore from "stores/useStore";
 import factory from "tests/factory";
 // import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderAppWithComponent } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 
@@ -45,13 +45,9 @@ const mockUser = factory( "LocalUser", {
 // } );
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState();
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true
   } );
 } );
 

--- a/tests/integration/MyObservationsLocalization.test.js
+++ b/tests/integration/MyObservationsLocalization.test.js
@@ -47,8 +47,8 @@ const mockUser = factory( "LocalUser", {
 beforeEach( ( ) => {
   const initialState = useStore.getInitialState();
   useStore.setState( {
-    ...initialState,
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true
     }

--- a/tests/integration/MyObservationsSimple.test.js
+++ b/tests/integration/MyObservationsSimple.test.js
@@ -5,10 +5,10 @@ import { screen, waitFor } from "@testing-library/react-native";
 import MyObservationsContainer from "components/MyObservations/MyObservationsContainer.tsx";
 import React from "react";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
-import useStore from "stores/useStore";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderAppWithComponent } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 
 const mockUnsyncedObservations = [
@@ -84,13 +84,9 @@ const displayItemByText = text => {
 };
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: true,
-      isAllAddObsOptionsMode: false
-    }
+  setStoreStateLayout( {
+    isDefaultMode: true,
+    isAllAddObsOptionsMode: false
   } );
 } );
 

--- a/tests/integration/MyObservationsSimple.test.js
+++ b/tests/integration/MyObservationsSimple.test.js
@@ -89,7 +89,6 @@ beforeEach( ( ) => {
     layout: {
       ...initialState.layout,
       isDefaultMode: true,
-      shownOnce: {},
       isAllAddObsOptionsMode: false
     }
   } );

--- a/tests/integration/MyObservationsSimple.test.js
+++ b/tests/integration/MyObservationsSimple.test.js
@@ -84,8 +84,10 @@ const displayItemByText = text => {
 };
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: true,
       shownOnce: {},
       isAllAddObsOptionsMode: false

--- a/tests/integration/PhotoDeletion.test.js
+++ b/tests/integration/PhotoDeletion.test.js
@@ -7,9 +7,9 @@ import {
 import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice.ts";
-import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
 
@@ -74,14 +74,10 @@ const topSuggestion = {
 };
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true,
-      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true,
+    screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT
   } );
   inatjs.computervision.score_image.mockResolvedValue( makeResponse( [topSuggestion] ) );
 } );

--- a/tests/integration/PhotoDeletion.test.js
+++ b/tests/integration/PhotoDeletion.test.js
@@ -74,8 +74,10 @@ const topSuggestion = {
 };
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true,
       screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT

--- a/tests/integration/PhotoImport.test.js
+++ b/tests/integration/PhotoImport.test.js
@@ -8,10 +8,10 @@ import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import * as ImagePicker from "react-native-image-picker";
 import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice.ts";
-import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 
 // We're explicitly testing navigation here so we want react-navigation
@@ -89,14 +89,10 @@ beforeAll( async () => {
 } );
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+    isAllAddObsOptionsMode: true
   } );
   inatjs.computervision.score_image.mockResolvedValue( makeResponse( [topSuggestion] ) );
 } );

--- a/tests/integration/PhotoImport.test.js
+++ b/tests/integration/PhotoImport.test.js
@@ -89,8 +89,10 @@ beforeAll( async () => {
 } );
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
       isAllAddObsOptionsMode: true

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -45,6 +45,7 @@ beforeAll( async ( ) => {
   useStore.setState( initialStoreState, true );
   useStore.setState( {
     layout: {
+      ...initialStoreState.layout,
       isDefaultMode: false
     }
   } );

--- a/tests/integration/SuggestionsWithSyncedObs.test.js
+++ b/tests/integration/SuggestionsWithSyncedObs.test.js
@@ -11,6 +11,7 @@ import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderAppWithObservations } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut, TEST_JWT } from "tests/helpers/user";
 
@@ -43,11 +44,8 @@ afterAll( uniqueRealmAfterAll );
 const initialStoreState = useStore.getState( );
 beforeAll( async ( ) => {
   useStore.setState( initialStoreState, true );
-  useStore.setState( {
-    layout: {
-      ...initialStoreState.layout,
-      isDefaultMode: false
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false
   } );
   // userEvent recommends fake timers
   jest.useFakeTimers( );

--- a/tests/integration/SuggestionsWithUnsyncedObs.test.js
+++ b/tests/integration/SuggestionsWithUnsyncedObs.test.js
@@ -186,10 +186,12 @@ const setupAppWithSignedInUser = async hasLocation => {
   const observations = hasLocation
     ? makeMockObservationsWithLocation( )
     : makeMockObservations( );
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     observations,
     currentObservation: observations[0],
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
       isAllAddObsOptionsMode: true

--- a/tests/integration/SuggestionsWithUnsyncedObs.test.js
+++ b/tests/integration/SuggestionsWithUnsyncedObs.test.js
@@ -14,6 +14,7 @@ import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice.ts";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import { renderAppWithObservations } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
@@ -186,16 +187,14 @@ const setupAppWithSignedInUser = async hasLocation => {
   const observations = hasLocation
     ? makeMockObservationsWithLocation( )
     : makeMockObservations( );
-  const initialState = useStore.getInitialState( );
   useStore.setState( {
     observations,
-    currentObservation: observations[0],
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
-      isAllAddObsOptionsMode: true
-    }
+    currentObservation: observations[0]
+  } );
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+    isAllAddObsOptionsMode: true
   } );
   await renderAppWithObservations( observations, __filename );
   return { observations };

--- a/tests/integration/navigation/AICamera.test.js
+++ b/tests/integration/navigation/AICamera.test.js
@@ -82,8 +82,10 @@ const mockUser = factory( "LocalUser" );
 
 beforeEach( async ( ) => {
   await signIn( mockUser, { realm: global.mockRealms[__filename] } );
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
       isAllAddObsOptionsMode: true

--- a/tests/integration/navigation/AICamera.test.js
+++ b/tests/integration/navigation/AICamera.test.js
@@ -8,9 +8,9 @@ import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import { BackHandler } from "react-native";
 import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice.ts";
-import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 import { getPredictionsForImage } from "vision-camera-plugin-inatvision";
@@ -82,14 +82,10 @@ const mockUser = factory( "LocalUser" );
 
 beforeEach( async ( ) => {
   await signIn( mockUser, { realm: global.mockRealms[__filename] } );
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+    isAllAddObsOptionsMode: true
   } );
   inatjs.computervision.score_image.mockResolvedValue( makeResponse( [topSuggestion] ) );
 } );

--- a/tests/integration/navigation/AddObsButton.test.js
+++ b/tests/integration/navigation/AddObsButton.test.js
@@ -2,8 +2,8 @@ import { screen, userEvent } from "@testing-library/react-native";
 import AddObsButton from "components/AddObsModal/AddObsButton";
 import i18next from "i18next";
 import React from "react";
-import useStore from "stores/useStore";
 import { renderComponent } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 
 const actor = userEvent.setup();
 
@@ -81,13 +81,9 @@ describe( "AddObsButton", ( ) => {
 } );
 
 describe( "with advanced user layout", ( ) => {
-  const initialState = useStore.getInitialState( );
   beforeEach( ( ) => {
-    useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isAllAddObsOptionsMode: true
-      }
+    setStoreStateLayout( {
+      isAllAddObsOptionsMode: true
     } );
   } );
 
@@ -121,12 +117,9 @@ describe( "with advanced user layout", ( ) => {
 
   describe( "with advanced AICamera-only setting", ( ) => {
     beforeEach( ( ) => {
-      useStore.setState( {
-        layout: {
-          ...initialState.layout,
-          isDefaultMode: false,
-          isAllAddObsOptionsMode: false
-        }
+      setStoreStateLayout( {
+        isDefaultMode: false,
+        isAllAddObsOptionsMode: false
       } );
     } );
 

--- a/tests/integration/navigation/AddObsButton.test.js
+++ b/tests/integration/navigation/AddObsButton.test.js
@@ -81,9 +81,11 @@ describe( "AddObsButton", ( ) => {
 } );
 
 describe( "with advanced user layout", ( ) => {
+  const initialState = useStore.getInitialState( );
   beforeEach( ( ) => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isAllAddObsOptionsMode: true
       }
     } );
@@ -121,6 +123,7 @@ describe( "with advanced user layout", ( ) => {
     beforeEach( ( ) => {
       useStore.setState( {
         layout: {
+          ...initialState.layout,
           isDefaultMode: false,
           isAllAddObsOptionsMode: false
         }

--- a/tests/integration/navigation/Explore.test.js
+++ b/tests/integration/navigation/Explore.test.js
@@ -87,8 +87,10 @@ beforeAll( async () => {
 } );
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true
     }

--- a/tests/integration/navigation/Explore.test.js
+++ b/tests/integration/navigation/Explore.test.js
@@ -8,10 +8,10 @@ import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import ReactNativePermissions from "react-native-permissions";
 import Observation from "realmModels/Observation";
-import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut, TEST_JWT } from "tests/helpers/user";
 
@@ -87,13 +87,9 @@ beforeAll( async () => {
 } );
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true
   } );
 } );
 

--- a/tests/integration/navigation/MediaViewer.test.js
+++ b/tests/integration/navigation/MediaViewer.test.js
@@ -10,6 +10,7 @@ import {
   renderApp,
   renderAppWithObservations
 } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 
@@ -50,13 +51,9 @@ jest.mock( "sharedHooks/useSuggestions/useOnlineSuggestions.ts", ( ) => jest.fn(
   }
 } ) ) );
 
-const initialState = useStore.getInitialState();
 beforeEach( async () => {
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false
   } );
 } );
 
@@ -155,11 +152,8 @@ describe( "MediaViewer navigation", ( ) => {
     }
 
     beforeEach( ( ) => {
-      useStore.setState( {
-        layout: {
-          ...initialState.layout,
-          isAllAddObsOptionsMode: true
-        }
+      setStoreStateLayout( {
+        isAllAddObsOptionsMode: true
       } );
     } );
 

--- a/tests/integration/navigation/MediaViewer.test.js
+++ b/tests/integration/navigation/MediaViewer.test.js
@@ -50,9 +50,11 @@ jest.mock( "sharedHooks/useSuggestions/useOnlineSuggestions.ts", ( ) => jest.fn(
   }
 } ) ) );
 
+const initialState = useStore.getInitialState();
 beforeEach( async () => {
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false
     }
   } );
@@ -155,6 +157,7 @@ describe( "MediaViewer navigation", ( ) => {
     beforeEach( ( ) => {
       useStore.setState( {
         layout: {
+          ...initialState.layout,
           isAllAddObsOptionsMode: true
         }
       } );

--- a/tests/integration/navigation/MyObservations.test.js
+++ b/tests/integration/navigation/MyObservations.test.js
@@ -4,10 +4,10 @@ import {
 import initI18next from "i18n/initI18next";
 import inatjs from "inaturalistjs";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
-import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 
@@ -84,13 +84,9 @@ const topSuggestion = {
 const actor = userEvent.setup( );
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true
   } );
   inatjs.computervision.score_image.mockResolvedValue( makeResponse( [topSuggestion] ) );
 } );

--- a/tests/integration/navigation/MyObservations.test.js
+++ b/tests/integration/navigation/MyObservations.test.js
@@ -84,8 +84,10 @@ const topSuggestion = {
 const actor = userEvent.setup( );
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true
     }

--- a/tests/integration/navigation/ObsEdit.test.js
+++ b/tests/integration/navigation/ObsEdit.test.js
@@ -15,6 +15,7 @@ import faker from "tests/helpers/faker";
 import {
   renderAppWithObservations
 } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 
@@ -106,13 +107,9 @@ const uploadObsEditObservation = async options => {
 };
 
 beforeEach( ( ) => {
-  const initialState = useStore.getInitialState( );
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true
   } );
 } );
 

--- a/tests/integration/navigation/ObsEdit.test.js
+++ b/tests/integration/navigation/ObsEdit.test.js
@@ -106,8 +106,10 @@ const uploadObsEditObservation = async options => {
 };
 
 beforeEach( ( ) => {
+  const initialState = useStore.getInitialState( );
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true
     }

--- a/tests/integration/navigation/PhotoLibrary.test.js
+++ b/tests/integration/navigation/PhotoLibrary.test.js
@@ -38,6 +38,8 @@ beforeAll( uniqueRealmBeforeAll );
 afterAll( uniqueRealmAfterAll );
 // /UNIQUE REALM SETUP
 
+const initialState = useStore.getInitialState();
+
 beforeAll( async () => {
   await initI18next();
 } );
@@ -75,6 +77,7 @@ describe( "PhotoLibrary navigation", ( ) => {
   beforeEach( ( ) => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT,
         isAllAddObsOptionsMode: true
       }
@@ -116,6 +119,7 @@ describe( "PhotoLibrary navigation when suggestions screen is preferred next scr
   beforeEach( () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
         isAllAddObsOptionsMode: true
       }

--- a/tests/integration/navigation/PhotoLibrary.test.js
+++ b/tests/integration/navigation/PhotoLibrary.test.js
@@ -79,6 +79,7 @@ describe( "PhotoLibrary navigation", ( ) => {
       layout: {
         ...initialState.layout,
         screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT,
+        isDefaultMode: false,
         isAllAddObsOptionsMode: true
       }
     } );

--- a/tests/integration/navigation/PhotoLibrary.test.js
+++ b/tests/integration/navigation/PhotoLibrary.test.js
@@ -7,9 +7,9 @@ import {
 import initI18next from "i18n/initI18next";
 import * as rnImagePicker from "react-native-image-picker";
 import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice.ts";
-import useStore from "stores/useStore";
 import faker from "tests/helpers/faker";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 
 // We're explicitly testing navigation here so we want react-navigation
@@ -37,8 +37,6 @@ jest.mock( "providers/contexts", ( ) => {
 beforeAll( uniqueRealmBeforeAll );
 afterAll( uniqueRealmAfterAll );
 // /UNIQUE REALM SETUP
-
-const initialState = useStore.getInitialState();
 
 beforeAll( async () => {
   await initI18next();
@@ -75,13 +73,10 @@ const navigateToPhotoImporter = async ( ) => {
 describe( "PhotoLibrary navigation", ( ) => {
   global.withAnimatedTimeTravelEnabled( );
   beforeEach( ( ) => {
-    useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT,
-        isDefaultMode: false,
-        isAllAddObsOptionsMode: true
-      }
+    setStoreStateLayout( {
+      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT,
+      isDefaultMode: false,
+      isAllAddObsOptionsMode: true
     } );
   } );
 
@@ -118,12 +113,9 @@ describe( "PhotoLibrary navigation", ( ) => {
 describe( "PhotoLibrary navigation when suggestions screen is preferred next screen", () => {
   global.withAnimatedTimeTravelEnabled();
   beforeEach( () => {
-    useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
-        isAllAddObsOptionsMode: true
-      }
+    setStoreStateLayout( {
+      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+      isAllAddObsOptionsMode: true
     } );
   } );
   it( "advances to Suggestions when one photo is selected", async () => {

--- a/tests/integration/navigation/SoundRecorder.test.js
+++ b/tests/integration/navigation/SoundRecorder.test.js
@@ -5,8 +5,8 @@ import {
   within
 } from "@testing-library/react-native";
 import initI18next from "i18n/initI18next";
-import useStore from "stores/useStore";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 
 // We're explicitly testing navigation here so we want react-navigation
@@ -37,12 +37,8 @@ afterAll( uniqueRealmAfterAll );
 
 beforeAll( async () => {
   await initI18next();
-  const initialState = useStore.getInitialState();
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isAllAddObsOptionsMode: true
   } );
 } );
 

--- a/tests/integration/navigation/SoundRecorder.test.js
+++ b/tests/integration/navigation/SoundRecorder.test.js
@@ -37,8 +37,10 @@ afterAll( uniqueRealmAfterAll );
 
 beforeAll( async () => {
   await initI18next();
+  const initialState = useStore.getInitialState();
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isAllAddObsOptionsMode: true
     }
   } );

--- a/tests/integration/navigation/StandardCamera.test.js
+++ b/tests/integration/navigation/StandardCamera.test.js
@@ -6,8 +6,8 @@ import {
 } from "@testing-library/react-native";
 import initI18next from "i18n/initI18next";
 import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice.ts";
-import useStore from "stores/useStore";
 import { renderApp } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 
 // We're explicitly testing navigation here so we want react-navigation
@@ -36,15 +36,11 @@ beforeAll( uniqueRealmBeforeAll );
 afterAll( uniqueRealmAfterAll );
 // /UNIQUE REALM SETUP
 
-const initialState = useStore.getInitialState();
 beforeAll( async () => {
   await initI18next();
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false,
-      isAllAddObsOptionsMode: true
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false,
+    isAllAddObsOptionsMode: true
   } );
 } );
 
@@ -71,13 +67,10 @@ const navigateToCamera = async ( ) => {
 describe( "StandardCamera navigation with advanced user layout", ( ) => {
   global.withAnimatedTimeTravelEnabled( );
   beforeEach( () => {
-    useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false,
-        isAllAddObsOptionsMode: true,
-        screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT
-      }
+    setStoreStateLayout( {
+      isDefaultMode: false,
+      isAllAddObsOptionsMode: true,
+      screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT
     } );
   } );
 
@@ -110,13 +103,10 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
 
   describe( "when navigating to Suggestions", ( ) => {
     beforeEach( () => {
-      useStore.setState( {
-        layout: {
-          ...initialState.layout,
-          isDefaultMode: false,
-          screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
-          isAllAddObsOptionsMode: true
-        }
+      setStoreStateLayout( {
+        isDefaultMode: false,
+        screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+        isAllAddObsOptionsMode: true
       } );
     } );
 

--- a/tests/integration/navigation/StandardCamera.test.js
+++ b/tests/integration/navigation/StandardCamera.test.js
@@ -36,10 +36,12 @@ beforeAll( uniqueRealmBeforeAll );
 afterAll( uniqueRealmAfterAll );
 // /UNIQUE REALM SETUP
 
+const initialState = useStore.getInitialState();
 beforeAll( async () => {
   await initI18next();
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false,
       isAllAddObsOptionsMode: true
     }
@@ -71,6 +73,7 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
   beforeEach( () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false,
         isAllAddObsOptionsMode: true,
         screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT
@@ -109,6 +112,7 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
     beforeEach( () => {
       useStore.setState( {
         layout: {
+          ...initialState.layout,
           isDefaultMode: false,
           screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
           isAllAddObsOptionsMode: true

--- a/tests/integration/navigation/Suggestions.test.js
+++ b/tests/integration/navigation/Suggestions.test.js
@@ -14,6 +14,7 @@ import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderAppWithObservations } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 import { signIn, signOut } from "tests/helpers/user";
 
@@ -103,13 +104,9 @@ beforeAll( async () => {
   jest.useFakeTimers( );
 } );
 
-const initialState = useStore.getInitialState( );
 beforeEach( async () => {
-  useStore.setState( {
-    layout: {
-      ...initialState.layout,
-      isDefaultMode: false
-    }
+  setStoreStateLayout( {
+    isDefaultMode: false
   } );
 } );
 
@@ -257,13 +254,10 @@ describe( "Suggestions", ( ) => {
   describe( "when reached from AI Camera directly", ( ) => {
     beforeEach( async ( ) => {
       await signIn( mockUser, { realm: global.mockRealms[__filename] } );
-      useStore.setState( {
-        layout: {
-          ...initialState.layout,
-          isDefaultMode: false,
-          screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
-          isAllAddObsOptionsMode: true
-        }
+      setStoreStateLayout( {
+        isDefaultMode: false,
+        screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+        isAllAddObsOptionsMode: true
       } );
       inatjs.computervision.score_image
         .mockResolvedValue( makeResponse( [topSuggestion] ) );

--- a/tests/integration/navigation/Suggestions.test.js
+++ b/tests/integration/navigation/Suggestions.test.js
@@ -103,9 +103,11 @@ beforeAll( async () => {
   jest.useFakeTimers( );
 } );
 
+const initialState = useStore.getInitialState( );
 beforeEach( async () => {
   useStore.setState( {
     layout: {
+      ...initialState.layout,
       isDefaultMode: false
     }
   } );
@@ -257,6 +259,7 @@ describe( "Suggestions", ( ) => {
       await signIn( mockUser, { realm: global.mockRealms[__filename] } );
       useStore.setState( {
         layout: {
+          ...initialState.layout,
           isDefaultMode: false,
           screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
           isAllAddObsOptionsMode: true

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -9,6 +9,7 @@ import useStore from "stores/useStore";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
 import { renderComponent } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 
 jest.mock( "@react-navigation/drawer", ( ) => {
   const actualNav = jest.requireActual( "@react-navigation/drawer" );
@@ -79,13 +80,9 @@ describe( "CustomTabBar", () => {
 } );
 
 describe( "CustomTabBar with advanced user layout", () => {
-  const initialState = useStore.getInitialState( );
   beforeAll( ( ) => {
-    useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isAllAddObsOptionsMode: true
-      }
+    setStoreStateLayout( {
+      isAllAddObsOptionsMode: true
     } );
   } );
 

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -79,9 +79,11 @@ describe( "CustomTabBar", () => {
 } );
 
 describe( "CustomTabBar with advanced user layout", () => {
+  const initialState = useStore.getInitialState( );
   beforeAll( ( ) => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isAllAddObsOptionsMode: true
       }
     } );

--- a/tests/unit/components/MyObservations/SimpleUploadBannerContainer.test.js
+++ b/tests/unit/components/MyObservations/SimpleUploadBannerContainer.test.js
@@ -22,6 +22,8 @@ const deletionStore = {
   syncingStatus: SYNC_PENDING
 };
 
+const initialState = useStore.getInitialState();
+
 beforeAll( ( ) => {
   jest.useFakeTimers( );
 } );
@@ -30,6 +32,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays syncing text before beginning uploads when sync button tapped", ( ) => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       numUnuploadedObservations: 1,
@@ -45,6 +48,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays a pending upload", ( ) => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_PENDING,
@@ -64,6 +68,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays an upload in progress", ( ) => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       initialNumObservationsInQueue: 1,
@@ -81,6 +86,7 @@ describe( "SimpleUploadBannerContainer", () => {
     const numUploadsAttempted = 1;
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       numUploadsAttempted,
@@ -97,6 +103,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays multiple pending uploads", () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_PENDING,
@@ -116,6 +123,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays multiple uploads in progress", () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_IN_PROGRESS,
@@ -133,6 +141,7 @@ describe( "SimpleUploadBannerContainer", () => {
     const numUploadsAttempted = 7;
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       numUploadsAttempted,
@@ -149,6 +158,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays 1 upload completed and 4 failed", () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       numUploadsAttempted: 5,
@@ -156,7 +166,10 @@ describe( "SimpleUploadBannerContainer", () => {
       syncingStatus: SYNC_PENDING,
       initialNumObservationsInQueue: 5,
       errorsByUuid: {
-        1: true, 2: true, 3: true, 4: true
+        1: true,
+        2: true,
+        3: true,
+        4: true
       }
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
@@ -170,6 +183,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays only error when all 5 uploads failed", () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_COMPLETE,
@@ -195,6 +209,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays 4 uploads completed and 1 failed", () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_COMPLETE,
@@ -230,6 +245,7 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays deletions completed", () => {
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       ...deletionStore,
@@ -247,6 +263,7 @@ describe( "SimpleUploadBannerContainer", () => {
     const deleteError = "Unknown problem deleting observations";
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       ...deletionStore,
@@ -266,6 +283,7 @@ describe( "SimpleUploadBannerContainer", () => {
     zustandStorage.setItem( "numOfUserObservations", 1 );
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_PENDING,
@@ -287,6 +305,7 @@ describe( "SimpleUploadBannerContainer", () => {
     zustandStorage.setItem( "numOfUserObservations", 2 );
     useStore.setState( {
       layout: {
+        ...initialState.layout,
         isDefaultMode: false
       },
       uploadStatus: UPLOAD_PENDING,

--- a/tests/unit/components/MyObservations/SimpleUploadBannerContainer.test.js
+++ b/tests/unit/components/MyObservations/SimpleUploadBannerContainer.test.js
@@ -23,8 +23,6 @@ const deletionStore = {
   syncingStatus: SYNC_PENDING
 };
 
-const initialState = useStore.getInitialState();
-
 beforeAll( ( ) => {
   jest.useFakeTimers( );
 } );
@@ -32,13 +30,12 @@ beforeAll( ( ) => {
 describe( "SimpleUploadBannerContainer", () => {
   it( "displays syncing text before beginning uploads when sync button tapped", ( ) => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       numUnuploadedObservations: 1,
       uploadStatus: UPLOAD_PENDING,
       syncingStatus: MANUAL_SYNC_IN_PROGRESS
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -48,12 +45,11 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays a pending upload", ( ) => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_PENDING,
       syncingStatus: SYNC_PENDING
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent(
       <SimpleUploadBannerContainer
@@ -68,14 +64,13 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays an upload in progress", ( ) => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       initialNumObservationsInQueue: 1,
       numUploadsAttempted: 1,
       uploadStatus: UPLOAD_IN_PROGRESS,
       syncingStatus: SYNC_PENDING
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -86,14 +81,13 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays a completed upload", () => {
     const numUploadsAttempted = 1;
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       numUploadsAttempted,
       uploadStatus: UPLOAD_COMPLETE,
       syncingStatus: SYNC_PENDING,
       initialNumObservationsInQueue: numUploadsAttempted
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -103,12 +97,11 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays multiple pending uploads", () => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_PENDING,
       syncingStatus: SYNC_PENDING
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent(
       <SimpleUploadBannerContainer
@@ -123,14 +116,13 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays multiple uploads in progress", () => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_IN_PROGRESS,
       numUploadsAttempted: 2,
       syncingStatus: SYNC_PENDING,
       initialNumObservationsInQueue: 5
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -141,14 +133,13 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays multiple completed uploads", () => {
     const numUploadsAttempted = 7;
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       numUploadsAttempted,
       uploadStatus: UPLOAD_COMPLETE,
       syncingStatus: SYNC_PENDING,
       initialNumObservationsInQueue: numUploadsAttempted
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -158,10 +149,6 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays 1 upload completed and 4 failed", () => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       numUploadsAttempted: 5,
       uploadStatus: UPLOAD_COMPLETE,
       syncingStatus: SYNC_PENDING,
@@ -173,6 +160,9 @@ describe( "SimpleUploadBannerContainer", () => {
         4: true
       }
     } );
+    setStoreStateLayout( {
+      isDefaultMode: false
+    } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
     const successText = screen.getByText( /1 observation uploaded/ );
@@ -183,10 +173,6 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays only error when all 5 uploads failed", () => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_COMPLETE,
       syncingStatus: SYNC_PENDING,
       initialNumObservationsInQueue: 5,
@@ -199,6 +185,9 @@ describe( "SimpleUploadBannerContainer", () => {
         5: true
       }
     } );
+    setStoreStateLayout( {
+      isDefaultMode: false
+    } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
     const errorText = screen.getByText( /5 uploads failed/ );
@@ -209,15 +198,14 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays 4 uploads completed and 1 failed", () => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_COMPLETE,
       syncingStatus: SYNC_PENDING,
       initialNumObservationsInQueue: 5,
       numUploadsAttempted: 5,
       errorsByUuid: { 1: true }
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -245,14 +233,13 @@ describe( "SimpleUploadBannerContainer", () => {
 
   it( "displays deletions completed", () => {
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       ...deletionStore,
       currentDeleteCount: 1,
       deleteQueue: [{}],
       initialNumDeletionsInQueue: 1
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -263,13 +250,12 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "displays deletion error", ( ) => {
     const deleteError = "Unknown problem deleting observations";
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       ...deletionStore,
       deleteError,
       initialNumDeletionsInQueue: 2
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent( <SimpleUploadBannerContainer currentUser={mockUser} /> );
 
@@ -283,13 +269,12 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "should hide banner if logged out and only one observation", ( ) => {
     zustandStorage.setItem( "numOfUserObservations", 1 );
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_PENDING,
       syncingStatus: SYNC_PENDING,
       numOfUserObservations: 1
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent(
       <SimpleUploadBannerContainer

--- a/tests/unit/components/MyObservations/SimpleUploadBannerContainer.test.js
+++ b/tests/unit/components/MyObservations/SimpleUploadBannerContainer.test.js
@@ -12,6 +12,7 @@ import {
 } from "stores/createUploadObservationsSlice.ts";
 import useStore, { zustandStorage } from "stores/useStore";
 import { renderComponent } from "tests/helpers/render";
+import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 
 const mockUser = {};
 
@@ -304,12 +305,11 @@ describe( "SimpleUploadBannerContainer", () => {
   it( "should show banner if logged out with more than one observation", ( ) => {
     zustandStorage.setItem( "numOfUserObservations", 2 );
     useStore.setState( {
-      layout: {
-        ...initialState.layout,
-        isDefaultMode: false
-      },
       uploadStatus: UPLOAD_PENDING,
       syncingStatus: SYNC_PENDING
+    } );
+    setStoreStateLayout( {
+      isDefaultMode: false
     } );
     renderComponent(
       <SimpleUploadBannerContainer


### PR DESCRIPTION
I think this is in line with how we want to setup our integration tests, first let the entire store load it's defaults and then only set the specific flags we want to have for the single test suite. Even though we did not specify the store to be replaced with the object we are passing in in those instances, the `layout` key of the store does get replaced with only the object passed in, i.e. the new object used in the `setState` call is not merged with the existing defaults.
I ran across some issues when I accessed the `shownOnce` key of the `layout` slice from the store in the AddObsButton which is shown prominently in the app, which would have required to setState in all those test files (like it was done [here](https://github.com/inaturalist/iNaturalistReactNative/pull/2932/commits/484e23bff5d46045cfd8a916d3ecb4bb079f96a8)). So, I think this here is the solution truer to what we want to do: Use defaults and only override what we need.

Copilot summary:
This pull request focuses on improving test setup consistency across multiple test files by introducing the use of `useStore.getInitialState()` to ensure the initial state of the `layout` store is properly set before each test. Additionally, redundant state-setting code has been removed to simplify test cases.

### Test Setup Consistency Improvements:
* **General Initialization**: Added calls to `useStore.getInitialState()` across various test files to ensure the `layout` store starts with its default state. This change standardizes the setup process for tests. [[1]](diffhunk://#diff-8e45299af3ecb614af14932388888a62e3fbd5f2be789fbf9bebec333905b098R139-R142) [[2]](diffhunk://#diff-6850583f590281d835e3954aeb375abc036227b8efd7817f4cacaa66c841012eR48-R51) [[3]](diffhunk://#diff-8cd345fffd5e98e442ba7b824a03c461ac0b2c0594503eedb73f622eb213eb29R87-R90) [[4]](diffhunk://#diff-df9774c605f9c54f3c72280df303114a42cff2d8011f14103672594d6a869a9dR77-R80) [[5]](diffhunk://#diff-4b4e80cbf4a5dd0aebe97a34c891a20053e8eed78b1ad44e571d9b79a92299cfR92-R95) [[6]](diffhunk://#diff-472f5009aa0b211c01860bf860187fe36097278aa4859b890d489f4a607ab935R85-R88) [[7]](diffhunk://#diff-b6c1be2acd640ddd04cda906fe2d1cb85de3d6ffe08dc48b30f0ed28ab676652R84-R88) [[8]](diffhunk://#diff-383f43432c65f60e658f5ccae18754597c59a8424d2ecc16feb3f5fbef8897d4R90-R93) [[9]](diffhunk://#diff-98ebfb262c145b2f35436f2e1d7d551e17f86a12fe1bb201341c19b35551fe38R53-R57) [[10]](diffhunk://#diff-46ac7e046d3a2018c3af0bd6b8d51dbe2cdb3340c81c38357b96a03f142d6390R87-R90) [[11]](diffhunk://#diff-116e0c746a78a5065eaa59a95bfbe0330dc7aced68eb42ca2138924de62123d4R109-R112) [[12]](diffhunk://#diff-f0e7e8773f7028ce7b7921366b603fb2f0d931cec181421bc49f21e2f5b5889eR41-R42) [[13]](diffhunk://#diff-8bd202548be388d88f57dd4d52de7a45f580b4e9e8ee1706ea5b6158174c8bd9R40-R43) [[14]](diffhunk://#diff-728add8a454bf1e2dd954ceeb2b003d8ef3f66fe333bff66e32748d26f88e50fR39-R44) [[15]](diffhunk://#diff-b68efc42332b4452a1102ba4328d160ddcdd1bafe419ec4c27bdede976f0b501R106-R110) [[16]](diffhunk://#diff-199260b4a38570937dad4ad26c2b0ac2669caac161e608efae0f13f93161b20dR82-R86) [[17]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R25-R26)

* **Simplification of State Setting**: Removed redundant state-setting code in tests, relying instead on spreading `initialState.layout` to ensure the layout state is consistent and avoids duplication. [[1]](diffhunk://#diff-8e45299af3ecb614af14932388888a62e3fbd5f2be789fbf9bebec333905b098L359-L364) [[2]](diffhunk://#diff-b6c1be2acd640ddd04cda906fe2d1cb85de3d6ffe08dc48b30f0ed28ab676652R126) [[3]](diffhunk://#diff-f0e7e8773f7028ce7b7921366b603fb2f0d931cec181421bc49f21e2f5b5889eR80-R82) [[4]](diffhunk://#diff-f0e7e8773f7028ce7b7921366b603fb2f0d931cec181421bc49f21e2f5b5889eR123) [[5]](diffhunk://#diff-728add8a454bf1e2dd954ceeb2b003d8ef3f66fe333bff66e32748d26f88e50fR76) [[6]](diffhunk://#diff-728add8a454bf1e2dd954ceeb2b003d8ef3f66fe333bff66e32748d26f88e50fR115) [[7]](diffhunk://#diff-b68efc42332b4452a1102ba4328d160ddcdd1bafe419ec4c27bdede976f0b501R262) [[8]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R35) [[9]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R51) [[10]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R71) [[11]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R89) [[12]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R106) [[13]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R126) [[14]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R144) [[15]](diffhunk://#diff-fd0a56cb0229f43884df7edf1ad2d188226d4c1b533761da6576c696ae603bf5R161-R172)

### Removal of Redundant Code:
* **`tests/helpers/uniqueRealm.js`**: Removed unused code related to `useStore.setState` in the `uniqueRealmBeforeAll` function to clean up the helper file.