### PR TITLE
Update react-native-maps to 1.20.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1326,7 +1326,7 @@ PODS:
     - React-Core
   - react-native-mail (6.1.1):
     - React-Core
-  - react-native-maps (1.13.0):
+  - react-native-maps (1.20.1):
     - React-Core
   - react-native-mmkv (2.12.2):
     - DoubleConversion
@@ -2378,7 +2378,7 @@ SPEC CHECKSUMS:
   react-native-image-resizer: 24c5d06fae2176dc0caed4b6396e02befb44064a
   react-native-keep-awake: 03b74eebe4f2bb5e8478fc8f420651a92463b6f8
   react-native-mail: 6e83813066984b26403d3fdfe79ac7bb31857e3c
-  react-native-maps: 85da55259d35bd50b5161d2ec0ee153d454158cc
+  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
   react-native-mmkv: a6e08ad1b51b84af075f91798f8a92c878472265
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-orientation-locker: dbd3f6ddbe9e62389cb0807dc2af63f6c36dec36

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "react-native-localize": "^3.1.0",
         "react-native-logs": "^5.1.0",
         "react-native-mail": "github:chirag04/react-native-mail",
-        "react-native-maps": "^1.13.0",
+        "react-native-maps": "1.20.1",
         "react-native-mmkv": "^2.12.2",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-modal-datetime-picker": "^18.0.0",
@@ -18323,9 +18323,10 @@
       "license": "MIT"
     },
     "node_modules/react-native-maps": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.13.0.tgz",
-      "integrity": "sha512-NC5gD3/F2t/0uw/PrKrJKO/1fdBWcaYYEeH/M6IyrhRwyKRgSG/WV/3sN+7Yy6ID8n1jl/EbESduIV4kMJ6kWg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13"
       },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-native-localize": "^3.1.0",
     "react-native-logs": "^5.1.0",
     "react-native-mail": "github:chirag04/react-native-mail",
-    "react-native-maps": "^1.13.0",
+    "react-native-maps": "1.20.1",
     "react-native-mmkv": "^2.12.2",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",


### PR DESCRIPTION
Compiled and tested in Debug and Release mode on both platforms.

According to the changelog, this is the last version that supports RN with the old architecture.

Half of [MOB-904](https://linear.app/inaturalist/issue/MOB-904)