### PR TITLE
Remove Image.getSize mock

### DIFF
--- a/tests/unit/components/ObsDetails/ObsMedia.test.js
+++ b/tests/unit/components/ObsDetails/ObsMedia.test.js
@@ -2,11 +2,8 @@ import { render, screen, waitFor } from "@testing-library/react-native";
 import ObsMedia from "components/ObsDetails/ObsMedia";
 import _ from "lodash";
 import React from "react";
-import { Image } from "react-native";
 import factory from "tests/factory";
 import faker from "tests/helpers/faker";
-
-Image.getSize = jest.fn( ( _uri, _callback ) => async () => ( { width: 1024, height: 768 } ) );
 
 const mockObservation = factory( "LocalObservation", {
   created_at: "2022-11-27T19:07:41-08:00",


### PR DESCRIPTION
The conversation [here](https://github.com/inaturalist/iNaturalistReactNative/pull/3200) showed we do not require this mock. The second test of a component that relies on this function does not mock it (`tests/unit/components/Match/Match.test.js`), so I opt for removing it here to make the two tests the same in this regard.