### PR TITLE
Performance: limit API fields for Explore observations fetch

### DIFF
--- a/src/components/Explore/hooks/useInfiniteExploreScroll.js
+++ b/src/components/Explore/hooks/useInfiniteExploreScroll.js
@@ -18,7 +18,9 @@ const useInfiniteExploreScroll = ( { params: newInputParams, enabled }: Object )
   const baseParams = useMemo( () => ( {
     ...newInputParams,
     fields: {
-      ...Observation.EXPLORE_LIST_FIELDS,
+      // the most data we display in the UI on any Observations view in Explore
+      // is the same amount of data we show for the Advanced list mode in MyObservations
+      ...Observation.ADVANCED_MODE_LIST_FIELDS,
       user: { // included here for "exclude by current user" in explore filters
         id: true,
         uuid: true,

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -82,51 +82,6 @@ class Observation extends Realm.Object {
     }
   };
 
-  static EXPLORE_LIST_FIELDS = {
-    created_at: true,
-    comments: {
-      current: true
-    },
-    geojson: true,
-    geoprivacy: true,
-    id: true,
-    identifications: {
-      current: true
-    },
-    latitude: true,
-    longitude: true,
-    observation_photos: ObservationPhoto.OBSERVATION_PHOTOS_FIELDS,
-    observed_time_zone: true,
-    place_guess: true,
-    quality_grade: true,
-    obscured: true,
-    observation_sounds: {
-      id: true
-    },
-    taxon: {
-      iconic_taxon_name: true,
-      is_active: true,
-      name: true,
-      preferred_common_name: true,
-      rank: true,
-      rank_level: true
-    },
-    taxon_geoprivacy: true,
-    time_observed_at: true
-  };
-
-  static LIST_FIELDS = {
-    ...Observation.EXPLORE_LIST_FIELDS,
-    comments: Comment.COMMENT_FIELDS,
-    created_at: true,
-    identifications: Identification.ID_FIELDS,
-    observation_sounds: ObservationSound.OBSERVATION_SOUNDS_FIELDS,
-    private_geojson: true,
-    private_place_guess: true,
-    taxon: Taxon.TAXON_FIELDS,
-    user: User && User.FIELDS
-  };
-
   static DEFAULT_MODE_LIST_FIELDS = {
     created_at: true,
     id: true, // needed to get next page in infinite queries


### PR DESCRIPTION
Limit Explore Observation fields to what's displayed in list view. Re: app is slow