### PR TITLE
Update react native reanimated

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1404,7 +1404,51 @@ PODS:
     - React-Core
   - RNPermissions (4.1.5):
     - React-Core
-  - RNReanimated (3.11.0):
+  - RNReanimated (3.15.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/reanimated (= 3.15.5)
+    - RNReanimated/worklets (= 3.15.5)
+    - Yoga
+  - RNReanimated/reanimated (3.15.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - RNReanimated/worklets (3.15.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1908,7 +1952,7 @@ SPEC CHECKSUMS:
   RNGoogleSignin: ba93c1137f8d5cebdd39b04f493fd212ddf5ecd6
   RNLocalize: 080849cb8a824d9f759b8a5ae00c8321d46dbed0
   RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f
-  RNReanimated: b91f99db7e41b501dd71aab52fcc620118991f65
+  RNReanimated: 17e0cb093222e9c92a0349f0e07912693f46fc27
   RNScreens: df14a2a11e7afb57e6f35f8964d206271f4dae44
   RNShareMenu: e1cdfa3b9af89416afc75a80377cfd0de4f30ded
   RNStoreReview: 613c43e9132998ed41a65946e20c223c91b36464

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1487,7 +1487,7 @@ PODS:
   - VisionCamera/React (4.5.2):
     - React-Core
     - VisionCamera/FrameProcessors
-  - VisionCameraPluginInatVision (5.3.0-rc.0):
+  - VisionCameraPluginInatVision (5.3.0-rc.1):
     - React-Core
   - Yoga (0.0.0)
 
@@ -1916,7 +1916,7 @@ SPEC CHECKSUMS:
   RNVectorIcons: 6c795cacc9276decc31d8e1a139b9cc6fc0479ca
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   VisionCamera: 25a205cf335599192d84171d0925d5bd45433608
-  VisionCameraPluginInatVision: 6eace74efbce44b4df258b2c2a45232c76846cdc
+  VisionCameraPluginInatVision: ad9a001b70676d2f9b0ea22f60c04d5fed3d3a52
   Yoga: 272dddd3c0e1e23d09ba81ed55ddfa7fdd3caa17
 
 PODFILE CHECKSUM: c92c85936cdaceff02009b29b05bbb2fe1d7b943

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
         "react-native-paper": "^5.12.3",
         "react-native-permissions": "^4.1.5",
-        "react-native-reanimated": "3.11.0",
+        "react-native-reanimated": "3.15.5",
         "react-native-reanimated-carousel": "^3.5.1",
         "react-native-render-html": "^6.3.4",
         "react-native-restart": "^0.0.27",
@@ -1202,7 +1202,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
       "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -12184,7 +12183,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.2.1.tgz",
       "integrity": "sha512-HYiUrq5qTRFqMuQu3jEHqxXLk1zsSJiby9Lja/k42wHjabZG7tN9rOuzT/PEFf+Wa7rsnHLMHRWIu0mgcJ0ewQ==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=4",
         "npm": ">=3",
@@ -18116,15 +18114,18 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.11.0.tgz",
-      "integrity": "sha512-BNw/XDgUfs8UhfY1X6IniU8kWpnotWGyt8qmQviaHisTi5lvwnaOdXQKfN1KGONx6ekdFRHRP5EFwLi0UajwKA==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.15.5.tgz",
+      "integrity": "sha512-admqeZ0w235vQqYPy+IUgmHu5gwKi9+b7AQRV1yIK3MbAMLYx+RY+tTUtx1CNE5X+rNZ6eSQssW5z77yTwIusg==",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
         "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
         "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
         "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
         "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
         "invariant": "^2.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "realm": "^20.1.0",
         "sanitize-html": "^2.13.0",
         "uuid": "^11.0.5",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#be7e5faed370bf307a062e728b5cf80b9c7292fe",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#3c4a3246b5672ec642711b6d41f7484043232dfb",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -20950,10 +20950,9 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "5.3.0-rc.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#be7e5faed370bf307a062e728b5cf80b9c7292fe",
-      "integrity": "sha512-KerEC93NqxLvfLgdbMD2KMl2NlGd92T6YyZ5M8ClsHjFT/jcIkYblTyB6e6eov48BGsApX55f4Q7fDchKG78eA==",
-      "license": "MIT",
+      "version": "5.3.0-rc.1",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#3c4a3246b5672ec642711b6d41f7484043232dfb",
+      "integrity": "sha512-l5TulEpjMlzJ8AENCtiST5woLPAzVbYAi/4CO3aSlFXfOF/wcyKcmyZClD10HC5uQpyfv+BLoBI0ZA7bVIJncA==",
       "dependencies": {
         "h3-js": "^4.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
         "react-native-paper": "^5.12.3",
         "react-native-permissions": "^4.1.5",
-        "react-native-reanimated": "^3.11.0",
+        "react-native-reanimated": "3.11.0",
         "react-native-reanimated-carousel": "^3.5.1",
         "react-native-render-html": "^6.3.4",
         "react-native-restart": "^0.0.27",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
     "react-native-paper": "^5.12.3",
     "react-native-permissions": "^4.1.5",
-    "react-native-reanimated": "3.11.0",
+    "react-native-reanimated": "3.15.5",
     "react-native-reanimated-carousel": "^3.5.1",
     "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.27",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
     "react-native-paper": "^5.12.3",
     "react-native-permissions": "^4.1.5",
-    "react-native-reanimated": "^3.11.0",
+    "react-native-reanimated": "3.11.0",
     "react-native-reanimated-carousel": "^3.5.1",
     "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.27",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "realm": "^20.1.0",
     "sanitize-html": "^2.13.0",
     "uuid": "^11.0.5",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#be7e5faed370bf307a062e728b5cf80b9c7292fe",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#3c4a3246b5672ec642711b6d41f7484043232dfb",
     "zustand": "^4.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 3.15.x of react-native-reanimated is the minimum version that supports react-native 0.75.x.
This PR is blocking the update to RN 0.75 because in the branch of the RN update the app did not compile on Android with an error message that react-native-reanimated is the culprit. (Have tested to update locally and this PR here actually resolves this issue).