### PR TITLE
Update react-native-safe-area-context to latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1406,7 +1406,7 @@ PODS:
     - React-Core
   - react-native-restart (0.0.27):
     - React-Core
-  - react-native-safe-area-context (4.14.1):
+  - react-native-safe-area-context (5.5.1):
     - React-Core
   - react-native-sensitive-info (6.0.0-alpha.9):
     - React-Core
@@ -2410,7 +2410,7 @@ SPEC CHECKSUMS:
   react-native-orientation-locker: dbd3f6ddbe9e62389cb0807dc2af63f6c36dec36
   react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
   react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  react-native-safe-area-context: 758e894ca5a9bd1868d2a9cfbca7326a2b6bf9dc
+  react-native-safe-area-context: 827032edf27079702cbd006f11dc79451a2d744b
   react-native-sensitive-info: ee358bf2b901ac3d04f63ff637b31daee44ea87f
   react-native-slider: 1a4b42f71aea07eee94d7327fddce0db5f25feca
   react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "react-native-reanimated-carousel": "^3.5.1",
         "react-native-render-html": "^6.3.4",
         "react-native-restart": "^0.0.27",
-        "react-native-safe-area-context": "^4.14.1",
+        "react-native-safe-area-context": "^5.5.1",
         "react-native-screens": "4.4.0",
         "react-native-sensitive-info": "^6.0.0-alpha.9",
         "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
@@ -18049,9 +18049,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.14.1.tgz",
-      "integrity": "sha512-+tUhT5WBl8nh5+P+chYhAjR470iCByf9z5EYdCEbPaAK3Yfzw+o8VRPnUgmPAKlSccOgQBxx3NOl/Wzckn9ujg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.5.1.tgz",
+      "integrity": "sha512-WYxV+mm7SWuapVWxq2071lkQlDUXjSwcu7Cc2bUtNcF80/Bl0WnuWAZ8+tO46M38PclMrQIIgbv83BvDHJNQ5g==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "react-native-reanimated-carousel": "^3.5.1",
     "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.27",
-    "react-native-safe-area-context": "^4.14.1",
+    "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "4.4.0",
     "react-native-sensitive-info": "^6.0.0-alpha.9",
     "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",


### PR DESCRIPTION
Update of a package in preparation for RN 0.77, react-native-safe-area-context v5.1.0 introduces support for RN 0.77.x. on Android. But the latest version also compiles.

Have compiled for Debug and Release on iOS and for Debug on Android (having some build issues on Android but that should not matter for this PR) and tested the app in places where a notched phone should show correct UI.