### PR TITLE
use explicit navigation back to obsedit when adding evidence

### DIFF
--- a/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
+++ b/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
@@ -167,9 +167,7 @@ const usePrepareStoreAndNavigate = ( ) => {
       await updateObsWithCameraPhotos( addPhotoPermissionResult, userLocation, logStageIfAICamera );
       await deleteStageIfAICamera( );
       setSentinelFileName( null );
-      return navigation.canGoBack()
-        ? navigation.goBack()
-        : navigation.navigate( "ObsEdit", { lastScreen: "Camera" } );
+      return navigation.navigate( "ObsEdit", { lastScreen: "Camera" } );
     }
 
     await createObsWithCameraPhotos(


### PR DESCRIPTION
I should've checked this more carefully before, this corrects (again) the issue where, when adding evidence via camera to an already saved observation, you land back on MyObs after tapping the green checkmark, without saving the new image.

the `canGoBack` check was returning true, and I think what was happening in that case was we were popping the Camera screen and returning to the `TabNavigator`, which just puts us on its default screen (ObsList), so we bypass the chance to save the new image we just took.