### PR TITLE
typescriptify Developer.js and refactor size calculation

### DIFF
--- a/src/components/Developer/Developer.tsx
+++ b/src/components/Developer/Developer.tsx
@@ -10,7 +10,7 @@ import {
 } from "components/SharedComponents";
 import { fontMonoClass, View } from "components/styledComponents";
 import { t } from "i18next";
-import React, { PropsWithChildren } from "react";
+import React, { type PropsWithChildren } from "react";
 import { I18nManager, Platform, Text } from "react-native";
 import Config from "react-native-config";
 import RNFS from "react-native-fs";

--- a/src/components/Developer/hooks/useAppSize.ts
+++ b/src/components/Developer/hooks/useAppSize.ts
@@ -124,19 +124,19 @@ type AppSize = {
   [directoryName: string]: DirectoryEntrySize[]
 }
 
-export async function fetchAppSize(): Promise<AppSize> {
-  const existingDirectories = await Promise.all(
+async function fetchAppSize(): Promise<AppSize> {
+  const maybeExistingDirectories = await Promise.all(
     directories.map( async directory => ( {
       directory,
       exists: await RNFS.exists( directory.path )
     } ) )
   );
-  const filteredDirectories = existingDirectories
+  const existingDirectories = maybeExistingDirectories
     .filter( dir => dir.exists )
     .map( dir => dir.directory );
 
   const directoryToDirectorySizesKvps = await Promise.all(
-    filteredDirectories.map( async dir => {
+    existingDirectories.map( async dir => {
       const directoryEntrySizes = await getDirectoryEntrySizes( dir.path );
       return [dir.directoryName, directoryEntrySizes] as [string, DirectoryEntrySize[]];
     } )


### PR DESCRIPTION
The primary changes here are:
- adding more types to `useAppSize`
- separating the `AppSizes` calculation from the hook and fixing the wonky promise / mutable state logic
- moving the AppSize display in Developer.js to an independent component instead of render helper functions in the main component

MOB-986