### PR TITLE
Fix: warnings from upgraded reanimated library

### DIFF
--- a/src/components/Camera/StandardCamera/PhotoCarousel.tsx
+++ b/src/components/Camera/StandardCamera/PhotoCarousel.tsx
@@ -81,7 +81,7 @@ const PhotoCarousel = ( {
         }
       ]
     } ),
-    [rotation?.value]
+    [rotation]
   );
 
   const renderSkeleton = useCallback( ( ) => ( takingPhoto

--- a/src/components/Camera/hooks/useRotation.ts
+++ b/src/components/Camera/hooks/useRotation.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   useAnimatedStyle,
   useSharedValue,
@@ -26,7 +27,10 @@ const useRotation = ( ) => {
   const { deviceOrientation } = useDeviceOrientation( );
 
   const rotation = useSharedValue( 0 );
-  rotation.value = rotationValue( deviceOrientation );
+
+  useEffect( ( ) => {
+    rotation.value = rotationValue( deviceOrientation );
+  }, [deviceOrientation, rotation] );
 
   const rotatableAnimatedStyle = useAnimatedStyle(
     () => ( {
@@ -36,7 +40,7 @@ const useRotation = ( ) => {
         }
       ]
     } ),
-    [rotation.value]
+    [deviceOrientation]
   );
 
   return {


### PR DESCRIPTION
Added some fixes for the following warning, which was popping up frequently in the AICamera (and PhotoCarousel of the StandardCamera). TLDR: shared values should not be in used in dependency arrays, since they cause render-time reads but don't actually rerender the component.

Stated differently, reanimated runs on two threads: the JS thread and the UI thread. Shared values are designed for the UI thread, not the JS thread, in order to be non-blocking. When React reads the value in a dependency array, this forces React to read it on the JS thread and adds overhead. This fix should be a slight performance improvement.

```
If you don't want to see this message, you can disable the `strict` mode. Refer to:
https://docs.swmansion.com/react-native-reanimated/docs/debugging/logger-configuration for more details.
 WARN  [Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property or use `get` method of a shared value while React is rendering a component.
```