### PR TITLE
reverse spread order for grid styles

### DIFF
--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -213,8 +213,8 @@ const ObservationsFlashList: Function = forwardRef( ( {
   const contentContainerStyle = useMemo( ( ) => {
     if ( layout === "list" ) { return contentContainerStyleProp; }
     return {
-      ...contentContainerStyleProp,
-      ...flashListStyle
+      ...flashListStyle,
+      ...contentContainerStyleProp
     };
   }, [
     contentContainerStyleProp,


### PR DESCRIPTION
[MOB-888](https://linear.app/inaturalist/issue/MOB-888/on-explore-observations-grid-view-ui-is-covered-up)

Fixes an issue where the first couple tiles in explore grid view are partially covered by the explore header by changing the spread order of the styles applied, so the correct `paddingTop` is not overridden.