### PR TITLE
Teach TypeScript about SVG imports.

### DIFF
--- a/src/types/react-navigation.d.ts
+++ b/src/types/react-navigation.d.ts
@@ -1,0 +1,7 @@
+import { RootStackParamList } from "@react-navigation/native";
+
+declare global {
+  namespace ReactNavigation {
+    type RootParamList = RootStackParamList
+  }
+}

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,5 +1,3 @@
-import { RootStackParamList } from "@react-navigation/native";
-
 // Using typescript with react-native-svg-transformer
 // from https://www.npmjs.com/package/react-native-svg-transformer?activeTab
 declare module "*.svg" {
@@ -8,10 +6,4 @@ declare module "*.svg" {
 
   const content: FC<SvgProps>;
   export default content;
-}
-
-declare global {
-  namespace ReactNavigation {
-    type RootParamList = RootStackParamList
-  }
 }


### PR DESCRIPTION
See https://stackoverflow.com/questions/58726319/typescript-cannot-find-module-when-import-svg-file.

# Before

<img width="869" height="79" alt="Screenshot 2025-10-17 at 12 30 57 AM" src="https://github.com/user-attachments/assets/67436a1a-3cf0-4f25-b577-06b7490334ff" />


# After

<img width="487" height="77" alt="Screenshot 2025-10-17 at 12 30 20 AM" src="https://github.com/user-attachments/assets/9e910b53-cd79-4d3b-aa5e-62af65662c65" />
