### PR TITLE
MOB-978 turn off restricted-syntax rule to allow forof loops

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,7 @@ module.exports = {
     "no-var": 1,
     "operator-linebreak": [2, "before"],
     "prefer-const": [2, { destructuring: "all" }],
+    "no-restricted-syntax": 0,
     // "react/forbid-prop-types": 0,
     "react/prop-types": 0,
     "react/destructuring-assignment": 0,


### PR DESCRIPTION
The eslint rule disallowing `forof` loops is from the airbnb config but is [based on outdated optimization guidance](https://stackoverflow.com/a/72072751/31670731). There are some cases where this forcing us to use "[].forEach" where I think this is actually harmful when it's not obvious that the async callback is unawaited, such as https://github.com/inaturalist/iNaturalistReactNative/blob/362ed537ee7e13df9175dc406f00b6a65058087d/src/sharedHelpers/sentinelFiles.ts#L74-L82