### PR TITLE
pre-determine layout if ai camera not supported

### DIFF
--- a/src/components/AddObsBottomSheet/AddObsBottomSheet.tsx
+++ b/src/components/AddObsBottomSheet/AddObsBottomSheet.tsx
@@ -91,6 +91,16 @@ const AddObsBottomSheet = ( {
     t
   ] );
 
+  const optionRows = AI_CAMERA_SUPPORTED
+    ? [
+      [obsCreateItems.standardCamera, obsCreateItems.photoLibrary],
+      [obsCreateItems.soundRecorder, obsCreateItems.aiCamera]
+    ]
+    : [
+      [obsCreateItems.standardCamera],
+      [obsCreateItems.soundRecorder, obsCreateItems.photoLibrary]
+    ];
+
   const renderAddObsIcon = ( {
     accessibilityHint,
     accessibilityLabel,
@@ -133,15 +143,11 @@ const AddObsBottomSheet = ( {
     >
       <View className="flex-column gap-y-4 pb-4 px-4">
 
-        <View className={ROW_CLASS}>
-          {renderAddObsIcon( obsCreateItems.standardCamera )}
-          {renderAddObsIcon( obsCreateItems.photoLibrary )}
-        </View>
-
-        <View className={ROW_CLASS}>
-          {renderAddObsIcon( obsCreateItems.soundRecorder )}
-          {AI_CAMERA_SUPPORTED && renderAddObsIcon( obsCreateItems.aiCamera )}
-        </View>
+        {optionRows.map( row => (
+          <View key={row.map( i => i.testID ).join( "-" )} className={ROW_CLASS}>
+            {row.map( item => renderAddObsIcon( item ) )}
+          </View>
+        ) )}
 
         <Pressable
           className="bg-mediumGray w-full flex-row items-center py-[10px] px-5 rounded-lg


### PR DESCRIPTION
[MOB-1034](https://linear.app/inaturalist/issue/MOB-1034/obs-sheet-when-ai-camera-is-not-available)

Before:
<img width="300" height="2532" alt="IMG_0035" src="https://github.com/user-attachments/assets/23ba171e-0fd4-4b80-b4ad-77b3db623615" />

After:
<img width="300" height="2532" alt="IMG_0036" src="https://github.com/user-attachments/assets/e9ebd1b8-c5d1-4d17-8b4e-77a253e905d1" />
