### PR TITLE
Create react-native-exception-handler+2.10.10.patch

### DIFF
--- a/patches/react-native-exception-handler+2.10.10.patch
+++ b/patches/react-native-exception-handler+2.10.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-exception-handler/android/build.gradle b/node_modules/react-native-exception-handler/android/build.gradle
+index c1dca20..21596d5 100644
+--- a/node_modules/react-native-exception-handler/android/build.gradle
++++ b/node_modules/react-native-exception-handler/android/build.gradle
+@@ -1,7 +1,7 @@
+ 
+ buildscript {
+     repositories {
+-        jcenter()
++        mavenCentral()
+     }
+ 
+     dependencies {


### PR DESCRIPTION
This patch is required to compile the library on react-native 0.82