### PR TITLE
fix add evidence with standard camera in obsedit flow

### DIFF
--- a/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
+++ b/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
@@ -167,7 +167,7 @@ const usePrepareStoreAndNavigate = ( ) => {
       await updateObsWithCameraPhotos( addPhotoPermissionResult, userLocation, logStageIfAICamera );
       await deleteStageIfAICamera( );
       setSentinelFileName( null );
-      return navigation.goBack( );
+      return navigation.navigate( "ObsEdit", { lastScreen: "Camera" } );
     }
 
     await createObsWithCameraPhotos(

--- a/src/components/ObsEdit/Sheets/AddEvidenceSheet.js
+++ b/src/components/ObsEdit/Sheets/AddEvidenceSheet.js
@@ -39,14 +39,12 @@ const AddEvidenceSheet = ( {
           <EvidenceButton
             icon="camera"
             handlePress={( ) => {
-              // Since we're on ObsEdit, the "Camera" screen might already be in
-              // the stack, e.g. the AICamera, so if we use navigate() we risk
-              // going *back* to it and popping ObsEdit off the stack. Instead,
-              // we *push* another instance of that screen on to the stack so we
-              // can return to ObsEdit
-              navigation.push( "Camera", {
-                addEvidence: true,
-                camera: "Standard",
+              navigation.navigate( "NoBottomTabStackNavigator", {
+                screen: "Camera",
+                params: {
+                  addEvidence: true,
+                  camera: "Standard",
+                },
               } );
             }}
             disabled={disableAddingMoreEvidence}


### PR DESCRIPTION
closes [MOB-1208](https://linear.app/inaturalist/issue/MOB-1208/cant-open-camera-from-edit-observation)

This was actually working fine from ObsCreate and was only broken when accessing ObsEdit from My Observations.
We were throwing this error ```The action 'PUSH' with payload {"name":"Camera","params":{"addEvidence":true,"camera":"Standard"}} was not handled by any navigator.``` because when you're in MyObs, you're in a different navigator where `Camera` doesn't exist. I just followed the pattern set by the photo library and sound recorder, Where we explicitly nav to `NoBottomTabStackNavigator`. Tested every flow I could think of and never had the problem with the AI camera that the comment was warning of. 
The change in `usePrepareStoreandNavigate` ensures we land back in ObsEdit after adding a photo this way, otherwise we land back on MyObs with no image saved. I'm not entirely sure why that was happening, probably because we were going back() to the `TabNavigator`, and the initial route for that navigator is MyObs.

This is another case where having a unified navigation structure would be cool.