### PR TITLE
Update react-native-share-menu to build with use_frameworks static

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1924,7 +1924,26 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - RNShareMenu (6.0.0):
-    - React
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNStoreReview (0.4.3):
     - React-Core
   - RNSVG (15.12.0):
@@ -2430,7 +2449,7 @@ SPEC CHECKSUMS:
   RNPermissions: f14c20f4eb7a20fff611ad9f467da7bb5872ac4f
   RNReanimated: 3bc1666ae96a75a47688fe0ebc4e79340872a1c0
   RNScreens: 9f99e18ee2c72a203651a9bbe322825fe5525d2f
-  RNShareMenu: e1cdfa3b9af89416afc75a80377cfd0de4f30ded
+  RNShareMenu: 1d285109182098f9f5f449c121080692f2300801
   RNStoreReview: 613c43e9132998ed41a65946e20c223c91b36464
   RNSVG: ae1766b2492f8915a1ee25095871f00a4f132093
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/package-lock.json
+++ b/package-lock.json
@@ -18776,8 +18776,12 @@
     },
     "node_modules/react-native-share-menu": {
       "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/inaturalist/react-native-share-menu.git#35581f2cb940e7d82045d628de6ae27e7e080ded",
-      "license": "MIT"
+      "resolved": "git+ssh://git@github.com/inaturalist/react-native-share-menu.git#205079862081d134405b3f435d7fed551c73f550",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-store-review": {
       "version": "0.4.3",

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-share-menu/ios/ShareMenuManager.m b/node_modules/react-native-share-menu/ios/ShareMenuManager.m
+index d64822e..308ec99 100644
+--- a/node_modules/react-native-share-menu/ios/ShareMenuManager.m
++++ b/node_modules/react-native-share-menu/ios/ShareMenuManager.m
+@@ -6,7 +6,7 @@
+ //
+ 
+ #import "ShareMenuManager.h"
+-#import <RNShareMenu/RNShareMenu-Swift.h>
++#import "RNShareMenu-Swift.h"
+ 
+ #import <React/RCTLinkingManager.h>
+ 

--- a/src/components/PhotoSharing.tsx
+++ b/src/components/PhotoSharing.tsx
@@ -4,7 +4,7 @@ import { View } from "components/styledComponents";
 import React, {
   useCallback, useEffect, useRef, useState
 } from "react";
-import { Alert, Platform } from "react-native";
+import { Alert } from "react-native";
 import Observation from "realmModels/Observation";
 import { useLayoutPrefs } from "sharedHooks";
 import useStore from "stores/useStore";
@@ -60,36 +60,15 @@ const PhotoSharing = ( ) => {
   }, [sharedText, prepareObsEdit, isDefaultMode, resetNavigator, screenAfterPhotoEvidence] );
 
   useEffect( ( ) => {
-    const { mimeType, data } = item;
-
-    if ( Platform.OS === "android" && !mimeType.startsWith( "image/" ) ) {
-      Alert.alert( "Android photo share failed: not an image file" );
-      return;
-    }
+    const { data } = item;
 
     // when sharing, we need to reset zustand like we do while
     // navigating through the AddObsModal
     resetObservationFlowSlice( );
 
-    // Create a new observation with multiple shared photos (one or more)
-    let photoUris;
-
-    // data is returned as a string for a single photo on Android
-    // and an object with an array of data strings on iOS, i.e.
-    // [{"data": "", "", "mimeType": "image/jpeg]
-    if ( Array.isArray( data ) ) {
-      photoUris = data;
-    } else {
-      photoUris = [data];
-    }
-
-    if ( Platform.OS === "android" ) {
-      photoUris = photoUris.map( x => ( { image: { uri: x } } ) );
-    } else {
-      photoUris = photoUris
-        .filter( x => x.mimeType && x.mimeType.startsWith( "image/" ) )
-        .map( x => ( { image: { uri: x.data } } ) );
-    }
+    const photoUris = data
+      .filter( x => x.mimeType && x.mimeType.startsWith( "image/" ) )
+      .map( x => ( { image: { uri: x.data } } ) );
 
     if ( photoUris.length === 1 ) {
       createObservationAndNavigate( photoUris );

--- a/tests/unit/components/PhotoSharing.test.js
+++ b/tests/unit/components/PhotoSharing.test.js
@@ -2,7 +2,7 @@ import { CommonActions } from "@react-navigation/native";
 import { act, waitFor } from "@testing-library/react-native";
 import PhotoSharing from "components/PhotoSharing";
 import React from "react";
-import { Alert, Platform } from "react-native";
+import { Alert } from "react-native";
 import Observation from "realmModels/Observation";
 import { useLayoutPrefs } from "sharedHooks";
 import useStore from "stores/useStore";
@@ -69,14 +69,8 @@ const setupMocks = ( overrides = {} ) => {
   };
 };
 
-const mockIOSPhoto = {
-  mimeType: JPEG,
+const mockShare = {
   data: [{ data: "file://photo.jpg", mimeType: "image/jpeg" }]
-};
-
-const mockAndroidPhoto = {
-  mimeType: "image/jpeg",
-  data: "file://photo.jpg"
 };
 
 const expectNavigationReset = ( mockDispatch, screenName, lastScreen = "PhotoSharing" ) => {
@@ -99,18 +93,13 @@ describe( "PhotoSharing", ( ) => {
     jest.clearAllMocks( );
   } );
 
-  afterEach( ( ) => {
-    // test iOS as default, but test Android in a few specific tests
-    Platform.OS = "ios";
-  } );
-
   describe( "Share Single Photo", ( ) => {
     const singlePhotoData = {
-      ...mockIOSPhoto,
+      ...mockShare,
       extraData: { userInput: "Share photo with description" }
     };
 
-    it( "should handle single photo in default mode on iOS", async ( ) => {
+    it( "should handle single photo in default mode", async ( ) => {
       const mocks = setupMocks( );
       mockUseRoute.mockReturnValue( createMockRoute( singlePhotoData ) );
 
@@ -130,39 +119,9 @@ describe( "PhotoSharing", ( ) => {
       expectNavigationReset( mocks.dispatch, "Match" );
     } );
 
-    it( "should handle single photo in advanced mode on iOS", async ( ) => {
+    it( "should handle single photo in advanced mode", async ( ) => {
       const mocks = setupMocks( { isDefaultMode: false, screenAfterPhotoEvidence: "ObsEdit" } );
       mockUseRoute.mockReturnValue( createMockRoute( singlePhotoData ) );
-
-      renderComponent( <PhotoSharing /> );
-
-      await waitFor( ( ) => {
-        expectNavigationReset( mocks.dispatch, "ObsEdit" );
-      } );
-    } );
-
-    it( "should handle single photo in default mode on Android", async ( ) => {
-      Platform.OS = "android";
-      const mocks = setupMocks( );
-      mockUseRoute.mockReturnValue( createMockRoute( mockAndroidPhoto ) );
-
-      renderComponent( <PhotoSharing /> );
-
-      await waitFor( ( ) => {
-        expect( mocks.dispatch ).toHaveBeenCalled( );
-      } );
-
-      expect( mocks.resetObservationFlowSlice ).toHaveBeenCalled( );
-      expect( Observation.createObservationWithPhotos ).toHaveBeenCalledWith( [
-        { image: { uri: "file://photo.jpg" } }
-      ] );
-      expectNavigationReset( mocks.dispatch, "Match" );
-    } );
-
-    it( "should handle single photo in advanced mode on Android", async ( ) => {
-      Platform.OS = "android";
-      const mocks = setupMocks( { isDefaultMode: false, screenAfterPhotoEvidence: "ObsEdit" } );
-      mockUseRoute.mockReturnValue( createMockRoute( mockAndroidPhoto ) );
 
       renderComponent( <PhotoSharing /> );
 
@@ -193,7 +152,7 @@ describe( "PhotoSharing", ( ) => {
     it( "should handle photo with no description", async ( ) => {
       const mocks = setupMocks( );
 
-      mockUseRoute.mockReturnValue( createMockRoute( mockIOSPhoto ) );
+      mockUseRoute.mockReturnValue( createMockRoute( mockShare ) );
 
       renderComponent( <PhotoSharing /> );
 
@@ -235,35 +194,7 @@ describe( "PhotoSharing", ( ) => {
       expect( Observation.createObservationWithPhotos ).not.toHaveBeenCalled( );
     } );
 
-    it( "should navigate to GroupPhotos for multiple photos on Android", async ( ) => {
-      Platform.OS = "android";
-
-      const mocks = setupMocks( );
-      const androidMultiplePhotosData = {
-        mimeType: "image/jpeg",
-        data: ["file://photo1.jpg", "file://photo2.jpg"],
-        extraData: { userInput: "Multiple photos" }
-      };
-
-      mockUseRoute.mockReturnValue( createMockRoute( androidMultiplePhotosData ) );
-
-      renderComponent( <PhotoSharing /> );
-
-      await waitFor( ( ) => {
-        expect( mocks.setPhotoImporterState ).toHaveBeenCalledWith( {
-          photoLibraryUris: ["file://photo1.jpg", "file://photo2.jpg"],
-          groupedPhotos: [
-            { photos: [{ image: { uri: "file://photo1.jpg" } }] },
-            { photos: [{ image: { uri: "file://photo2.jpg" } }] }
-          ],
-          firstObservationDefaults: { description: "Multiple photos" }
-        } );
-      } );
-      expectNavigationReset( mocks.dispatch, "GroupPhotos" );
-      expect( Observation.createObservationWithPhotos ).not.toHaveBeenCalled( );
-    } );
-
-    it( "should filter out non-image files on iOS", async ( ) => {
+    it( "should filter out non-image files", async ( ) => {
       const mocks = setupMocks( );
       const mixedData = {
         ...multiplePhotosData,
@@ -290,7 +221,7 @@ describe( "PhotoSharing", ( ) => {
   describe( "Back navigation", ( ) => {
     it( "should handle expected behavior for blur/focus navigation", async ( ) => {
       const mocks = setupMocks( );
-      const testItem = mockIOSPhoto;
+      const testItem = mockShare;
       const testRoute = createMockRoute( testItem );
       let blurCallback;
       let focusCallback;


### PR DESCRIPTION
Compiled and tested in Debug and Release mode on iOS and Android.

The actual change in the library to make it run on iOS inside the Podfile code had to be reverted using a patch because the library now only works with static.