### PR TITLE
Update react native worklets core 1.5.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1406,10 +1406,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-worklets-core (1.3.3):
-    - React
-    - React-callinvoker
+  - react-native-worklets-core (1.5.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.75.5)
   - React-NativeModulesApple (0.75.5):
     - glog
@@ -2298,7 +2315,7 @@ SPEC CHECKSUMS:
   react-native-slider: fd8dfe056a342976c7addd61fd564736a7a753e6
   react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988
   react-native-webview: 6b122cfd8a37514759d0efe101267f00fc6d23a7
-  react-native-worklets-core: f730c01db8ea3d580e322617f4a631206f1905fb
+  react-native-worklets-core: a7fb4fee321f4af49820f92bf6252b5fe9c41a74
   React-nativeconfig: 237c862aab56a7426301fcbbb8dd6988745231e0
   React-NativeModulesApple: 5b3c2bcfa3a53b22da441b35189e902ede27513d
   React-perflogger: 46ce3b295add69087b7c5ff325b55a6c7af204fc
@@ -2352,4 +2369,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c92c85936cdaceff02009b29b05bbb2fe1d7b943
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "react-native-vision-camera": "4.5.2",
         "react-native-volume-manager": "^1.10.0",
         "react-native-webview": "^13.8.4",
-        "react-native-worklets-core": "1.3.3",
+        "react-native-worklets-core": "1.5.0",
         "realm": "^20.1.0",
         "sanitize-html": "^2.13.0",
         "uuid": "^11.0.5",
@@ -18292,15 +18292,11 @@
       }
     },
     "node_modules/react-native-worklets-core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/react-native-worklets-core/-/react-native-worklets-core-1.3.3.tgz",
-      "integrity": "sha512-wlkuhpUo4Wd9WBcnKuXWv775rYNYMfDxUySCZYxd3VDtwnF8PHPqAJllVIlHjamPNKpcitFvAgQa/C3YOsJwgQ==",
-      "license": "MIT",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-worklets-core/-/react-native-worklets-core-1.5.0.tgz",
+      "integrity": "sha512-LtXzd08140dK4Y5YIir6oALz+28tkAEZfFZgwaxOh1FnmJ/oGKeNoX+SBWOIQoe12C4i5BvGvh+X/bRGO9mEmQ==",
       "dependencies": {
         "string-hash-64": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-native-vision-camera": "4.5.2",
     "react-native-volume-manager": "^1.10.0",
     "react-native-webview": "^13.8.4",
-    "react-native-worklets-core": "1.3.3",
+    "react-native-worklets-core": "1.5.0",
     "realm": "^20.1.0",
     "sanitize-html": "^2.13.0",
     "uuid": "^11.0.5",


### PR DESCRIPTION
Update of a package in preparation for RN 0.76, react-native-worklets-core v1.5.0 introduces support for RN 0.76.x.

Have compiled for Debug and Release and tested the camera with frame processor which is the only component that uses this.