### PR TITLE
pass elements to flashlist instead of functions

### DIFF
--- a/src/components/Notifications/NotificationsList.tsx
+++ b/src/components/Notifications/NotificationsList.tsx
@@ -13,6 +13,8 @@ import type { RealmUser } from "realmModels/types";
 import { useTranslation } from "sharedHooks";
 import type { Notification } from "sharedHooks/useInfiniteNotificationsScroll";
 
+const ItemSeparator = ( ) => <View className="border-b border-lightGray" />;
+
 interface Props {
   currentUser: RealmUser | null;
   data: Notification[];
@@ -50,8 +52,6 @@ const NotificationsList = ( {
   const renderItem = useCallback( ( { item }: RenderItemProps ) => (
     <NotificationsListItem notification={item} />
   ), [] );
-
-  const renderItemSeparator = ( ) => <View className="border-b border-lightGray" />;
 
   const footerComponent = useMemo( ( ) => (
     <InfiniteScrollLoadingWheel
@@ -112,7 +112,7 @@ const NotificationsList = ( {
 
   return (
     <CustomFlashList
-      ItemSeparatorComponent={renderItemSeparator}
+      ItemSeparatorComponent={ItemSeparator}
       ListEmptyComponent={emptyComponent}
       ListFooterComponent={footerComponent}
       data={data}


### PR DESCRIPTION
closes [MOB-717](https://linear.app/inaturalist/issue/MOB-717/flickering-notifications-loading-circle)

The problem here was that our `renderEmptyComponent` function was being redefined when dependencies changed, and thus un/remounted, which made the spinner look glitchy. If we pass a memoized element to the flashlist instead, we just update the tree when a dependency changes, rather than re-mount, so the animation is smooth. Went ahead and made the same change for the footer loading animation.