### PR TITLE
Do Not Merge. larger runner experiments

### DIFF
--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   checksecret:
     name: check for oauth client
-    runs-on: macos-13
+    runs-on: macos-15-large # from https://github.com/actions/runner-images | Paid!
     outputs:
       is_SECRETS_PRESENT_set: ${{ steps.checksecret_job.outputs.is_SECRETS_PRESENT_set }}
     steps:
@@ -31,7 +31,7 @@ jobs:
   test:
     needs: checksecret
     if: needs.checksecret.outputs.is_SECRETS_PRESENT_set == 'true'
-    runs-on: macos-13
+    runs-on: macos-15-large # from https://github.com/actions/runner-images | Paid!
     # Kill the task if not finished after 120 minutes
     timeout-minutes: 120
 
@@ -146,7 +146,7 @@ jobs:
     name: Notify Slack
     needs: test
     if: ${{ success() || failure() }}
-    runs-on: macos-13
+    runs-on: macos-15-large # from https://github.com/actions/runner-images | Paid!
     steps:
       - uses: iRoachie/slack-github-actions@v2.3.0
         if: env.SLACK_WEBHOOK_URL != null


### PR DESCRIPTION
experimenting with larger test runners to gather information on runtime, reliability and (now) costs

https://github.com/actions/runner-images

Once succeeding, will do a couple runs on each of 

`macos-15-large` (intel)
`macos-15-xlarge` (arm64)

and maybe `macos-26-*` (forward, beta) and `macos-14-*` (backward) if it makes sense.