### PR TITLE
Update react-native-svg to latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1960,7 +1960,7 @@ PODS:
     - React
   - RNStoreReview (0.4.3):
     - React-Core
-  - RNSVG (15.8.0):
+  - RNSVG (15.12.0):
     - React-Core
   - RNVectorIcons (10.2.0):
     - DoubleConversion
@@ -2461,7 +2461,7 @@ SPEC CHECKSUMS:
   RNScreens: 295d9c0aaeb7f680d03d7e9b476569a4959aae89
   RNShareMenu: e1cdfa3b9af89416afc75a80377cfd0de4f30ded
   RNStoreReview: 613c43e9132998ed41a65946e20c223c91b36464
-  RNSVG: 8542aa11770b27563714bbd8494a8436385fc85f
+  RNSVG: df335373ea2cb29876864e6a2ea8c86aad305838
   RNVectorIcons: 4330d8f8f8f4184f436e0c08ae9950431ffe466e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   VisionCamera: 1470a7fa013e22de7481640a4d9c597ad6f13919

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "react-native-sensitive-info": "^6.0.0-alpha.9",
         "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
         "react-native-store-review": "^0.4.3",
-        "react-native-svg": "15.8.0",
+        "react-native-svg": "^15.12.0",
         "react-native-svg-transformer": "^1.3.0",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-vector-icons": "^10.2.0",
@@ -18089,9 +18089,9 @@
       "integrity": "sha512-RSQ6vx2j4p41GwTqNv2VV7yold62j5qDbGEBAjFi6gkXMrMpxFMg+82FPjbh6012tqv6Ebzwfqw6S4m4d7sddw=="
     },
     "node_modules/react-native-svg": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.8.0.tgz",
-      "integrity": "sha512-KHJzKpgOjwj1qeZzsBjxNdoIgv2zNCO9fVcoq2TEhTRsVV5DGTZ9JzUZwybd7q4giT/H3RdtqC3u44dWdO0Ffw==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.0.tgz",
+      "integrity": "sha512-iE25PxIJ6V0C6krReLquVw6R0QTsRTmEQc4K2Co3P6zsimU/jltcDBKYDy1h/5j9S/fqmMeXnpM+9LEWKJKI6A==",
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-native-sensitive-info": "^6.0.0-alpha.9",
     "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
     "react-native-store-review": "^0.4.3",
-    "react-native-svg": "15.8.0",
+    "react-native-svg": "^15.12.0",
     "react-native-svg-transformer": "^1.3.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-vector-icons": "^10.2.0",


### PR DESCRIPTION
Update of a package in preparation for RN 0.77, react-native-svg v15.11.0 introduces support for RN 0.77.x. But the latest version also compiles.

The only place we use this library is in the PhotoCount component, so wherever we show the number of photos that one observation has inside the icon for multiple photos.

Have compiled for Debug and Release on both platforms and tested that this component still looks okay.