### PR TITLE
Fix: Back button not showing on ObsEdit

### DIFF
--- a/src/components/SharedComponents/Buttons/BackButton.tsx
+++ b/src/components/SharedComponents/Buttons/BackButton.tsx
@@ -51,6 +51,7 @@ const BackButton = ( {
 }: Props ) => {
   const { isRTL } = I18nManager;
   const navigation = useNavigation();
+  const canGoBack = navigation?.canGoBack( );
   const tintColor = color || colors.darkGray;
   const { t } = useTranslation( );
 
@@ -73,7 +74,7 @@ const BackButton = ( {
     />
   );
 
-  if ( navigation?.canGoBack( ) ) {
+  if ( onPress || canGoBack ) {
     return (
       <HeaderBackButton
         backImage={backImage}


### PR DESCRIPTION
Have not seen a ticket for this but I was reproducibly hitting this every time once React compiler was enabled.