### PR TITLE
Replace usages of `React.Node` with `React.ReactNode`.

### DIFF
--- a/src/components/MyObservations/LoginBanner.tsx
+++ b/src/components/MyObservations/LoginBanner.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 const LoginBanner = ( {
   currentUser
-}: Props ): React.Node => {
+}: Props ): React.ReactNode => {
   const { t } = useTranslation( );
   const navigation = useNavigation();
   const loginBannerDismissed = useStore( state => state.layout.loginBannerDismissed );

--- a/src/components/SharedComponents/FlashList/FlashListEmptyWrapper.tsx
+++ b/src/components/SharedComponents/FlashList/FlashListEmptyWrapper.tsx
@@ -7,7 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 const FOOTER_HEIGHT = 77;
 
 interface Props {
-  children: React.Node;
+  children: React.ReactNode;
   containerClassName?: string;
   headerHeight: number;
   emptyItemHeight: number;


### PR DESCRIPTION
The React TypeScript types define the latter, but not the former.