### PR TITLE
MOB-921 fix explore grid layout

### DIFF
--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -251,7 +251,8 @@ const ObservationsFlashList: Function = forwardRef( ( {
 
   const extraData = {
     gridItemWidth,
-    numColumns
+    numColumns,
+    layout
   };
 
   // only used id as a fallback key because after upload


### PR DESCRIPTION
[MOB-921](https://linear.app/inaturalist/issue/MOB-921/grid-view-explore-bug)

Fixed an issue where Explore was showing List layout items in a Grid layout. I believe what was happening here is the `layout` prop was causing the underlying Flashlist to update the UI layout, but nothing was prompting renderItem to be called again as neither the `data` nor `extraData` props were changing.