### PR TITLE
use Subheading2 over Heading2 for location name

### DIFF
--- a/src/components/SharedComponents/SimpleObservationLocation.tsx
+++ b/src/components/SharedComponents/SimpleObservationLocation.tsx
@@ -4,7 +4,9 @@ import React from "react";
 import { useTranslation } from "sharedHooks";
 
 interface Props {
-  observation: object;
+  observation: {
+    private_place_guess?: string
+  };
 }
 
 const SimpleObservationLocation = ( {
@@ -13,7 +15,7 @@ const SimpleObservationLocation = ( {
   const { t } = useTranslation( );
   const displayLocation = checkCamelAndSnakeCase(
     observation,
-    "private_place_guess" in observation
+    observation.private_place_guess
       ? "privatePlaceGuess"
       : "placeGuess"
   );


### PR DESCRIPTION
This was one of the two areas mentioned in MOB-744 that needed fixing, but it looks like the other instance in for the Taxon name is already corrected for the named uses.