### PR TITLE
remove notifications fetch timeout in favor of adding 'still loading'…

### DIFF
--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -32,7 +32,7 @@ const NotificationsContainer = ( {
     isError,
     isFetching,
     isInitialLoading,
-    loadingTimedOut,
+    showStillLoadingMessage,
     notifications,
     refetch,
   } = useInfiniteNotificationsScroll( notificationParams );
@@ -70,7 +70,7 @@ const NotificationsContainer = ( {
       isFetching={isFetching}
       isInitialLoading={isInitialLoading}
       isConnected={isConnected}
-      loadingTimedOut={loadingTimedOut}
+      showStillLoadingMessage={showStillLoadingMessage}
       onEndReached={fetchNextPage}
       reload={refetch}
       refreshing={refreshing}

--- a/src/components/Notifications/NotificationsList.tsx
+++ b/src/components/Notifications/NotificationsList.tsx
@@ -1,6 +1,7 @@
 import NotificationsListItem from "components/Notifications/NotificationsListItem";
 import {
   ActivityIndicator,
+  Body1,
   Body2,
   CustomFlashList,
   CustomRefreshControl,
@@ -22,7 +23,7 @@ interface Props {
   isFetching?: boolean;
   isInitialLoading?: boolean;
   isConnected: boolean | null;
-  loadingTimedOut: boolean;
+  showStillLoadingMessage: boolean;
   onEndReached: ( ) => void;
   onRefresh: ( ) => void;
   refreshing: boolean;
@@ -42,7 +43,7 @@ const NotificationsList = ( {
   isFetching,
   isInitialLoading,
   isConnected,
-  loadingTimedOut,
+  showStillLoadingMessage,
   onEndReached,
   onRefresh,
   reload,
@@ -61,16 +62,20 @@ const NotificationsList = ( {
   ), [isFetching, isConnected, data.length] );
 
   const emptyComponent = useMemo( ( ) => {
-    // show an offline/retry state if the user isn't connected or this request just takes too long
-    if ( isConnected === false || loadingTimedOut ) {
+    // Offline/retry when disconnected or request fails
+    if ( isConnected === false || isError ) {
       return <OfflineNotice onPress={reload} />;
     }
 
-    // Loading
     if ( isInitialLoading ) {
       return (
         <View className="h-full justify-center">
           <ActivityIndicator size={50} />
+          {showStillLoadingMessage && (
+            <Body1 className="mt-4 text-center mx-12">
+              {t( "Still-loading" )}
+            </Body1>
+          )}
         </View>
       );
     }
@@ -81,9 +86,6 @@ const NotificationsList = ( {
     if ( !currentUser ) {
       msg = t( "Once-you-create-and-upload-observations" );
       msg2 = t( "You-will-see-notifications" );
-    }
-    if ( isError ) {
-      msg = t( "Something-went-wrong" );
     }
 
     return (
@@ -97,7 +99,7 @@ const NotificationsList = ( {
     isError,
     isInitialLoading,
     isConnected,
-    loadingTimedOut,
+    showStillLoadingMessage,
     reload,
     t,
   ] );

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -1202,6 +1202,7 @@ Start-upload = Start upload
 # Accessibility hint for button that starts recording a sound
 Starts-recording-sound = Starts recording sound
 Stay-on-this-screen = Stay on this screen while your location loads.
+Still-loading = Still loading...
 Still-need-help = Still need help? You can file a support request here.
 # Button or accessibility label for an interactive element that stops an upload
 Stop-upload = Stop upload

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -754,6 +754,7 @@
   "Start-upload": "Start upload",
   "Starts-recording-sound": "Starts recording sound",
   "Stay-on-this-screen": "Stay on this screen while your location loads.",
+  "Still-loading": "Still loading...",
   "Still-need-help": "Still need help? You can file a support request here.",
   "Stop-upload": "Stop upload",
   "Stop-verb": "Stop",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -1202,6 +1202,7 @@ Start-upload = Start upload
 # Accessibility hint for button that starts recording a sound
 Starts-recording-sound = Starts recording sound
 Stay-on-this-screen = Stay on this screen while your location loads.
+Still-loading = Still loading...
 Still-need-help = Still need help? You can file a support request here.
 # Button or accessibility label for an interactive element that stops an upload
 Stop-upload = Stop upload

--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { fetchObservationUpdates, fetchRemoteObservations } from "api/observations";
 import type {
   ApiNotification,
@@ -28,7 +27,7 @@ interface InfiniteNotificationsScrollResponse {
   isError?: boolean;
   isFetching?: boolean;
   isInitialLoading?: boolean;
-  loadingTimedOut: boolean;
+  showStillLoadingMessage: boolean;
   notifications: Notification[];
   refetch: ( ) => void;
 }
@@ -94,8 +93,7 @@ const useInfiniteNotificationsScroll = (
 ): InfiniteNotificationsScrollResponse => {
   const currentUser = useCurrentUser( );
   const realm = useRealm( );
-  const queryClient = useQueryClient();
-  const [loadingTimedOut, setLoadingTimedOut] = useState( false );
+  const [showStillLoadingMessage, setShowStillLoadingMessage] = useState( false );
 
   const queryKey = useMemo(
     () => ["useInfiniteNotificationsScroll", JSON.stringify( notificationParams )],
@@ -159,11 +157,11 @@ const useInfiniteNotificationsScroll = (
     },
   );
 
-  // We want to timeout and show an offline/retry state if this request takes too long
+  // After 5 seconds of loading, we add a "Still loading..." message to the UI
   useEffect( () => {
     // Reset if we get data
     if ( data !== undefined && !isFetching ) {
-      setLoadingTimedOut( false );
+      setShowStillLoadingMessage( false );
       return undefined;
     }
 
@@ -172,22 +170,20 @@ const useInfiniteNotificationsScroll = (
       return undefined;
     }
 
-    // Set a timeout and cancel the query if we hit the limit
     const timer = setTimeout( () => {
       if ( data === undefined && isFetching ) {
-        queryClient.cancelQueries( { queryKey } );
-        setLoadingTimedOut( true );
+        setShowStillLoadingMessage( true );
       }
     }, LOADING_TIMEOUT );
 
     // eslint-disable-next-line consistent-return
     return () => clearTimeout( timer );
-  }, [data, isFetching, queryKey, queryClient] );
+  }, [data, isFetching] );
 
   // Reset when user manually retries
   useEffect( () => {
     if ( isFetching ) {
-      setLoadingTimedOut( false );
+      setShowStillLoadingMessage( false );
     }
   }, [isFetching] );
 
@@ -196,7 +192,7 @@ const useInfiniteNotificationsScroll = (
     isError,
     isFetching,
     isInitialLoading,
-    loadingTimedOut,
+    showStillLoadingMessage,
     // Disable fetchNextPage if signed out
     fetchNextPage: currentUser
       ? fetchNextPage


### PR DESCRIPTION
… copy

closes [MOB-1222](https://linear.app/inaturalist/issue/MOB-1222/replace-notifications-offlineretry-gate-with-secondary-loading-state)

There's an argument to be made, now that this is only a presentational change, that the timer should live in the component instead of the hook. Happy to move it over if anyone feels strongly about it; left it in the hook for now to keep this change smaller and because it feels like we might want to re-visit this.

The offline/retry gate should still show if the request totally times out, and I got rid of the unhelpful "something went wrong" error.