### PR TITLE
Remove manual linking for packages

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,11 +2,5 @@ pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'iNaturalistReactNative'
-include ':react-native-exception-handler'
-project(':react-native-exception-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-exception-handler/android')
-include ':react-native-localize'
-project(':react-native-localize').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-localize/android')
-include ':react-native-pure-jwt'
-project(':react-native-pure-jwt').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-pure-jwt/android')
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')


### PR DESCRIPTION
These entries are not required anymore. Autolinking takes care of this now.

Compiled and tested in Debug and Release mode on Android.