### PR TITLE
(CI) run detox once (leaner flags) then retry once on failure with recordings / verbose logs

### DIFF
--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -213,6 +213,7 @@ jobs:
         brew install applesimutils
 
     - name: Ensure servers are running
+      id: status_check
       run: |
         # is rails running?
         curl -I --fail "https://staging.inaturalist.org/ping"
@@ -220,16 +221,22 @@ jobs:
         curl -I --fail "https://stagingapi.inaturalist.org/v2/taxa"
 
     - name: Run e2e test
-      run: npm run e2e:test:ios
-      
+      run: |
+        npm run e2e:test:ios
+
     - name: Run e2e test (retry, with logs)
-      if: failure()
-      run: npm run e2e:test:ios -- --take-screenshots failing --record-videos failing --record-logs all -l trace
+      # do not retry if status check fails
+      if: ${{ failure() && steps.status_check.outcome != 'failure' }}
+      run: |
+        # provide more debugging context on retry failure
+        # we're explicitly not using `detox test --retries` for this reason
+        npm run e2e:test:ios -- --take-screenshots failing --record-videos failing --record-logs all -l trace
     
     # The artifacts for the failing tests are available for download on github.com on the page of the individual actions run
     - name: Store Detox artifacts on test failure
       uses: actions/upload-artifact@v4
-      if: failure()
+      # no artifacts if status check fails
+      if: ${{ failure() && steps.status_check.outcome != 'failure' }}
       with:
         name: detox-artifacts
         path: artifacts


### PR DESCRIPTION
We regularly have false negative failures on e2e ios, which we manually rerun. We can add an inline retry so we don't have to manually re-run as often. 

We can also limit the trace-level logs and recordings to only running on the retry to minimize the load on the first run. For this reason, I'm adding the retry as an explicit separate step instead of using Detox CLI's retry flag.