### PR TITLE
Add key for components resulting from a .map

### DIFF
--- a/src/components/AddObsBottomSheet/AddObsBottomSheet.tsx
+++ b/src/components/AddObsBottomSheet/AddObsBottomSheet.tsx
@@ -110,6 +110,7 @@ const AddObsBottomSheet = ( {
     text
   }: ObsCreateItem ) => (
     <Pressable
+      key={testID}
       className="bg-white w-1/2 flex-column items-center py-4 rounded-lg flex-1 shadow-sm
       shadow-black/25 active:opacity-50"
       onPress={onPress}


### PR DESCRIPTION
Fixes a dev build warning:

Each child in a list should have a unique "key" prop.
Check the render method of `View`. It was passed a child from AddObsBottomSheet.