### PR TITLE
Fix type error and unnecessary rendering in `LocationIndicator`.

### DIFF
--- a/src/components/SharedComponents/Map/LocationIndicator.tsx
+++ b/src/components/SharedComponents/Map/LocationIndicator.tsx
@@ -18,16 +18,15 @@ const LocationIndicator = ( {
   positionalAccuracy
 }: Props ) => (
   <>
-    {!!positionalAccuracy
-      && (
-        <Circle
-          center={{ latitude, longitude }}
-          radius={positionalAccuracy}
-          strokeWidth={2}
-          strokeColor={colors.inatGreen}
-          fillColor="rgba( 116, 172, 0, 0.2 )"
-        />
-      )}
+    {!!positionalAccuracy && (
+      <Circle
+        center={{ latitude, longitude }}
+        radius={positionalAccuracy}
+        strokeWidth={2}
+        strokeColor={colors.inatGreen}
+        fillColor="rgba( 116, 172, 0, 0.2 )"
+      />
+    )}
     <Marker
       coordinate={{ latitude, longitude }}
     >


### PR DESCRIPTION
<img width="763" height="257" alt="Screenshot 2025-11-03 at 7 51 58 PM" src="https://github.com/user-attachments/assets/9dc2077d-e4ee-4032-87e8-d72032a3d8c6" />

This pull request resolves the type error above.

In addition, one functional difference is it prevents the `Circle` component from rendering in the document tree when `positionalAccuracy` is `0` since `!!positionalAccuracy` is false-y. Despite that difference, there should be no difference visually since a circle with no radius wouldn't have ever be visible.