### PR TITLE
Shutdown Realm after tests complete to avoid Jest open connections warning.

### DIFF
--- a/tests/realm.setup.js
+++ b/tests/realm.setup.js
@@ -49,4 +49,5 @@ beforeAll( async ( ) => {
 // Ensure the realm connection gets closed
 afterAll( ( ) => {
   global.realm?.close( );
+  Realm.shutdown();
 } );


### PR DESCRIPTION
Currently on `main`, if you run `npx jest tests/unit/components/ObsEdit/DatePicker.test.js`, you will get a warning after the test is run about connections remaining open:

---

<img width="1211" height="225" alt="Screenshot 2025-10-26 at 1 39 03 AM" src="https://github.com/user-attachments/assets/476c2037-edfe-4676-9639-ce0c6882d333" />

---

This seems to be because Realm keeps some connections open, even [after calling `close` on the instance](https://github.com/inaturalist/iNaturalistReactNative/blob/f6b3ba1841e9c1c93f5530a68c0fa67c622fcd05/tests/realm.setup.js#L51) (see also https://github.com/realm/realm-js/issues/1387 and https://github.com/realm/realm-js/issues/2993).

To work around this, this pull request introduces a call to `Realm.shutdown()` after all tests are done, to ensure all Realm connections and async operations are closed. This resoles the warning and Jest now gracefully exits after the test runs:

---

<img width="849" height="184" alt="Screenshot 2025-10-26 at 1 39 15 AM" src="https://github.com/user-attachments/assets/d9727008-a3a7-4dad-90f0-2d5301c87af4" />
