### PR TITLE
Introduce a type declaration file for Tailwind config colors.

### DIFF
--- a/src/styles/tailwindColors.d.ts
+++ b/src/styles/tailwindColors.d.ts
@@ -1,0 +1,30 @@
+declare module "styles/tailwindColors" {
+  export interface TailwindColors {
+    accessibleGreen: string;
+    black: string;
+    darkGray: string;
+    darkGrayDisabled: string;
+    darkModeGray: string;
+    inatGreen: string;
+    inatGreenDisabled: string;
+    inatGreenDisabledDark: string;
+    lightGray: string;
+    mediumGray: string;
+    mediumGrayGhost: string;
+    warningRed: string;
+    warningRedDisabled: string;
+    warningYellow: string;
+    white: string;
+    yellow: string;
+    red: string;
+    green: string;
+    blue: string;
+    deepPink: string;
+    deeppink: string;
+    DeepPink: string;
+    orange: string;
+  }
+
+  const colors: TailwindColors;
+  export default colors;
+}


### PR DESCRIPTION
Before:

```
coreyf@Coreys-MacBook-Air ~/d/i/iNaturalistReactNative (main)> npx tsc --allowJs false | wc
    1897   28150  291952
```


After:

```
coreyf@Coreys-MacBook-Air ~/d/i/iNaturalistReactNative (main)> npx tsc --allowJs false | wc
    1832   26961  274829
```

Extracted from https://github.com/inaturalist/iNaturalistReactNative/pull/3180


