### PR TITLE
MOB-1039 apply member delimiter style and autofix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,7 +148,8 @@ module.exports = {
     "@typescript-eslint/consistent-type-imports": ["error", {
       fixStyle: "separate-type-imports"
     }],
-    "import/consistent-type-specifier-style": ["error", "prefer-top-level"]
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+    "@stylistic/member-delimiter-style": "error"
   },
   ignorePatterns: ["!.detoxrc.js", "/coverage/*", "/vendor/*", "**/flow-typed"],
   settings: {
@@ -168,7 +169,8 @@ module.exports = {
         "@typescript-eslint/no-wrapper-object-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/consistent-type-imports": "off",
-        "import/consistent-type-specifier-style": "off"
+        "import/consistent-type-specifier-style": "off",
+        "@stylistic/member-delimiter-style": "off"
       }
     },
     {

--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -66,10 +66,10 @@ export interface ErrorWithResponse {
     json: () => Promise<{
       status: string;
       errors: Array<{
-        errorCode: string,
-        message: string,
-        from: string | null,
-        stack: string | null,
+        errorCode: string;
+        message: string;
+        from: string | null;
+        stack: string | null;
       }>;
     }>;
   };

--- a/src/api/log.ts
+++ b/src/api/log.ts
@@ -17,7 +17,7 @@ const api = create( {
   }
 } );
 
-function isError( error: { message?: string, stack?: string } ) {
+function isError( error: { message?: string; stack?: string } ) {
   if ( error instanceof Error ) return true;
   if ( error?.stack && error?.message ) return true;
   return false;

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -20,12 +20,12 @@ interface SearchResponse extends ApiResponse {
     project?: ApiProject;
     taxon?: ApiTaxon;
     user?: ApiUser;
-  }[]
+  }[];
 }
 
 interface SearchParams extends ApiParams {
   q?: string;
-  sources?: string | string[]
+  sources?: string | string[];
 }
 
 const PARAMS: ApiParams = {

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -145,7 +145,7 @@ export interface ApiObservation extends ApiRecord {
 }
 
 export interface ApiObservationsSearchResponse extends ApiResponse {
-  results: ApiObservation[]
+  results: ApiObservation[];
 }
 
 export const ORDER_BY_CREATED_AT = "created_at";

--- a/src/components/AddObsBottomSheet/AddObsBottomSheet.tsx
+++ b/src/components/AddObsBottomSheet/AddObsBottomSheet.tsx
@@ -12,18 +12,18 @@ import colors from "styles/tailwindColors";
 interface Props {
   closeBottomSheet: ( ) => void;
   navAndCloseBottomSheet: ( screen: string, params?: {
-    camera?: string
+    camera?: string;
   } ) => void;
   hidden: boolean;
 }
 
 type ObsCreateItem = {
-  text: string,
-  icon: string,
-  onPress: ( ) => void,
-  testID: string,
-  accessibilityLabel: string,
-  accessibilityHint: string
+  text: string;
+  icon: string;
+  onPress: ( ) => void;
+  testID: string;
+  accessibilityLabel: string;
+  accessibilityHint: string;
 }
 
 const majorVersionIOS = parseInt( String( Platform.Version ), 10 );

--- a/src/components/Camera/CameraView.tsx
+++ b/src/components/Camera/CameraView.tsx
@@ -32,20 +32,20 @@ Reanimated.addWhitelistedNativeProps( {
 } );
 
 interface Props {
-  animatedProps: CameraProps,
-  cameraRef: React.RefObject<Camera | null>,
-  cameraScreen: "standard" | "ai",
-  debugFormat: CameraDeviceFormat | undefined,
-  device: CameraDevice,
-  frameProcessor?: () => void,
-  onCameraError: ( error: CameraRuntimeError ) => void,
-  onCaptureError: ( error: CameraRuntimeError ) => void,
-  onClassifierError: ( error: CameraRuntimeError ) => void,
-  onDeviceNotSupported: ( error: CameraRuntimeError ) => void,
-  panToZoom: PanGesture,
-  pinchToZoom: PinchGesture,
-  resizeMode?: "cover" | "contain",
-  inactive?: boolean
+  animatedProps: CameraProps;
+  cameraRef: React.RefObject<Camera | null>;
+  cameraScreen: "standard" | "ai";
+  debugFormat: CameraDeviceFormat | undefined;
+  device: CameraDevice;
+  frameProcessor?: () => void;
+  onCameraError: ( error: CameraRuntimeError ) => void;
+  onCaptureError: ( error: CameraRuntimeError ) => void;
+  onClassifierError: ( error: CameraRuntimeError ) => void;
+  onDeviceNotSupported: ( error: CameraRuntimeError ) => void;
+  panToZoom: PanGesture;
+  pinchToZoom: PinchGesture;
+  resizeMode?: "cover" | "contain";
+  inactive?: boolean;
 }
 
 // A container for the Camera component

--- a/src/components/Camera/CameraWithDevice.tsx
+++ b/src/components/Camera/CameraWithDevice.tsx
@@ -11,23 +11,23 @@ import StandardCamera from "./StandardCamera/StandardCamera";
 const isTablet = DeviceInfo.isTablet( );
 
 interface Props {
-  cameraType: string,
-  device: CameraDevice,
-  camera: object,
-  flipCamera: ( ) => void,
-  handleCheckmarkPress: ( ) => void,
+  cameraType: string;
+  device: CameraDevice;
+  camera: object;
+  flipCamera: ( ) => void;
+  handleCheckmarkPress: ( ) => void;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  toggleFlash: Function,
-  takingPhoto: boolean,
+  toggleFlash: Function;
+  takingPhoto: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  takePhotoAndStoreUri: Function,
-  newPhotoUris: Array<object>,
+  takePhotoAndStoreUri: Function;
+  newPhotoUris: Array<object>;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  setNewPhotoUris: Function,
-  takePhotoOptions: object,
-  userLocation: UserLocation | null,
-  hasLocationPermissions: boolean,
-  requestLocationPermissions: () => void,
+  setNewPhotoUris: Function;
+  takePhotoOptions: object;
+  userLocation: UserLocation | null;
+  hasLocationPermissions: boolean;
+  requestLocationPermissions: () => void;
 }
 
 const CameraWithDevice = ( {

--- a/src/components/Camera/FadeInOutView.tsx
+++ b/src/components/Camera/FadeInOutView.tsx
@@ -4,8 +4,8 @@ import { Animated } from "react-native";
 import colors from "styles/tailwindColors";
 
 interface Props {
-  takingPhoto: boolean,
-  cameraType: string
+  takingPhoto: boolean;
+  cameraType: string;
 }
 
 const fade = value => ( {

--- a/src/components/Camera/FocusSquare.tsx
+++ b/src/components/Camera/FocusSquare.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Animated } from "react-native";
 
 interface Props {
-  animatedStyle: object
+  animatedStyle: object;
 }
 
 const FocusSquare = ( { animatedStyle }: Props ) => {

--- a/src/components/Developer/Developer.tsx
+++ b/src/components/Developer/Developer.tsx
@@ -75,7 +75,7 @@ const boldClassname = ( line: string, isDirectory = false ) => classnames(
 
 interface DirectorySizesProps {
   directoryName: string;
-  directoryEntrySizes: DirectoryEntrySize[]
+  directoryEntrySizes: DirectoryEntrySize[];
 }
 
 /* eslint-disable i18next/no-literal-string */

--- a/src/components/Developer/hooks/useAppSize.ts
+++ b/src/components/Developer/hooks/useAppSize.ts
@@ -121,7 +121,7 @@ export function getTotalDirectorySize( directoryItems: DirectoryEntrySize[] ): n
 }
 
 type AppSize = {
-  [directoryName: string]: DirectoryEntrySize[]
+  [directoryName: string]: DirectoryEntrySize[];
 }
 
 async function fetchAppSize(): Promise<AppSize> {

--- a/src/components/Explore/MapView.tsx
+++ b/src/components/Explore/MapView.tsx
@@ -50,19 +50,19 @@ const centeredLoadingWheel = {
 
 interface Props {
   // Bounding box of the observations retrieved for the query params
-  observationBounds?: MapBoundaries,
+  observationBounds?: MapBoundaries;
   queryParams: {
     taxon_id?: number;
     return_bounds?: boolean;
     order?: string;
     orderBy?: string;
   };
-  isLoading: boolean,
-  hasLocationPermissions?: boolean,
+  isLoading: boolean;
+  hasLocationPermissions?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  renderLocationPermissionsGate: Function,
+  renderLocationPermissionsGate: Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  requestLocationPermissions: Function
+  requestLocationPermissions: Function;
 }
 
 const MapView = ( {

--- a/src/components/Explore/SearchScreens/ExploreProjectSearch.tsx
+++ b/src/components/Explore/SearchScreens/ExploreProjectSearch.tsx
@@ -21,8 +21,8 @@ const DROP_SHADOW = getShadow( {
 } );
 
 type Props = {
-  closeModal: ( ) => void,
-  updateProject: ( project: ApiProject ) => void
+  closeModal: ( ) => void;
+  updateProject: ( project: ApiProject ) => void;
 };
 
 const ExploreProjectSearch = ( { closeModal, updateProject }: Props ) => {

--- a/src/components/FullPageWebView/FullPageWebView.tsx
+++ b/src/components/FullPageWebView/FullPageWebView.tsx
@@ -62,14 +62,14 @@ type FullPageWebViewParams = {
 }
 
 type ParamList = {
-  FullPageWebView: FullPageWebViewParams
+  FullPageWebView: FullPageWebViewParams;
 }
 
 type WebViewSource = {
   uri: string;
   headers?: {
-    Authorization?: string | null
-  }
+    Authorization?: string | null;
+  };
 }
 
 export function onShouldStartLoadWithRequest(

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -187,9 +187,9 @@ const getUsername = async (): Promise<string> => getSensitiveItem( "username" );
  */
 const signOut = async (
   options: {
-    realm?: Realm,
-    clearRealm?: boolean,
-    queryClient?: QueryClient
+    realm?: Realm;
+    clearRealm?: boolean;
+    queryClient?: QueryClient;
   } = {
     clearRealm: false,
     queryClient: undefined
@@ -579,7 +579,7 @@ async function authenticateUserByAssertion(
 }
 
 interface CreateUserResponse {
-  errors?: string[]
+  errors?: string[];
 }
 
 /**

--- a/src/components/LoginSignUp/ForgotPassword.tsx
+++ b/src/components/LoginSignUp/ForgotPassword.tsx
@@ -15,7 +15,7 @@ import LoginSignUpWrapper from "./LoginSignUpWrapper";
 
 type RenderProps = {
   // eslint-disable-next-line react/no-unused-prop-types
-  scrollViewRef: { current: null | React.Ref<typeof ScrollView> }
+  scrollViewRef: { current: null | React.Ref<typeof ScrollView> };
 };
 
 const ForgotPassword = ( ) => {

--- a/src/components/LoginSignUp/ForgotPasswordForm.tsx
+++ b/src/components/LoginSignUp/ForgotPasswordForm.tsx
@@ -16,8 +16,8 @@ import useKeyboardInfo from "sharedHooks/useKeyboardInfo";
 import LoginSignUpInputField from "./LoginSignUpInputField";
 
 type Props = {
-  reset: ( email: string ) => Promise<void>,
-  scrollViewRef?: { current: null | ElementRef<typeof ScrollView> },
+  reset: ( email: string ) => Promise<void>;
+  scrollViewRef?: { current: null | ElementRef<typeof ScrollView> };
 }
 
 const ForgotPasswordForm = ( { reset, scrollViewRef }: Props ): Node => {

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -28,7 +28,7 @@ import LoginSignUpInputField from "./LoginSignUpInputField";
 const { useRealm } = RealmContext;
 
 interface Props {
-  scrollViewRef?: React.Ref
+  scrollViewRef?: React.Ref;
 }
 
 interface LoginFormParams {
@@ -38,7 +38,7 @@ interface LoginFormParams {
 }
 
 type ParamList = {
-  LoginFormParams: LoginFormParams
+  LoginFormParams: LoginFormParams;
 }
 
 const LoginForm = ( {

--- a/src/components/LoginSignUp/LoginSignUpWrapper.tsx
+++ b/src/components/LoginSignUp/LoginSignUpWrapper.tsx
@@ -18,8 +18,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import colors from "styles/tailwindColors";
 
 interface Props extends PropsWithChildren {
-  backgroundSource: ImageSourcePropType,
-  imageStyle?: StyleProp<ImageStyle>
+  backgroundSource: ImageSourcePropType;
+  imageStyle?: StyleProp<ImageStyle>;
 }
 
 const windowHeight = Dimensions.get( "window" ).height;

--- a/src/components/Match/AdditionalSuggestions/SuggestionsResult.tsx
+++ b/src/components/Match/AdditionalSuggestions/SuggestionsResult.tsx
@@ -15,12 +15,12 @@ import {
 } from "sharedHooks";
 
 type Props = {
-  confidence: number,
-  handlePress?: ( ) => void,
-  taxon: RealmTaxon | ApiTaxon,
-  testID?: string,
-  updateMaxHeight?: ( height: number ) => void,
-  forcedHeight: number
+  confidence: number;
+  handlePress?: ( ) => void;
+  taxon: RealmTaxon | ApiTaxon;
+  testID?: string;
+  updateMaxHeight?: ( height: number ) => void;
+  forcedHeight: number;
 }
 
 const SuggestionsResult = ( {

--- a/src/components/Match/MatchHeader.tsx
+++ b/src/components/Match/MatchHeader.tsx
@@ -19,7 +19,7 @@ interface Props {
     score?: number;
     taxon?: RealmTaxon;
   };
-  hideObservationStatus?: boolean
+  hideObservationStatus?: boolean;
 }
 
 const MatchHeader = ( { topSuggestion, hideObservationStatus }: Props ) => {

--- a/src/components/Match/MatchTaxonSearchScreen.tsx
+++ b/src/components/Match/MatchTaxonSearchScreen.tsx
@@ -59,7 +59,7 @@ const MatchTaxonSearchScreen = ( ) => {
     // no-unused-prop-types failing for components defined at runtime seems to
     // be a bug. These props are clearly used
     // eslint-disable-next-line react/no-unused-prop-types
-    ( { item: taxon, index }: { item: ApiTaxon, index: number } ) => (
+    ( { item: taxon, index }: { item: ApiTaxon; index: number } ) => (
       <TaxonResult
         accessibilityLabel={t( "Choose-taxon" )}
         fetchRemote={false}

--- a/src/components/MediaViewer/CustomImageZoom.tsx
+++ b/src/components/MediaViewer/CustomImageZoom.tsx
@@ -12,9 +12,9 @@ const MIN_SCALE = 0.5;
 const MAX_SCALE = 5;
 
 interface Props {
-  uri: string
-  setZooming: ( ) => void,
-  selectedMediaIndex: number
+  uri: string;
+  setZooming: ( ) => void;
+  selectedMediaIndex: number;
 }
 
 const CustomImageZoom = ( {

--- a/src/components/MyObservations/MyObservationsContainer.tsx
+++ b/src/components/MyObservations/MyObservationsContainer.tsx
@@ -42,8 +42,8 @@ import MyObservationsSimple, {
 const { useRealm } = RealmContext;
 
 interface SpeciesCount {
-  count: number,
-  taxon: RealmTaxon
+  count: number;
+  taxon: RealmTaxon;
 }
 
 interface SyncOptions {
@@ -243,9 +243,9 @@ const MyObservationsContainer = ( ): React.FC => {
   const onScroll = ( scrollEvent: {
     nativeEvent: {
       contentOffset: {
-        y: number
-      }
-    }
+        y: number;
+      };
+    };
   } ) => setMyObsOffset( scrollEvent.nativeEvent.contentOffset.y );
 
   const numOfUserObservations = zustandStorage.getItem( "numOfUserObservations" );

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -38,8 +38,8 @@ import SimpleTaxonGridItem from "./SimpleTaxonGridItem";
 import StatTab from "./StatTab";
 
 interface SpeciesCount {
-  count: number,
-  taxon: RealmTaxon
+  count: number;
+  taxon: RealmTaxon;
 }
 
 export interface Props {

--- a/src/components/MyObservations/SimpleTaxonGridItem.tsx
+++ b/src/components/MyObservations/SimpleTaxonGridItem.tsx
@@ -17,15 +17,15 @@ const imageClassNames = [
 ];
 
 interface SpeciesCount {
-  count: number,
-  taxon: RealmTaxon
+  count: number;
+  taxon: RealmTaxon;
 }
 
 export interface Props {
   accessibleName: string;
   navToTaxonDetails: ( ) => void;
   source: {
-    uri: string
+    uri: string;
   };
   style?: object;
   speciesCount: SpeciesCount;

--- a/src/components/Notifications/NotificationsList.tsx
+++ b/src/components/Notifications/NotificationsList.tsx
@@ -14,16 +14,16 @@ import { useTranslation } from "sharedHooks";
 import type { Notification } from "sharedHooks/useInfiniteNotificationsScroll";
 
 type Props = {
-  currentUser: RealmUser | null,
-  data: Notification[],
-  isError?: boolean,
-  isFetching?: boolean,
-  isInitialLoading?: boolean,
-  isConnected: boolean | null,
-  onEndReached: ( ) => void,
-  onRefresh: ( ) => void,
-  refreshing: boolean,
-  reload: ( ) => void
+  currentUser: RealmUser | null;
+  data: Notification[];
+  isError?: boolean;
+  isFetching?: boolean;
+  isInitialLoading?: boolean;
+  isConnected: boolean | null;
+  onEndReached: ( ) => void;
+  onRefresh: ( ) => void;
+  refreshing: boolean;
+  reload: ( ) => void;
 };
 
 interface RenderItemProps {

--- a/src/components/Notifications/NotificationsListItem.tsx
+++ b/src/components/Notifications/NotificationsListItem.tsx
@@ -8,7 +8,7 @@ import type { Notification } from "sharedHooks/useInfiniteNotificationsScroll";
 import { OBS_DETAILS_TAB } from "stores/createLayoutSlice";
 
 type Props = {
-  notification: Notification
+  notification: Notification;
 };
 
 const NotificationsListItem = ( { notification }: Props ) => {

--- a/src/components/Notifications/ObsNotification.tsx
+++ b/src/components/Notifications/ObsNotification.tsx
@@ -12,7 +12,7 @@ import type { Notification } from "sharedHooks/useInfiniteNotificationsScroll";
 import colors from "styles/tailwindColors";
 
 interface Props {
-  notification: Notification
+  notification: Notification;
 }
 
 const ObsNotification = ( { notification }: Props ) => {

--- a/src/components/Notifications/ObsNotificationText.tsx
+++ b/src/components/Notifications/ObsNotificationText.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "sharedHooks";
 import type { Notification } from "sharedHooks/useInfiniteNotificationsScroll";
 
 interface Props {
-  notification: Notification
+  notification: Notification;
 }
 
 const ObsNotificationText = ( { notification }: Props ) => {

--- a/src/components/ObsDetails/ActivityTab/DisagreementText.tsx
+++ b/src/components/ObsDetails/ActivityTab/DisagreementText.tsx
@@ -10,15 +10,15 @@ interface Props {
     preferred_common_name?: string;
     rank: string;
     rank_level: number;
-  },
-  username: string,
-  withdrawn?: boolean
+  };
+  username: string;
+  withdrawn?: boolean;
 }
 
 // TODO replace when we've properly typed Realm object
 interface User {
   prefers_common_names?: boolean;
-  prefers_scientific_name_first?: boolean
+  prefers_scientific_name_first?: boolean;
 }
 
 const DisagreementText = ( { taxon, username, withdrawn }: Props ) => {

--- a/src/components/ObsDetails/DetailsTab/LocationSection.tsx
+++ b/src/components/ObsDetails/DetailsTab/LocationSection.tsx
@@ -19,7 +19,7 @@ import DetailsMapHeader from "./DetailsMapHeader";
 import ObscurationExplanation from "./ObscurationExplanation";
 
 interface Props {
-  observation: Observation
+  observation: Observation;
 }
 
 const DETAILS_MAP_MODAL_STYLE = { margin: 0 };

--- a/src/components/ObsDetails/DetailsTab/ProjectSection.tsx
+++ b/src/components/ObsDetails/DetailsTab/ProjectSection.tsx
@@ -20,7 +20,7 @@ interface Props {
     non_traditional_projects: Array<{
       project: object;
     }>;
-  }
+  };
 }
 
 const ProjectSection = ( { observation }: Props ) => {

--- a/src/components/ObsDetails/Sheets/PotentialDisagreementSheet.tsx
+++ b/src/components/ObsDetails/Sheets/PotentialDisagreementSheet.tsx
@@ -12,10 +12,10 @@ import type { RealmTaxon } from "realmModels/types";
 import { useCurrentUser, useTranslation } from "sharedHooks";
 
 interface Props {
-  onPressClose: () => void,
+  onPressClose: () => void;
   onPotentialDisagreePressed: ( _checkedValue: string ) => void;
-  newTaxon: RealmTaxon | ApiTaxon,
-  oldTaxon: RealmTaxon | ApiTaxon
+  newTaxon: RealmTaxon | ApiTaxon;
+  oldTaxon: RealmTaxon | ApiTaxon;
 }
 
 const PotentialDisagreementSheet = ( {

--- a/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
+++ b/src/components/ObsDetails/Sheets/SuggestIDSheet.tsx
@@ -11,17 +11,17 @@ import type { Node } from "react";
 import React from "react";
 
 interface Props {
-  hidden?: boolean,
+  hidden?: boolean;
   identification: {
-    body?: string,
-    taxon: { id: number }
-  }
+    body?: string;
+    taxon: { id: number };
+  };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onSuggestId:Function,
+  onSuggestId:Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  editIdentBody: Function,
+  editIdentBody: Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onPressClose: Function
+  onPressClose: Function;
 }
 
 const SuggestIDSheet = ( {

--- a/src/components/ObsDetailsDefaultMode/CommunitySection/DisagreementText.tsx
+++ b/src/components/ObsDetailsDefaultMode/CommunitySection/DisagreementText.tsx
@@ -11,15 +11,15 @@ interface Props {
     preferred_common_name?: string;
     rank: string;
     rank_level: number;
-  },
-  username: string,
-  withdrawn?: boolean
+  };
+  username: string;
+  withdrawn?: boolean;
 }
 
 // TODO replace when we've properly typed Realm object
 interface User {
   prefers_common_names?: boolean;
-  prefers_scientific_name_first?: boolean
+  prefers_scientific_name_first?: boolean;
 }
 
 const DisagreementText = ( { taxon, username, withdrawn }: Props ) => {

--- a/src/components/ObsDetailsDefaultMode/LocationSection/LocationSection.tsx
+++ b/src/components/ObsDetailsDefaultMode/LocationSection/LocationSection.tsx
@@ -13,8 +13,8 @@ import { useCurrentUser } from "sharedHooks";
 import ObscurationExplanation from "./ObscurationExplanation";
 
 interface Props {
-  belongsToCurrentUser: boolean,
-  observation: RealmObservation
+  belongsToCurrentUser: boolean;
+  observation: RealmObservation;
 }
 
 const LocationSection = ( {

--- a/src/components/ObsDetailsDefaultMode/MoreSection/DQAButton.tsx
+++ b/src/components/ObsDetailsDefaultMode/MoreSection/DQAButton.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { useCurrentUser } from "sharedHooks";
 
 interface Props {
-  observationUUID: string
+  observationUUID: string;
 }
 
 const DQAButton = ( { observationUUID }: Props ) => {

--- a/src/components/ObsDetailsDefaultMode/MoreSection/ProjectButton.tsx
+++ b/src/components/ObsDetailsDefaultMode/MoreSection/ProjectButton.tsx
@@ -12,7 +12,7 @@ interface Props {
     non_traditional_projects: Array<{
       project: object;
     }>;
-  }
+  };
 }
 
 const ProjectButton = ( { observation }: Props ) => {

--- a/src/components/ObsDetailsDefaultMode/MoreSection/ShareButton.tsx
+++ b/src/components/ObsDetailsDefaultMode/MoreSection/ShareButton.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { Alert, Platform, Share } from "react-native";
 
 type Props = {
-  id: number
+  id: number;
 }
 
 const OBSERVATION_URL = "https://www.inaturalist.org/observations";

--- a/src/components/ObsDetailsDefaultMode/ObsDetailsDefaultMode.tsx
+++ b/src/components/ObsDetailsDefaultMode/ObsDetailsDefaultMode.tsx
@@ -27,22 +27,22 @@ import StatusSection from "./StatusSection/StatusSection";
 const cardClassBottom = "rounded-b-2xl border-lightGray border-[2px] pb-3 border-t-0 -mt-0.5 mb-4";
 
 type Props = {
-  activityItems: Array<object>,
-  addingActivityItem: boolean,
-  belongsToCurrentUser: boolean,
-  currentUser: RealmUser,
-  isConnected: boolean,
-  navToSuggestions: () => void,
-  observation: RealmObservation & Observation & { id: number },
-  openAddCommentSheet: () => void,
-  openAgreeWithIdSheet: () => void,
-  refetchRemoteObservation: () => void,
-  refetchSubscriptions: () => void,
-  showAddCommentSheet: () => void,
-  subscriptions: object,
-  targetActivityItemID: number,
-  wasSynced: boolean,
-  uuid: string
+  activityItems: Array<object>;
+  addingActivityItem: boolean;
+  belongsToCurrentUser: boolean;
+  currentUser: RealmUser;
+  isConnected: boolean;
+  navToSuggestions: () => void;
+  observation: RealmObservation & Observation & { id: number };
+  openAddCommentSheet: () => void;
+  openAgreeWithIdSheet: () => void;
+  refetchRemoteObservation: () => void;
+  refetchSubscriptions: () => void;
+  showAddCommentSheet: () => void;
+  subscriptions: object;
+  targetActivityItemID: number;
+  wasSynced: boolean;
+  uuid: string;
 }
 
 const ObsDetailsDefaultMode = ( {

--- a/src/components/ObsDetailsDefaultMode/ObsDetailsDefaultModeScreensWrapper.tsx
+++ b/src/components/ObsDetailsDefaultMode/ObsDetailsDefaultModeScreensWrapper.tsx
@@ -13,8 +13,8 @@ import {
 import SavedMatchContainer from "./SavedMatch/SavedMatchContainer";
 
 type RouteParams = {
-    targetActivityItemID?: number,
-    uuid: string,
+    targetActivityItemID?: number;
+    uuid: string;
 }
 
 const ObsDetailsDefaultModeScreensWrapper = () => {

--- a/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatch.tsx
+++ b/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatch.tsx
@@ -14,8 +14,8 @@ import { useTranslation } from "sharedHooks";
 import SavedMatchHeaderRight from "./SavedMatchHeaderRight";
 
 interface Props {
-  observation: RealmObservation,
-  navToTaxonDetails: ( ) => void,
+  observation: RealmObservation;
+  navToTaxonDetails: ( ) => void;
 }
 
 const SavedMatch = ( {

--- a/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatchContainer.tsx
+++ b/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatchContainer.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import type { RealmObservation } from "realmModels/types";
 
 interface Props {
-  observation: RealmObservation,
+  observation: RealmObservation;
 }
 
 const SavedMatchContainer = ( { observation }: Props ) => {

--- a/src/components/ObsDetailsDefaultMode/Sheets/SuggestIDSheet.tsx
+++ b/src/components/ObsDetailsDefaultMode/Sheets/SuggestIDSheet.tsx
@@ -11,17 +11,17 @@ import type { Node } from "react";
 import React from "react";
 
 interface Props {
-  hidden?: boolean,
+  hidden?: boolean;
   identification: {
-    body?: string,
-    taxon: { id: number }
-  }
+    body?: string;
+    taxon: { id: number };
+  };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onSuggestId:Function,
+  onSuggestId:Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  editIdentBody: Function,
+  editIdentBody: Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onPressClose: Function
+  onPressClose: Function;
 }
 
 const SuggestIDSheet = ( {

--- a/src/components/ObsEdit/BottomButtons.tsx
+++ b/src/components/ObsEdit/BottomButtons.tsx
@@ -19,15 +19,15 @@ export const SAVE = "save";
 export type ButtonType = typeof SAVE | typeof UPLOAD | null;
 
 type Props = {
-  buttonPressed: ButtonType,
-  canSaveOnly: boolean,
+  buttonPressed: ButtonType;
+  canSaveOnly: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  handlePress: Function,
-  loading: boolean,
-  showFocusedChangesButton: boolean,
-  showFocusedUploadButton: boolean
-  showHalfOpacity: boolean,
-  wasSynced: boolean,
+  handlePress: Function;
+  loading: boolean;
+  showFocusedChangesButton: boolean;
+  showFocusedUploadButton: boolean;
+  showHalfOpacity: boolean;
+  wasSynced: boolean;
 }
 
 const BottomButtons = ( {

--- a/src/components/ObsEdit/BottomButtonsContainer.tsx
+++ b/src/components/ObsEdit/BottomButtonsContainer.tsx
@@ -21,14 +21,14 @@ import MissingEvidenceSheet from "./Sheets/MissingEvidenceSheet";
 const { useRealm } = RealmContext;
 
 type Props = {
-  passesEvidenceTest: boolean,
-  observations: Array<object>,
-  currentObservation: RealmObservation,
-  currentObservationIndex: number,
+  passesEvidenceTest: boolean;
+  observations: Array<object>;
+  currentObservation: RealmObservation;
+  currentObservationIndex: number;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  setCurrentObservationIndex: Function,
+  setCurrentObservationIndex: Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  transitionAnimation: Function
+  transitionAnimation: Function;
 }
 
 const BottomButtonsContainer = ( {

--- a/src/components/ObsEdit/Sheets/GeoprivacySheet.tsx
+++ b/src/components/ObsEdit/Sheets/GeoprivacySheet.tsx
@@ -12,9 +12,9 @@ import useTranslation from "sharedHooks/useTranslation";
 type Geoprivacy = null | GEOPRIVACY_OPEN | GEOPRIVACY_OBSCURED | GEOPRIVACY_PRIVATE;
 
 type Props = {
-  onPressClose: ( ) => void,
-  selectedValue?: Geoprivacy,
-  updateGeoprivacyStatus: ( Geoprivacy ) => void
+  onPressClose: ( ) => void;
+  selectedValue?: Geoprivacy;
+  updateGeoprivacyStatus: ( Geoprivacy ) => void;
 }
 
 const GeoprivacySheet = ( {

--- a/src/components/ObservationsFlashList/ObsPressable.tsx
+++ b/src/components/ObservationsFlashList/ObsPressable.tsx
@@ -7,21 +7,21 @@ import ObsGridItem from "./ObsGridItem";
 import ObsListItem from "./ObsListItem";
 
 type Props = {
-  currentUser: object,
-  queued: boolean,
-  explore: boolean,
-  hideMetadata?: boolean,
-  hideObsUploadStatus?: boolean,
-  hideObsStatus?: boolean,
-  isSimpleObsStatus?: boolean,
-  hideRGLabel?: boolean,
-  onUploadButtonPress: ( ) => void,
-  onItemPress: ( ) => void,
-  gridItemStyle: object,
-  layout: "list" | "grid",
-  observation: RealmObservation,
-  uploadProgress: number,
-  unsynced: boolean
+  currentUser: object;
+  queued: boolean;
+  explore: boolean;
+  hideMetadata?: boolean;
+  hideObsUploadStatus?: boolean;
+  hideObsStatus?: boolean;
+  isSimpleObsStatus?: boolean;
+  hideRGLabel?: boolean;
+  onUploadButtonPress: ( ) => void;
+  onItemPress: ( ) => void;
+  gridItemStyle: object;
+  layout: "list" | "grid";
+  observation: RealmObservation;
+  uploadProgress: number;
+  unsynced: boolean;
 };
 
 const ObsPressable = ( {

--- a/src/components/ProjectDetails/ProjectRuleItem.tsx
+++ b/src/components/ProjectDetails/ProjectRuleItem.tsx
@@ -6,7 +6,7 @@ import React, { useState } from "react";
 import { useCurrentUser, useTranslation } from "sharedHooks";
 
 interface Props {
-  rule: object
+  rule: object;
 }
 
 const ProjectRuleItem = ( { rule }: Props ) => {

--- a/src/components/ProjectList/ProjectList.tsx
+++ b/src/components/ProjectList/ProjectList.tsx
@@ -12,12 +12,12 @@ import {
 import ProjectListItem from "./ProjectListItem";
 
 interface Props {
-  projects: Array<object>
-  ListEmptyComponent?: React.JSX.Element
-  ListFooterComponent?: React.JSX.Element
-  onEndReached?: ( ) => void
-  onPress?: ( project: ApiProject ) => void
-  accessibilityLabel?: string
+  projects: Array<object>;
+  ListEmptyComponent?: React.JSX.Element;
+  ListFooterComponent?: React.JSX.Element;
+  onEndReached?: ( ) => void;
+  onPress?: ( project: ApiProject ) => void;
+  accessibilityLabel?: string;
 }
 
 const ProjectList = ( {

--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -34,11 +34,11 @@ interface Props {
   isFetchingNextPage: boolean;
   isLoading: boolean;
   memberId?: number;
-  projects: object[],
+  projects: object[];
   requestPermissions: () => void;
   searchInput: string;
   setSearchInput: ( _text: string ) => void;
-  tabs: Tab[],
+  tabs: Tab[];
 }
 
 const Projects = ( {

--- a/src/components/SharedComponents/ActivityAnimation/Confetti.tsx
+++ b/src/components/SharedComponents/ActivityAnimation/Confetti.tsx
@@ -19,15 +19,15 @@ import Animated, {
 import colors from "styles/tailwindColors";
 
 type ConfettiProps = PropsWithChildren<{
-  count: number
-  duration?: number
+  count: number;
+  duration?: number;
 }>
 
 type AnimatedElementProps = PropsWithChildren<{
-  index: number
-  count: number
-  animation: SharedValue<number>
-  duration: number
+  index: number;
+  count: number;
+  animation: SharedValue<number>;
+  duration: number;
 }>
 
 const AnimatedElement = memo(

--- a/src/components/SharedComponents/Buttons/Button.tsx
+++ b/src/components/SharedComponents/Buttons/Button.tsx
@@ -15,7 +15,7 @@ interface ButtonProps {
   disabled?: boolean;
   forceDark?: boolean;
   icon?: string;
-  iconPosition?: string,
+  iconPosition?: string;
   level?: string;
   loading?: boolean;
   onPress: ( _event?: GestureResponderEvent ) => void;

--- a/src/components/SharedComponents/Buttons/INatIconButton.tsx
+++ b/src/components/SharedComponents/Buttons/INatIconButton.tsx
@@ -23,7 +23,7 @@ interface Props extends PropsWithChildren {
   // There is probably a better way to indicate that this tailwind prop is
   // supported everywhere, but I haven't found it yet. ~~~kueda 20241016
   // eslint-disable-next-line react/no-unused-prop-types
-  className?: string,
+  className?: string;
   color?: string;
   disabled?: boolean;
   height?: number;

--- a/src/components/SharedComponents/FlashList/InfiniteScrollLoadingWheel.tsx
+++ b/src/components/SharedComponents/FlashList/InfiniteScrollLoadingWheel.tsx
@@ -5,10 +5,10 @@ import React from "react";
 import { useTranslation } from "sharedHooks";
 
 interface Props {
-  layout?: string,
-  isConnected?: boolean | null,
-  hideLoadingWheel: boolean,
-  explore?: boolean
+  layout?: string;
+  isConnected?: boolean | null;
+  hideLoadingWheel: boolean;
+  explore?: boolean;
 }
 
 const InfiniteScrollLoadingWheel = ( {

--- a/src/components/SharedComponents/Map/DetailsMap.tsx
+++ b/src/components/SharedComponents/Map/DetailsMap.tsx
@@ -22,20 +22,20 @@ import { getShadow } from "styles/global";
 import colors from "styles/tailwindColors";
 
 interface Props {
-  closeModal: () => void,
-  coordinateString?: string,
-  headerTitle?: React.ReactNode,
+  closeModal: () => void;
+  coordinateString?: string;
+  headerTitle?: React.ReactNode;
   // TODO MOB-1038: reconcile the type issues here requiring the intersection
-  observation?: Observation & RealmObservation,
-  region?: Region,
-  tileMapParams: Record<string, string> | null,
+  observation?: Observation & RealmObservation;
+  region?: Region;
+  tileMapParams: Record<string, string> | null;
 }
 
 interface FloatingActionButtonProps {
-  accessibilityLabel: string,
-  buttonClassName: string,
-  icon: string,
-  onPress: ( event?: GestureResponderEvent ) => void,
+  accessibilityLabel: string;
+  buttonClassName: string;
+  icon: string;
+  onPress: ( event?: GestureResponderEvent ) => void;
 }
 
 const FloatingActionButton = ( {

--- a/src/components/SharedComponents/Modal.tsx
+++ b/src/components/SharedComponents/Modal.tsx
@@ -7,11 +7,11 @@ import RNModal from "react-native-modal";
 interface Props {
   showModal: boolean;
   closeModal: () => void;
-  modal: React.ReactNode,
+  modal: React.ReactNode;
   backdropOpacity?: number;
   fullScreen?: boolean;
-  onModalHide?: () => void,
-  style?: ViewStyle,
+  onModalHide?: () => void;
+  style?: ViewStyle;
   animationIn?: string;
   animationOut?: string;
   disableSwipeDirection?: boolean;

--- a/src/components/SharedComponents/OverlayHeader.tsx
+++ b/src/components/SharedComponents/OverlayHeader.tsx
@@ -10,9 +10,9 @@ import React from "react";
 import colors from "styles/tailwindColors";
 
 interface Props extends PropsWithChildren {
-  invertToWhiteBackground: boolean
+  invertToWhiteBackground: boolean;
   headerRight?: React.JSX.Element;
-  testID: string,
+  testID: string;
 }
 
 const OverlayHeader = ( {

--- a/src/components/SharedComponents/QualityGradeStatus/QualityGradeStatus.tsx
+++ b/src/components/SharedComponents/QualityGradeStatus/QualityGradeStatus.tsx
@@ -7,9 +7,9 @@ import * as React from "react";
 import colors from "styles/tailwindColors";
 
 interface Props {
-  qualityGrade: string | null,
-  color?: string,
-  opacity?: number
+  qualityGrade: string | null;
+  color?: string;
+  opacity?: number;
 }
 
 const qualityGradeSVG = (

--- a/src/components/SharedComponents/SearchBar.tsx
+++ b/src/components/SharedComponents/SearchBar.tsx
@@ -18,7 +18,7 @@ interface Props {
   containerClass?: string;
   handleTextChange: ( _text: string ) => void;
   hasShadow?: boolean;
-  input?: React.RefObject<RNTextInput | null> | React.MutableRefObject<RNTextInput | undefined>,
+  input?: React.RefObject<RNTextInput | null> | React.MutableRefObject<RNTextInput | undefined>;
   placeholder?: string;
   testID?: string;
   value: string;

--- a/src/components/SharedComponents/Sheets/BottomSheetStandardBackdrop.tsx
+++ b/src/components/SharedComponents/Sheets/BottomSheetStandardBackdrop.tsx
@@ -7,8 +7,8 @@ import {
 import React from "react";
 
 type Props = {
-  props: BottomSheetBackdropProps,
-  onPress: ( ) => void
+  props: BottomSheetBackdropProps;
+  onPress: ( ) => void;
 }
 
 const BottomSheetStandardBackdrop = ( { props, onPress }: Props ) => (

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -8,25 +8,25 @@ import React, { useState } from "react";
 import useTranslation from "sharedHooks/useTranslation";
 
 interface Props {
-  bottomComponent?: React.JSX.Element
-  buttonRowClassName?: string
+  bottomComponent?: React.JSX.Element;
+  buttonRowClassName?: string;
   confirm: ( _checkedValue: string ) => void;
   confirmText?: string;
-  headerText: string,
-  insideModal?: boolean,
+  headerText: string;
+  insideModal?: boolean;
   onPressClose?: ( ) => void;
   radioValues: {
     [key: string]: {
-      value: string,
-      icon?: string,
-      label: string,
-      text?: string,
-      buttonText?: string,
-    }
-  },
-  selectedValue?: string,
-  testID?: string,
-  topDescriptionText?: React.JSX.Element,
+      value: string;
+      icon?: string;
+      label: string;
+      text?: string;
+      buttonText?: string;
+    };
+  };
+  selectedValue?: string;
+  testID?: string;
+  topDescriptionText?: React.JSX.Element;
 }
 
 const RadioButtonSheet = ( {

--- a/src/components/SharedComponents/SimpleObservationLocation.tsx
+++ b/src/components/SharedComponents/SimpleObservationLocation.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "sharedHooks";
 
 interface Props {
   observation: {
-    private_place_guess?: string
+    private_place_guess?: string;
   };
 }
 

--- a/src/components/SharedComponents/TaxonSearch.tsx
+++ b/src/components/SharedComponents/TaxonSearch.tsx
@@ -22,9 +22,9 @@ interface Props {
   isLoading?: boolean;
   isLocal?: boolean;
   renderItem: (
-    { item, index }: { item: RealmTaxon, index: number }
+    { item, index }: { item: RealmTaxon; index: number }
   ) => React.ReactElement<unknown>;
-  taxa: RealmTaxon[]
+  taxa: RealmTaxon[];
 }
 
 const TaxonSearch = ( {

--- a/src/components/SharedComponents/UploadProgressBar.tsx
+++ b/src/components/SharedComponents/UploadProgressBar.tsx
@@ -6,7 +6,7 @@ import colors from "styles/tailwindColors";
 const PROGRESS_BAR_STYLE = { backgroundColor: "transparent" };
 
 type Props = {
-  progress: number
+  progress: number;
 }
 
 const UploadProgressBar = ( { progress }: Props ): Node => (

--- a/src/components/SharedComponents/UploadStatus/UploadCompleteIcon.tsx
+++ b/src/components/SharedComponents/UploadStatus/UploadCompleteIcon.tsx
@@ -4,8 +4,8 @@ import { View } from "components/styledComponents";
 import React from "react";
 
 type Props = {
-  iconClasses: Array<string>,
-  completeColor: string
+  iconClasses: Array<string>;
+  completeColor: string;
 }
 
 const UploadCompleteIcon = ( {

--- a/src/components/SharedComponents/UploadStatus/UploadStatus.tsx
+++ b/src/components/SharedComponents/UploadStatus/UploadStatus.tsx
@@ -26,7 +26,7 @@ interface Props extends PropsWithChildren {
   progress: number;
   uniqueKey: string;
   queued: boolean;
-  obsStatus: ReactComponent
+  obsStatus: ReactComponent;
 }
 
 const UploadStatus = ( {

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -98,8 +98,8 @@ const LINKIFY_OPTIONS: Opts = {
 };
 
 interface Props extends React.PropsWithChildren {
-  text: string,
-  htmlStyle?: object,
+  text: string;
+  htmlStyle?: object;
 }
 
 const UserText = ( {

--- a/src/components/Suggestions/SuggestionsContainer.tsx
+++ b/src/components/Suggestions/SuggestionsContainer.tsx
@@ -55,7 +55,7 @@ export type Suggestion = {
   taxon: {
     id: number;
     name: string;
-  }
+  };
 };
 
 export type TopSuggestionType = string;

--- a/src/components/Suggestions/SuggestionsFooter.tsx
+++ b/src/components/Suggestions/SuggestionsFooter.tsx
@@ -14,36 +14,36 @@ import Attribution from "./Attribution";
 
 type Props = {
   debugData: {
-    onlineFetchStatus: string,
-    offlineFetchStatus: string,
-    selectedPhotoUri: string,
-    onlineSuggestionsUpdatedAt: Date,
-    timedOut: boolean,
-    shouldUseEvidenceLocation: boolean,
-    topSuggestionType: string,
-    onlineSuggestions: [],
-    usingOfflineSuggestions: boolean,
-    onlineSuggestionsError: Error,
+    onlineFetchStatus: string;
+    offlineFetchStatus: string;
+    selectedPhotoUri: string;
+    onlineSuggestionsUpdatedAt: Date;
+    timedOut: boolean;
+    shouldUseEvidenceLocation: boolean;
+    topSuggestionType: string;
+    onlineSuggestions: [];
+    usingOfflineSuggestions: boolean;
+    onlineSuggestionsError: Error;
     suggestions: {
-      otherSuggestions: [],
+      otherSuggestions: [];
       topSuggestion: {
         taxon: {
-          id: number,
-          name: string
-        },
-        combined_score: number
-      }
-    }
-  },
+          id: number;
+          name: string;
+        };
+        combined_score: number;
+      };
+    };
+  };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  handleSkip: Function,
+  handleSkip: Function;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  hideLocationToggleButton: Function,
-  hideSkip?: boolean,
-  observers: Array<string>,
-  shouldUseEvidenceLocation: boolean,
+  hideLocationToggleButton: Function;
+  hideSkip?: boolean;
+  observers: Array<string>;
+  shouldUseEvidenceLocation: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  toggleLocation: Function
+  toggleLocation: Function;
 };
 
 const SuggestionsFooter = ( {

--- a/src/components/Suggestions/helpers/flattenUploadParams.ts
+++ b/src/components/Suggestions/helpers/flattenUploadParams.ts
@@ -7,10 +7,10 @@ const outputPath = computerVisionPath;
 
 type FlattenUploadArgs = {
   image: {
-    uri: string,
-    name: string,
-    type: string
-  }
+    uri: string;
+    name: string;
+    type: string;
+  };
 }
 
 const flattenUploadParams = async (

--- a/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts
+++ b/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts
@@ -9,7 +9,7 @@ const useNavigateWithTaxonSelected = (
   // mysterious background nonsense happening after this screen loses focus
   unselectTaxon: () => void,
   options: {
-    vision: boolean
+    vision: boolean;
   }
 ) => {
   const navigation = useNavigation( );

--- a/src/components/TaxonDetails/TaxonomyCommonName.tsx
+++ b/src/components/TaxonDetails/TaxonomyCommonName.tsx
@@ -5,7 +5,7 @@ import React from "react";
 interface Props {
   commonName: string;
   scientificNameFirst?: boolean;
-  isCurrentTaxon?: boolean
+  isCurrentTaxon?: boolean;
 }
 
 const TaxonomyCommonName = ( {

--- a/src/components/TaxonDetails/TaxonomyTaxon.tsx
+++ b/src/components/TaxonDetails/TaxonomyTaxon.tsx
@@ -9,7 +9,7 @@ import TaxonomyCommonName from "./TaxonomyCommonName";
 import TaxonomyScientificName from "./TaxonomyScientificName";
 
 interface Props {
-  currentUser: { login: string, id: number };
+  currentUser: { login: string; id: number };
   isChild?: boolean;
   isCurrentTaxon?: boolean;
   navigateToTaxonDetails: ( _taxonId: number ) => void;

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -14,15 +14,15 @@ const CONTAINER_STYLE = {
 };
 
 interface Props {
-  ListEmptyComponent?: React.JSX.Element
-  ListFooterComponent?: React.JSX.Element
-  onEndReached?: ( ) => void
-  refreshing?: boolean
-  users: Array<object>
-  onPress?: ( ) => void
-  accessibilityLabel?: string
-  keyboardShouldPersistTaps?: string
-  contentContainerStyle?: ViewStyle
+  ListEmptyComponent?: React.JSX.Element;
+  ListFooterComponent?: React.JSX.Element;
+  onEndReached?: ( ) => void;
+  refreshing?: boolean;
+  users: Array<object>;
+  onPress?: ( ) => void;
+  accessibilityLabel?: string;
+  keyboardShouldPersistTaps?: string;
+  contentContainerStyle?: ViewStyle;
 }
 
 const UserList = ( {

--- a/src/components/UserList/UserListItem.tsx
+++ b/src/components/UserList/UserListItem.tsx
@@ -8,12 +8,12 @@ import User from "realmModels/User";
 import { useTranslation } from "sharedHooks";
 
 interface Props {
-  item: object
-  countText: string
+  item: object;
+  countText: string;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onPress?: Function
-  accessibilityLabel?: string
-  pressable?: boolean
+  onPress?: Function;
+  accessibilityLabel?: string;
+  pressable?: boolean;
 }
 
 const UserListItem = ( {

--- a/src/navigation/FadeInView.tsx
+++ b/src/navigation/FadeInView.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Animated } from "react-native";
 
 interface Props {
-  children: React.JSX.Element
+  children: React.JSX.Element;
 }
 
 const FadeInView = ( { children }: Props ) => {

--- a/src/providers/ExploreContext.tsx
+++ b/src/providers/ExploreContext.tsx
@@ -157,134 +157,134 @@ export interface MapBoundaries {
 }
 
 interface PLACE {
-  display_name: string,
-  id: number,
-  place_type: number,
+  display_name: string;
+  id: number;
+  place_type: number;
   point_geojson: {
-    coordinates: Array<number>
-  },
+    coordinates: Array<number>;
+  };
   bounding_box_geojson?: {
-    coordinates: Array<number>
-  },
-  type: string
+    coordinates: Array<number>;
+  };
+  type: string;
 }
 
 interface DefaultLocation {
-  placeMode: PLACE_MODE,
-  lat?: number,
-  lng?: number,
-  radius?: number
+  placeMode: PLACE_MODE;
+  lat?: number;
+  lng?: number;
+  radius?: number;
 }
 
 type ExploreProviderProps = {children: React.ReactNode}
 type State = {
-  casual: boolean,
-  created_d1: string | null | undefined,
-  created_d2: string | null | undefined,
-  created_on: string | null | undefined,
-  d1: string | null | undefined,
-  d2: string | null | undefined,
-  dateObserved: DATE_OBSERVED,
-  dateUploaded: DATE_UPLOADED,
-  establishmentMean: ESTABLISHMENT_MEAN,
-  hrank: TAXONOMIC_RANK | undefined | null,
-  iconic_taxa: string[] | undefined,
-  lat?: number,
-  lng?: number,
-  lrank: TAXONOMIC_RANK | undefined | null,
-  media: MEDIA,
-  months: number[] | null | undefined,
-  needsID: boolean,
-  nelat?: number,
-  nelng?: number,
-  observed_on: string | null | undefined,
-  photoLicense: PHOTO_LICENSE,
-  place: PLACE | null | undefined,
-  place_guess: string,
-  placeMode: PLACE_MODE,
-  place_id: number | null | undefined,
+  casual: boolean;
+  created_d1: string | null | undefined;
+  created_d2: string | null | undefined;
+  created_on: string | null | undefined;
+  d1: string | null | undefined;
+  d2: string | null | undefined;
+  dateObserved: DATE_OBSERVED;
+  dateUploaded: DATE_UPLOADED;
+  establishmentMean: ESTABLISHMENT_MEAN;
+  hrank: TAXONOMIC_RANK | undefined | null;
+  iconic_taxa: string[] | undefined;
+  lat?: number;
+  lng?: number;
+  lrank: TAXONOMIC_RANK | undefined | null;
+  media: MEDIA;
+  months: number[] | null | undefined;
+  needsID: boolean;
+  nelat?: number;
+  nelng?: number;
+  observed_on: string | null | undefined;
+  photoLicense: PHOTO_LICENSE;
+  place: PLACE | null | undefined;
+  place_guess: string;
+  placeMode: PLACE_MODE;
+  place_id: number | null | undefined;
   // TODO: technically this is not any object but a "Project"
   // and should be typed as such (e.g., in realm model)
-  project: object | undefined | null,
-  project_id: number | undefined | null,
-  radius?: number,
-  researchGrade: boolean,
-  return_bounds: boolean | undefined,
-  reviewedFilter: REVIEWED,
-  sortBy: SORT_BY,
-  swlat?: number,
-  swlng?: number,
+  project: object | undefined | null;
+  project_id: number | undefined | null;
+  radius?: number;
+  researchGrade: boolean;
+  return_bounds: boolean | undefined;
+  reviewedFilter: REVIEWED;
+  sortBy: SORT_BY;
+  swlat?: number;
+  swlng?: number;
   // TODO: technically this is not any object but a "Taxon"
   // and should be typed as such (e.g., in realm model)
-  taxon: object | undefined | null,
-  taxon_id: number | undefined | null,
+  taxon: object | undefined | null;
+  taxon_id: number | undefined | null;
   // TODO: technically this is not any object but a "User"
   // and should be typed as such (e.g., in realm model)
-  user: object | undefined | null,
-  user_id: number | undefined | null,
-  excludeUser: object | undefined | null,
-  verifiable: boolean,
-  wildStatus: WILD_STATUS
+  user: object | undefined | null;
+  user_id: number | undefined | null;
+  excludeUser: object | undefined | null;
+  verifiable: boolean;
+  wildStatus: WILD_STATUS;
 }
 type Action = {type: EXPLORE_ACTION.RESET}
-  | {type: EXPLORE_ACTION.DISCARD, snapshot: State}
-  | {type: EXPLORE_ACTION.SET_USER, user: object | null, userId: number | null, storedState: State}
+  | {type: EXPLORE_ACTION.DISCARD; snapshot: State}
+  | {type: EXPLORE_ACTION.SET_USER; user: object | null; userId: number | null; storedState: State}
   | {
-    type: EXPLORE_ACTION.EXCLUDE_USER,
-    user: null,
-    userId: null,
-    excludeUser: object,
-    storedState: State
+    type: EXPLORE_ACTION.EXCLUDE_USER;
+    user: null;
+    userId: null;
+    excludeUser: object;
+    storedState: State;
   }
   | {
-    type: EXPLORE_ACTION.CHANGE_TAXON,
-    taxon: { id: number } | null,
-    taxonId: number,
-    taxonName: string,
-    storedState?: State
+    type: EXPLORE_ACTION.CHANGE_TAXON;
+    taxon: { id: number } | null;
+    taxonId: number;
+    taxonName: string;
+    storedState?: State;
   }
   | { type: EXPLORE_ACTION.FILTER_BY_ICONIC_TAXON_UNKNOWN }
-  | {type: EXPLORE_ACTION.SET_EXPLORE_LOCATION, exploreLocation: DefaultLocation}
+  | {type: EXPLORE_ACTION.SET_EXPLORE_LOCATION; exploreLocation: DefaultLocation}
   | {
-    type: EXPLORE_ACTION.SET_PLACE,
-    place: PLACE,
-    placeId: number,
-    placeGuess?: string,
-    lat: number,
-    lng: number,
-    radius: number,
-    storedState: State
+    type: EXPLORE_ACTION.SET_PLACE;
+    place: PLACE;
+    placeId: number;
+    placeGuess?: string;
+    lat: number;
+    lng: number;
+    radius: number;
+    storedState: State;
   }
   | {type: EXPLORE_ACTION.SET_PLACE_MODE_NEARBY}
   | {type: EXPLORE_ACTION.SET_PLACE_MODE_WORLDWIDE}
   | {type: EXPLORE_ACTION.SET_PLACE_MODE_MAP_AREA}
   | {type: EXPLORE_ACTION.SET_PLACE_MODE_PLACE}
   | {
-      type: EXPLORE_ACTION.SET_PROJECT,
-      project: object | null,
-      projectId: number | null,
-      storedState: State
+      type: EXPLORE_ACTION.SET_PROJECT;
+      project: object | null;
+      projectId: number | null;
+      storedState: State;
     }
-  | {type: EXPLORE_ACTION.CHANGE_SORT_BY, sortBy: SORT_BY}
+  | {type: EXPLORE_ACTION.CHANGE_SORT_BY; sortBy: SORT_BY}
   | {type: EXPLORE_ACTION.TOGGLE_RESEARCH_GRADE}
   | {type: EXPLORE_ACTION.TOGGLE_NEEDS_ID}
   | {type: EXPLORE_ACTION.TOGGLE_CASUAL}
-  | {type: EXPLORE_ACTION.SET_HIGHEST_TAXONOMIC_RANK, hrank: TAXONOMIC_RANK}
-  | {type: EXPLORE_ACTION.SET_LOWEST_TAXONOMIC_RANK, lrank: TAXONOMIC_RANK}
+  | {type: EXPLORE_ACTION.SET_HIGHEST_TAXONOMIC_RANK; hrank: TAXONOMIC_RANK}
+  | {type: EXPLORE_ACTION.SET_LOWEST_TAXONOMIC_RANK; lrank: TAXONOMIC_RANK}
   | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_ALL}
-  | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_EXACT, observedOn: string}
-  | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_RANGE, d1: string, d2: string}
-  | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_MONTHS, months: number[]}
+  | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_EXACT; observedOn: string}
+  | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_RANGE; d1: string; d2: string}
+  | {type: EXPLORE_ACTION.SET_DATE_OBSERVED_MONTHS; months: number[]}
   | {type: EXPLORE_ACTION.SET_DATE_UPLOADED_ALL}
-  | {type: EXPLORE_ACTION.SET_DATE_UPLOADED_EXACT, createdOn: string}
-  | {type: EXPLORE_ACTION.SET_DATE_UPLOADED_RANGE, createdD1: string, createdD2: string}
-  | {type: EXPLORE_ACTION.SET_MEDIA, media: MEDIA}
-  | {type: EXPLORE_ACTION.SET_ESTABLISHMENT_MEAN, establishmentMean: ESTABLISHMENT_MEAN}
-  | {type: EXPLORE_ACTION.SET_WILD_STATUS, wildStatus: WILD_STATUS}
-  | {type: EXPLORE_ACTION.SET_REVIEWED, reviewedFilter: REVIEWED}
-  | {type: EXPLORE_ACTION.SET_PHOTO_LICENSE, photoLicense: PHOTO_LICENSE}
-  | {type: EXPLORE_ACTION.SET_MAP_BOUNDARIES, mapBoundaries: MapBoundaries}
-  | {type: EXPLORE_ACTION.USE_STORED_STATE, storedState: State}
+  | {type: EXPLORE_ACTION.SET_DATE_UPLOADED_EXACT; createdOn: string}
+  | {type: EXPLORE_ACTION.SET_DATE_UPLOADED_RANGE; createdD1: string; createdD2: string}
+  | {type: EXPLORE_ACTION.SET_MEDIA; media: MEDIA}
+  | {type: EXPLORE_ACTION.SET_ESTABLISHMENT_MEAN; establishmentMean: ESTABLISHMENT_MEAN}
+  | {type: EXPLORE_ACTION.SET_WILD_STATUS; wildStatus: WILD_STATUS}
+  | {type: EXPLORE_ACTION.SET_REVIEWED; reviewedFilter: REVIEWED}
+  | {type: EXPLORE_ACTION.SET_PHOTO_LICENSE; photoLicense: PHOTO_LICENSE}
+  | {type: EXPLORE_ACTION.SET_MAP_BOUNDARIES; mapBoundaries: MapBoundaries}
+  | {type: EXPLORE_ACTION.USE_STORED_STATE; storedState: State}
 type Dispatch = ( action: Action ) => void
 
 const ExploreContext = React.createContext<

--- a/src/realmModels/ObservationPhoto.ts
+++ b/src/realmModels/ObservationPhoto.ts
@@ -79,8 +79,8 @@ class ObservationPhoto extends Realm.Object {
   // I think it is only called after certain transformations on the Realm result,
   // but it is not important for my current linear ticket so I'll skip typing it more
   static mapObservationPhotoForMyObsDefaultMode( observationPhoto: {
-    photo?: { url?: string, localFilePath?: string },
-    uuid?: string
+    photo?: { url?: string; localFilePath?: string };
+    uuid?: string;
   } ) {
     return {
       photo: {
@@ -105,7 +105,7 @@ class ObservationPhoto extends Realm.Object {
 
   static createObsPhotosWithPosition = async (
     photos: string[] | { image: { uri: string } }[],
-    { position, local }: { position: number, local: boolean }
+    { position, local }: { position: number; local: boolean }
   ) => {
     let photoPosition = position;
     return Promise.all(
@@ -128,7 +128,7 @@ class ObservationPhoto extends Realm.Object {
   // linear ticket so I'll skip typing it
   static async deleteRemotePhoto(
     uri: string,
-    currentObservation?: { observationPhotos?: { photo: { url?: string }, uuid: string }[] }
+    currentObservation?: { observationPhotos?: { photo: { url?: string }; uuid: string }[] }
   ) {
     const obsPhotoToDelete = currentObservation?.observationPhotos?.find(
       p => p.photo?.url === uri
@@ -155,7 +155,7 @@ class ObservationPhoto extends Realm.Object {
   // linear ticket so I'll skip typing it
   static async deletePhoto(
     uri: string,
-    currentObservation?: { observationPhotos?: { photo: { url?: string }, uuid: string }[] }
+    currentObservation?: { observationPhotos?: { photo: { url?: string }; uuid: string }[] }
   ) {
     if ( uri.includes( "https://" ) ) {
       ObservationPhoto.deleteRemotePhoto( uri, currentObservation );
@@ -170,8 +170,8 @@ class ObservationPhoto extends Realm.Object {
   // linear ticket so I'll skip typing it
   static mapObsPhotoUris(
     observation: {
-      observationPhotos?: { photo: RealmPhoto }[],
-      observation_photos?: { photo: RealmPhoto }[]
+      observationPhotos?: { photo: RealmPhoto }[];
+      observation_photos?: { photo: RealmPhoto }[];
     }
   ) {
     const obsPhotos = observation?.observationPhotos || observation?.observation_photos;
@@ -190,8 +190,8 @@ class ObservationPhoto extends Realm.Object {
   // linear ticket so I'll skip typing it
   static mapInnerPhotos(
     observation: {
-      observationPhotos?: { photo: object }[],
-      observation_photos?: { photo: object }[]
+      observationPhotos?: { photo: object }[];
+      observation_photos?: { photo: object }[];
     }
   ) {
     const obsPhotos = observation?.observationPhotos || observation?.observation_photos;

--- a/src/sharedHelpers/clearCaches.ts
+++ b/src/sharedHelpers/clearCaches.ts
@@ -11,14 +11,14 @@ const logger = log.extend( "clearCaches.ts" );
 interface RealmObservation {
   observationPhotos: {
     photo: {
-      localFilePath: string
-    }
-  }[],
+      localFilePath: string;
+    };
+  }[];
   observationSounds: {
     sound: {
-      file_url: string
-    }
-  }[]
+      file_url: string;
+    };
+  }[];
 }
 
 const clearRotatedOriginalPhotosDirectory = async ( ) => {

--- a/src/sharedHelpers/removeSyncedFilesFromDirectory.ts
+++ b/src/sharedHelpers/removeSyncedFilesFromDirectory.ts
@@ -12,10 +12,10 @@ const MAX_FOLDER_SIZE = 5 * 1024 * 1024 * 1024; // 5GB in bytes
 const TOO_NEW_THRESHOLD = 24 * 60 * 60 * 1000; // Files modified in the last 1 day (in milliseconds)
 
 type FileDetails = {
-  name: string,
-  path: string,
-  size: number,
-  modifiedTime: number
+  name: string;
+  path: string;
+  size: number;
+  modifiedTime: number;
 };
 
 const removeSyncedFilesFromDirectory = async (

--- a/src/sharedHelpers/resizeImage.ts
+++ b/src/sharedHelpers/resizeImage.ts
@@ -3,14 +3,14 @@ import ImageResizer from "@bam.tech/react-native-image-resizer";
 const resizeImage = async (
   pathOrUri: string,
   options: {
-    width: number,
-    height?: number,
-    rotation?: number,
-    outputPath?: string,
+    width: number;
+    height?: number;
+    rotation?: number;
+    outputPath?: string;
     imageOptions?: {
-      mode?: string,
-      onlyScaleDown?: boolean
-    }
+      mode?: string;
+      onlyScaleDown?: boolean;
+    };
   }
 ): Promise<string> => {
   const {

--- a/src/sharedHooks/useDebugMode.ts
+++ b/src/sharedHooks/useDebugMode.ts
@@ -3,7 +3,7 @@ import { zustandStorage } from "stores/useStore";
 
 const DEBUG_MODE = "debugMode";
 
-const useDebugMode = ( ): { isDebug: boolean, toggleDebug: () => void } => {
+const useDebugMode = ( ): { isDebug: boolean; toggleDebug: () => void } => {
   const [isDebug, setDebug] = useState( false );
 
   useEffect( ( ) => {

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -12,10 +12,10 @@ interface ObsFlowParams {
     previousScreen?: {
       name: string;
       params: {
-        uuid?: string
-      }
-    }
-  }
+        uuid?: string;
+      };
+    };
+  };
 }
 
 interface Options {

--- a/src/sharedHooks/useFontScale.ts
+++ b/src/sharedHooks/useFontScale.ts
@@ -5,7 +5,7 @@ import {
 import DeviceInfo from "react-native-device-info";
 
 const useFontScale = ( ): {
-  isLargeFontScale: boolean
+  isLargeFontScale: boolean;
 } => {
   const [isLargeFontScale, setIsLargeFontScale] = useState<boolean>( false );
 

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -61,7 +61,7 @@ async function fetchObsByUUIDs(
   authOptions: ApiOpts,
   realm: Realm,
   options: {
-    save?: boolean
+    save?: boolean;
   } = {}
 ) {
   // TODO convert api/observations to TS

--- a/src/sharedHooks/useInfiniteUserScroll.ts
+++ b/src/sharedHooks/useInfiniteUserScroll.ts
@@ -8,7 +8,7 @@ const useInfiniteUserScroll = (
   ids: Array<object>,
   newInputParams: object,
   options: {
-    enabled: boolean
+    enabled: boolean;
   }
 ): object => {
   const baseParams = {

--- a/src/sharedHooks/useSuggestions/useOfflineSuggestions.ts
+++ b/src/sharedHooks/useSuggestions/useOfflineSuggestions.ts
@@ -25,23 +25,23 @@ interface OfflineSuggestion {
 const useOfflineSuggestions = (
   photoUri: string,
   options: {
-    onFetchError: ( _p: { isOnline: boolean } ) => void,
-    onFetched: ( _p: { isOnline: boolean } ) => void,
-    latitude: number,
-    longitude: number,
-    tryOfflineSuggestions: boolean
+    onFetchError: ( _p: { isOnline: boolean } ) => void;
+    onFetched: ( _p: { isOnline: boolean } ) => void;
+    latitude: number;
+    longitude: number;
+    tryOfflineSuggestions: boolean;
   }
 ): {
   offlineSuggestions: {
-    results: OfflineSuggestion[],
-    commonAncestor: OfflineSuggestion | undefined
+    results: OfflineSuggestion[];
+    commonAncestor: OfflineSuggestion | undefined;
   };
   refetchOfflineSuggestions: () => void;
 } => {
   const realm = useRealm( );
   const [offlineSuggestions, setOfflineSuggestions] = useState<{
-    results: OfflineSuggestion[],
-    commonAncestor: OfflineSuggestion | undefined
+    results: OfflineSuggestion[];
+    commonAncestor: OfflineSuggestion | undefined;
   }>( { results: [], commonAncestor: undefined } );
   const [error, setError] = useState( null );
 
@@ -70,7 +70,7 @@ const useOfflineSuggestions = (
     const iconicTaxa = realm?.objects( "Taxon" ).filtered( "isIconic = true" );
     const iconicTaxaIds = iconicTaxa.map( t => t.id );
     const iconicTaxaLookup: {
-      [key: number]: string
+      [key: number]: string;
     } = iconicTaxa.reduce( ( acc, t ) => {
       acc[t.id] = t.name;
       return acc;

--- a/src/sharedHooks/useWatchPosition.ts
+++ b/src/sharedHooks/useWatchPosition.ts
@@ -13,11 +13,11 @@ export const TARGET_POSITIONAL_ACCURACY = 10;
 const MAX_POSITION_AGE_MS = 60_000;
 
 export interface UserLocation {
-  latitude: number,
-  longitude: number,
-  positional_accuracy: number,
-  altitude: number | null,
-  altitudinal_accuracy: number | null
+  latitude: number;
+  longitude: number;
+  positional_accuracy: number;
+  altitude: number | null;
+  altitudinal_accuracy: number | null;
 }
 
 const geolocationOptions = {
@@ -27,7 +27,7 @@ const geolocationOptions = {
 };
 
 const useWatchPosition = ( options: {
-  shouldFetchLocation: boolean
+  shouldFetchLocation: boolean;
 } ) => {
   const navigation = useNavigation( );
   const [currentPosition, setCurrentPosition] = useState<GeolocationResponse | null>( null );

--- a/src/stores/createExploreSlice.ts
+++ b/src/stores/createExploreSlice.ts
@@ -5,8 +5,8 @@ const DEFAULT_STATE = {
 };
 
 interface ExploreSlice {
-  exploreView: string,
-  setExploreView: ( _view: string ) => void
+  exploreView: string;
+  setExploreView: ( _view: string ) => void;
 }
 
 const createExploreSlice: StateCreator<ExploreSlice> = set => ( {

--- a/src/stores/createRootExploreSlice.ts
+++ b/src/stores/createRootExploreSlice.ts
@@ -6,10 +6,10 @@ const DEFAULT_STATE = {
 };
 
 interface RootExploreSlice {
-  rootStoredParams: object,
-  setRootStoredParams: ( _params: object ) => void,
-  rootExploreView: string,
-  setRootExploreView: ( _view: string ) => void
+  rootStoredParams: object;
+  setRootStoredParams: ( _params: object ) => void;
+  rootExploreView: string;
+  setRootExploreView: ( _view: string ) => void;
 }
 
 const createRootExploreSlice: StateCreator<RootExploreSlice> = set => ( {

--- a/src/stores/createSyncObservationsSlice.ts
+++ b/src/stores/createSyncObservationsSlice.ts
@@ -13,13 +13,13 @@ type SyncingStatus = typeof SYNC_PENDING
   | typeof AUTOMATIC_SYNC_IN_PROGRESS;
 
 interface SyncObservationsSlice {
-  autoSyncAbortController: AbortController | null,
-  currentDeleteCount: number,
-  deleteError: string | null,
-  deleteQueue: Array<string>,
-  deletionsCompletedAt: Date | null,
-  initialNumDeletionsInQueue: number,
-  syncingStatus: SyncingStatus
+  autoSyncAbortController: AbortController | null;
+  currentDeleteCount: number;
+  deleteError: string | null;
+  deleteQueue: Array<string>;
+  deletionsCompletedAt: Date | null;
+  initialNumDeletionsInQueue: number;
+  syncingStatus: SyncingStatus;
 }
 
 const DEFAULT_STATE: SyncObservationsSlice = {

--- a/src/stores/createUploadObservationsSlice.ts
+++ b/src/stores/createUploadObservationsSlice.ts
@@ -14,25 +14,25 @@ type UploadStatus = typeof UPLOAD_PENDING
   | typeof UPLOAD_CANCELLED;
 
 interface TotalUploadProgress {
-  uuid: string,
-  currentIncrements: number,
-  totalIncrements: number,
-  totalProgress: number
+  uuid: string;
+  currentIncrements: number;
+  totalIncrements: number;
+  totalProgress: number;
 }
 
 interface UploadObservationsSlice {
-  abortController: AbortController | null,
-  currentUpload: RealmObservation | null,
-  errorsByUuid: object,
-  multiError: string | null,
-  initialNumObservationsInQueue: number,
-  numUnuploadedObservations: number,
-  numUploadsAttempted: number,
-  totalToolbarIncrements: number,
-  totalToolbarProgress: number,
-  totalUploadProgress: Array<TotalUploadProgress>,
-  uploadQueue: Array<string>,
-  uploadStatus: UploadStatus
+  abortController: AbortController | null;
+  currentUpload: RealmObservation | null;
+  errorsByUuid: object;
+  multiError: string | null;
+  initialNumObservationsInQueue: number;
+  numUnuploadedObservations: number;
+  numUploadsAttempted: number;
+  totalToolbarIncrements: number;
+  totalToolbarProgress: number;
+  totalUploadProgress: Array<TotalUploadProgress>;
+  uploadQueue: Array<string>;
+  uploadStatus: UploadStatus;
 }
 
 const DEFAULT_STATE: UploadObservationsSlice = {

--- a/src/uploaders/mediaUploader.ts
+++ b/src/uploaders/mediaUploader.ts
@@ -15,7 +15,7 @@ export type ActionType = "upload" | "attach" | "update";
 
 interface UploadOptions {
   api_token?: string;
-  signal: AbortController
+  signal: AbortController;
 }
 
 interface MediaApiResponse {
@@ -32,7 +32,7 @@ interface MappedObservationPhotoForUpdating {
   observation_photo: {
     observation_id: number;
     position: number;
-  }
+  };
 }
 
 interface MappedObservationPhotoForAttaching {
@@ -41,7 +41,7 @@ interface MappedObservationPhotoForAttaching {
     observation_id: number;
     photo_id: number;
     position: number;
-  }
+  };
 }
 
 interface MappedPhotoForUploading {
@@ -58,7 +58,7 @@ interface MappedSoundForUploading {
     uri: string;
     name: string;
     type: string;
-  }
+  };
 }
 
 interface MappedObservationSoundForAttaching {

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -22,7 +22,7 @@ const logger = log.extend( "observationUploader" );
 
 interface UploadOptions {
   api_token?: string;
-  signal: AbortController
+  signal: AbortController;
 }
 
 interface UploadParams {

--- a/src/uploaders/utils/realmSync.ts
+++ b/src/uploaders/utils/realmSync.ts
@@ -6,7 +6,7 @@ function findRecordInRealm(
   recordUUID: string | null,
   type: string,
   options?: {
-    record: object
+    record: object;
   }
 ): object | null {
   if ( !realm || realm.isClosed ) return null;
@@ -53,7 +53,7 @@ function handleRecordUpdateError(
   type: string,
   serverId: number,
   options?: {
-    record: object
+    record: object;
   }
 ): void {
   // Try it one more time in case it was invalidated but it's still in the
@@ -84,11 +84,11 @@ const markRecordUploaded = (
   recordUUID: string | null,
   type: string,
   response: {
-    results: Array<{id: number}>
+    results: Array<{id: number}>;
   },
   realm: object,
   options?: {
-    record: object
+    record: object;
   }
 ) => {
   if ( !realm || realm.isClosed ) return;


### PR DESCRIPTION
This adds the `@stylistic/member-delimiter-style` eslint rule (https://eslint.style/rules/member-delimiter-style) with the default settings, enforcing semicolon `;` as the property delimiter for all TS interface and types. It applies `eslint --fix` to fix all existing violations.