### PR TITLE
Keep behaviour of no animation when navigating between different root stacks

### DIFF
--- a/src/navigation/RootStackNavigator.tsx
+++ b/src/navigation/RootStackNavigator.tsx
@@ -17,7 +17,7 @@ const RootStackNavigator = ( ) => {
   const [onboardingShown] = useOnboardingShown( );
 
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator screenOptions={{ headerShown: false, animation: "none" }}>
       {!onboardingShown
         ? (
           <Stack.Screen


### PR DESCRIPTION
There was an issue with "wrong" navigation animation, especially when X-ing out of the standard camera flow for a new observation. This change makes it so we keep the current navigation animation behaviour when navigating between former root drawer screens.