### PR TITLE
Improve return typing of `src/sharedHooks/useAuthenticatedQuery` function.

### DIFF
--- a/src/sharedHooks/useAuthenticatedQuery.ts
+++ b/src/sharedHooks/useAuthenticatedQuery.ts
@@ -11,13 +11,13 @@ interface QueryOptions {
   retry?: boolean;
 }
 
-type QueryFunction = ( options: { api_token: string | null } ) => Promise<unknown>;
+type QueryFunction<Response> = ( options: { api_token: string | null } ) => Promise<Response>;
 
 // Should work like React Query's useQuery except it calls the queryFunction
 // with an object that includes the JWT
-const useAuthenticatedQuery = (
+const useAuthenticatedQuery = <Response>(
   queryKey: string[],
-  queryFunction: QueryFunction,
+  queryFunction: QueryFunction<Response>,
   queryOptions: QueryOptions = {}
 ) => {
   const [userLoggedIn, setUserLoggedIn] = useState<boolean | null>( LOGGED_IN_UNKNOWN );


### PR DESCRIPTION
# Before

<img width="455" height="53" alt="Screenshot 2025-11-11 at 1 05 02 AM" src="https://github.com/user-attachments/assets/278589d6-a1d1-4edc-b971-0a4c830201b0" />

# After

<img width="462" height="59" alt="Screenshot 2025-11-11 at 1 04 55 AM" src="https://github.com/user-attachments/assets/819dc9ac-2dcf-4fb3-be16-96c85a2076b2" />
