### PR TITLE
don't run test workflow on every push, PR trigger handles PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@
 ##
 name: Tests
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
This updates the `Tests` workflow triggers to [match e2e](https://github.com/inaturalist/iNaturalistReactNative/blob/main/.github/workflows/e2e_ios.yml#L5-L10). The main goal / impact of this is that we won't build pushes to branches that _aren't_ associated with PRs / before a branch is PR'd. 