### PR TITLE
Remove GestureResponderEvent as a param

### DIFF
--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -8,7 +8,7 @@ import Zoom from "components/Camera/Buttons/Zoom";
 import TabletButtons from "components/Camera/TabletButtons";
 import { View } from "components/styledComponents";
 import React from "react";
-import type { GestureResponderEvent, ViewStyle } from "react-native";
+import type { ViewStyle } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import type { CameraDeviceFormat, TakePhotoOptions } from "react-native-vision-camera";
 import { useLayoutPrefs } from "sharedHooks";
@@ -18,10 +18,10 @@ import AIDebugButton from "./AIDebugButton";
 const isTablet = DeviceInfo.isTablet();
 
 interface Props {
-  handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
+  handleZoomButtonPress: ( ) => void;
   confidenceThreshold?: number;
   cropRatio?: string;
-  flipCamera: ( _event: GestureResponderEvent ) => void;
+  flipCamera: ( ) => void;
   fps?: number;
   handleClose: ( ) => void;
   hasFlash: boolean;
@@ -39,10 +39,10 @@ interface Props {
   takePhoto: () => Promise<void>;
   takePhotoOptions: TakePhotoOptions;
   takingPhoto: boolean;
-  toggleFlash: ( _event: GestureResponderEvent ) => void;
+  toggleFlash: ( ) => void;
   zoomTextValue: string;
   useLocation: boolean;
-  toggleLocation: ( _event: GestureResponderEvent ) => void;
+  toggleLocation: ( ) => void;
   deleteSentinelFile: ( ) => Promise<void>;
 }
 

--- a/src/components/Camera/Buttons/Flash.tsx
+++ b/src/components/Camera/Buttons/Flash.tsx
@@ -3,13 +3,13 @@ import RotatableIconWrapper from "components/Camera/RotatableIconWrapper";
 // eslint-disable-next-line max-len
 import TransparentCircleButton from "components/SharedComponents/Buttons/TransparentCircleButton";
 import React from "react";
-import type { GestureResponderEvent, ViewStyle } from "react-native";
+import type { ViewStyle } from "react-native";
 import type { TakePhotoOptions } from "react-native-vision-camera";
 import { useTranslation } from "sharedHooks";
 
 interface Props {
   rotatableAnimatedStyle: ViewStyle;
-  toggleFlash: ( _event: GestureResponderEvent ) => void;
+  toggleFlash: ( ) => void;
   hasFlash?: boolean;
   takePhotoOptions: TakePhotoOptions;
   flashClassName?: string;

--- a/src/components/Camera/Buttons/Location.tsx
+++ b/src/components/Camera/Buttons/Location.tsx
@@ -1,12 +1,12 @@
 import RotatableIconWrapper from "components/Camera/RotatableIconWrapper";
 import TransparentCircleButton from "components/SharedComponents/Buttons/TransparentCircleButton";
 import React from "react";
-import type { GestureResponderEvent, ViewStyle } from "react-native";
+import type { ViewStyle } from "react-native";
 import { useTranslation } from "sharedHooks";
 
 interface Props {
   rotatableAnimatedStyle: ViewStyle;
-  toggleLocation: ( _event: GestureResponderEvent ) => void;
+  toggleLocation: ( ) => void;
   useLocation?: boolean;
 }
 

--- a/src/components/SharedComponents/Buttons/INatIconButton.tsx
+++ b/src/components/SharedComponents/Buttons/INatIconButton.tsx
@@ -30,7 +30,7 @@ interface Props extends PropsWithChildren {
   icon?: string;
   // Only show the icon with all the same layout, don't make it a button
   iconOnly?: boolean;
-  onPress: ( _event?: GestureResponderEvent ) => void;
+  onPress: ( _event: GestureResponderEvent ) => void;
   // Inserts a white or colored view under the icon so an holes in the shape show as
   // white
   preventTransparency?: boolean;
@@ -178,7 +178,7 @@ const INatIconButton = ( {
     );
   }
 
-  const handlePressWithTracking = ( event?: GestureResponderEvent ) => {
+  const handlePressWithTracking = ( event: GestureResponderEvent ) => {
     if ( testID ) {
       const currentRoute = getCurrentRoute( );
       logger.info( `Button tap: ${testID}-${currentRoute?.name || "undefined"}` );


### PR DESCRIPTION
This has been discussed a bit in a previous PR. If we actually do not use this param in the onPress handler, let's just remove it from the type.