### PR TITLE
add condition to stop fetching once we've fetched all results

### DIFF
--- a/src/sharedHooks/useInfiniteScroll.js
+++ b/src/sharedHooks/useInfiniteScroll.js
@@ -11,9 +11,9 @@ const useInfiniteScroll = (
   },
 ): Object => {
   const baseParams = {
-    ...newInputParams,
     per_page: 10,
     ttl: -1,
+    ...newInputParams,
   };
 
   const {


### PR DESCRIPTION
closes [MOB-1168](https://linear.app/inaturalist/issue/MOB-1168/infinite-re-rendering-loading-spinner-in-species-list)

Initially I was thinking of this as a performance-related follow-up to sorting species, but `useInfiniteScroll` is used in several places in the app, so this issue is fixed in these places as well:
- Alternate explore views: `IdentifiersView`, `ObserversView`, and `SpeciesView`, accessed by tapping the dark gray bar at the top
- Project search in Explore
- Project member list