### PR TITLE
Update @shopify/flash-list to latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1764,7 +1764,7 @@ PODS:
     - React-Core
   - RNDeviceInfo (10.13.1):
     - React-Core
-  - RNFlashList (1.7.2):
+  - RNFlashList (1.8.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2451,7 +2451,7 @@ SPEC CHECKSUMS:
   RNCPicker: fb82ba6cfba077a80a32412bc7b5391130a4e25f
   RNDateTimePicker: 392bdc0d6863b5de2fe9b957c82c25b6a038db29
   RNDeviceInfo: 538b62f03991eb4a2a15cf6fec5fff6bb5edc34e
-  RNFlashList: 294ab318aff413909ee42ff2bba6be075bb4a10c
+  RNFlashList: 490b55e0e9e01b30e7a289aa0543f0aee659d6b8
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: 873293eddd5c833779f6100823ac2445660249fe
   RNGoogleSignin: ba93c1137f8d5cebdd39b04f493fd212ddf5ecd6

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@react-navigation/native-stack": "^7.3.13",
         "@realm/react": "^0.11.0",
         "@sayem314/react-native-keep-awake": "^1.3.1",
-        "@shopify/flash-list": "^1.7.2",
+        "@shopify/flash-list": "^1.8.3",
         "@tanstack/react-query": "^5.29.0",
         "apisauce": "^3.1.0",
         "classnames": "^2.5.1",
@@ -5458,12 +5458,12 @@
       }
     },
     "node_modules/@shopify/flash-list": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-1.7.2.tgz",
-      "integrity": "sha512-rnadpDht/mlJLDM02HBni49EJJQhc51zjJ3diGnTz3MV6U8vK9Hztou+2C5d6bNLb4oZvSG5f7NTWejkipyMLw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-1.8.3.tgz",
+      "integrity": "sha512-vXuj6JyuMjONVOXjEhWFeaONPuWN/53Cl2LeyeM8TZ0JzUcNU+BE6iyga1/yyJeDf0K7YPgAE/PcUX2+DM1LiA==",
       "dependencies": {
-        "recyclerlistview": "4.2.1",
-        "tslib": "2.6.3"
+        "recyclerlistview": "4.2.3",
+        "tslib": "2.8.1"
       },
       "peerDependencies": {
         "@babel/runtime": "*",
@@ -18535,10 +18535,9 @@
       }
     },
     "node_modules/recyclerlistview": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.1.tgz",
-      "integrity": "sha512-NtVYjofwgUCt1rEsTp6jHQg/47TWjnO92TU2kTVgJ9wsc/ely4HnizHHa+f/dI7qaw4+zcSogElrLjhMltN2/g==",
-      "license": "Apache-2.0",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
       "dependencies": {
         "lodash.debounce": "4.0.8",
         "prop-types": "15.8.1",
@@ -20358,8 +20357,7 @@
     "node_modules/ts-object-utils": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
-      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
-      "license": "ISC"
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA=="
     },
     "node_modules/ts-regex-builder": {
       "version": "1.7.1",
@@ -20410,9 +20408,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@react-navigation/native-stack": "^7.3.13",
     "@realm/react": "^0.11.0",
     "@sayem314/react-native-keep-awake": "^1.3.1",
-    "@shopify/flash-list": "^1.7.2",
+    "@shopify/flash-list": "^1.8.3",
     "@tanstack/react-query": "^5.29.0",
     "apisauce": "^3.1.0",
     "classnames": "^2.5.1",


### PR DESCRIPTION
Update of a package in preparation for RN 0.77, @shopify/flash-list v1.7.3 introduces support for RN 0.77.x. on Android. But the latest version also compiles.

Have compiled for Debug and Release on both platforms successfully and tested Explore, Notifications, MyObs and Project lists.