### PR TITLE
Update react-native-webview to latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1434,7 +1434,7 @@ PODS:
   - react-native-volume-manager (1.10.0):
     - Mute
     - React-Core
-  - react-native-webview (13.8.4):
+  - react-native-webview (13.15.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2414,7 +2414,7 @@ SPEC CHECKSUMS:
   react-native-sensitive-info: ee358bf2b901ac3d04f63ff637b31daee44ea87f
   react-native-slider: 1a4b42f71aea07eee94d7327fddce0db5f25feca
   react-native-volume-manager: d9d2863a2374420af89c89662333ea6adf506988
-  react-native-webview: 0c8e44a3d67061caf6afe14d1f9fcbab0cf768f8
+  react-native-webview: ab7d17cb9fd64af9f4a9e3936248364995518f74
   react-native-worklets-core: bfbf1cce2251a85a23d739e46a77682a29fc8889
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678
   React-NativeModulesApple: cebca2e5320a3d66e123cade23bd90a167ffce5e

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "react-native-vision-camera": "^4.7.0",
         "react-native-volume-manager": "^1.10.0",
         "react-native-walkthrough-tooltip": "^1.6.0",
-        "react-native-webview": "^13.8.4",
+        "react-native-webview": "^13.15.0",
         "react-native-worklets-core": "1.5.0",
         "realm": "^20.1.0",
         "sanitize-html": "^2.13.0",
@@ -18223,24 +18223,16 @@
       }
     },
     "node_modules/react-native-webview": {
-      "version": "13.8.4",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.8.4.tgz",
-      "integrity": "sha512-dFoM9EfkAb++ZzycZyKRnjZtNUn85cf6bWp1iBlkgyNml7ULzR1gfaPT3qESoA3K1RfTmf5Xhw0M2In2A3a3wg==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
       "dependencies": {
-        "escape-string-regexp": "2.0.0",
+        "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-webview/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/react-native-worklets-core": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-native-vision-camera": "^4.7.0",
     "react-native-volume-manager": "^1.10.0",
     "react-native-walkthrough-tooltip": "^1.6.0",
-    "react-native-webview": "^13.8.4",
+    "react-native-webview": "^13.15.0",
     "react-native-worklets-core": "1.5.0",
     "realm": "^20.1.0",
     "sanitize-html": "^2.13.0",


### PR DESCRIPTION
Update of a package in preparation for RN 0.77, react-native-webview v13.13.0 introduces support for RN 0.77.x. on Android. But the latest version also compiles.

Have compiled for Debug and Release on iOS and for Debug on Android (having some build issues on Android but that should not matter for this PR).
Tested the display of webviews in the app: UserText on and observation detail still renders bold text; announcements are stills shown (have created a test announcement on staging = Debug; have not tested on Release); I can still navigate to the Account Settings (on Debug builds the Account Settings are showing me a 401 Authorization Required error, but that is already happening on main, so not a regression).

