### PR TITLE
center align carousel title text

### DIFF
--- a/src/components/Onboarding/OnboardingCarousel.js
+++ b/src/components/Onboarding/OnboardingCarousel.js
@@ -54,7 +54,7 @@ const SlideItem = props => {
               height={item.iconProps.height}
             />
           )}
-        <Heading1 className="text-white mt-[30px]">
+        <Heading1 className="text-white mt-[30px] text-center">
           {item.title}
         </Heading1>
         <Body1 className="text-center text-white mt-[20px]">


### PR DESCRIPTION
[MOB-648](https://linear.app/inaturalist/issue/MOB-648/carousel-titles-should-be-center-aligned)