### PR TITLE
on dismiss photo permissions gate, reset the navigator and go to ObsList

### DIFF
--- a/src/components/SharedComponents/PermissionGateContainer.tsx
+++ b/src/components/SharedComponents/PermissionGateContainer.tsx
@@ -263,7 +263,12 @@ const PermissionGateContainer = ( {
     if ( onModalHideProp ) {
       onModalHideProp( );
     }
-    if ( !withoutNavigation ) navigation.goBack( );
+    if ( !withoutNavigation ) {
+      navigation.navigate( "TabNavigator", {
+        screen: "ObservationsTab",
+        params: { screen: "ObsList" },
+      } );
+    }
   }, [
     navigation,
     onModalHideProp,


### PR DESCRIPTION
closes [MOB-1116](https://linear.app/inaturalist/issue/MOB-1116/tapping-x-on-photo-permission-gate-shows-a-black-screen)

@jtklein I tested this change on top of my changes [here](https://github.com/inaturalist/iNaturalistReactNative/pull/3403) and things seem mostly fine:

- Dismissing the gate: AddObsButton > dismiss permissions gate > land on MyObs
- Before giving camera permission, add evidence to existing obs: ObsEdit > add evidence (camera) > see gate > dismiss gate: this will put you back on MyObs. **Arguably you should land back in ObsEdit but I think is is a minor issue. What do you think?** we want people to accept permissions and I assume most will. If you do accept photo permissions from this flow, you'll see the standard camera, the save photos permissions gate, and land back on ObsEdit with the new photo added.
- After allowing camera permissions, adding evidence during ObsCreate flow: works as expected. 
