### PR TITLE
Fix spurious test user by setting `currentUser`.

### DIFF
--- a/tests/unit/components/ObsEdit/ObsEdit.test.js
+++ b/tests/unit/components/ObsEdit/ObsEdit.test.js
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react-native";
 import ObsEdit from "components/ObsEdit/ObsEdit";
 import React from "react";
 import { View } from "react-native";
+import * as useCurrentUser from "sharedHooks/useCurrentUser";
 import useStore from "stores/useStore";
 import factory from "tests/factory";
 import { renderComponent, wrapInNavigationContainer } from "tests/helpers/render";
@@ -48,6 +49,7 @@ const mockObservation = factory( "LocalObservation", {
 
 describe( "ObsEdit", () => {
   beforeEach( ( ) => {
+    jest.spyOn( useCurrentUser, "default" ).mockImplementation( ( ) => mockUser );
     useStore.setState( {
       currentObservation: mockObservation,
       observations: [mockObservation]


### PR DESCRIPTION
The spurious failure was seen here and in other pull requests:

https://github.com/inaturalist/iNaturalistReactNative/actions/runs/18662797244/job/53207075939?pr=3152

```
ObsEdit › displays the number of photos in global state obsPhotos

    User tried to edit observation they do not own

      102 |   // This should never, ever happen
      103 |   if ( currentObservation?.user && currentUser && currentUser.id !== currentObservation.user.id ) {
    > 104 |     throw new Error( "User tried to edit observation they do not own" );
          |           ^
      105 |   }
      106 |
      107 |   return (

      at ObsEdit (src/components/ObsEdit/ObsEdit.js:104:11)
      at Object.Component [as react-stack-bottom-frame] (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:12679:20)
      at callComponentInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:3622:25)
      at renderWithHooks (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:5635:19)
      at updateFunctionComponent (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7086:18)
      at callback (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:540:16)
      at runWithFiberInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10925:22)
      at performUnitOfWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10763:41)
      at workLoopSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10744:11)
      at renderRootSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10299:39)
      at performWorkOnRoot (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1894:7)
      at performSyncWorkOnRoot (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1761:21)
      at flushSyncWorkAcrossRoots_impl (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11290:13)
      at flushPassiveEffects (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11159:11)
      at callback (node_modules/react/cjs/react.development.js:862:34)
      at flushActQueue (node_modules/react/cjs/react.development.js:1151:10)
      at actImplementation (node_modules/@testing-library/react-native/src/act.ts:30:25)
      at renderWithAct (node_modules/@testing-library/react-native/src/render-act.ts:13:11)
      at renderInternal (node_modules/@testing-library/react-native/src/render.tsx:69:33)
      at renderInternal (node_modules/@testing-library/react-native/src/render.tsx:44:10)
      at renderMethod (tests/helpers/render.js:41:10)
      at Object.<anonymous> (tests/unit/components/ObsEdit/ObsEdit.test.js:65:20)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:7)
      at Object.<anonymous> (node_modules/@babel/runtime/helpers/asyncToGenerator.js:14:12)
```

It appears that occasionally the observation's user and `currentUser`'s user do not align. This is likely because `currentUser` is _not_ stubbed during the test, unlike `observation.user` which _is_ stubbed during the test.