### PR TITLE
Update react native gesture handler

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1376,7 +1376,7 @@ PODS:
     - Yoga
   - RNFS (2.20.0):
     - React-Core
-  - RNGestureHandler (2.16.0):
+  - RNGestureHandler (2.18.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1904,7 +1904,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 538b62f03991eb4a2a15cf6fec5fff6bb5edc34e
   RNFlashList: 916adaa9dc946dbafed435175982e31e767b07b0
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNGestureHandler: bf7e84b2e4b6dd9c77079c39c16a4ec59099c7ab
+  RNGestureHandler: d5aafad9a7d1506a8bcab6fbc04384372c8ca86b
   RNGoogleSignin: ba93c1137f8d5cebdd39b04f493fd212ddf5ecd6
   RNLocalize: 080849cb8a824d9f759b8a5ae00c8321d46dbed0
   RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.3",
         "react-native-fs": "^2.20.0",
         "react-native-geocoder-reborn": "^0.9.0",
-        "react-native-gesture-handler": "^2.16.0",
+        "react-native-gesture-handler": "2.18.1",
         "react-native-get-random-values": "^1.11.0",
         "react-native-image-picker": "github:inaturalist/react-native-image-picker",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
@@ -17908,14 +17908,13 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.0.tgz",
-      "integrity": "sha512-1hFkx7RIfeJSyTQQ0Nkv4icFVZ5+XjQkd47OgZMBFzoB7ecL+nFSz8KLi3OCWOhq+nbHpSPlSG5VF3CQNCJpWA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.18.1.tgz",
+      "integrity": "sha512-WF2fxQ5kTaxHghlkBM4YxO86SyGWVwrSNgJ1E8z/ZtL2xD5B3bg5agvuVFfOzvceC114yq71s6E9vKPz94ZxRw==",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.3",
     "react-native-fs": "^2.20.0",
     "react-native-geocoder-reborn": "^0.9.0",
-    "react-native-gesture-handler": "^2.16.0",
+    "react-native-gesture-handler": "2.18.1",
     "react-native-get-random-values": "^1.11.0",
     "react-native-image-picker": "github:inaturalist/react-native-image-picker",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/tests/integration/navigation/PhotoLibrary.test.js
+++ b/tests/integration/navigation/PhotoLibrary.test.js
@@ -60,7 +60,6 @@ const actor = userEvent.setup( );
 
 const navigateToPhotoImporter = async ( ) => {
   await waitFor( ( ) => {
-    global.timeTravel( );
     expect( screen.getByText( /Use iNaturalist to identify/ ) ).toBeVisible( );
   } );
   const tabBar = await screen.findByTestId( "CustomTabBar" );
@@ -71,7 +70,6 @@ const navigateToPhotoImporter = async ( ) => {
 };
 
 describe( "PhotoLibrary navigation", ( ) => {
-  global.withAnimatedTimeTravelEnabled( );
   beforeEach( ( ) => {
     setStoreStateLayout( {
       screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.OBS_EDIT,
@@ -91,7 +89,7 @@ describe( "PhotoLibrary navigation", ( ) => {
     const groupPhotosText = await screen.findByText( /Group Photos/ );
     await waitFor( ( ) => {
       // user should land on GroupPhotos
-      expect( groupPhotosText ).toBeTruthy( );
+      expect( groupPhotosText ).toBeVisible( );
     } );
   } );
 
@@ -103,18 +101,18 @@ describe( "PhotoLibrary navigation", ( ) => {
     );
     renderApp( );
     await navigateToPhotoImporter( );
+    const obsEditText = await screen.findByText( /New Observation/ );
     await waitFor( () => {
-      global.timeTravel();
-      expect( screen.getByText( /New Observation/ ) ).toBeVisible();
+      expect( obsEditText ).toBeVisible();
     } );
   } );
 } );
 
 describe( "PhotoLibrary navigation when suggestions screen is preferred next screen", () => {
-  global.withAnimatedTimeTravelEnabled();
   beforeEach( () => {
     setStoreStateLayout( {
       screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.SUGGESTIONS,
+      isDefaultMode: false,
       isAllAddObsOptionsMode: true
     } );
   } );
@@ -124,18 +122,9 @@ describe( "PhotoLibrary navigation when suggestions screen is preferred next scr
     } ) );
     renderApp();
     await navigateToPhotoImporter();
+    const addAnIDText = await screen.findByText( /Add an ID Later/ );
     await waitFor( () => {
-      global.timeTravel();
-      // TODO: Johannes 25-02-25
-      // At this point in the test the screen is not advancing to the next screen
-      // it is stuck on the "PhotoLibrary" screen. I don't know why this is happening since
-      // it is working when navigating to ObsEdit, see above. Furthermore, uncommenting this
-      // but commenting out the above describe will make this test pass, so I think it is more
-      // something with test setup.
-      // I feel that is more important to move quickly before our launch deadline. So, I'll
-      // comment this out which means the test does not actually test the navigation to the
-      // Suggestions screen.
-      // expect( screen.getByText( /Add an ID Later/ ) ).toBeVisible();
+      expect( addAnIDText ).toBeVisible();
     } );
   } );
 } );

--- a/tests/integration/navigation/StandardCamera.test.js
+++ b/tests/integration/navigation/StandardCamera.test.js
@@ -54,7 +54,6 @@ jest.mock( "sharedHelpers/fetchAccurateUserLocation", () => ( {
 
 const navigateToCamera = async ( ) => {
   await waitFor( ( ) => {
-    global.timeTravel( );
     expect( screen.getByText( /Use iNaturalist to identify/ ) ).toBeVisible( );
   } );
   const tabBar = await screen.findByTestId( "CustomTabBar" );
@@ -65,7 +64,6 @@ const navigateToCamera = async ( ) => {
 };
 
 describe( "StandardCamera navigation with advanced user layout", ( ) => {
-  global.withAnimatedTimeTravelEnabled( );
   beforeEach( () => {
     setStoreStateLayout( {
       isDefaultMode: false,
@@ -82,7 +80,6 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
       const closeButton = await within( cameraNavButtons ).findByLabelText( "Close" );
       await actor.press( closeButton );
       await waitFor( ( ) => {
-        global.timeTravel( );
         expect( screen.getByText( /Use iNaturalist to identify/ ) ).toBeVisible( );
       } );
     } );
@@ -96,7 +93,6 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
     const checkmarkButton = await screen.findByLabelText( "View suggestions" );
     await actor.press( checkmarkButton );
     await waitFor( ( ) => {
-      global.timeTravel( );
       expect( screen.getByText( /New Observation/ ) ).toBeVisible( );
     } );
   } );
@@ -118,7 +114,6 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
       const checkmarkButton = await screen.findByLabelText( "View suggestions" );
       await actor.press( checkmarkButton );
       await waitFor( ( ) => {
-        global.timeTravel( );
         expect( screen.getByText( /ADD AN ID/ ) ).toBeVisible( );
       } );
     } );

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -4,7 +4,6 @@
 // eslint-disable-next-line simple-import-sort/imports
 import "react-native-get-random-values";
 
-import "react-native-gesture-handler/jestSetup";
 import "@shopify/flash-list/jestSetup";
 
 import mockBottomSheet from "@gorhom/bottom-sheet/mock";


### PR DESCRIPTION
This is another library that currently does not compile with RN 0.75.
According to their GitHub release notes react-native-gesture-handler version 2.18.x introduces support for RN 0.75.

I have no idea what these "time travel" functions are in the updated tests, but I did get them to pass by removing these calls. I think less calls required make for better tests, so I would argue this is correct.
