### PR TITLE
Use Photo.getLocalPhotoUri helper to display local photo

### DIFF
--- a/src/components/Match/PhotosSection.js
+++ b/src/components/Match/PhotosSection.js
@@ -34,7 +34,7 @@ const PhotosSection = ( {
 
   const localTaxonPhotos = taxon?.taxonPhotos;
   const observationPhoto = obsPhotos?.[0]?.photo?.url
-  || obsPhotos?.[0]?.photo?.localFilePath;
+  || Photo.getLocalPhotoUri( obsPhotos?.[0]?.photo?.localFilePath );
 
   const taxonPhotos = compact(
     localTaxonPhotos


### PR DESCRIPTION
Closes MOB-1064

We introduced this helper function a while ago because on iOS between app updates the folder names for cached photos can change. This was not an issue on the Match screen because you couldn't access it for an observation that was saved with a previous app version. But it is required here now.