### PR TITLE
consider incomplete observations uploadable for logged out users

### DIFF
--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -205,7 +205,8 @@ const MyObservationsSimple = ( {
     numUnuploadedObservations > 0 && numUnuploadedObsMissingBasics > 0
   ), [numUnuploadedObservations, numUnuploadedObsMissingBasics] );
 
-  const numUploadableObservations = isDefaultMode
+  // if user is not logged in, we'll consider all obs 'uploadable' to shepherd people to login flow
+  const numUploadableObservations = isDefaultMode && !!currentUser
     ? numUnuploadedObservations - numUnuploadedObsMissingBasics
     : numUnuploadedObservations;
 


### PR DESCRIPTION
[MOB-979](https://linear.app/inaturalist/issue/MOB-979/logged-out-users-with-2-or-more-saved-observations-not-seeing-the)

Our upload banner will only display when there are saved observations we consider 'uploadable', ie they have all the data required. In an early app-use state, the user likely hasn't given us all the permissions need to make complete observations, however, the banner does double-duty and is also the way logged out users are encouraged to log in, so it needs to show anyway in these cases.

All I've done here is add an extra condition so that if the user isn't logged in, we'll count any observation, complete or not, as uploadable.