### PR TITLE
Do not log empty sentinel files to the server

### DIFF
--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -350,6 +350,7 @@ const AICamera = ( {
         zoomTextValue={zoomTextValue}
         useLocation={useLocation}
         toggleLocation={toggleLocation}
+        deleteSentinelFile={() => deleteSentinelFile( sentinelFileName )}
       />
     </>
   );

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -31,9 +31,9 @@ interface Props {
   debugFormat?: CameraDeviceFormat;
   // Those five are debug only so I don't bother with types
   setConfidenceThreshold?: Function;
-  setCropRatio?: Function,
-  setFPS?: Function,
-  setNumStoredResults?: Function,
+  setCropRatio?: Function;
+  setFPS?: Function;
+  setNumStoredResults?: Function;
   changeDebugFormat?: Function;
   showPrediction: boolean;
   showZoomButton: boolean;

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -44,6 +44,7 @@ interface Props {
   zoomTextValue: string;
   useLocation: boolean;
   toggleLocation: ( _event: GestureResponderEvent ) => void;
+  deleteSentinelFile: ( ) => Promise<void>;
 }
 
 const AICameraButtons = ( {
@@ -71,7 +72,8 @@ const AICameraButtons = ( {
   toggleFlash,
   zoomTextValue,
   useLocation,
-  toggleLocation
+  toggleLocation,
+  deleteSentinelFile
 }: Props ) => {
   const { isDefaultMode } = useLayoutPrefs();
   if ( isTablet ) {
@@ -93,6 +95,7 @@ const AICameraButtons = ( {
         useLocation={useLocation}
         toggleLocation={toggleLocation}
         isDefaultMode={isDefaultMode}
+        deleteSentinelFile={deleteSentinelFile}
       />
     );
   }
@@ -158,6 +161,7 @@ const AICameraButtons = ( {
           <PhotoLibraryIcon
             rotatableAnimatedStyle={rotatableAnimatedStyle}
             disabled={takingPhoto}
+            deleteSentinelFile={deleteSentinelFile}
           />
         </View>
       </View>

--- a/src/components/Camera/Buttons/PhotoLibraryIcon.tsx
+++ b/src/components/Camera/Buttons/PhotoLibraryIcon.tsx
@@ -10,12 +10,17 @@ import colors from "styles/tailwindColors";
 
 interface Props {
   rotatableAnimatedStyle: ViewStyle;
+  deleteSentinelFile: ( ) => Promise<void>;
   disabled?: boolean;
 }
 
 const isTablet = DeviceInfo.isTablet();
 
-const PhotoLibraryIcon = ( { rotatableAnimatedStyle, disabled }: Props ) => {
+const PhotoLibraryIcon = ( {
+  rotatableAnimatedStyle,
+  deleteSentinelFile,
+  disabled
+}: Props ) => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
 
@@ -33,11 +38,14 @@ const PhotoLibraryIcon = ( { rotatableAnimatedStyle, disabled }: Props ) => {
           "border-2",
           "rounded"
         )}
-        onPress={( ) => navigation.push( "PhotoLibrary", {
-          cmonBack: true,
-          lastScreen: "Camera",
-          fromAICamera: true
-        } )}
+        onPress={() => {
+          deleteSentinelFile();
+          navigation.push( "PhotoLibrary", {
+            cmonBack: true,
+            lastScreen: "Camera",
+            fromAICamera: true
+          } );
+        }}
         accessibilityLabel={t( "Photo-importer" )}
         accessibilityHint={t( "Navigates-to-photo-importer" )}
         icon="photo-library"

--- a/src/components/Camera/TabletButtons.tsx
+++ b/src/components/Camera/TabletButtons.tsx
@@ -50,13 +50,14 @@ interface Props {
   rotatableAnimatedStyle: ViewStyle;
   showPrediction?: boolean;
   showZoomButton: boolean;
-  takePhoto: () => Promise<void>;
+  takePhoto: ( ) => Promise<void>;
   takePhotoOptions: TakePhotoOptions;
   toggleFlash: ( _event: GestureResponderEvent ) => void;
   zoomTextValue: string;
   useLocation: boolean;
   toggleLocation: ( _event: GestureResponderEvent ) => void;
   isDefaultMode: boolean;
+  deleteSentinelFile: ( ) => Promise<void>;
 }
 
 // Empty space where a camera button should be so buttons don't jump around
@@ -93,7 +94,8 @@ const TabletButtons = ( {
   zoomTextValue,
   useLocation,
   toggleLocation,
-  isDefaultMode
+  isDefaultMode,
+  deleteSentinelFile
 }: Props ) => {
   const tabletCameraOptionsClasses = [
     "absolute",
@@ -168,6 +170,7 @@ const TabletButtons = ( {
           <PhotoLibraryIcon
             rotatableAnimatedStyle={rotatableAnimatedStyle}
             disabled={disabledPhotoLibrary}
+            deleteSentinelFile={deleteSentinelFile}
           />
         </View>
       ) }

--- a/src/components/StartupService.js
+++ b/src/components/StartupService.js
@@ -69,10 +69,10 @@ const StartupService = ( ) => {
   useEffect( ( ) => {
     const initializeApp = async ( ) => {
       const checkForSignedInUser = async ( ) => {
-      // check to see if this is a fresh install of the app
-      // if it is, delete realm file when we sign the user out of the app
-      // this handles the case where a user deletes the app, then reinstalls
-      // and expects to be signed out with no previously saved data
+        // check to see if this is a fresh install of the app
+        // if it is, delete realm file when we sign the user out of the app
+        // this handles the case where a user deletes the app, then reinstalls
+        // and expects to be signed out with no previously saved data
         const isFreshInstall = store.getBoolean( IS_FRESH_INSTALL );
         if ( isFreshInstall ) {
           store.set( IS_FRESH_INSTALL, false );

--- a/src/sharedHelpers/sentinelFiles.ts
+++ b/src/sharedHelpers/sentinelFiles.ts
@@ -73,7 +73,11 @@ const findAndLogSentinelFiles = async ( ) => {
 
   files.forEach( async file => {
     const existingContent = await RNFS.readFile( file.path, "utf8" );
-    logger.error( "Camera flow error: ", existingContent );
+
+    const sentinelData = JSON.parse( existingContent );
+    if ( sentinelData.stages && sentinelData.stages.length > 0 ) {
+      logger.error( "Camera flow error: ", existingContent );
+    }
     await unlink( file.path );
   } );
   return files;


### PR DESCRIPTION
There were two issues here as far as I can see:
1. Sentinel files are created every time the camera starts, and supposedly deleted every time the flow exits without any error. So, when the user closes the camera without error, or takes a photo without error. We were not deleting the files though when the user pressed the gallery button and exited the camera this way, thereby leaving one sentinel file with empty stages on every such time.
2. When it was time to log sentinel files to the server (every app start) we were also sending them to the server when there were no actual stages logged.

So, I have changed to: delete sentinel files when exiting through gallery button, do not log sentinel file that has no stages data, i.e. was created and never interacted with (which means we also don't know what went wrong anyway).

Closes MOB-883