### PR TITLE
Fix: Observations shown without data

### DIFF
--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -70,7 +70,8 @@ async function fetchObsByUUIDs(
     {
       fields: {
         user: {
-          id: true
+          id: true,
+          login: true
         },
         ...Observation.ADVANCED_MODE_LIST_FIELDS
       }

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -68,20 +68,7 @@ async function fetchObsByUUIDs(
   const observations: ApiObservation[] | null = await fetchRemoteObservations(
     uuids,
     {
-      fields: {
-        user: {
-          id: true
-        },
-        observation_photos: {
-          uuid: true,
-          photo: {
-            url: true
-          }
-        },
-        observation_sounds: {
-          uuid: true
-        }
-      }
+      fields: Observation.ADVANCED_MODE_LIST_FIELDS
     },
     authOptions
   );

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -68,7 +68,12 @@ async function fetchObsByUUIDs(
   const observations: ApiObservation[] | null = await fetchRemoteObservations(
     uuids,
     {
-      fields: Observation.ADVANCED_MODE_LIST_FIELDS
+      fields: {
+        user: {
+          id: true
+        },
+        ...Observation.ADVANCED_MODE_LIST_FIELDS
+      }
     },
     authOptions
   );


### PR DESCRIPTION
Closes MOB-866
Observations that were fetched from server on the notifications screen were inserted into the local database with limited data, because we started requesting less data from the API. The major problem with that was that they were interpreted as having a "Missing date" which on the Me tab sorts them to the top of the list. While not being a data corruption issue per se it looks like something is wrong with the data.
I switched back to request more fields again for observations loaded from notifications. Instead of all fields, we now request the "Advanced fields" which is the max of data we show anywhere in the app.