### PR TITLE
Fix: Stringify error contexts

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ setNativeExceptionHandler(
       // Store crash data for retrieval on next app launch
       zustandStorage.setItem( "LAST_CRASH_DATA", JSON.stringify( crashData ) );
 
-      logger.error( `Native Error: ${exceptionString}`, crashData );
+      logger.error( `Native Error: ${exceptionString}`, JSON.stringify( crashData ) );
     } catch ( e ) {
       // Last-ditch attempt to log something
       logger.error( `Native Error: ${exceptionString} (failed to save context)`, e );

--- a/src/sharedHelpers/logging.js
+++ b/src/sharedHelpers/logging.js
@@ -94,14 +94,14 @@ function reactQueryRetry( failureCount, error, options = {} ) {
       if ( apiError.status === 401 || apiError.status === 403 ) {
         // If we get a 401 or 403, call getJWT
         // which has a timestamp check if we need to refresh the token
-        logger.error( "JWT error detected in React Query retry:", {
+        logger.error( "JWT error detected in React Query retry:", JSON.stringify( {
           queryKey: options?.queryKey
             ? inspect( options.queryKey )
             : "unknown",
           url: error?.response?.url,
           routeName: options?.routeName || error?.routeName,
           timestamp: new Date().toISOString()
-        } );
+        } ) );
 
         try {
           await getJWT( true ); // Force refresh token

--- a/src/sharedHooks/useAuthenticatedMutation.js
+++ b/src/sharedHooks/useAuthenticatedMutation.js
@@ -40,7 +40,7 @@ const useAuthenticatedMutation = (
           errorMessage: error.message || "JWT is missing or invalid"
         };
 
-        logger.error( "401 JWT error in mutation:", errorContext );
+        logger.error( "401 JWT error in mutation:", JSON.stringify( errorContext ) );
 
         // Try to refresh the token explicitly
         // Important: We don't await this to avoid blocking the error handling
@@ -62,7 +62,7 @@ const useAuthenticatedMutation = (
           timestamp: new Date().toISOString()
         };
 
-        logger.error( "429 in mutation:", errorContext );
+        logger.error( "429 in mutation:", JSON.stringify( errorContext ) );
 
         return handleError( error, {
           context: errorContext,


### PR DESCRIPTION
Some error logs on our servers appear as "[object Object]", so using `JSON.stringify` before sending the data is required.