### PR TITLE
Update react-native-keep-awake to version ^1.3.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1321,7 +1321,7 @@ PODS:
     - React-Core
   - react-native-image-resizer (3.0.11):
     - React-Core
-  - react-native-keep-awake (1.2.3):
+  - react-native-keep-awake (1.3.1):
     - React-Core
   - react-native-mail (6.1.1):
     - React-Core
@@ -2285,7 +2285,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-image-picker: b64848e41db57068721d5db3cea54e32ecb92791
   react-native-image-resizer: 24c5d06fae2176dc0caed4b6396e02befb44064a
-  react-native-keep-awake: 3c347cbcb834e5ce4b5717e9e2734b374f6fd70f
+  react-native-keep-awake: 03b74eebe4f2bb5e8478fc8f420651a92463b6f8
   react-native-mail: 6e83813066984b26403d3fdfe79ac7bb31857e3c
   react-native-maps: 85da55259d35bd50b5161d2ec0ee153d454158cc
   react-native-mmkv: f84bf6f48c906911695f9cd16d39d4fb78fcd5a4

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/native-stack": "^7.3.13",
         "@realm/react": "^0.11.0",
-        "@sayem314/react-native-keep-awake": "^1.2.3",
+        "@sayem314/react-native-keep-awake": "^1.3.1",
         "@shopify/flash-list": "^1.7.2",
         "@tanstack/react-query": "^5.29.0",
         "apisauce": "^3.1.0",
@@ -5524,9 +5524,9 @@
       }
     },
     "node_modules/@sayem314/react-native-keep-awake": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@sayem314/react-native-keep-awake/-/react-native-keep-awake-1.2.3.tgz",
-      "integrity": "sha512-Vk/1cYfEiZpKUKDH1c4NzRwSROcIRGjH/QY0/AnDoYTY01LJiqn9h7xKmLl7VtZlvgTkhcWwISpFSPYDU5TfwA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sayem314/react-native-keep-awake/-/react-native-keep-awake-1.3.1.tgz",
+      "integrity": "sha512-gAqLCVQ2SgrMki9MZJzQiYn9EjOGDYze+dYKs7s7T4qfRrUxCK8Pe50mE0Y/WQqzaYY6uzdjTHzmWhACiEy5Zw==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/sayem314"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/native-stack": "^7.3.13",
     "@realm/react": "^0.11.0",
-    "@sayem314/react-native-keep-awake": "^1.2.3",
+    "@sayem314/react-native-keep-awake": "^1.3.1",
     "@shopify/flash-list": "^1.7.2",
     "@tanstack/react-query": "^5.29.0",
     "apisauce": "^3.1.0",


### PR DESCRIPTION
Update of a package in preparation for RN 0.76, react-native-keep-awake v1.3.1 fixes build issues with RN 0.76.x.

Have compiled for Debug and Release and tested that uploading of multiple observations does not let the phone get into sleep mode (auto-Lock on iOS) until upload is finished (+ Auto-Lock time).