### PR TITLE
Repair ObsWheel tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
         "react-native-vector-icons": "^10.2.0",
         "react-native-vision-camera": "^4.7.0",
         "react-native-volume-manager": "^1.10.0",
-        "react-native-walkthrough-tooltip": "^1.6.0",
         "react-native-webview": "^13.15.0",
         "react-native-worklets-core": "1.5.0",
         "realm": "^20.1.0",
@@ -17443,11 +17442,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
-    },
     "node_modules/react-freeze": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
@@ -18211,18 +18205,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-walkthrough-tooltip": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-walkthrough-tooltip/-/react-native-walkthrough-tooltip-1.6.0.tgz",
-      "integrity": "sha512-8DHpcqsF+2VULYnKJCSZtllhlFUFiZcWCwOlw5RLkS451ElxPWJn9ShOFVZtkPMcwQAirq3SovumVM7Y/li0Fw==",
-      "dependencies": {
-        "prop-types": "^15.6.1",
-        "react-fast-compare": "^2.0.4"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.24"
       }
     },
     "node_modules/react-native-webview": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-vision-camera": "^4.7.0",
     "react-native-volume-manager": "^1.10.0",
-    "react-native-walkthrough-tooltip": "^1.6.0",
     "react-native-webview": "^13.15.0",
     "react-native-worklets-core": "1.5.0",
     "realm": "^20.1.0",

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -27,7 +27,7 @@ const AddObsButton = ( ): React.Node => {
   const showKey = "AddObsButtonTooltip";
   const shownOnce = useStore( state => state.layout.shownOnce );
   const setShownOnce = useStore( state => state.layout.setShownOnce );
-  // const justFinishedSignup = useStore( state => state.layout.justFinishedSignup );
+  const justFinishedSignup = useStore( state => state.layout.justFinishedSignup );
   const numOfUserObservations = zustandStorage.getItem( "numOfUserObservations" );
   // Base trigger condition in all cases:
   // Only show the tooltip if the user has only AI camera as an option in this button.
@@ -37,31 +37,27 @@ const AddObsButton = ( ): React.Node => {
   if ( !currentUser ) {
     // If a user is logged out, they should see the tooltip after making their second observation.
     triggerCondition = triggerCondition && numOfUserObservations > 1;
-  } else {
-    // Temporarily disabled the tooltip for new users, as it is freezing the app in some cases.
-    triggerCondition = false;
+  } else if ( justFinishedSignup ) {
+    // If a user creates a new account, they should see the tooltip right after
+    // dismissing the account creation pivot card and landing on My Obs.
+    // Because of the above check for logged out users, we can assume
+    // that the user here has either 0 or 1 observation. Which in turn
+    // currently means that we show the account creation pivot card.
+    triggerCondition = triggerCondition && !!shownOnce["account-creation"];
+  } else if ( numOfUserObservations > 50 ) {
+    // If a user logs in to an existing account with <=50 observations,
+    // they should see the tooltip right after landing on My Obs after signing in
+    //
+    // If a user is already logged in and updates the app when tooltip is released,
+    // they should see the tooltip the first time they open the app after updating
+    //
+    // Both those cases are covered by not changing the base trigger condition.
+    //
+    // If a user logs in to an existing account with >50 observations, they should
+    // see the tooltip right after dismissing the "Welcome back!" pivot card
+    // and landing on My Obs.
+    triggerCondition = triggerCondition && !!shownOnce["fifty-observation"];
   }
-  // else if ( justFinishedSignup ) {
-  //   // If a user creates a new account, they should see the tooltip right after
-  //   // dismissing the account creation pivot card and landing on My Obs.
-  //   // Because of the above check for logged out users, we can assume
-  //   // that the user here has either 0 or 1 observation. Which in turn
-  //   // currently means that we show the account creation pivot card.
-  //   triggerCondition = triggerCondition && !!shownOnce["account-creation"];
-  // } else if ( numOfUserObservations > 50 ) {
-  //   // If a user logs in to an existing account with <=50 observations,
-  //   // they should see the tooltip right after landing on My Obs after signing in
-  //   //
-  //   // If a user is already logged in and updates the app when tooltip is released,
-  //   // they should see the tooltip the first time they open the app after updating
-  //   //
-  //   // Both those cases are covered by not changing the base trigger condition.
-  //   //
-  //   // If a user logs in to an existing account with >50 observations, they should
-  //   // see the tooltip right after dismissing the "Welcome back!" pivot card
-  //   // and landing on My Obs.
-  //   triggerCondition = triggerCondition && !!shownOnce["fifty-observation"];
-  // }
 
   // The tooltip should only appear once per app download.
   const tooltipIsVisible = !shownOnce[showKey] && triggerCondition;

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -116,6 +116,18 @@ const AddObsButton = ( ): React.Node => {
 
   return (
     <>
+      {/* match the animation timing on FadeInView.tsx */}
+      <Modal
+        animationIn="fadeIn"
+        animationOut="fadeOut"
+        animationInTiming={250}
+        animationOutTiming={250}
+        showModal={showModal}
+        closeModal={tooltipIsVisible
+          ? undefined
+          : closeModal}
+        modal={addObsModal}
+      />
       <GradientButton
         sizeClassName="w-[69px] h-[69px] mb-[5px]"
         onLongPress={() => {
@@ -136,18 +148,6 @@ const AddObsButton = ( ): React.Node => {
         }
         iconName={isAllAddObsOptionsMode && "plus"}
         iconSize={isAllAddObsOptionsMode && 31}
-      />
-      {/* match the animation timing on FadeInView.tsx */}
-      <Modal
-        animationIn="fadeIn"
-        animationOut="fadeOut"
-        animationInTiming={250}
-        animationOutTiming={250}
-        showModal={showModal}
-        closeModal={tooltipIsVisible
-          ? undefined
-          : closeModal}
-        modal={addObsModal}
       />
     </>
   );

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -2,12 +2,11 @@
 
 import { CommonActions, useNavigation } from "@react-navigation/native";
 import AddObsModal from "components/AddObsModal/AddObsModal.tsx";
-import { Body2, Modal } from "components/SharedComponents";
+import { Modal } from "components/SharedComponents";
 import GradientButton from "components/SharedComponents/Buttons/GradientButton.tsx";
 import { t } from "i18next";
 import { getCurrentRoute } from "navigation/navigationUtils.ts";
 import * as React from "react";
-import Tooltip from "react-native-walkthrough-tooltip";
 import { log } from "sharedHelpers/logger";
 import { useCurrentUser, useLayoutPrefs } from "sharedHooks";
 import useStore, { zustandStorage } from "stores/useStore";
@@ -67,13 +66,6 @@ const AddObsButton = ( ): React.Node => {
   // The tooltip should only appear once per app download.
   const tooltipIsVisible = !shownOnce[showKey] && triggerCondition;
 
-  const contentStyle = {
-    height: 50,
-    paddingVertical: 16,
-    paddingHorizontal: 20,
-    borderRadius: 16
-  };
-
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const navigation = useNavigation( );
   React.useEffect( ( ) => {
@@ -114,10 +106,43 @@ const AddObsButton = ( ): React.Node => {
   };
   const navToARCamera = ( ) => { navAndCloseModal( "Camera", { camera: "AI" } ); };
 
-  const addObsModal = <AddObsModal closeModal={closeModal} navAndCloseModal={navAndCloseModal} />;
+  const addObsModal = (
+    <AddObsModal
+      closeModal={closeModal}
+      navAndCloseModal={navAndCloseModal}
+      tooltipIsVisible
+      dismissTooltip={( ) => {
+        if ( tooltipIsVisible ) setShownOnce( showKey );
+      }}
+    />
+  );
 
   return (
     <>
+      <GradientButton
+        sizeClassName="w-[69px] h-[69px] mb-[5px]"
+        onLongPress={() => {
+          if ( !isAllAddObsOptionsMode ) openModal();
+        }}
+        onPress={() => {
+          if ( tooltipIsVisible ) {
+            return;
+          }
+          if ( isAllAddObsOptionsMode ) {
+            openModal();
+          } else {
+            navToARCamera();
+          }
+        }}
+        accessibilityLabel={t( "Add-observations" )}
+        accessibilityHint={
+          isAllAddObsOptionsMode
+            ? t( "Shows-observation-creation-options" )
+            : t( "Opens-AI-camera" )
+        }
+        iconName={isAllAddObsOptionsMode && "plus"}
+        iconSize={isAllAddObsOptionsMode && 31}
+      />
       {/* match the animation timing on FadeInView.tsx */}
       <Modal
         animationIn="fadeIn"
@@ -128,43 +153,6 @@ const AddObsButton = ( ): React.Node => {
         closeModal={closeModal}
         modal={addObsModal}
       />
-      <Tooltip
-        isVisible={tooltipIsVisible}
-        content={(
-          <Body2>
-            {t( "Press-and-hold-to-view-more-options" )}
-          </Body2>
-        )}
-        contentStyle={contentStyle}
-        placement="top"
-        arrowSize={{ width: 21, height: 16 }}
-        backgroundColor="rgba(0,0,0,0.7)"
-        disableShadow
-      >
-        <GradientButton
-          sizeClassName="w-[69px] h-[69px] mb-[5px]"
-          onLongPress={() => {
-            if ( tooltipIsVisible ) setShownOnce( showKey );
-            if ( !isAllAddObsOptionsMode ) openModal();
-          }}
-          onPress={() => {
-            if ( tooltipIsVisible ) {
-              return;
-            }
-            if ( isAllAddObsOptionsMode ) {
-              openModal( );
-            } else {
-              navToARCamera( );
-            }
-          }}
-          accessibilityLabel={t( "Add-observations" )}
-          accessibilityHint={isAllAddObsOptionsMode
-            ? t( "Shows-observation-creation-options" )
-            : t( "Opens-AI-camera" )}
-          iconName={isAllAddObsOptionsMode && "plus"}
-          iconSize={isAllAddObsOptionsMode && 31}
-        />
-      </Tooltip>
     </>
   );
 };

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -33,17 +33,18 @@ const AddObsButton = ( ): React.Node => {
   // Only show the tooltip if the user has only AI camera as an option in this button.
   // Only show the tooltip on MyObservations screen.
   let triggerCondition = !isAllAddObsOptionsMode && currentRoute?.name === "ObsList";
-  // If logged out, user should see the tooltip after making their second observation
-  if ( !currentUser ) {
-    // If a user is logged out, they should see the tooltip after making their second observation.
-    triggerCondition = triggerCondition && numOfUserObservations > 1;
-  } else if ( justFinishedSignup ) {
+  if ( justFinishedSignup ) {
     // If a user creates a new account, they should see the tooltip right after
     // dismissing the account creation pivot card and landing on My Obs.
-    // Because of the above check for logged out users, we can assume
-    // that the user here has either 0 or 1 observation. Which in turn
-    // currently means that we show the account creation pivot card.
-    triggerCondition = triggerCondition && !!shownOnce["account-creation"];
+    // TODO: Have disabled the tooltip for new account creations because of a bug with the
+    // account creation pivot card not showing. Which makes this trigger condition
+    // not work as expected.
+    // triggerCondition = triggerCondition && !!shownOnce["account-creation"];
+    triggerCondition = false;
+  } else if ( !currentUser ) {
+    // If logged out, user should see the tooltip after making their second observation
+    // If a user is logged out, they should see the tooltip after making their second observation.
+    triggerCondition = triggerCondition && numOfUserObservations > 1;
   } else if ( numOfUserObservations > 50 ) {
     // If a user logs in to an existing account with <=50 observations,
     // they should see the tooltip right after landing on My Obs after signing in

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -122,9 +122,6 @@ const AddObsButton = ( ): React.Node => {
           if ( !isAllAddObsOptionsMode ) openModal();
         }}
         onPress={() => {
-          if ( tooltipIsVisible ) {
-            return;
-          }
           if ( isAllAddObsOptionsMode ) {
             openModal();
           } else {

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -110,7 +110,7 @@ const AddObsButton = ( ): React.Node => {
     <AddObsModal
       closeModal={closeModal}
       navAndCloseModal={navAndCloseModal}
-      tooltipIsVisible
+      tooltipIsVisible={tooltipIsVisible}
       dismissTooltip={( ) => {
         if ( tooltipIsVisible ) setShownOnce( showKey );
       }}

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -69,6 +69,22 @@ const AddObsButton = ( ): React.Node => {
 
   // The tooltip should only appear once per app download.
   const tooltipIsVisible = !shownOnce[showKey] && triggerCondition;
+  React.useEffect( () => {
+    // If the tooltip visibility condition changes from false to true,
+    // we set the showModal state to true because the tooltip is in the modal.
+    // We have a lot of modals in the app, so we use a timeout to avoid opening two modals
+    // at the same time, like the PivotCards for example that in some cases were just closed
+    // by the user.
+    let timeoutId;
+    if ( tooltipIsVisible ) {
+      timeoutId = setTimeout( () => {
+        openModal();
+      }, 400 );
+    }
+    return () => {
+      clearTimeout( timeoutId );
+    };
+  }, [tooltipIsVisible, openModal] );
 
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const navigation = useNavigation( );

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -41,6 +41,13 @@ const AddObsButton = ( ): React.Node => {
     // not work as expected.
     // triggerCondition = triggerCondition && !!shownOnce["account-creation"];
     triggerCondition = false;
+  } else if ( numOfUserObservations === undefined
+      || numOfUserObservations === null
+      || typeof numOfUserObservations !== "number" ) {
+    // If numOfUserObservations is undefined or null, we can not know if we should show the
+    // tooltip to the user. Usually this happens when the user logs in before making an
+    // observation, then we need to fetch the number of observations from server.
+    triggerCondition = false;
   } else if ( !currentUser ) {
     // If logged out, user should see the tooltip after making their second observation
     // If a user is logged out, they should see the tooltip after making their second observation.

--- a/src/components/AddObsModal/AddObsButton.js
+++ b/src/components/AddObsModal/AddObsButton.js
@@ -150,7 +150,9 @@ const AddObsButton = ( ): React.Node => {
         animationInTiming={250}
         animationOutTiming={250}
         showModal={showModal}
-        closeModal={closeModal}
+        closeModal={tooltipIsVisible
+          ? undefined
+          : closeModal}
         modal={addObsModal}
       />
     </>

--- a/src/components/AddObsModal/AddObsModal.tsx
+++ b/src/components/AddObsModal/AddObsModal.tsx
@@ -141,9 +141,16 @@ const AddObsModal = ( {
     if ( tooltipIsVisible ) {
       return (
         <View className="justify-center items-center">
-          <View className="bg-white rounded-2xl px-5 py-4 mb-5">
+          <View className="bg-white rounded-2xl px-5 py-4">
             <Body2>{t( "Press-and-hold-to-view-more-options" )}</Body2>
           </View>
+          <View
+            className={classnames(
+              // I could not figure out how to use "border-x-transparent",
+              "border-l-[10px] border-r-[10px] border-x-[#00000000]",
+              "border-t-[16px] border-t-white mb-2"
+            )}
+          />
           <GradientButton
             sizeClassName="w-[69px] h-[69px]"
             onPress={() => {}}

--- a/src/components/AddObsModal/AddObsModal.tsx
+++ b/src/components/AddObsModal/AddObsModal.tsx
@@ -147,9 +147,7 @@ const AddObsModal = ( {
           <GradientButton
             sizeClassName="w-[69px] h-[69px]"
             onPress={() => {}}
-            onLongPress={() => {
-              if ( tooltipIsVisible ) dismissTooltip( );
-            }}
+            onLongPress={() => dismissTooltip( )}
             accessibilityLabel={t( "Add-observations" )}
             accessibilityHint={t( "Shows-observation-creation-options" )}
           />

--- a/src/components/AddObsModal/AddObsModal.tsx
+++ b/src/components/AddObsModal/AddObsModal.tsx
@@ -1,7 +1,9 @@
 import classnames from "classnames";
 import {
+  Body2,
   INatIconButton
 } from "components/SharedComponents";
+import GradientButton from "components/SharedComponents/Buttons/GradientButton.tsx";
 import { View } from "components/styledComponents";
 import React, { useMemo } from "react";
 import { Platform, StatusBar } from "react-native";
@@ -17,6 +19,8 @@ interface Props {
   navAndCloseModal: ( screen: string, params?: {
     camera?: string
   } ) => void;
+  tooltipIsVisible: boolean;
+  dismissTooltip: () => void;
 }
 
 const majorVersionIOS = parseInt( String( Platform.Version ), 10 );
@@ -39,7 +43,9 @@ const MARGINS = AI_CAMERA_SUPPORTED
     soundRecorder: "ml-[20px] bottom-[33px]"
   };
 
-const AddObsModal = ( { closeModal, navAndCloseModal }: Props ) => {
+const AddObsModal = ( {
+  closeModal, navAndCloseModal, tooltipIsVisible, dismissTooltip
+}: Props ) => {
   const { t } = useTranslation( );
 
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
@@ -131,23 +137,49 @@ const AddObsModal = ( { closeModal, navAndCloseModal }: Props ) => {
     />
   );
 
+  const renderContent = ( ) => {
+    if ( tooltipIsVisible ) {
+      return (
+        <View className="justify-center items-center">
+          <View className="bg-white rounded-2xl px-5 py-4 mb-5">
+            <Body2>{t( "Press-and-hold-to-view-more-options" )}</Body2>
+          </View>
+          <GradientButton
+            sizeClassName="w-[69px] h-[69px]"
+            onPress={() => {}}
+            onLongPress={() => {
+              if ( tooltipIsVisible ) dismissTooltip( );
+            }}
+            accessibilityLabel={t( "Add-observations" )}
+            accessibilityHint={t( "Shows-observation-creation-options" )}
+          />
+        </View>
+      );
+    }
+    return (
+      <>
+        <AddObsModalHelp obsCreateItems={obsCreateItems} />
+        <View className={classnames( ROW_CLASS, {
+          "bottom-[20px]": !AI_CAMERA_SUPPORTED
+        } )}
+        >
+          {renderAddObsIcon( obsCreateItems.standardCamera )}
+          {AI_CAMERA_SUPPORTED && renderAddObsIcon( obsCreateItems.aiCamera )}
+          {renderAddObsIcon( obsCreateItems.photoLibrary )}
+        </View>
+        <View className={classnames( ROW_CLASS, "items-center" )}>
+          {renderAddObsIcon( obsCreateItems.noEvidence )}
+          {renderAddObsIcon( obsCreateItems.closeButton )}
+          {renderAddObsIcon( obsCreateItems.soundRecorder )}
+        </View>
+      </>
+    );
+  };
+
   return (
     <>
       <StatusBar barStyle="light-content" backgroundColor="black" />
-      <AddObsModalHelp obsCreateItems={obsCreateItems} />
-      <View className={classnames( ROW_CLASS, {
-        "bottom-[20px]": !AI_CAMERA_SUPPORTED
-      } )}
-      >
-        {renderAddObsIcon( obsCreateItems.standardCamera )}
-        {AI_CAMERA_SUPPORTED && renderAddObsIcon( obsCreateItems.aiCamera )}
-        {renderAddObsIcon( obsCreateItems.photoLibrary )}
-      </View>
-      <View className={classnames( ROW_CLASS, "items-center" )}>
-        {renderAddObsIcon( obsCreateItems.noEvidence )}
-        {renderAddObsIcon( obsCreateItems.closeButton )}
-        {renderAddObsIcon( obsCreateItems.soundRecorder )}
-      </View>
+      { renderContent( ) }
     </>
   );
 };

--- a/tests/unit/components/AddObsModal/__snapshots__/AddObsButton.test.js.snap
+++ b/tests/unit/components/AddObsModal/__snapshots__/AddObsButton.test.js.snap
@@ -19,147 +19,143 @@ exports[`AddObsButton renders correctly 1`] = `
     }
   >
     <View
-      onLayout={[Function]}
-    >
-      <View
-        accessibilityHint="Opens AI camera."
-        accessibilityLabel="Add observations"
-        accessibilityRole="button"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": false,
-            "expanded": undefined,
-            "selected": undefined,
-          }
+      accessibilityHint="Opens AI camera."
+      accessibilityLabel="Add observations"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
         }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
           [
-            [
-              {
-                "width": 69,
+            {
+              "width": 69,
+            },
+            {
+              "height": 69,
+            },
+            {
+              "marginBottom": 5,
+            },
+            {
+              "borderBottomLeftRadius": 9999,
+              "borderBottomRightRadius": 9999,
+              "borderTopLeftRadius": 9999,
+              "borderTopRightRadius": 9999,
+            },
+            {
+              "overflow": "hidden",
+            },
+            {
+              "elevation": 5,
+              "shadowColor": "rgba( 0, 0, 0, 0.25 )",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
               },
-              {
-                "height": 69,
-              },
-              {
-                "marginBottom": 5,
-              },
-              {
-                "borderBottomLeftRadius": 9999,
-                "borderBottomRightRadius": 9999,
-                "borderTopLeftRadius": 9999,
-                "borderTopRightRadius": 9999,
-              },
-              {
-                "overflow": "hidden",
-              },
-              {
-                "elevation": 5,
-                "shadowColor": "rgba( 0, 0, 0, 0.25 )",
-                "shadowOffset": {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 0.25,
-                "shadowRadius": 2,
-              },
-            ],
+              "shadowOpacity": 0.25,
+              "shadowRadius": 2,
+            },
+          ],
+        ]
+      }
+      testID="add-obs-button"
+    >
+      <BVLinearGradient
+        angle={156.95}
+        colors={
+          [
+            4285836288,
+            4280909703,
           ]
         }
-        testID="add-obs-button"
+        endPoint={
+          {
+            "x": 0.5,
+            "y": 1,
+          }
+        }
+        locations={null}
+        startPoint={
+          {
+            "x": 0.5,
+            "y": 0,
+          }
+        }
+        useAngle={true}
       >
-        <BVLinearGradient
-          angle={156.95}
-          colors={
+        <View
+          style={
             [
-              4285836288,
-              4280909703,
+              [
+                {
+                  "flexGrow": 1,
+                },
+                {
+                  "aspectRatio": 1,
+                },
+                {
+                  "display": "flex",
+                },
+                {
+                  "alignItems": "center",
+                },
+                {
+                  "justifyContent": "center",
+                },
+              ],
             ]
           }
-          endPoint={
-            {
-              "x": 0.5,
-              "y": 1,
-            }
-          }
-          locations={null}
-          startPoint={
-            {
-              "x": 0.5,
-              "y": 0,
-            }
-          }
-          useAngle={true}
         >
-          <View
+          <Text
+            allowFontScaling={false}
+            selectable={false}
             style={
               [
-                [
-                  {
-                    "flexGrow": 1,
-                  },
-                  {
-                    "aspectRatio": 1,
-                  },
-                  {
-                    "display": "flex",
-                  },
-                  {
-                    "alignItems": "center",
-                  },
-                  {
-                    "justifyContent": "center",
-                  },
-                ],
+                {
+                  "color": "#ffffff",
+                  "fontSize": 47,
+                },
+                null,
+                {
+                  "fontFamily": "INatIcon",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
               ]
             }
           >
-            <Text
-              allowFontScaling={false}
-              selectable={false}
-              style={
-                [
-                  {
-                    "color": "#ffffff",
-                    "fontSize": 47,
-                  },
-                  null,
-                  {
-                    "fontFamily": "INatIcon",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  {},
-                ]
-              }
-            >
-              
-            </Text>
-          </View>
-        </BVLinearGradient>
-      </View>
+            
+          </Text>
+        </View>
+      </BVLinearGradient>
     </View>
   </View>
 </View>

--- a/tests/unit/components/BottomTabNavigator/__snapshots__/CustomTabBar.test.js.snap
+++ b/tests/unit/components/BottomTabNavigator/__snapshots__/CustomTabBar.test.js.snap
@@ -370,147 +370,143 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <View
-              accessibilityHint="Shows observation creation options"
-              accessibilityLabel="Add observations"
-              accessibilityRole="button"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": false,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
+            accessibilityHint="Shows observation creation options"
+            accessibilityLabel="Add observations"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
               }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
               }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
                 [
-                  [
-                    {
-                      "width": 69,
+                  {
+                    "width": 69,
+                  },
+                  {
+                    "height": 69,
+                  },
+                  {
+                    "marginBottom": 5,
+                  },
+                  {
+                    "borderBottomLeftRadius": 9999,
+                    "borderBottomRightRadius": 9999,
+                    "borderTopLeftRadius": 9999,
+                    "borderTopRightRadius": 9999,
+                  },
+                  {
+                    "overflow": "hidden",
+                  },
+                  {
+                    "elevation": 5,
+                    "shadowColor": "rgba( 0, 0, 0, 0.25 )",
+                    "shadowOffset": {
+                      "height": 2,
+                      "width": 0,
                     },
-                    {
-                      "height": 69,
-                    },
-                    {
-                      "marginBottom": 5,
-                    },
-                    {
-                      "borderBottomLeftRadius": 9999,
-                      "borderBottomRightRadius": 9999,
-                      "borderTopLeftRadius": 9999,
-                      "borderTopRightRadius": 9999,
-                    },
-                    {
-                      "overflow": "hidden",
-                    },
-                    {
-                      "elevation": 5,
-                      "shadowColor": "rgba( 0, 0, 0, 0.25 )",
-                      "shadowOffset": {
-                        "height": 2,
-                        "width": 0,
-                      },
-                      "shadowOpacity": 0.25,
-                      "shadowRadius": 2,
-                    },
-                  ],
+                    "shadowOpacity": 0.25,
+                    "shadowRadius": 2,
+                  },
+                ],
+              ]
+            }
+            testID="add-obs-button"
+          >
+            <BVLinearGradient
+              angle={156.95}
+              colors={
+                [
+                  4285836288,
+                  4280909703,
                 ]
               }
-              testID="add-obs-button"
+              endPoint={
+                {
+                  "x": 0.5,
+                  "y": 1,
+                }
+              }
+              locations={null}
+              startPoint={
+                {
+                  "x": 0.5,
+                  "y": 0,
+                }
+              }
+              useAngle={true}
             >
-              <BVLinearGradient
-                angle={156.95}
-                colors={
+              <View
+                style={
                   [
-                    4285836288,
-                    4280909703,
+                    [
+                      {
+                        "flexGrow": 1,
+                      },
+                      {
+                        "aspectRatio": 1,
+                      },
+                      {
+                        "display": "flex",
+                      },
+                      {
+                        "alignItems": "center",
+                      },
+                      {
+                        "justifyContent": "center",
+                      },
+                    ],
                   ]
                 }
-                endPoint={
-                  {
-                    "x": 0.5,
-                    "y": 1,
-                  }
-                }
-                locations={null}
-                startPoint={
-                  {
-                    "x": 0.5,
-                    "y": 0,
-                  }
-                }
-                useAngle={true}
               >
-                <View
+                <Text
+                  allowFontScaling={false}
+                  selectable={false}
                   style={
                     [
-                      [
-                        {
-                          "flexGrow": 1,
-                        },
-                        {
-                          "aspectRatio": 1,
-                        },
-                        {
-                          "display": "flex",
-                        },
-                        {
-                          "alignItems": "center",
-                        },
-                        {
-                          "justifyContent": "center",
-                        },
-                      ],
+                      {
+                        "color": "#ffffff",
+                        "fontSize": 31,
+                      },
+                      null,
+                      {
+                        "fontFamily": "INatIcon",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      {},
                     ]
                   }
                 >
-                  <Text
-                    allowFontScaling={false}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "color": "#ffffff",
-                          "fontSize": 31,
-                        },
-                        null,
-                        {
-                          "fontFamily": "INatIcon",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        {},
-                      ]
-                    }
-                  >
-                    
-                  </Text>
-                </View>
-              </BVLinearGradient>
-            </View>
+                  
+                </Text>
+              </View>
+            </BVLinearGradient>
           </View>
         </View>
       </View>


### PR DESCRIPTION
Almost closes MOB-785 (see below).

Basically, I think one of the reasons this tooltip was buggy before was that we have a lot of modals opening and closing at the same time. In the case of a user logging in with >50 obs, they would see AccountCreation onboarding modal, tooltip modal, AddObs modal, all in tight sequence.
So, since the only option to leave the tooltip should be to make a long press on the GradientButton that then directly opens the ObsWheel modal, I decided to move the tooltip into the ObsWheel modal itself, and a long-press just switches to the other content. This way we can remove the need for one npm package, and get rid of one modal to modal transition.
Overall, this fixes all bugs I have previously encountered with the tooltip.

One side note though: While I was testing the condition of a user hat just signs up I encountered a bug that the Account creation pivot card is not showing when the user signs up before making one observation. This messes with the trigger condition for the tooltip which should show directly after closing the account creation pivot card. So, I have for now not implemented the tooltip for user that just signed up.