### PR TITLE
Update react native gesture handler 2.20

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1709,7 +1709,7 @@ PODS:
     - Yoga
   - RNFS (2.20.0):
     - React-Core
-  - RNGestureHandler (2.18.1):
+  - RNGestureHandler (2.20.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2335,7 +2335,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 538b62f03991eb4a2a15cf6fec5fff6bb5edc34e
   RNFlashList: 076a14c3a81a9e70b8a3bc52a06cf28490e4c437
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNGestureHandler: 011b703e87c0008b9e0375dca87f37f34a5133e8
+  RNGestureHandler: 27a63f2218affdf1a426d56682f9b174904838b3
   RNGoogleSignin: ba93c1137f8d5cebdd39b04f493fd212ddf5ecd6
   RNLocalize: 080849cb8a824d9f759b8a5ae00c8321d46dbed0
   RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f
@@ -2352,4 +2352,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c92c85936cdaceff02009b29b05bbb2fe1d7b943
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.3",
         "react-native-fs": "^2.20.0",
         "react-native-geocoder-reborn": "^0.9.0",
-        "react-native-gesture-handler": "2.18.1",
+        "react-native-gesture-handler": "2.20.2",
         "react-native-get-random-values": "^1.11.0",
         "react-native-image-picker": "github:inaturalist/react-native-image-picker",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
@@ -17821,9 +17821,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.18.1.tgz",
-      "integrity": "sha512-WF2fxQ5kTaxHghlkBM4YxO86SyGWVwrSNgJ1E8z/ZtL2xD5B3bg5agvuVFfOzvceC114yq71s6E9vKPz94ZxRw==",
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.2.tgz",
+      "integrity": "sha512-HqzFpFczV4qCnwKlvSAvpzEXisL+Z9fsR08YV5LfJDkzuArMhBu2sOoSPUF/K62PCoAb+ObGlTC83TKHfUd0vg==",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-native-exif-reader": "github:inaturalist/react-native-exif-reader#v0.4.3",
     "react-native-fs": "^2.20.0",
     "react-native-geocoder-reborn": "^0.9.0",
-    "react-native-gesture-handler": "2.18.1",
+    "react-native-gesture-handler": "2.20.2",
     "react-native-get-random-values": "^1.11.0",
     "react-native-image-picker": "github:inaturalist/react-native-image-picker",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",


### PR DESCRIPTION
Update of a package in preparation for RN 0.76, react-native-gesture-handler v2.20.0 introduces support for RN 0.76.x.

Have compiled for Debug and Release and tested the camera and zooming into a photo in the media viewer which are the two components I can see this library being imported.