### PR TITLE
Disable spellcheck functionality in login form fields.

### DIFF
--- a/src/components/LoginSignUp/LoginSignUpInputField.tsx
+++ b/src/components/LoginSignUp/LoginSignUpInputField.tsx
@@ -18,7 +18,7 @@ const OUTLINE_STYLE = {
   borderRadius: 8
 };
 
-const LoginSignUpInputField: Function = forwardRef( ( {
+const LoginSignUpInputField = forwardRef( ( {
   accessibilityLabel,
   autoComplete,
   headerText,
@@ -48,6 +48,7 @@ const LoginSignUpInputField: Function = forwardRef( ( {
       onChangeText={onChangeText}
       secureTextEntry={secureTextEntry}
       selectionColor={String( colors?.darkGray )}
+      spellCheck={false}
       testID={testID}
       textContentType={textContentType}
     />


### PR DESCRIPTION
Also resolved an ESLint warning:

```
  21:30  warning  The `Function` type accepts any function-like value.
Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type

✖ 1 problem (0 errors, 1 warning)
```

# Before

<img width="334" height="94" alt="Screenshot 2025-08-31 at 12 50 04 PM" src="https://github.com/user-attachments/assets/9c71aade-d74a-43d9-8de0-ff5da1b40a81" />

# After

<img width="341" height="94" alt="Screenshot 2025-08-31 at 12 49 29 PM" src="https://github.com/user-attachments/assets/1c573e52-c38a-4a7b-80f7-cb6233287154" />
