### PR TITLE
Update @react-native-community/slider to 4.5.7

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1410,7 +1410,7 @@ PODS:
     - React-Core
   - react-native-sensitive-info (6.0.0-alpha.9):
     - React-Core
-  - react-native-slider (4.5.0):
+  - react-native-slider (4.5.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2412,7 +2412,7 @@ SPEC CHECKSUMS:
   react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
   react-native-safe-area-context: 758e894ca5a9bd1868d2a9cfbca7326a2b6bf9dc
   react-native-sensitive-info: ee358bf2b901ac3d04f63ff637b31daee44ea87f
-  react-native-slider: 1a4b42f71aea07eee94d7327fddce0db5f25feca
+  react-native-slider: 17b95cfd8f73820eb494e05cfc7416922b14bde5
   react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988
   react-native-webview: 0c8e44a3d67061caf6afe14d1f9fcbab0cf768f8
   react-native-worklets-core: bfbf1cce2251a85a23d739e46a77682a29fc8889

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@react-native-community/geolocation": "^3.2.1",
         "@react-native-community/hooks": "^3.0.0",
         "@react-native-community/netinfo": "^11.3.1",
-        "@react-native-community/slider": "^4.5.0",
+        "@react-native-community/slider": "^4.5.7",
         "@react-native-google-signin/google-signin": "^13.1.0",
         "@react-native-picker/picker": "^2.7.2",
         "@react-navigation/bottom-tabs": "^7.3.13",
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/@react-native-community/slider": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.0.tgz",
-      "integrity": "sha512-pyUvNTvu5IfCI5abzqRfO/dd3A009RC66RXZE6t0gyOwI/j0QDlq9VZRv3rjkpuIvNTnsYj+m5BHlh0DkSYUyA=="
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.7.tgz",
+      "integrity": "sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ=="
     },
     "node_modules/@react-native-google-signin/google-signin": {
       "version": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@react-native-community/geolocation": "^3.2.1",
     "@react-native-community/hooks": "^3.0.0",
     "@react-native-community/netinfo": "^11.3.1",
-    "@react-native-community/slider": "^4.5.0",
+    "@react-native-community/slider": "^4.5.7",
     "@react-native-google-signin/google-signin": "^13.1.0",
     "@react-native-picker/picker": "^2.7.2",
     "@react-navigation/bottom-tabs": "^7.3.13",


### PR DESCRIPTION
Update of a package in preparation for the New Architecture, which was introduced in versions after 4.5.0. The latest version of this package compiles well.

The only place we use this library (outside of debug mode) is in the SoundSlider component, so after recording a sound you should be able to use a slide to control the timestamp of the sound being played.

Have compiled for Debug and Release on both platforms and tested that this component still works as expected.