### PR TITLE
Consistent location permission asks

### DIFF
--- a/src/components/Match/EmptyMapSection.js
+++ b/src/components/Match/EmptyMapSection.js
@@ -8,10 +8,12 @@ import { View } from "react-native";
 import { useTranslation } from "sharedHooks";
 
 type Props = {
+  isFetchingLocation: boolean,
   handleAddLocationPressed: ( ) => void
 }
 
 const EmptyMapSection = ( {
+  isFetchingLocation,
   handleAddLocationPressed
 }: Props ) => {
   const { t } = useTranslation( );
@@ -37,6 +39,8 @@ const EmptyMapSection = ( {
           level="neutral"
           text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
           onPress={handleAddLocationPressed}
+          loading={isFetchingLocation}
+          disabled={isFetchingLocation}
           accessibilityLabel={t( "Edit-location" )}
           accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
         />

--- a/src/components/Match/Match.js
+++ b/src/components/Match/Match.js
@@ -29,6 +29,7 @@ type Props = {
   obsPhotos: Array<Object>,
   handleSaveOrDiscardPress: ( ) => void,
   navToTaxonDetails: ( ) => void,
+  isFetchingLocation: boolean,
   handleAddLocationPressed: ( ) => void,
   topSuggestion: Object,
   otherSuggestions: Array<Object>,
@@ -44,6 +45,7 @@ const Match = ( {
   obsPhotos,
   handleSaveOrDiscardPress,
   navToTaxonDetails,
+  isFetchingLocation,
   handleAddLocationPressed,
   topSuggestion,
   otherSuggestions,
@@ -104,6 +106,8 @@ const Match = ( {
                   className="mx-4 mb-[30px]"
                   level="neutral"
                   text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
+                  loading={isFetchingLocation}
+                  disabled={isFetchingLocation}
                   onPress={handleAddLocationPressed}
                   accessibilityLabel={t( "Edit-location" )}
                   accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
@@ -156,6 +160,8 @@ const Match = ( {
               level="neutral"
               text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
               onPress={handleAddLocationPressed}
+              loading={isFetchingLocation}
+              disabled={isFetchingLocation}
               accessibilityLabel={t( "Edit-location" )}
               accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
             />
@@ -188,7 +194,12 @@ const Match = ( {
         />
         <View className="border-[1.5px] border-white" />
         {!latitude
-          ? <EmptyMapSection handleAddLocationPressed={handleAddLocationPressed} />
+          ? (
+            <EmptyMapSection
+              handleAddLocationPressed={handleAddLocationPressed}
+              isFetchingLocation={isFetchingLocation}
+            />
+          )
           : (
             <MapSection observation={observation} taxon={taxon} />
           )}
@@ -223,6 +234,8 @@ const Match = ( {
             level="neutral"
             text={t( "ADD-LOCATION-FOR-BETTER-IDS" )}
             onPress={handleAddLocationPressed}
+            loading={isFetchingLocation}
+            disabled={isFetchingLocation}
             accessibilityLabel={t( "Edit-location" )}
             accessibilityHint={t( "Add-location-to-refresh-suggestions" )}
           />

--- a/src/components/Match/MatchContainer.js
+++ b/src/components/Match/MatchContainer.js
@@ -97,7 +97,9 @@ const MatchContainer = ( ) => {
   const updateObservationKeys = useStore( state => state.updateObservationKeys );
   const navigation = useNavigation( );
   const {
-    hasPermissions, renderPermissionsGate, requestPermissions
+    hasPermissions,
+    renderPermissionsGate,
+    requestPermissions
   } = useLocationPermission( );
 
   const obsPhotos = currentObservation?.observationPhotos;
@@ -217,16 +219,16 @@ const MatchContainer = ( ) => {
     }
   }, [] );
 
-  const shouldFetchUserLocation = hasPermissions
-    && shouldFetchObservationLocation( currentObservation );
+  const [needLocation, setNeedLocation] = useState(
+    shouldFetchObservationLocation( currentObservation )
+  );
+  const shouldFetchLocation = hasPermissions && needLocation;
 
   const {
     stopWatch,
     subscriptionId,
     userLocation
-  } = useWatchPosition( {
-    shouldFetchLocation: shouldFetchUserLocation
-  } );
+  } = useWatchPosition( { shouldFetchLocation } );
 
   const getCurrentUserPlaceName = useCallback( async () => {
     if ( currentUserLocation?.latitude ) {
@@ -462,7 +464,15 @@ const MatchContainer = ( ) => {
           iconicTaxon={iconicTaxon}
           setIconicTaxon={setIconicTaxon}
         />
-        {renderPermissionsGate( { onPermissionGranted: getCurrentUserPlaceName } )}
+        {renderPermissionsGate( {
+          // If the user grants location permission while on this screen,
+          // we want to start watching the location no matter how the observation
+          // was created (camera, sound recorder, etc.)
+          onPermissionGranted: () => {
+            setNeedLocation( true );
+            getCurrentUserPlaceName( );
+          }
+        } )}
         {/* eslint-disable i18next/no-literal-string */}
         {/* eslint-disable react/jsx-one-expression-per-line */}
         {/* eslint-disable max-len */}

--- a/src/components/Match/MatchContainer.js
+++ b/src/components/Match/MatchContainer.js
@@ -217,8 +217,8 @@ const MatchContainer = ( ) => {
     }
   }, [] );
 
-  const shouldFetchUserLocation
-  = shouldFetchObservationLocation( currentObservation ) && hasPermissions;
+  const shouldFetchUserLocation = hasPermissions
+    && shouldFetchObservationLocation( currentObservation );
 
   const {
     stopWatch,

--- a/src/components/Match/MatchContainer.js
+++ b/src/components/Match/MatchContainer.js
@@ -225,6 +225,7 @@ const MatchContainer = ( ) => {
   const shouldFetchLocation = hasPermissions && needLocation;
 
   const {
+    isFetchingLocation,
     stopWatch,
     subscriptionId,
     userLocation
@@ -467,6 +468,7 @@ const MatchContainer = ( ) => {
           onSuggestionChosen={onSuggestionChosen}
           handleSaveOrDiscardPress={handleSaveOrDiscardPress}
           navToTaxonDetails={navToTaxonDetails}
+          isFetchingLocation={isFetchingLocation}
           handleAddLocationPressed={handleAddLocationPressed}
           topSuggestion={topSuggestionWithLocalTaxon}
           otherSuggestions={suggestionsWithLocalTaxonPhotos}

--- a/src/components/Match/MatchContainer.js
+++ b/src/components/Match/MatchContainer.js
@@ -230,6 +230,23 @@ const MatchContainer = ( ) => {
     userLocation
   } = useWatchPosition( { shouldFetchLocation } );
 
+  const navToLocationPicker = useCallback( ( ) => {
+    stopWatch( subscriptionId );
+    navigation.navigate( "LocationPicker" );
+  }, [stopWatch, subscriptionId, navigation] );
+
+  const latitude = currentObservation?.latitude;
+  const longitude = currentObservation?.longitude;
+  const hasLocation = !!( latitude && longitude );
+
+  const handleAddLocationPressed = ( ) => {
+    if ( !hasLocation && !hasPermissions ) {
+      requestPermissions();
+    } else {
+      navToLocationPicker();
+    }
+  };
+
   const getCurrentUserPlaceName = useCallback( async () => {
     if ( currentUserLocation?.latitude ) {
       const placeGuess
@@ -304,12 +321,6 @@ const MatchContainer = ( ) => {
     if ( !currentPlaceGuess ) return;
     updateObservationKeys( { place_guess: currentPlaceGuess } );
   }, [currentPlaceGuess, updateObservationKeys] );
-
-  const handleAddLocationPressed = ( ) => {
-    if ( !hasPermissions ) {
-      requestPermissions( );
-    }
-  };
 
   const onSuggestionChosen = useCallback( selection => {
     const suggestionsList = [...orderedSuggestions];
@@ -471,6 +482,11 @@ const MatchContainer = ( ) => {
           onPermissionGranted: () => {
             setNeedLocation( true );
             getCurrentUserPlaceName( );
+          },
+          // If the user does not give location permissions in any form,
+          // navigate to the location picker (if granted we just continue fetching the location)
+          onModalHide: ( ) => {
+            if ( !hasPermissions ) navToLocationPicker( );
           }
         } )}
         {/* eslint-disable i18next/no-literal-string */}

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -179,8 +179,6 @@ const ObsEdit = ( ): Node => {
       {renderLocationPermissionGate( {
         // If the user does not give location permissions in any form,
         // navigate to the location picker (if granted we just continue fetching the location)
-        onRequestDenied: navToLocationPicker,
-        onRequestBlocked: navToLocationPicker,
         onModalHide: ( ) => {
           if ( !hasLocationPermission ) navToLocationPicker();
         }

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -7,12 +7,7 @@ import type { Node } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 import { Animated } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
-import shouldFetchObservationLocation, {
-  isFromCamera,
-  isFromNoEvidence,
-  isFromSoundRecorder,
-  isNew
-} from "sharedHelpers/shouldFetchObservationLocation.ts";
+import shouldFetchObservationLocation from "sharedHelpers/shouldFetchObservationLocation.ts";
 import { useCurrentUser, useLocationPermission, useWatchPosition } from "sharedHooks";
 import useStore from "stores/useStore";
 import { getShadow } from "styles/global";
@@ -44,7 +39,6 @@ const ObsEdit = ( ): Node => {
   const currentUser = useCurrentUser( );
   const {
     hasPermissions: hasLocationPermission,
-    hasBlockedPermissions: hasBlockedLocationPermission,
     renderPermissionsGate: renderLocationPermissionGate,
     requestPermissions: requestLocationPermission
   } = useLocationPermission( );
@@ -90,17 +84,11 @@ const ObsEdit = ( ): Node => {
     navigation.navigate( "LocationPicker" );
   }, [stopWatch, subscriptionId, navigation] );
 
+  const latitude = currentObservation?.latitude;
+  const longitude = currentObservation?.longitude;
+  const hasLocation = !!( latitude && longitude );
   const onLocationPress = ( ) => {
-    if (
-      !hasLocationPermission
-      && !hasBlockedLocationPermission
-      && isNew( currentObservation )
-      && (
-        isFromCamera( currentObservation )
-        || isFromSoundRecorder( currentObservation )
-        || isFromNoEvidence( currentObservation )
-      )
-    ) {
+    if ( !hasLocation && !hasLocationPermission ) {
       requestLocationPermission( );
     } else {
       navToLocationPicker( );

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -35,6 +35,9 @@ const ObsEdit = ( ): Node => {
   const savedOrUploadedMultiObsFlow = useStore( state => state.savedOrUploadedMultiObsFlow );
   const [passesEvidenceTest, setPassesEvidenceTest] = useState( false );
   const [resetScreen, setResetScreen] = useState( false );
+  const [needLocation, setNeedLocation] = useState(
+    shouldFetchObservationLocation( currentObservation )
+  );
   const isFocused = useIsFocused( );
   const currentUser = useCurrentUser( );
   const {
@@ -59,8 +62,7 @@ const ObsEdit = ( ): Node => {
     ...DROP_SHADOW
   };
 
-  const shouldFetchLocation = hasLocationPermission
-    && shouldFetchObservationLocation( currentObservation );
+  const shouldFetchLocation = hasLocationPermission && needLocation;
 
   const {
     isFetchingLocation,
@@ -165,6 +167,10 @@ const ObsEdit = ( ): Node => {
         />
       )}
       {renderLocationPermissionGate( {
+        // If the user grants location permission while on this screen,
+        // we want to start watching the location no matter how the observation
+        // was created (camera, sound recorder, etc.)
+        onPermissionGranted: ( ) => setNeedLocation( true ),
         // If the user does not give location permissions in any form,
         // navigate to the location picker (if granted we just continue fetching the location)
         onModalHide: ( ) => {

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -241,12 +241,14 @@ const Map = forwardRef( ( {
   };
 
   const handleCurrentLocationPress = useCallback( ( ) => {
+    if ( !hasPermissions ) {
+      requestPermissions( );
+    }
     // If we aren't showing the user's location, we won't have a location to
     // zoom to yet, so first we need to turn that on, and we'll re-call this
     // function in an effect when we have a location
     if ( !showsUserLocation ) {
       setShowsUserLocation( true );
-      requestPermissions( );
       return;
     }
     // If we're supposed to be showing user location but we don't have it, ask
@@ -255,7 +257,6 @@ const Map = forwardRef( ( {
     // skipping onCurrentLocationPress here because the handlers
     // are handling the permissions request outside of this component (example: Explore MapView)
     if ( !userLocation && onCurrentLocationPress === undefined ) {
-      requestPermissions( );
       return;
     }
     if ( onCurrentLocationPress ) {
@@ -287,6 +288,7 @@ const Map = forwardRef( ( {
     }
   }, [
     onCurrentLocationPress,
+    hasPermissions,
     requestPermissions,
     screenHeight,
     screenWidth,

--- a/src/sharedHelpers/shouldFetchObservationLocation.ts
+++ b/src/sharedHelpers/shouldFetchObservationLocation.ts
@@ -13,7 +13,7 @@ function originalPhotoUri( observation: RealmObservation ) {
   return observation?.observationPhotos?.[0]?.originalPhotoUri || "";
 }
 
-export function isNew( observation: RealmObservation ) {
+function isNew( observation: RealmObservation ) {
   return (
     observation
     && !observation._created_at
@@ -21,29 +21,18 @@ export function isNew( observation: RealmObservation ) {
   );
 }
 
-export function isFromGallery( observation: RealmObservation ) {
+function isFromGallery( observation: RealmObservation ) {
   return originalPhotoUri( observation ).includes( photoLibraryPhotosPath );
 }
 
-export function isFromSharing( observation: RealmObservation ) {
+function isFromSharing( observation: RealmObservation ) {
   // Shared photo paths will look something like Shared/AppGroup/sdgsdgsdgk
   const uri = originalPhotoUri( observation );
   return uri && !uri.includes( DocumentDirectoryPath );
 }
 
-export function isFromCamera( observation: RealmObservation ) {
+function isFromCamera( observation: RealmObservation ) {
   return originalPhotoUri( observation ).includes( rotatedOriginalPhotosPath );
-}
-
-export function isFromSoundRecorder( observation: RealmObservation ) {
-  return observation?.observationSounds?.length > 0;
-}
-
-export function isFromNoEvidence( observation: RealmObservation ) {
-  return !(
-    observation?.observationSounds?.length > 0
-    || observation?.observationPhotos?.length > 0
-  );
 }
 
 function shouldFetchObservationLocation( observation: RealmObservation ) {


### PR DESCRIPTION
The main idea behind this PR is to make our location permission asks consistent.
According to the overarching issue (MOB-875), the main tasks that are done here are:
On ObsEdit, for the "Add Location" CTA the first press without permission should always open the permission request flow. 
In any map, a press on the "My Location" button without permission should always ask for permission and then i granted zoom to the current location.

While working on these changes it became apparent that several other issues are closely related and can be addressed here as well. So, this PR also closes these issues: MOB-676, MOB-423, MOB-867, MOB-714