### PR TITLE
Allow android users to upload images from their photo picker.

### DIFF
--- a/src/components/PhotoImporter/PhotoLibrary.js
+++ b/src/components/PhotoImporter/PhotoLibrary.js
@@ -87,7 +87,10 @@ const PhotoLibrary = ( ): Node => {
     const movedImages = await Promise.all( selectedImages.map( async ( { image } ) => {
       const { fileName } = image;
       const destPath = `${path}/${fileName}`;
-      const sourcePath = `${RNFS.TemporaryDirectoryPath}/${fileName}`;
+      // Get image from uri on android. TemporaryDirectoryPath results in an ANR
+      const sourcePath = Platform.OS === "android"
+        ? image.uri
+        : `${RNFS.TemporaryDirectoryPath}/${fileName}`;
       await RNFS.moveFile( sourcePath, destPath );
       return {
         image: {


### PR DESCRIPTION
# Changes
* Change android `sourcePath` to rely on the `uri` from the image object rather than manually constructing a path that is invalid using `RNFS.TemporaryDirectoryPath`.
* Keep iOS the same to avoid modifying working behvaior

# Testing
Testing device: Google Pixel 8 Pro on Android 16

In my testing, the original string `sourcePath` results in `/data/user/0/org.inaturalist.iNaturalistMobile/cache/PXL_20250993_190445459.jpg`.

This change maintains existing iOS behavior, while android ends up returning a valid path like: `file:///data/user/0/org.inaturalist.iNaturalistMobile/cache/rn_image_picker_lib_temp_477gg239e-a586-471d-847a-1593c516d940.jpg`.

For consideration:

* Nothing was being logged on error, the upload transition screen was just stuck on an infinite load. It could be useful to add logging or consider a toast for users in the case that some or all of their photo uploads fail.
* This not tested at the minimum supported OS for android to verify behavior, but I can do more testing if necessary.

Closes #2907