### PR TITLE
disable pan down gestures for PickerSheet

### DIFF
--- a/src/components/SharedComponents/Sheets/BottomSheet.tsx
+++ b/src/components/SharedComponents/Sheets/BottomSheet.tsx
@@ -42,6 +42,7 @@ interface Props {
   containerClass?: string;
   scrollEnabled?: boolean;
   enablePanDownToClose?: boolean;
+  enableContentPanningGesture?: boolean;
 }
 
 const StandardBottomSheet = ( {
@@ -58,6 +59,7 @@ const StandardBottomSheet = ( {
   testID,
   scrollEnabled = true,
   enablePanDownToClose = true,
+  enableContentPanningGesture = true,
 }: Props ): Node => {
   if ( snapPoints ) {
     throw new Error( "BottomSheet does not accept snapPoints as a prop." );
@@ -116,6 +118,7 @@ const StandardBottomSheet = ( {
       accessible={false}
       onDismiss={handleClose}
       enablePanDownToClose={enablePanDownToClose}
+      enableContentPanningGesture={enableContentPanningGesture}
     >
       <BottomSheetScrollView
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}

--- a/src/components/SharedComponents/Sheets/PickerSheet.js
+++ b/src/components/SharedComponents/Sheets/PickerSheet.js
@@ -41,6 +41,7 @@ const PickerSheet = ( {
       insideModal={insideModal}
       scrollEnabled={false}
       enablePanDownToClose={false}
+      enableContentPanningGesture={false}
     >
       <View className="p-5">
         <Picker


### PR DESCRIPTION
closes [MOB-1106](https://linear.app/inaturalist/issue/MOB-1106/scrolling-on-a-bottom-sheet-with-a-list-should-not-close-the-bottom)

Pickers and bottom sheets don't play nice together.

https://github.com/user-attachments/assets/ce18a6e0-a0a3-45b5-aa5c-a20aa982d885

You can see there is still a bit of a bounce when scrolling down, but you can no longer dismiss the sheet this way--this is how the UI acts for the Explore Filter picker sheets already, so at least the experience is now consistent.

You can also see there is an issue with the scroll animation being duplicated.
I created a separate issue for that here: https://linear.app/inaturalist/issue/MOB-1165/duplicative-scroll-when-selecting-a-language