### PR TITLE
Fix opening of email client for password reset by introducing android…

### DIFF
--- a/android/app/src/main/java/com/inaturalistreactnative/MainApplication.kt
+++ b/android/app/src/main/java/com/inaturalistreactnative/MainApplication.kt
@@ -12,6 +12,8 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 
+import org.inaturalist.iNaturalistMobile.EmailIntentPackage;
+
 class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost =
@@ -20,6 +22,7 @@ class MainApplication : Application(), ReactApplication {
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:
               // add(MyReactNativePackage())
+              add(EmailIntentPackage())
             }
 
         override fun getJSMainModuleName(): String = "index"

--- a/android/app/src/main/java/org/inaturalist/iNaturalistMobile/EmailIntentModule.kt
+++ b/android/app/src/main/java/org/inaturalist/iNaturalistMobile/EmailIntentModule.kt
@@ -1,0 +1,19 @@
+package org.inaturalist.iNaturalistMobile
+
+import android.content.Intent
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class EmailIntentModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName() = "EmailIntentModule"
+
+    @ReactMethod
+    fun openEmailClient() {
+        val intent = Intent(Intent.ACTION_MAIN)
+        intent.addCategory(Intent.CATEGORY_APP_EMAIL)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        reactApplicationContext.startActivity(intent)
+    }
+}

--- a/android/app/src/main/java/org/inaturalist/iNaturalistMobile/EmailIntentPackage.kt
+++ b/android/app/src/main/java/org/inaturalist/iNaturalistMobile/EmailIntentPackage.kt
@@ -1,0 +1,19 @@
+package org.inaturalist.iNaturalistMobile
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class EmailIntentPackage : ReactPackage {
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        val modules = ArrayList<NativeModule>()
+        modules.add(EmailIntentModule(reactContext))
+        return modules
+    }
+}

--- a/tests/unit/helpers/mail.test.js
+++ b/tests/unit/helpers/mail.test.js
@@ -1,0 +1,105 @@
+import {
+  Alert, Linking, NativeModules, Platform
+} from "react-native";
+
+import { openInbox } from "../../../src/sharedHelpers/mail";
+
+// Mock i18next t function
+jest.mock( "i18next", () => ( {
+  t: jest.fn( key => {
+    switch ( key ) {
+      case "No-email-app-installed":
+        return "No email app installed";
+      case "No-email-app-installed-body-check-other":
+        return "Please check your device settings for other email options.";
+      case "Something-went-wrong":
+        return "Something went wrong";
+      default:
+        return key;
+    }
+  } )
+} ) );
+
+jest.mock( "react-native", () => ( {
+  Linking: {
+    canOpenURL: jest.fn(),
+    openURL: jest.fn()
+  },
+  Alert: {
+    alert: jest.fn()
+  },
+  Platform: {
+    OS: "android"
+  },
+  NativeModules: {
+    EmailIntentModule: {
+      openEmailClient: jest.fn()
+    }
+  }
+} ) );
+
+describe( "openInbox", () => {
+  beforeEach( () => {
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+  } );
+
+  it( "should call EmailIntentModule.openEmailClient on Android", async () => {
+    Platform.OS = "android";
+    await openInbox();
+    expect( NativeModules.EmailIntentModule.openEmailClient ).toHaveBeenCalledTimes( 1 );
+    expect( Linking.canOpenURL ).not.toHaveBeenCalled();
+    expect( Linking.openURL ).not.toHaveBeenCalled();
+  } );
+
+  it(
+    "should show an alert if EmailIntentModule.openEmailClient throws an error on Android",
+    async () => {
+      Platform.OS = "android";
+      NativeModules.EmailIntentModule.openEmailClient.mockImplementationOnce( () => {
+        throw new Error( "Test error" );
+      } );
+      await openInbox();
+      expect( Alert.alert ).toHaveBeenCalledTimes( 1 );
+      expect( Alert.alert ).toHaveBeenCalledWith(
+        "No email app installed",
+        "Please check your device settings for other email options."
+      );
+    }
+  );
+
+  it( "should call Linking.openURL on iOS if canOpenURL returns true", async () => {
+    Platform.OS = "ios";
+    Linking.canOpenURL.mockResolvedValue( true );
+    await openInbox();
+    expect( Linking.canOpenURL ).toHaveBeenCalledWith( "message:0" );
+    expect( Linking.openURL ).toHaveBeenCalledWith( "message:0" );
+    expect( NativeModules.EmailIntentModule.openEmailClient ).not.toHaveBeenCalled();
+  } );
+
+  it( "should show an alert on iOS if canOpenURL returns false", async () => {
+    Platform.OS = "ios";
+    Linking.canOpenURL.mockResolvedValue( false );
+    await openInbox();
+    expect( Linking.canOpenURL ).toHaveBeenCalledWith( "message:0" );
+    expect( Linking.openURL ).not.toHaveBeenCalled();
+    expect( Alert.alert ).toHaveBeenCalledTimes( 1 );
+    expect( Alert.alert ).toHaveBeenCalledWith(
+      "No email app installed",
+      "Please check your device settings for other email options."
+    );
+  } );
+
+  it( "should show an alert on iOS if openURL throws an error", async () => {
+    Platform.OS = "ios";
+    Linking.canOpenURL.mockResolvedValue( true );
+    Linking.openURL.mockImplementationOnce( () => {
+      throw new Error( "Test error" );
+    } );
+    await openInbox();
+    expect( Linking.canOpenURL ).toHaveBeenCalledWith( "message:0" );
+    expect( Linking.openURL ).toHaveBeenCalledWith( "message:0" );
+    expect( Alert.alert ).toHaveBeenCalledTimes( 1 );
+    expect( Alert.alert ).toHaveBeenCalledWith( "Something went wrong", "Test error" );
+  } );
+} );


### PR DESCRIPTION
… native module

Create a native module to correctly open registered eamil clients on Android devices. This resolves an issue where the built-in React Native `Linking.sendIntent` fails to launch the email application due to [inability to add intent categories](https://github.com/facebook/react-native/blob/86cad7d69099baaaeae10ac7c0912a023101f257/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java#L185), leading to a "Permission Denial" error related to `PLAY_SETUP_SERVICE`.

* New `EmailIntentModule` within Android to handle `ACTION_MAIN` with `CATEGORY_APP_EMAIL` intent.

* Updates `openInbox` function in `mail.ts` to use new native module, while retaining iOS logic

* Adds unit tests for `openInbox`

Closes #2527 

Fresh Sim Video


https://github.com/user-attachments/assets/e930103c-ddf9-41ff-b522-d2c45950d273

