### PR TITLE
make user list an array by default

### DIFF
--- a/src/components/Explore/SearchScreens/ExploreUserSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreUserSearch.js
@@ -34,7 +34,7 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ): Node => {
   const currentUser = useCurrentUser();
 
   // TODO: replace this with infinite scroll like ExploreFlashList
-  const { data: userList, isLoading, refetch } = useAuthenticatedQuery(
+  const { data: userList = [], isLoading, refetch } = useAuthenticatedQuery(
     ["fetchSearchResults", userQuery],
     optsWithAuth => fetchSearchResults(
       {


### PR DESCRIPTION
[MOB-1035](https://linear.app/inaturalist/issue/MOB-1035/crash-on-explore-filters-user-search-on-certain-search-string)

`UserList` expects an array of user objects, but at some point in the request cycle before we get real results we return `undefined`. I just made the `userList` an empty array by default.