### PR TITLE
Refactor: Add comprehensive TypeScript types to Zustand store

### DIFF
--- a/src/stores/createExploreSlice.ts
+++ b/src/stores/createExploreSlice.ts
@@ -1,15 +1,10 @@
-import { StateCreator } from "zustand";
+import { ExploreSlice, StoreSlice } from "./types";
 
 const DEFAULT_STATE = {
   exploreView: "observations"
 };
 
-interface ExploreSlice {
-  exploreView: string,
-  setExploreView: ( _view: string ) => void
-}
-
-const createExploreSlice: StateCreator<ExploreSlice> = set => ( {
+const createExploreSlice: StoreSlice<ExploreSlice> = set => ( {
   ...DEFAULT_STATE,
   setExploreView: exploreView => set( ( ) => ( { exploreView } ) )
 } );

--- a/src/stores/createLayoutSlice.ts
+++ b/src/stores/createLayoutSlice.ts
@@ -1,3 +1,5 @@
+import { LayoutSlice, StoreSlice } from "./types";
+
 export enum OBS_DETAILS_TAB {
   ACTIVITY = "ACTIVITY",
   DETAILS = "DETAILS"
@@ -9,7 +11,7 @@ export enum SCREEN_AFTER_PHOTO_EVIDENCE {
   MATCH = "Match"
 }
 
-const createLayoutSlice = set => ( {
+const createLayoutSlice: StoreSlice<LayoutSlice> = set => ( {
   // Vestigial un-namespaced values
   isAdvancedUser: false,
   // Values that do not need to be persisted
@@ -43,7 +45,7 @@ const createLayoutSlice = set => ( {
     // to null so we can remove it in the future
     isAdvancedSuggestionsMode: null,
     screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE.MATCH,
-    setScreenAfterPhotoEvidence: ( newScreen: string ) => set( state => ( {
+    setScreenAfterPhotoEvidence: ( newScreen: SCREEN_AFTER_PHOTO_EVIDENCE ) => set( state => ( {
       layout: {
         ...state.layout,
         screenAfterPhotoEvidence: newScreen,

--- a/src/stores/createMyObsSlice.ts
+++ b/src/stores/createMyObsSlice.ts
@@ -1,4 +1,6 @@
-const createMyObsSlice = ( set, get ) => ( {
+import { MyObsSlice, StoreSlice } from "./types";
+
+const createMyObsSlice: StoreSlice<MyObsSlice> = ( set, get ) => ( {
   // Stores y offset of MyObs so we can scroll back to the user's position
   // when returning from the NoBottomTabStackNavigator (MyObs will be trashed
   // when navigating to ObsEdit, so we lose scroll position)

--- a/src/stores/createRootExploreSlice.ts
+++ b/src/stores/createRootExploreSlice.ts
@@ -1,18 +1,11 @@
-import { StateCreator } from "zustand";
+import { RootExploreSlice, StoreSlice } from "./types";
 
 const DEFAULT_STATE = {
   rootStoredParams: {},
   rootExploreView: "observations"
 };
 
-interface RootExploreSlice {
-  rootStoredParams: object,
-  setRootStoredParams: ( _params: object ) => void,
-  rootExploreView: string,
-  setRootExploreView: ( _view: string ) => void
-}
-
-const createRootExploreSlice: StateCreator<RootExploreSlice> = set => ( {
+const createRootExploreSlice: StoreSlice<RootExploreSlice> = set => ( {
   ...DEFAULT_STATE,
   setRootStoredParams: rootStoredParams => set( ( ) => ( { rootStoredParams } ) ),
   setRootExploreView: rootExploreView => set( ( ) => ( { rootExploreView } ) )

--- a/src/stores/createSyncObservationsSlice.ts
+++ b/src/stores/createSyncObservationsSlice.ts
@@ -1,28 +1,12 @@
-import { StateCreator } from "zustand";
+import { StoreSlice, SyncingStatus, SyncObservationsSlice } from "./types";
 
-export const SYNC_PENDING = "sync-pending";
-export const BEGIN_MANUAL_SYNC = "begin-manual-sync";
-export const BEGIN_AUTOMATIC_SYNC = "begin-automatic-sync";
-export const MANUAL_SYNC_IN_PROGRESS = "manual-sync-progress";
-export const AUTOMATIC_SYNC_IN_PROGRESS = "automatic-sync-progress";
+export const SYNC_PENDING = "sync-pending" as const;
+export const BEGIN_MANUAL_SYNC = "begin-manual-sync" as const;
+export const BEGIN_AUTOMATIC_SYNC = "begin-automatic-sync" as const;
+export const MANUAL_SYNC_IN_PROGRESS = "manual-sync-progress" as const;
+export const AUTOMATIC_SYNC_IN_PROGRESS = "automatic-sync-progress" as const;
 
-type SyncingStatus = typeof SYNC_PENDING
-  | typeof BEGIN_MANUAL_SYNC
-  | typeof BEGIN_AUTOMATIC_SYNC
-  | typeof MANUAL_SYNC_IN_PROGRESS
-  | typeof AUTOMATIC_SYNC_IN_PROGRESS;
-
-interface SyncObservationsSlice {
-  autoSyncAbortController: AbortController | null,
-  currentDeleteCount: number,
-  deleteError: string | null,
-  deleteQueue: Array<string>,
-  deletionsCompletedAt: Date | null,
-  initialNumDeletionsInQueue: number,
-  syncingStatus: SyncingStatus
-}
-
-const DEFAULT_STATE: SyncObservationsSlice = {
+const DEFAULT_STATE = {
   autoSyncAbortController: null,
   currentDeleteCount: 1,
   deleteError: null,
@@ -32,7 +16,7 @@ const DEFAULT_STATE: SyncObservationsSlice = {
   syncingStatus: SYNC_PENDING
 };
 
-const createSyncObservationsSlice: StateCreator<SyncObservationsSlice> = ( set, get ) => ( {
+const createSyncObservationsSlice: StoreSlice<SyncObservationsSlice> = ( set, get ) => ( {
   ...DEFAULT_STATE,
   addToDeleteQueue: ( uuids: string[] ) => set( state => {
     let copyOfDeleteQueue = state.deleteQueue;

--- a/src/stores/createUploadObservationsSlice.ts
+++ b/src/stores/createUploadObservationsSlice.ts
@@ -1,41 +1,14 @@
 import { activateKeepAwake, deactivateKeepAwake } from "@sayem314/react-native-keep-awake";
 import _ from "lodash";
-import type { RealmObservation } from "realmModels/types";
-import { StateCreator } from "zustand";
 
-export const UPLOAD_CANCELLED = "cancelled";
-export const UPLOAD_PENDING = "pending";
-export const UPLOAD_COMPLETE = "complete";
-export const UPLOAD_IN_PROGRESS = "in-progress";
+import { StoreSlice, UploadObservationsSlice, UploadStatus } from "./types";
 
-type UploadStatus = typeof UPLOAD_PENDING
-  | typeof UPLOAD_IN_PROGRESS
-  | typeof UPLOAD_COMPLETE
-  | typeof UPLOAD_CANCELLED;
+export const UPLOAD_CANCELLED = "cancelled" as const;
+export const UPLOAD_PENDING = "pending" as const;
+export const UPLOAD_COMPLETE = "complete" as const;
+export const UPLOAD_IN_PROGRESS = "in-progress" as const;
 
-interface TotalUploadProgress {
-  uuid: string,
-  currentIncrements: number,
-  totalIncrements: number,
-  totalProgress: number
-}
-
-interface UploadObservationsSlice {
-  abortController: AbortController | null,
-  currentUpload: RealmObservation | null,
-  errorsByUuid: object,
-  multiError: string | null,
-  initialNumObservationsInQueue: number,
-  numUnuploadedObservations: number,
-  numUploadsAttempted: number,
-  totalToolbarIncrements: number,
-  totalToolbarProgress: number,
-  totalUploadProgress: Array<TotalUploadProgress>,
-  uploadQueue: Array<string>,
-  uploadStatus: UploadStatus
-}
-
-const DEFAULT_STATE: UploadObservationsSlice = {
+const DEFAULT_STATE = {
   abortController: null,
   currentUpload: null,
   errorsByUuid: {},
@@ -97,7 +70,7 @@ const setTotalToolbarProgress = ( totalToolbarIncrements, totalUploadProgress ) 
     : 0
 );
 
-const createUploadObservationsSlice: StateCreator<UploadObservationsSlice> = ( set, get ) => ( {
+const createUploadObservationsSlice: StoreSlice<UploadObservationsSlice> = ( set, get ) => ( {
   ...DEFAULT_STATE,
   resetUploadObservationsSlice: ( ) => {
     // Preserve the abortController just in case something might try and use it

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,0 +1,207 @@
+import type { RealmObservation } from "realmModels/types";
+import { StateCreator } from "zustand";
+
+import {
+  OBS_DETAILS_TAB,
+  SCREEN_AFTER_PHOTO_EVIDENCE
+} from "./createLayoutSlice";
+import {
+  AUTOMATIC_SYNC_IN_PROGRESS,
+  BEGIN_AUTOMATIC_SYNC,
+  BEGIN_MANUAL_SYNC,
+  MANUAL_SYNC_IN_PROGRESS,
+  SYNC_PENDING
+} from "./createSyncObservationsSlice";
+import {
+  UPLOAD_CANCELLED,
+  UPLOAD_COMPLETE,
+  UPLOAD_IN_PROGRESS,
+  UPLOAD_PENDING
+} from "./createUploadObservationsSlice";
+
+export interface ExploreSlice {
+  exploreView: string;
+  setExploreView: ( _view: string ) => void;
+}
+
+export interface LayoutSlice {
+  isAdvancedUser: boolean;
+  obsDetailsTab: OBS_DETAILS_TAB;
+  setObsDetailsTab: ( newValue: OBS_DETAILS_TAB ) => void;
+  loggedInWhileInDefaultMode?: boolean;
+  setLoggedInWhileInDefaultMode: ( newValue: boolean ) => void;
+  layout: {
+    isDefaultMode: boolean;
+    setIsDefaultMode: ( newValue: boolean ) => void;
+    isAdvancedSuggestionsMode: null;
+    screenAfterPhotoEvidence: SCREEN_AFTER_PHOTO_EVIDENCE;
+    setScreenAfterPhotoEvidence: ( newScreen: SCREEN_AFTER_PHOTO_EVIDENCE ) => void;
+    isAllAddObsOptionsMode: boolean;
+    setIsAllAddObsOptionsMode: ( newValue: boolean ) => void;
+    shownOnce: { [key: string]: boolean };
+    setShownOnce: ( key: string ) => void;
+    resetShownOnce: () => void;
+    loginBannerDismissed: boolean;
+    setLoginBannerDismissed: () => void;
+    justFinishedSignup: boolean;
+    setJustFinishedSignup: ( newValue: boolean ) => void;
+  };
+}
+
+export interface MyObsSlice {
+  myObsOffset: number;
+  myObsOffsetToRestore: number;
+  resetMyObsOffsetToRestore: () => void;
+  setMyObsOffset: ( newOffset: number ) => void;
+  setMyObsOffsetToRestore: () => void;
+  numOfUserObservations: number;
+  setNumOfUserObservations: ( newNum: number ) => void;
+  numOfUserSpecies: number;
+  setNumOfUserSpecies: ( newNum: number ) => void;
+}
+
+export interface ObservationFlowSlice {
+  aICameraSuggestion: unknown;
+  cameraRollUris: string[];
+  currentObservation: RealmObservation | null;
+  currentObservationIndex: number;
+  evidenceToAdd: string[];
+  photoLibraryUris: string[];
+  groupedPhotos: unknown[];
+  observations: RealmObservation[];
+  observationMarkedAsViewedAt: Date | null;
+  cameraUris: string[];
+  savingPhoto: boolean;
+  savedOrUploadedMultiObsFlow: boolean;
+  unsavedChanges: boolean;
+  totalSavedObservations: number;
+  sentinelFileName: string | null;
+  newPhotoUris: string[];
+  deletePhotoFromObservation: ( uri: string ) => void;
+  deleteSoundFromObservation: ( uri: string ) => void;
+  resetObservationFlowSlice: () => void;
+  addCameraRollUris: ( uris: string[] ) => void;
+  setSavingPhoto: ( saving: boolean ) => void;
+  setCameraState: ( options: {
+    evidenceToAdd?: string[],
+    cameraUris?: string[]
+  } ) => void;
+  setCurrentObservationIndex: ( index: number ) => void;
+  setGroupedPhotos: ( photos: unknown[] ) => void;
+  setObservationMarkedAsViewedAt: ( date: Date ) => void;
+  setObservations: ( updatedObservations: RealmObservation[] ) => void;
+  setPhotoImporterState: ( options: {
+    photoLibraryUris?: string[],
+    savingPhoto?: boolean,
+    evidenceToAdd?: string[],
+    groupedPhotos?: unknown[],
+    observations?: RealmObservation[],
+    firstObservationDefaults?: unknown
+  } ) => void;
+  setSavedOrUploadedMultiObsFlow: () => void;
+  updateObservations: ( updatedObservations: RealmObservation[] ) => void;
+  updateObservationKeys: ( keysAndValues: unknown ) => void;
+  getCurrentObservation: () => RealmObservation | null;
+  prepareObsEdit: ( observation: RealmObservation ) => void;
+  prepareCamera: () => void;
+  incrementTotalSavedObservations: () => void;
+  setSentinelFileName: ( sentinelFileName: string ) => void;
+  setNewPhotoUris: ( newPhotoUris: string[] ) => void;
+  setAICameraSuggestion: ( suggestion: unknown ) => void;
+}
+
+export interface RootExploreSlice {
+  rootStoredParams: object;
+  setRootStoredParams: ( _params: object ) => void;
+  rootExploreView: string;
+  setRootExploreView: ( _view: string ) => void;
+}
+
+export type SyncingStatus =
+  | typeof SYNC_PENDING
+  | typeof BEGIN_MANUAL_SYNC
+  | typeof BEGIN_AUTOMATIC_SYNC
+  | typeof MANUAL_SYNC_IN_PROGRESS
+  | typeof AUTOMATIC_SYNC_IN_PROGRESS;
+
+export interface SyncObservationsSlice {
+  autoSyncAbortController: AbortController | null;
+  currentDeleteCount: number;
+  deleteError: string | null;
+  deleteQueue: Array<string>;
+  deletionsCompletedAt: Date | null;
+  initialNumDeletionsInQueue: number;
+  syncingStatus: SyncingStatus;
+  addToDeleteQueue: ( uuids: string[] ) => void;
+  removeFromDeleteQueue: () => void;
+  startNextDeletion: () => void;
+  completeLocalDeletions: () => void;
+  resetSyncObservationsSlice: () => void;
+  setDeletionError: ( message: string ) => void;
+  setSyncingStatus: ( syncingStatus: SyncingStatus ) => void;
+  resetSyncToolbar: () => void;
+  startManualSync: () => void;
+  startAutomaticSync: () => void;
+  completeSync: () => void;
+}
+
+export type UploadStatus =
+  | typeof UPLOAD_PENDING
+  | typeof UPLOAD_IN_PROGRESS
+  | typeof UPLOAD_COMPLETE
+  | typeof UPLOAD_CANCELLED;
+
+interface TotalUploadProgress {
+  uuid: string;
+  currentIncrements: number;
+  totalIncrements: number;
+  totalProgress: number;
+}
+
+export interface UploadObservationsSlice {
+  abortController: AbortController | null;
+  currentUpload: RealmObservation | null;
+  errorsByUuid: object;
+  multiError: string | null;
+  initialNumObservationsInQueue: number;
+  numUnuploadedObservations: number;
+  numUploadsAttempted: number;
+  totalToolbarIncrements: number;
+  totalToolbarProgress: number;
+  totalUploadProgress: Array<TotalUploadProgress>;
+  uploadQueue: Array<string>;
+  uploadStatus: UploadStatus;
+  resetUploadObservationsSlice: () => void;
+  addUploadError: ( error: string, obsUUID: string ) => void;
+  stopAllUploads: () => void;
+  setCannotUploadObservations: () => void;
+  setStartUploadObservations: () => void;
+  completeUploads: () => void;
+  updateTotalUploadProgress: ( uuid: string, increment: number ) => void;
+  setUploadStatus: ( uploadStatus: UploadStatus ) => void;
+  addToUploadQueue: ( uuids: string | string[] ) => void;
+  removeFromUploadQueue: () => void;
+  setCurrentUpload: ( observation: RealmObservation ) => void;
+  setTotalToolbarIncrements: ( queuedObservations: RealmObservation[] ) => void;
+  addTotalToolbarIncrements: ( observation: RealmObservation ) => void;
+  setNumUnuploadedObservations: ( numUnuploadedObservations: number ) => void;
+  removeDeletedObsFromUploadQueue: ( uuid: string ) => void;
+  getTotalUploadErrors: () => number;
+  getNumUploadedWithoutErrors: () => number;
+  getCompletedUploads: () => number;
+}
+
+export type StoreState = ExploreSlice &
+  LayoutSlice &
+  MyObsSlice &
+  ObservationFlowSlice &
+  RootExploreSlice &
+  SyncObservationsSlice &
+  UploadObservationsSlice;
+
+export type StoreSlice<T> = StateCreator<
+  StoreState,
+  [["zustand/persist", unknown]],
+  [],
+  T
+>;


### PR DESCRIPTION
This pull request introduces comprehensive TypeScript types to the Zustand store, enhancing type safety and will make it easier to migrate future files like `useState.js` which requires a single type definition for the entire store.

Changes made:

1.  **Centralized Type Definitions:** Created a new file, `src/stores/types.ts`, to house all Zustand-related type definitions, including interfaces for each slice and a unified `StoreState` type.
2.  **Typed Slice Creators:** Refactored all slice creator functions (e.g., `createLayoutSlice.ts`, `createExploreSlice.ts`) to use the new generic `StoreSlice` type, ensuring that each slice adheres to its defined interface.

I wrote this pull request in a way that does _not_ change any runtime behavior. All of the changes should only be typecheck related.