### PR TITLE
e2e ci continue on error for first test attempt

### DIFF
--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -228,8 +228,8 @@ jobs:
         npm run e2e:test:ios
 
     - name: Run e2e test (retry, with logs)
-      # don't run this if it's status check that failed, but _do_ if first test failed before continue-on-error marked it success
-      if: ${{ ( failure() && steps.status_check.outcome != 'failure' ) || steps.first_test_run.outcome == 'failure' }}
+      # if first_test_run fails, but we `continue-on-error`, failure() is false. so we need to check it's specific _outcome_
+      if: ${{ steps.first_test_run.outcome == 'failure' }}
       run: |
         # provide more debugging context on retry failure
         # we're explicitly not using `detox test --retries` because we want to run them w/ different options
@@ -238,8 +238,8 @@ jobs:
     # The artifacts for the failing tests are available for download on github.com on the page of the individual actions run
     - name: Store Detox artifacts on test failure
       uses: actions/upload-artifact@v4
-      # don't run this if it's status check that failed, but _do_ if first test failed before continue-on-error marked it success
-      if: ${{ ( failure() && steps.status_check.outcome != 'failure' ) || steps.first_test_run.outcome == 'failure' }}
+      # don't run this if it's status check that failed or if our first test run passes (no first_test_run check needed)
+      if: ${{ failure() && steps.status_check.outcome != 'failure' }}
       with:
         name: detox-artifacts
         path: artifacts


### PR DESCRIPTION
the retry added in #3294 _was_ running on the first test step failure, _but_ since the first test step failed, the job / workflow was marked as a failure (RED). [Example run](https://github.com/inaturalist/iNaturalistReactNative/actions/runs/20444034540/job/58745438372) where test 1 failed, the retry succeeded, but the overall workflow failed (and took a lot longer : p) 
<img width="438" height="350" alt="image" src="https://github.com/user-attachments/assets/fbc59340-403f-4899-b1ad-15aca337de4d" />


We need to add `continue-on-error` so this step doesn't contribute to the overall failure. The step is marked "successful" and continues executing. However, this means that `failure()` doesn't work as a condition for the retry. The solution is to have the retry condition reference the step directly and check its `outcome` property, which _does_ reflect the failure. Note: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context the docs explicitly confirm that `outcome` reflects the status _before_ `continue-on-error` is applied (the alternative `conclusion`, not used here, is if we wanted after). 