### PR TITLE
MOB-1190: freeze background stacks and clear stacks on tab press

### DIFF
--- a/src/navigation/BottomTabNavigator/CustomTabBarContainer.tsx
+++ b/src/navigation/BottomTabNavigator/CustomTabBarContainer.tsx
@@ -88,13 +88,15 @@ const CustomTabBarContainer: React.FC<Props> = ( { navigation, state } ) => {
 
   const activeTab = getActiveTab( );
 
-  const getTopScreenOfTab = useCallback( ( tabName: TabName ): string | undefined => {
+  const getTopScreenOfTab = useCallback( ( tabName: TabName ): string | null => {
     const navState = navigation.getState( );
     const tabRoute = navState.routes.find( r => r.name === tabName );
     const tabState = tabRoute?.state;
-    if ( !tabState || !tabState.routes ) return;
-    const topRoute = tabState.routes[tabState.index ?? tabState.routes.length - 1];
-    return topRoute?.name;
+    if ( tabState && tabState.routes ) {
+      const topRoute = tabState.routes[tabState.index ?? tabState.routes.length - 1];
+      return topRoute?.name;
+    }
+    return null;
   }, [navigation] );
 
   const tabs: TabConfig[] = useMemo( ( ) => ( [
@@ -109,8 +111,9 @@ const CustomTabBarContainer: React.FC<Props> = ( { navigation, state } ) => {
         const topScreen = getTopScreenOfTab( "MenuTab" );
         if ( topScreen === SCREEN_NAME_MENU && !isCurrentTab ) {
           navigation.navigate( "MenuTab" );
+        } else {
+          resetStack( "MenuTab", SCREEN_NAME_MENU );
         }
-        resetStack( "MenuTab", SCREEN_NAME_MENU );
       },
       active: SCREEN_NAME_MENU === activeTab,
     },
@@ -158,8 +161,9 @@ const CustomTabBarContainer: React.FC<Props> = ( { navigation, state } ) => {
         const topScreen = getTopScreenOfTab( "NotificationsTab" );
         if ( topScreen === SCREEN_NAME_NOTIFICATIONS && !isCurrentTab ) {
           navigation.navigate( "NotificationsTab" );
+        } else {
+          resetStack( "NotificationsTab", SCREEN_NAME_NOTIFICATIONS );
         }
-        resetStack( "NotificationsTab", SCREEN_NAME_NOTIFICATIONS );
       },
       active: SCREEN_NAME_NOTIFICATIONS === activeTab,
     },


### PR DESCRIPTION
This is my best reckoning of a fix.

When going between tabs, navigates to the next stack navigator without changing stack at all. Current behavior is to nav to the new tab and place a new screen on top.

When tapping the currently selected tab button, just the stack navigator that you're in is reset. Current behavior is to stay on the current tab and place a new screen on top.

