### PR TITLE
Check for current user before refetch notifications

### DIFF
--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -45,17 +45,19 @@ const NotificationsContainer = ( {
 
   useEffect( ( ) => {
     navigation.addListener( "focus", ( ) => {
-      if ( isConnected ) {
+      if ( isConnected && currentUser ) {
         refetch();
       }
     } );
-  }, [isConnected, navigation, refetch] );
+  }, [isConnected, currentUser, navigation, refetch] );
 
   const onRefresh = async () => {
-    setRefreshing( true );
-    await refetch();
-    if ( typeof ( onRefreshProp ) === "function" ) onRefreshProp( );
-    setRefreshing( false );
+    if ( currentUser ) {
+      setRefreshing( true );
+      await refetch();
+      if ( typeof ( onRefreshProp ) === "function" ) onRefreshProp( );
+      setRefreshing( false );
+    }
   };
 
   return (


### PR DESCRIPTION
Turns out the enabled flag as part of react query doesn't apply to refetch so we check for current user before refetching