### PR TITLE
Performance: speed up Notifications

### DIFF
--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -44,11 +44,12 @@ const NotificationsContainer = ( {
   }
 
   useEffect( ( ) => {
-    navigation.addListener( "focus", ( ) => {
+    const unsubscribe = navigation.addListener( "focus", ( ) => {
       if ( isConnected && currentUser ) {
         refetch();
       }
     } );
+    return unsubscribe;
   }, [isConnected, currentUser, navigation, refetch] );
 
   const onRefresh = async () => {

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -67,7 +67,22 @@ async function fetchObsByUUIDs(
   // TODO convert api/observations to TS
   const observations: ApiObservation[] | null = await fetchRemoteObservations(
     uuids,
-    { fields: Observation.FIELDS },
+    {
+      fields: {
+        user: {
+          id: true
+        },
+        observation_photos: {
+          uuid: true,
+          photo: {
+            url: true
+          }
+        },
+        observation_sounds: {
+          uuid: true
+        }
+      }
+    },
     authOptions
   );
   if ( options.save ) {


### PR DESCRIPTION
Closes MOB-853

- Fixes a memory leak where `useEffect` would run an infinite amount of times when returning from ObsDetails by running an unsubscribe cleanup on the add focus listener
- Fetch only the fields needed from API (photos, sounds, user_id) instead of fetching and passing around very large observation objects