### PR TITLE
Prevent WebView iframe loads from updating source

### DIFF
--- a/src/components/FullPageWebView/FullPageWebView.tsx
+++ b/src/components/FullPageWebView/FullPageWebView.tsx
@@ -73,7 +73,9 @@ type WebViewSource = {
 
 type WebViewRequest = {
   url: string;
-  navigationType: "click" | "other"
+  navigationType?: "click" | "other";
+  mainDocumentURL?: string | null;
+  isTopFrame?: boolean;
 }
 
 export function onShouldStartLoadWithRequest(
@@ -141,6 +143,22 @@ export function onShouldStartLoadWithRequest(
   }
 
   if ( params.skipSetSourceInShouldStartLoadWithRequest || !setSource ) {
+    return true;
+  }
+
+  const isTopLevelNavigation = ( ) => {
+    if ( typeof request.isTopFrame === "boolean" ) {
+      return request.isTopFrame;
+    }
+
+    if ( request.mainDocumentURL ) {
+      return request.mainDocumentURL === request.url;
+    }
+
+    return true;
+  };
+
+  if ( !isTopLevelNavigation( ) ) {
     return true;
   }
 

--- a/tests/unit/components/FullPageWebView/FullPageWebView.test.js
+++ b/tests/unit/components/FullPageWebView/FullPageWebView.test.js
@@ -68,5 +68,43 @@ describe( "FullPageWebView", ( ) => {
         expect( Linking.openURL ).not.toHaveBeenCalled( );
       } );
     } );
+
+    describe( "setSource", ( ) => {
+      it( "should update the source when navigating the top frame", ( ) => {
+        const url = "https://www.inaturalist.org";
+        const destination = "https://www.inaturalist.org/observations";
+        const request = {
+          url: destination,
+          mainDocumentURL: destination,
+          isTopFrame: true
+        };
+        const source = { uri: url };
+        const routeParams = { initialUrl: url };
+        const setSource = jest.fn();
+
+        expect(
+          onShouldStartLoadWithRequest( request, source, routeParams, setSource )
+        ).toBeTruthy();
+        expect( setSource ).toHaveBeenCalledWith( { ...source, uri: destination } );
+      } );
+
+      it( "should not update the source for iframe requests", ( ) => {
+        const url = "https://www.inaturalist.org";
+        const iframeUrl = "https://www.inaturalist.org/embed";
+        const request = {
+          url: iframeUrl,
+          mainDocumentURL: url,
+          isTopFrame: false
+        };
+        const source = { uri: url };
+        const routeParams = { initialUrl: url };
+        const setSource = jest.fn();
+
+        expect(
+          onShouldStartLoadWithRequest( request, source, routeParams, setSource )
+        ).toBeTruthy();
+        expect( setSource ).not.toHaveBeenCalled();
+      } );
+    } );
   } );
 } );


### PR DESCRIPTION
## Summary
- update FullPageWebView navigation handling to ignore non top-frame requests when updating the WebView source
- extend request typing to include main document metadata for navigation heuristics
- add unit tests to ensure iframe loads do not trigger source updates while top frame navigations still do

## Testing
- CI=1 npx jest tests/unit/components/FullPageWebView/FullPageWebView.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68cc9f78f4b4832d8f2fafadf827b7c1