### PR TITLE
Check if permission is granted before requesting location on Android

### DIFF
--- a/src/sharedHelpers/geolocationWrapper.ts
+++ b/src/sharedHelpers/geolocationWrapper.ts
@@ -78,8 +78,7 @@ export const checkLocationPermissions = async ( ) => {
     await checkMultiple( LOCATION_PERMISSIONS )
   );
 
-  // TODO: handle case where iOS permissions are not granted
-  if ( Platform.OS !== "android" && permissionResult !== RESULTS.GRANTED ) {
+  if ( permissionResult !== RESULTS.GRANTED ) {
     return null;
   }
   return permissionResult;


### PR DESCRIPTION
Closes MOB-796

Have tested this change, and as expected:
Photos taken without location permission are stored without location in exif data.
Photos taken with location permission granted are stored with location exif data.
(At least on my Pixel test device)