### PR TITLE
show offline/retry state for notifications when request takes too long

### DIFF
--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -14,6 +14,9 @@ import NotificationsTab, {
   OWNER_TAB,
 } from "./NotificationsTab";
 
+const OWNER_TAB_PARAMS = { observations_by: "owner" } as const;
+const FOLLOWING_TAB_PARAMS = { observations_by: "following" } as const;
+
 const Notifications = ( ) => {
   const [activeTab, setActiveTab] = useState<typeof OWNER_TAB | typeof OTHER_TAB>( OWNER_TAB );
   const { t } = useTranslation();
@@ -44,14 +47,14 @@ const Notifications = ( ) => {
       {activeTab === OWNER_TAB && (
         <NotificationsContainer
           currentUser={currentUser}
-          notificationParams={{ observations_by: "owner" }}
+          notificationParams={OWNER_TAB_PARAMS}
           onRefresh={( ) => EventRegister.emit( NOTIFICATIONS_REFRESHED, OWNER_TAB )}
         />
       )}
       {activeTab === OTHER_TAB && (
         <NotificationsContainer
           currentUser={currentUser}
-          notificationParams={{ observations_by: "following" }}
+          notificationParams={FOLLOWING_TAB_PARAMS}
           onRefresh={( ) => EventRegister.emit( NOTIFICATIONS_REFRESHED, OTHER_TAB )}
         />
       )}

--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -32,6 +32,7 @@ const NotificationsContainer = ( {
     isError,
     isFetching,
     isInitialLoading,
+    loadingTimedOut,
     notifications,
     refetch,
   } = useInfiniteNotificationsScroll( notificationParams );
@@ -69,6 +70,7 @@ const NotificationsContainer = ( {
       isFetching={isFetching}
       isInitialLoading={isInitialLoading}
       isConnected={isConnected}
+      loadingTimedOut={loadingTimedOut}
       onEndReached={fetchNextPage}
       reload={refetch}
       refreshing={refreshing}

--- a/src/components/Notifications/NotificationsList.tsx
+++ b/src/components/Notifications/NotificationsList.tsx
@@ -20,6 +20,7 @@ interface Props {
   isFetching?: boolean;
   isInitialLoading?: boolean;
   isConnected: boolean | null;
+  loadingTimedOut: boolean;
   onEndReached: ( ) => void;
   onRefresh: ( ) => void;
   refreshing: boolean;
@@ -39,6 +40,7 @@ const NotificationsList = ( {
   isFetching,
   isInitialLoading,
   isConnected,
+  loadingTimedOut,
   onEndReached,
   onRefresh,
   reload,
@@ -59,6 +61,12 @@ const NotificationsList = ( {
   ), [isFetching, isConnected, data.length] );
 
   const renderEmptyComponent = useCallback( ( ) => {
+    // show an offline/retry state if the user isn't connected or this request just takes too long
+    if ( isConnected === false || loadingTimedOut ) {
+      return <OfflineNotice onPress={reload} />;
+    }
+
+    // Loading
     if ( isInitialLoading ) {
       return (
         <View className="h-full justify-center">
@@ -67,10 +75,7 @@ const NotificationsList = ( {
       );
     }
 
-    if ( isConnected === false ) {
-      return <OfflineNotice onPress={reload} />;
-    }
-
+    // Empty/error state
     let msg = t( "No-Notifications-Found" );
     let msg2 = null;
     if ( !currentUser ) {
@@ -92,6 +97,7 @@ const NotificationsList = ( {
     isError,
     isInitialLoading,
     isConnected,
+    loadingTimedOut,
     reload,
     t,
   ] );

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -102,7 +102,14 @@ const useInfiniteNotificationsScroll = (
     [notificationParams],
   );
 
-  const infQueryResult = useAuthenticatedInfiniteQuery(
+  const {
+    data,
+    isFetching,
+    isInitialLoading,
+    isError,
+    refetch,
+    fetchNextPage,
+  } = useAuthenticatedInfiniteQuery(
     queryKey,
     async ( { pageParam }: { pageParam: number }, optsWithAuth: ApiOpts ) => {
       const params = { ...BASE_PARAMS, ...notificationParams };
@@ -155,19 +162,19 @@ const useInfiniteNotificationsScroll = (
   // We want to timeout and show an offline/retry state if this request takes too long
   useEffect( () => {
     // Reset if we get data
-    if ( infQueryResult.data !== undefined && !infQueryResult.isFetching ) {
+    if ( data !== undefined && !isFetching ) {
       setLoadingTimedOut( false );
       return undefined;
     }
 
     // Don't set timer if not loading
-    if ( !infQueryResult.isFetching ) {
+    if ( !isFetching ) {
       return undefined;
     }
 
     // Set a timeout and cancel the query if we hit the limit
     const timer = setTimeout( () => {
-      if ( infQueryResult.data === undefined && infQueryResult.isFetching ) {
+      if ( data === undefined && isFetching ) {
         queryClient.cancelQueries( { queryKey } );
         setLoadingTimedOut( true );
       }
@@ -175,26 +182,26 @@ const useInfiniteNotificationsScroll = (
 
     // eslint-disable-next-line consistent-return
     return () => clearTimeout( timer );
-  }, [infQueryResult.data, infQueryResult.isFetching, queryKey, queryClient] );
+  }, [data, isFetching, queryKey, queryClient] );
 
   // Reset when user manually retries
   useEffect( () => {
-    if ( infQueryResult.isFetching ) {
+    if ( isFetching ) {
       setLoadingTimedOut( false );
     }
-  }, [infQueryResult.isFetching] );
+  }, [isFetching] );
 
   return {
-    refetch: infQueryResult.refetch,
-    isError: infQueryResult.isError,
-    isFetching: infQueryResult.isFetching,
-    isInitialLoading: infQueryResult.isInitialLoading,
+    refetch,
+    isError,
+    isFetching,
+    isInitialLoading,
     loadingTimedOut,
     // Disable fetchNextPage if signed out
     fetchNextPage: currentUser
-      ? infQueryResult.fetchNextPage
+      ? fetchNextPage
       : ( ) => undefined,
-    notifications: flatten( infQueryResult?.data?.pages ),
+    notifications: flatten( data?.pages ),
   };
 };
 


### PR DESCRIPTION
closes [MOB-187](https://linear.app/inaturalist/issue/MOB-187/notifications-should-time-out-when-theres-low-connectivity)

Used a 5 second timeout which felt about right to me and was on the outer edge of being testable with the 'Very Bad Network' preset; sometimes notifications loaded and sometimes I got the offline state.

Opted to put this logic in the `useInfiniteNotificationsScrollHook` so that it was more similar to how we handle suggestions, but I could also see an argument for doing it in the component, since it's kind of presentational--essentially we're saying "you've seen this spinner for long enough, maybe try again later?" Doing it in the hook lets us actually cancel the query though. 

As an aside, it seems like we were eventually showing a `"something went wrong"` if the request takes long enough. In `useAuthenticatedInfiniteQuery`, we have some retry logic that will will eventually make `isError` true. In any case, this is a better experience I think.