### PR TITLE
Allow a logged in user to log in again with password only Debug login button

### DIFF
--- a/src/components/Developer/Developer.js
+++ b/src/components/Developer/Developer.js
@@ -107,6 +107,11 @@ const Developer = (): Node => {
           text="LOG"
           className="mb-5"
         />
+        <Button
+          onPress={() => navigation.navigate( "LoginStackNavigator" )}
+          text="LOG IN AGAIN"
+          className="mb-5"
+        />
         { // eslint-disable-next-line no-undef
           __DEV__ && (
             <>

--- a/src/components/Developer/Developer.js
+++ b/src/components/Developer/Developer.js
@@ -107,6 +107,7 @@ const Developer = (): Node => {
           text="LOG"
           className="mb-5"
         />
+        {/* TODO: this needs to be restricted to log in the current user and none other */}
         <Button
           onPress={() => navigation.navigate( "LoginStackNavigator" )}
           text="LOG IN AGAIN"


### PR DESCRIPTION
This flow should only be reachable through a new "login again button" from the Debug menu. (I do not see any harm though if reached outside of Debug menu).

I believe this is a quick fix for users that have problems with uploading saved but not synced observations. I could not recreate those problems in the production app in the field. However, I was able to get to a point of identifying one possible problem with our current assessments wether a user is considered logged-in, see https://linear.app/inaturalist/issue/MOB-851/users-unable-to-upload#comment-c72617c7
I have not figured out how a production app can get into this state, but I was able to create such a faulty state in the development app. This PR does fix this faulty state in the test version. So, I hope it also fixes it for affected users.