### PR TITLE
Simplify `name` property setting on API error classes.

### DIFF
--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -18,15 +18,12 @@ export class INatApiError extends Error {
     context?: Record<string, unknown> | null
   ) {
     super( JSON.stringify( json ) );
+    this.name = "INatApiError";
     this.json = json;
     this.status = status || Number( json.status );
     this.context = context || null;
   }
 }
-// https://wbinnssmith.com/blog/subclassing-error-in-modern-javascript/
-Object.defineProperty( INatApiError.prototype, "name", {
-  value: "INatApiError"
-} );
 
 export class INatApiUnauthorizedError extends INatApiError {
   constructor( context?: Record<string, unknown> ) {
@@ -36,12 +33,9 @@ export class INatApiUnauthorizedError extends INatApiError {
       context
     };
     super( errorJson, 401, context );
+    this.name = "INatApiUnauthorizedError";
   }
 }
-// https://wbinnssmith.com/blog/subclassing-error-in-modern-javascript/
-Object.defineProperty( INatApiUnauthorizedError.prototype, "name", {
-  value: "INatApiUnauthorizedError"
-} );
 
 export class INatApiTooManyRequestsError extends INatApiError {
   constructor( context?: Record<string, unknown> ) {
@@ -51,12 +45,9 @@ export class INatApiTooManyRequestsError extends INatApiError {
       context
     };
     super( errorJson, 429, context );
+    this.name = "INatApiTooManyRequestsError";
   }
 }
-
-Object.defineProperty( INatApiTooManyRequestsError.prototype, "name", {
-  value: "INatApiTooManyRequestsError"
-} );
 
 interface HandleErrorOptions {
   queryKey?: unknown[];


### PR DESCRIPTION
No need to go through `Object.defineProperty` to set a property on the class; we can just do that in the constructor. Also removes a comment to a dead link.