### PR TITLE
Avoid lint suppressions in `useEffect` by making returns consistent.

### DIFF
--- a/src/components/hooks/useWorkQueue.ts
+++ b/src/components/hooks/useWorkQueue.ts
@@ -1,6 +1,5 @@
 import { fetchUserMe, updateUsers } from "api/users";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
-import { noop } from "lodash";
 import { RealmContext } from "providers/contexts";
 import { useEffect, useState } from "react";
 import QueueItem from "realmModels/QueueItem";
@@ -65,7 +64,8 @@ const useWorkQueue = ( ) => {
 
   useEffect( ( ) => {
     if ( realm === null || realm.isClosed ) {
-      return noop;
+      // Satisfy the useEffect return type by returning a destructor function.
+      return () => {};
     }
     const queuedItems = realm.objects( "QueueItem" );
     // logger.info( `Initial queue size: ${queuedItems?.length}` );

--- a/src/sharedHooks/useInterval.ts
+++ b/src/sharedHooks/useInterval.ts
@@ -1,4 +1,3 @@
-import { noop } from "lodash";
 import { useEffect, useRef } from "react";
 
 function useInterval( callback:() => void, delay: number | null ) {
@@ -18,7 +17,8 @@ function useInterval( callback:() => void, delay: number | null ) {
       }
     }
     if ( delay === null ) {
-      return noop;
+      // Satisfy the useEffect return type by returning a destructor function.
+      return () => {};
     }
     const id = setInterval( tick, delay );
     return () => clearInterval( id );

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { noop } from "lodash";
 import { RealmContext } from "providers/contexts";
 import {
   useEffect, useRef,
@@ -44,7 +43,8 @@ const useLocalObservations = ( ): Object => {
 
   useEffect( ( ) => {
     if ( realm === null || realm.isClosed ) {
-      return noop;
+      // Satisfy the useEffect return type by returning a destructor function.
+      return () => {};
     }
     const localObservations = realm.objects( "Observation" );
 


### PR DESCRIPTION
`useEffect` expects all returns to either return `undefined`, or destructor functions. In some spots, we are return a mix, so there were lint suppressions added to ignore those cases. Instead of encouraging lint suppressions, this replaces those with return `noop` functions so we comply with the `useEffect` typing.
