### PR TITLE
Use module-level empty arrays for default props

### DIFF
--- a/src/components/ObsDetailsDefaultMode/ObsDetailsDefaultMode.tsx
+++ b/src/components/ObsDetailsDefaultMode/ObsDetailsDefaultMode.tsx
@@ -27,6 +27,8 @@ import StatusSection from "./StatusSection/StatusSection";
 
 const cardClassBottom = "rounded-b-2xl border-lightGray border-[2px] pb-3 border-t-0 -mt-0.5 mb-4";
 
+const EMPTY_ACTIVITY_ITEMS: object[] = [];
+
 interface Props {
   activityItems: object[];
   addingActivityItem: boolean;
@@ -47,7 +49,7 @@ interface Props {
 }
 
 const ObsDetailsDefaultMode = ( {
-  activityItems = [],
+  activityItems = EMPTY_ACTIVITY_ITEMS,
   addingActivityItem,
   belongsToCurrentUser,
   currentUser,

--- a/src/components/SharedComponents/IconicTaxonChooser.tsx
+++ b/src/components/SharedComponents/IconicTaxonChooser.tsx
@@ -36,9 +36,11 @@ const ICONIC_TAXA = [
   "unknown",
 ];
 
+const EMPTY_CHOSEN: string[] = [];
+
 const IconicTaxonChooser = ( {
   before,
-  chosen = [],
+  chosen = EMPTY_CHOSEN,
   onTaxonChosen,
   testID,
   withoutUnknown,

--- a/src/components/SharedComponents/Tabs/Tabs.tsx
+++ b/src/components/SharedComponents/Tabs/Tabs.tsx
@@ -28,10 +28,12 @@ interface Props {
   TextComponent?: typeof Heading4 | typeof Heading5;
 }
 
+const EMPTY_TABS: Tab[] = [];
+
 const Tabs = ( {
   activeId,
   activeColor = String( colors?.darkGray ),
-  tabs = [],
+  tabs = EMPTY_TABS,
   TabComponent,
   TextComponent = Heading4,
 }: Props ) => {

--- a/src/components/SharedComponents/TaxonSearch.tsx
+++ b/src/components/SharedComponents/TaxonSearch.tsx
@@ -16,6 +16,8 @@ const DROP_SHADOW = getShadow( {
   offsetHeight: 4,
 } );
 
+const EMPTY_TAXA: RealmTaxon[] = [];
+
 interface Props {
   query?: string;
   setQuery: ( newQuery: string ) => void;
@@ -33,7 +35,7 @@ const TaxonSearch = ( {
   query = "",
   renderItem,
   setQuery,
-  taxa = [],
+  taxa = EMPTY_TAXA,
 }: Props ) => {
   const { t } = useTranslation( );
   const { keyboardHeight, keyboardShown } = useKeyboardInfo( );


### PR DESCRIPTION
Inline defaults like `prop = []` create a new array every render, which can break memo/ref equality and cause extra re-renders. Hoist to const EMPTY_* per component.