### PR TITLE
Replace potentially problematic splatting behavior with `Object.assign`.

### DIFF
--- a/src/components/ObsDetails/MasonryLayout.js
+++ b/src/components/ObsDetails/MasonryLayout.js
@@ -26,7 +26,7 @@ const MasonryLayout = ( { items, onImagePress } ) => {
           return item;
         }
         const imageDimensions = await getImageDimensions( photoUrl( item ) );
-        return { ...item, ...imageDimensions };
+        return Object.assign( item, imageDimensions );
       } );
 
       const itemData = await Promise.all( itemPromises );


### PR DESCRIPTION
Extracted from https://github.com/inaturalist/iNaturalistReactNative/pull/3188, and see [this comment](https://github.com/inaturalist/iNaturalistReactNative/pull/3188#discussion_r2496101477).

Splatting does not copy the prototypal inheritance, which means you won't be able to call instance methods on the new splatted Realm Models.