### PR TITLE
Update TypeScript config to ignore Flow autgenerated stubs.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
       "styles": ["src/styles"],
       "tests": ["tests"],
     },
-    "types": ["nativewind/types"]
-  }
+    "types": ["nativewind/types"],
+  },
+  "exclude": [
+    "flow-typed"
+  ]
 }


### PR DESCRIPTION
By doing this, TypeScript will now resolve the types of the imports to the actual library, instead of the package stubbed to `any` in the Flow autogenerated stubs.

Prior to this change `npx tsc` reported 1121 errors. After this change, `npx tsc` reports 797 errors.

# Before

<img width="670" height="158" alt="Screenshot 2025-10-14 at 10 20 21 PM" src="https://github.com/user-attachments/assets/c3967ab0-06d8-44e7-a443-90c338a6e076" />

# After

<img width="1083" height="108" alt="Screenshot 2025-10-14 at 10 19 55 PM" src="https://github.com/user-attachments/assets/032051db-53cb-4e2f-8b0d-81bebd54e3ba" />

Notice that TypeScript also no longer lints against the `any` type.


