### PR TITLE
Recovery from observations not uploading

### DIFF
--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -44,10 +44,16 @@ const API_HOST: string = Config.OAUTH_API_URL || process.env.OAUTH_API_URL || "h
 // expire every 30 mins, so might as well be futureproof.
 const JWT_EXPIRATION_MINS = 25;
 
+interface AuthCache {
+  isLoggedIn: boolean | null;
+  lastChecked: number | null;
+  cacheTimeout: number;
+}
+
 /**
  * Cache for isLoggedIn, to avoid making too many calls to RNSInfo.getItem
  */
-const authCache = {
+const authCache: AuthCache = {
   isLoggedIn: null,
   lastChecked: null,
   cacheTimeout: 5000
@@ -55,10 +61,8 @@ const authCache = {
 
 /**
  * Clear cache for isLoggedIn.
- *
- * @returns {void}
  */
-const clearAuthCache = ( ) => {
+const clearAuthCache = ( ): void => {
   authCache.isLoggedIn = null;
   authCache.lastChecked = null;
 };
@@ -276,10 +280,9 @@ const getAnonymousJWT = (): string => {
  *  logged-in, use anonymous JWT
  * @returns {Promise<string|*>}
  */
-// $FlowIgnore
 const getJWT = async (
   allowAnonymousJWT = false,
-  logContext = null
+  logContext: string | null = null
 ): Promise<string | null> => {
   let jwtToken: string | undefined = await getSensitiveItem( "jwtToken" );
   const storedJwtGeneratedAt = await getSensitiveItem( "jwtGeneratedAt" );

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -238,7 +238,7 @@ const LoginForm = ( {
               : (
                 <View className="flex-row my-5 items-center justify-center mx-2">
                   <List2 className="ml-3 text-white font-medium">
-                    {t( "There-was-an-error-which-logging-in-again-might-fix" )}
+                    {t( "There-was-an-error-that-might-be-fixed-by-logging-in-again" )}
                   </List2>
                 </View>
               )

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -218,22 +218,30 @@ const LoginForm = ( {
         ) }
         <View ref={firstInputFieldRef}>
           {
-            !loginAgain && (
-              <LoginSignUpInputField
-                ref={emailRef}
-                accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
-                autoComplete="email"
-                headerText={t( "USERNAME-OR-EMAIL" )}
-                inputMode="email"
-                keyboardType="email-address"
-                onChangeText={( text: string ) => setEmail( text )}
-                testID="Login.email"
-                // https://github.com/facebook/react-native/issues/39411#issuecomment-1817575790
-                // textContentType prevents visual flickering, which is a temporary issue
-                // in iOS 17
-                textContentType="emailAddress"
-              />
-            )
+            !loginAgain
+              ? (
+                <LoginSignUpInputField
+                  ref={emailRef}
+                  accessibilityLabel={t( "USERNAME-OR-EMAIL" )}
+                  autoComplete="email"
+                  headerText={t( "USERNAME-OR-EMAIL" )}
+                  inputMode="email"
+                  keyboardType="email-address"
+                  onChangeText={( text: string ) => setEmail( text )}
+                  testID="Login.email"
+                  // https://github.com/facebook/react-native/issues/39411#issuecomment-1817575790
+                  // textContentType prevents visual flickering, which is a temporary issue
+                  // in iOS 17
+                  textContentType="emailAddress"
+                />
+              )
+              : (
+                <View className="flex-row my-5 items-center justify-center mx-2">
+                  <List2 className="ml-3 text-white font-medium">
+                    {t( "There-was-an-error-which-logging-in-again-might-fix" )}
+                  </List2>
+                </View>
+              )
           }
         </View>
         <LoginSignUpInputField

--- a/src/components/StartupService.js
+++ b/src/components/StartupService.js
@@ -90,6 +90,9 @@ const StartupService = ( ) => {
       };
       // don't remove this logger.info statement: it's used for internal metrics
       logger.info( "pickup" );
+      logger.info(
+        `App version: ${DeviceInfo.getVersion()}, build: ${DeviceInfo.getBuildNumber()}`
+      );
 
       try {
         await checkForSignedInUser( );

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1239,6 +1239,7 @@ The-iNaturalist-Network = The iNaturalist network is a collection of localized w
 # Describes what happens when geoprivacy is set to private
 The-location-will-not-be-visible-to-others = The location will not be visible to others, which might make the observation impossible to identify.
 The-models-that-suggest-species = The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sara Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.
+There-was-an-error-which-logging-in-again-might-fix = There was an error which logging in again might fix.
 #  Wild status sheet descriptions
 This-is-a-wild-organism = This is a wild organism and wasn't placed in this location by humans.
 This-is-how-taxon-names-will-be-displayed = This is how all taxon names will be displayed to you across iNaturalist:

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1239,7 +1239,7 @@ The-iNaturalist-Network = The iNaturalist network is a collection of localized w
 # Describes what happens when geoprivacy is set to private
 The-location-will-not-be-visible-to-others = The location will not be visible to others, which might make the observation impossible to identify.
 The-models-that-suggest-species = The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sara Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.
-There-was-an-error-which-logging-in-again-might-fix = There was an error which logging in again might fix.
+There-was-an-error-that-might-be-fixed-by-logging-in-again = There was an error that might be fixed by logging in again.
 #  Wild status sheet descriptions
 This-is-a-wild-organism = This is a wild organism and wasn't placed in this location by humans.
 This-is-how-taxon-names-will-be-displayed = This is how all taxon names will be displayed to you across iNaturalist:

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -784,7 +784,7 @@
   "The-iNaturalist-Network": "The iNaturalist network is a collection of localized websites that are fully connected to the global iNaturalist community. Network sites are supported by local institutions that promote local use and facilitate the use of data from iNaturalist to benefit local biodiversity.",
   "The-location-will-not-be-visible-to-others": "The location will not be visible to others, which might make the observation impossible to identify.",
   "The-models-that-suggest-species": "The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sara Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.",
-  "There-was-an-error-which-logging-in-again-might-fix": "There was an error which logging in again might fix.",
+  "There-was-an-error-that-might-be-fixed-by-logging-in-again": "There was an error that might be fixed by logging in again.",
   "This-is-a-wild-organism": "This is a wild organism and wasn't placed in this location by humans.",
   "This-is-how-taxon-names-will-be-displayed": "This is how all taxon names will be displayed to you across iNaturalist:",
   "This-is-your-identification-other-people-may-help-confirm-it": "This is your identification. Other people may help confirm it!",

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -784,6 +784,7 @@
   "The-iNaturalist-Network": "The iNaturalist network is a collection of localized websites that are fully connected to the global iNaturalist community. Network sites are supported by local institutions that promote local use and facilitate the use of data from iNaturalist to benefit local biodiversity.",
   "The-location-will-not-be-visible-to-others": "The location will not be visible to others, which might make the observation impossible to identify.",
   "The-models-that-suggest-species": "The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sara Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.",
+  "There-was-an-error-which-logging-in-again-might-fix": "There was an error which logging in again might fix.",
   "This-is-a-wild-organism": "This is a wild organism and wasn't placed in this location by humans.",
   "This-is-how-taxon-names-will-be-displayed": "This is how all taxon names will be displayed to you across iNaturalist:",
   "This-is-your-identification-other-people-may-help-confirm-it": "This is your identification. Other people may help confirm it!",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1239,7 +1239,7 @@ The-iNaturalist-Network = The iNaturalist network is a collection of localized w
 # Describes what happens when geoprivacy is set to private
 The-location-will-not-be-visible-to-others = The location will not be visible to others, which might make the observation impossible to identify.
 The-models-that-suggest-species = The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sara Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.
-There-was-an-error-which-logging-in-again-might-fix = There was an error which logging in again might fix.
+There-was-an-error-that-might-be-fixed-by-logging-in-again = There was an error that might be fixed by logging in again.
 #  Wild status sheet descriptions
 This-is-a-wild-organism = This is a wild organism and wasn't placed in this location by humans.
 This-is-how-taxon-names-will-be-displayed = This is how all taxon names will be displayed to you across iNaturalist:

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1547,3 +1547,4 @@ Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve 
 Zoom-to-current-location = Zoom to current location
 # Label for button that shows zoom level, e.g. on a camera
 zoom-x = { $zoom }×
+There-was-an-error-which-logging-in-again-might-fix = There was an error which logging in again might fix.

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1239,6 +1239,7 @@ The-iNaturalist-Network = The iNaturalist network is a collection of localized w
 # Describes what happens when geoprivacy is set to private
 The-location-will-not-be-visible-to-others = The location will not be visible to others, which might make the observation impossible to identify.
 The-models-that-suggest-species = The models that suggest species based on visual similarity and location are thanks in part to collaborations with Sara Beery, Tom Brooks, Elijah Cole, Christian Lange, Oisin Mac Aodha, Pietro Perona, and Grant Van Horn.
+There-was-an-error-which-logging-in-again-might-fix = There was an error which logging in again might fix.
 #  Wild status sheet descriptions
 This-is-a-wild-organism = This is a wild organism and wasn't placed in this location by humans.
 This-is-how-taxon-names-will-be-displayed = This is how all taxon names will be displayed to you across iNaturalist:
@@ -1547,4 +1548,3 @@ Zoom-in-as-much-as-possible-to-improve = Zoom in as much as possible to improve 
 Zoom-to-current-location = Zoom to current location
 # Label for button that shows zoom level, e.g. on a camera
 zoom-x = { $zoom }×
-There-was-an-error-which-logging-in-again-might-fix = There was an error which logging in again might fix.

--- a/src/sharedHooks/useTranslation.ts
+++ b/src/sharedHooks/useTranslation.ts
@@ -10,6 +10,7 @@ const useCustomTranslation = ( ) => {
       try {
         return original.t( key, options );
       } catch ( translationError ) {
+        // TODO: log how often this happens
         if ( translationError instanceof Error && !translationError.message.match( /NoClassDefFoundError/ ) ) {
           throw translationError;
         }

--- a/src/sharedHooks/useTranslation.ts
+++ b/src/sharedHooks/useTranslation.ts
@@ -10,7 +10,6 @@ const useCustomTranslation = ( ) => {
       try {
         return original.t( key, options );
       } catch ( translationError ) {
-        // TODO: log how often this happens
         if ( translationError instanceof Error && !translationError.message.match( /NoClassDefFoundError/ ) ) {
           throw translationError;
         }

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -5,7 +5,7 @@ import {
 import { getJWT } from "components/LoginSignUp/AuthenticationService.ts";
 import { AppState } from "react-native";
 import Realm from "realm";
-import { RealmObservation, RealmObservationPojo } from "realmModels/types.d.ts";
+import type { RealmObservation, RealmObservationPojo } from "realmModels/types";
 import { log } from "sharedHelpers/logger";
 import {
   markRecordUploaded,

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -110,7 +110,7 @@ async function uploadObservation(
   } catch ( error ) {
     const {
       errorContext, totalDuration
-    } = createErrorContext( "media_upload", uploadStartTime, observation.uuid );
+    } = createErrorContext( "media_upload", uploadStartTime );
     logger.error(
       `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
       + ": Media upload failed",
@@ -139,7 +139,7 @@ async function uploadObservation(
   } catch ( error ) {
     const {
       errorContext, totalDuration
-    } = createErrorContext( "observation_upload", uploadStartTime, observation.uuid );
+    } = createErrorContext( "observation_upload", uploadStartTime );
     logger.error(
       `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
       + ": Observation upload failed",
@@ -165,7 +165,7 @@ async function uploadObservation(
   } catch ( error ) {
     const {
       errorContext, totalDuration
-    } = createErrorContext( "media_attachment", uploadStartTime, observation.uuid );
+    } = createErrorContext( "media_attachment", uploadStartTime );
     logger.error(
       `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
       + ": Media attachment failed",
@@ -180,7 +180,7 @@ async function uploadObservation(
   } catch ( error ) {
     const {
       errorContext, totalDuration
-    } = createErrorContext( "realm_update", uploadStartTime, observation.uuid );
+    } = createErrorContext( "realm_update", uploadStartTime );
     logger.error(
       `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
       + ": Realm update failed",

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -15,6 +15,7 @@ import {
   attachMediaToObservation,
   uploadObservationMedia
 } from "uploaders/mediaUploader.ts";
+import { RecoverableError, RECOVERY_BY } from "uploaders/utils/errorHandling.ts";
 import { trackObservationUpload } from "uploaders/utils/progressTracker.ts";
 
 const logger = log.extend( "observationUploader" );
@@ -46,7 +47,9 @@ interface ObservationApiResponse {
 async function validateAndGetToken( ): Promise<string> {
   const apiToken = await getJWT( false, "upload" );
   if ( !apiToken ) {
-    throw new Error( "Gack, tried to upload an observation without API token!" );
+    const error = new RecoverableError( "Gack, tried to upload an observation without API token!" );
+    error.recoveryBy = RECOVERY_BY.LOGIN_AGAIN;
+    throw error;
   }
   return apiToken;
 }

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -119,7 +119,8 @@ async function uploadObservation(
       + ": Media upload failed",
       error
     );
-    throw new Error( `Media upload failed: ${error.message}` );
+    error.message = `Media upload failed: ${error.message}`;
+    throw error;
   }
 
   // Step 2: upload or modify observation with revalidated token
@@ -148,7 +149,8 @@ async function uploadObservation(
       + ": Observation upload failed",
       error
     );
-    throw new Error( `Observation upload failed: ${error.message}` );
+    error.message = `Observation upload failed: ${error.message}`;
+    throw error;
   }
 
   const { uuid: obsUUID } = response.results[0];
@@ -174,7 +176,8 @@ async function uploadObservation(
       + ": Media attachment failed",
       error
     );
-    throw new Error( `Media attachment failed: ${error.message}` );
+    error.message = `Media attachment failed: ${error.message}`;
+    throw error;
   }
 
   // Step 4: mark observation as uploaded in realm

--- a/src/uploaders/utils/errorHandling.ts
+++ b/src/uploaders/utils/errorHandling.ts
@@ -1,8 +1,27 @@
 import { INatApiError } from "api/error";
 import type { TFunction } from "i18next";
 
+export enum RECOVERY_BY {
+  LOGIN_AGAIN = "LOGIN_AGAIN"
+}
+export class RecoverableError extends Error {
+  recoveryPossible: boolean;
+
+  recoveryBy: RECOVERY_BY | undefined;
+
+  constructor( message: string ) {
+    super( message );
+    this.recoveryPossible = true;
+    this.recoveryBy = undefined;
+  }
+}
+// https://wbinnssmith.com/blog/subclassing-error-in-modern-javascript/
+Object.defineProperty( RecoverableError.prototype, "name", {
+  value: "RecoverableError"
+} );
+
 function handleUploadError(
-  uploadError: Error | INatApiError,
+  uploadError: Error | INatApiError | RecoverableError,
   t: TFunction
 ): string {
   let { message } = uploadError;

--- a/src/uploaders/utils/errorHandling.ts
+++ b/src/uploaders/utils/errorHandling.ts
@@ -1,6 +1,10 @@
 import { INatApiError } from "api/error";
+import type { TFunction } from "i18next";
 
-function handleUploadError( uploadError: Error | INatApiError, t: Function ): string {
+function handleUploadError(
+  uploadError: Error | INatApiError,
+  t: TFunction
+): string {
   let { message } = uploadError;
   if ( uploadError?.json?.errors ) {
     // TODO localize comma join

--- a/tests/unit/uploaders/utils/errorHandling.test.js
+++ b/tests/unit/uploaders/utils/errorHandling.test.js
@@ -20,9 +20,9 @@ describe( "errorHandling", ( ) => {
     test( "should return 'Connection problem' message for network errors", ( ) => {
       const networkError = new Error( "Network request failed" );
 
-      const result = handleUploadError( networkError, t );
+      const { message } = handleUploadError( networkError, t );
 
-      expect( result ).toBe( "Connection-problem-Please-try-again-later" );
+      expect( message ).toBe( "Connection-problem-Please-try-again-later" );
     } );
 
     test( "should return a string from an array of iNaturalist API errors", ( ) => {
@@ -34,9 +34,9 @@ describe( "errorHandling", ( ) => {
         ]
       };
 
-      const result = handleUploadError( apiError, t );
+      const { message } = handleUploadError( apiError, t );
 
-      expect( result ).toBe( "First error, Second error" );
+      expect( message ).toBe( "First error, Second error" );
     } );
 
     test( "should return a string from a nested array of iNaturalist API errors", ( ) => {
@@ -47,9 +47,9 @@ describe( "errorHandling", ( ) => {
         ]
       };
 
-      const result = handleUploadError( apiError, t );
+      const { message } = handleUploadError( apiError, t );
 
-      expect( result ).toBe( "Error 1, Error 2" );
+      expect( message ).toBe( "Error 1, Error 2" );
     } );
 
     test( "should return a string from a nested string "
@@ -61,9 +61,9 @@ describe( "errorHandling", ( ) => {
         ]
       };
 
-      const result = handleUploadError( apiError, t );
+      const { message } = handleUploadError( apiError, t );
 
-      expect( result ).toBe( "Nested error message string" );
+      expect( message ).toBe( "Nested error message string" );
     } );
 
     test( "should handle 410 errors for previously deleted observations or evidence", ( ) => {
@@ -74,9 +74,9 @@ describe( "errorHandling", ( ) => {
         ]
       };
 
-      const result = handleUploadError( apiError, t );
+      const { message } = handleUploadError( apiError, t );
 
-      expect( result ).toBe( "Resource was previously deleted" );
+      expect( message ).toBe( "Resource was previously deleted" );
     } );
   } );
 } );

--- a/tests/unit/uploaders/utils/errorHandling.test.js
+++ b/tests/unit/uploaders/utils/errorHandling.test.js
@@ -1,4 +1,5 @@
 import { handleUploadError } from "uploaders";
+import { RecoverableError, RECOVERY_BY } from "uploaders/utils/errorHandling.ts";
 
 describe( "errorHandling", ( ) => {
   // Mock translation function since we're passing that into the error handler
@@ -23,6 +24,27 @@ describe( "errorHandling", ( ) => {
       const { message } = handleUploadError( networkError, t );
 
       expect( message ).toBe( "Connection-problem-Please-try-again-later" );
+    } );
+
+    test( "should return recoveryPossible=true for network errors", () => {
+      const networkError = new Error( "Network request failed" );
+
+      const { recoveryPossible } = handleUploadError( networkError, t );
+
+      expect( recoveryPossible ).toBe( true );
+    } );
+
+    test( "should return recovery options for RecoverableErrors", () => {
+      const recoverableError = new RecoverableError( "Recoverable error" );
+      recoverableError.recoveryBy = RECOVERY_BY.LOGIN_AGAIN;
+
+      const { recoveryPossible, recoveryBy } = handleUploadError(
+        recoverableError,
+        t
+      );
+
+      expect( recoveryPossible ).toBe( true );
+      expect( recoveryBy ).toBe( RECOVERY_BY.LOGIN_AGAIN );
     } );
 
     test( "should return a string from an array of iNaturalist API errors", ( ) => {


### PR DESCRIPTION
We added a debug button to the app, to log in again. This has been tested by some user, and it does resolve the error of not being able to upload their observations. So, in this PR I am adding a recovery option whenever we hit the error of trying to upload an observation without api token (which will surely fail server side).
As recovery:
Navigate to login screen to login again (which replenishes the api token).
In addition, stop all ongoing uploads if multiple have been queued because they for sure also would error out.

I would not say this PR solves the ticket MOB-851, because it is still possible for the app to arrive at the error state of user not being able to upload. However, I think this workaround is enough to remove the "urgent" label for now.