### PR TITLE
apply link styles to UserText links

### DIFF
--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -8,7 +8,9 @@ import { isEqual, trim } from "lodash";
 import MarkdownIt from "markdown-it";
 import * as React from "react";
 import { Linking, useWindowDimensions } from "react-native";
-import HTML, { defaultSystemFonts, RenderersProps } from "react-native-render-html";
+import HTML, {
+  defaultSystemFonts, MixedStyleDeclaration, RenderersProps, TRenderEngineConfig
+} from "react-native-render-html";
 import WebView from "react-native-webview";
 import sanitizeHtml, { IOptions } from "sanitize-html";
 import colors from "styles/tailwindColors";
@@ -104,7 +106,7 @@ const UserText = ( {
   const navigation = useNavigation( );
 
   // Allow stringified children to serve as text if no prop provided
-  const text = textProp || children.toString( );
+  const text = textProp || children?.toString( ) || "";
   const { width } = useWindowDimensions( );
   let html = trim( text );
 
@@ -128,13 +130,19 @@ const UserText = ( {
   // <code>
 
   html = linkifyHtml( html, LINKIFY_OPTIONS );
-  const baseStyle = {
+  const baseStyle: MixedStyleDeclaration = {
     fontFamily: fontRegular,
     fontSize: 16,
     lineHeight: 22,
     color: colors.darkGray,
     ...htmlStyle,
     width: "100%"
+  };
+  const tagsStyles: TRenderEngineConfig["tagsStyles"] = {
+    a: {
+      textDecorationLine: "underline",
+      color: colors.inatGreen
+    }
   };
   const fonts = [fontRegular, ...defaultSystemFonts];
 
@@ -160,6 +168,7 @@ const UserText = ( {
   return (
     <HTML
       baseStyle={baseStyle}
+      tagsStyles={tagsStyles}
       contentWidth={width}
       source={{ html }}
       WebView={WebView}


### PR DESCRIPTION
Adds `a` styling via  `tagsStyles` https://meliorence.github.io/react-native-render-html/docs/guides/styling#mixed-style-records

|Before|After|
|---|---|
|<img width="300" height="643" alt="Fimmvörduháls Trail, Hvolsvöllur," src="https://github.com/user-attachments/assets/5cb11c92-4a1a-4884-bee2-aa938f04748a" />|<img width="304" height="646" alt="•Maps lane" src="https://github.com/user-attachments/assets/2636836d-7269-4bd4-9cac-2fda897cf628" />|