### PR TITLE
prevent calling API with a placeholder obsId

### DIFF
--- a/src/components/ObservationsFlashList/ObservationsFlashList.js
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.js
@@ -269,7 +269,7 @@ const ObservationsFlashList: Function = ( {
     if ( fetchFromLastObservation && data.length > 0 ) {
       const lastObservation = data[data.length - 1];
       const lastId = lastObservation?.id;
-      if ( lastId ) {
+      if ( lastId && !lastObservation?.empty ) {
         fetchFromLastObservation( lastId );
         return;
       }


### PR DESCRIPTION
Stumbled on this one while doing some API investigation, tracked it down to our infinite scroll treating our placeholder obs tiles as a "real" obs. We were trying to query w/ a placeholder id like "empty-6".

No real user impact AFACT, but about 2k instances over 1k installs in the past 7 days.

Error location: https://github.com/inaturalist/iNaturalistReactNative/blob/88be35eb18e4d5125ab4bfa0440eb24701ac9809/src/sharedHooks/useInfiniteObservationsScroll.js#L46-L59

Source of the `empty-#` placeholder: https://github.com/inaturalist/iNaturalistReactNative/blob/88be35eb18e4d5125ab4bfa0440eb24701ac9809/src/components/MyObservations/MyObservationsSimple.tsx#L250 

It might make sense to pull the "box filling" logic closer to the UI so we don't actually need to worry about this sort of thing, but since `ObservationsFlashList` is shared between `MyObservationsSimple` and `ObservationsView`, I'm choosing not to pick that up right now.

closes MOB-1179