### PR TITLE
Lazy-init needLocation state to avoid rerender work

### DIFF
--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -267,7 +267,7 @@ const MatchContainer = ( ) => {
   }, [] );
 
   const [needLocation, setNeedLocation] = useState(
-    shouldFetchObservationLocation( currentObservation ),
+    () => shouldFetchObservationLocation( currentObservation ),
   );
   const shouldFetchLocation = !!( hasPermissions && needLocation );
 


### PR DESCRIPTION
Changes the argument of setState from a boolean to a function which is then used to derive the initial state only on first render. Otherwise shouldFetchObservationLocation is invoked on every render.