### PR TITLE
handle dismiss in BottomSheet

### DIFF
--- a/src/components/SharedComponents/Sheets/BottomSheet.tsx
+++ b/src/components/SharedComponents/Sheets/BottomSheet.tsx
@@ -67,7 +67,7 @@ const StandardBottomSheet = ( {
   const insets = useSafeAreaInsets( );
 
   const handleClose = useCallback( ( ) => {
-    onPressClose( );
+    if ( onPressClose ) onPressClose( );
 
     if ( insideModal ) {
       sheetRef.current?.collapse( );
@@ -113,6 +113,7 @@ const StandardBottomSheet = ( {
       ref={sheetRef}
       style={marginOnWide}
       accessible={false}
+      onDismiss={handleClose}
     >
       <BottomSheetScrollView
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}


### PR DESCRIPTION
[MOB-403](https://linear.app/inaturalist/issue/MOB-403/feedback-modal-cannot-reopen-after-dismissal-by-swipe)

We were getting into a weird state when a user closed a `BottomSheet` via swipe down instead of the close button. It seems like the library knows how to handle the UI, but the parent that renders the bottomsheet wasn't being made aware of the state change, so on subsequent presses to open the bottomsheet, no state changes and nothing happens. 

It seems like this was happening in a few other places too; the `AddEvidenceSheet` for example--this change should fix all those instances.