### PR TITLE
Fix error when invoking `npm run lint:tsc`.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "*": ["src/*"],
-      "appConstants": "src/appConstants",
+      "appConstants": ["src/appConstants"],
       "api": ["src/api"],
       "components": ["src/components"],
       "dictionaries": ["src/dictionaries"],


### PR DESCRIPTION
Hi! I am checking out the project and noticed there are a bunch of TypeScript errors when I open some of the files I was reading. I ran `tsc` and noticed there's an error with the current TypeScript configuration file:

```
tsconfig.json:7:23 - error TS5063: Substitutions for pattern 'appConstants' should be an array.

7       "appConstants": "src/appConstants",
                        ~~~~~~~~~~~~~~~~~~
```

This change should resolve that error, which will allow the `tsc` linter to be executed from the terminal.