### PR TITLE
MOB-1186: log storage metrics on startup

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -20,6 +20,7 @@ import Observation from "realmModels/Observation";
 import User from "realmModels/User";
 import { valueToBreakpoint } from "sharedHelpers/breakpoint";
 import { log } from "sharedHelpers/logger";
+import getStorageMetrics from "sharedHelpers/storageMetrics";
 import { useCurrentUser, useLayoutPrefs, useTranslation } from "sharedHooks";
 import { zustandStorage } from "stores/useStore";
 import colors from "styles/tailwindColors";
@@ -154,7 +155,7 @@ const Menu = ( ) => {
     navigation.goBack( );
   };
 
-  const onSubmitFeedback = useCallback( ( feedbackText: string ) => {
+  const onSubmitFeedback = useCallback( async ( feedbackText: string ) => {
     if ( !isConnected ) {
       showOfflineAlert( t );
       return false;
@@ -203,11 +204,13 @@ const Menu = ( ) => {
         identifications: "loggedout",
         remoteObservations: "loggedout",
       };
+    const storageMetrics = await getStorageMetrics( realm?.path ).catch( () => ( {} ) );
     const feedbackContext = {
       ...modeContext,
       ...loggedInContext,
       // can have unsynced obs when logged out
       locallySavedOnlyObservations,
+      ...storageMetrics,
     };
     feedbackLogger.infoWithExtra( feedbackText, feedbackContext );
     Alert.alert( t( "Feedback-Submitted" ), t( "Thank-you-for-sharing-your-feedback" ) );

--- a/src/components/StartupService.tsx
+++ b/src/components/StartupService.tsx
@@ -6,20 +6,19 @@ import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
 import { LogBox } from "react-native";
 import DeviceInfo from "react-native-device-info";
-import RNFS from "react-native-fs";
 import Orientation from "react-native-orientation-locker";
 import Realm from "realm";
 import clearCaches from "sharedHelpers/clearCaches";
 import { IS_FRESH_INSTALL, store } from "sharedHelpers/installData";
-import { log, logFilePath } from "sharedHelpers/logger";
+import { log } from "sharedHelpers/logger";
 import { addARCameraFiles } from "sharedHelpers/mlModel";
 import { findAndLogSentinelFiles } from "sharedHelpers/sentinelFiles";
+import getStorageMetrics from "sharedHelpers/storageMetrics";
 import {
   usePerformance,
 } from "sharedHooks";
 import { isDebugMode } from "sharedHooks/useDebugMode";
 import { zustandStorage } from "stores/useStore";
-import zustandMMKVBackingStorage from "stores/zustandMMKVBackingStorage";
 
 // Ignore warnings about 3rd parties that haven't implemented the new
 // NativeEventEmitter interface methods yet. As of 20230517, this is coming
@@ -99,17 +98,8 @@ const StartupService = ( ) => {
 
       const logStorageMetrics = async ( ) => {
         try {
-          const realmBytes = realm?.path
-            ? ( await RNFS.stat( realm.path ).catch( () => ( { size: 0 } ) ) ).size
-            : "NA";
-          const logFileBytes = logFilePath
-            ? ( await RNFS.stat( logFilePath ).catch( () => ( { size: 0 } ) ) ).size
-            : "NA";
-          logger.infoWithExtra( "storage_metrics", {
-            realm_db_bytes: realmBytes,
-            mmkv_bytes: zustandMMKVBackingStorage.size,
-            log_file_bytes: logFileBytes,
-          } );
+          const metrics = await getStorageMetrics( realm?.path );
+          logger.infoWithExtra( "storage_metrics", metrics );
         } catch ( e ) {
           logger.info( "storage_metrics collection failed", e );
         }

--- a/src/sharedHelpers/storageMetrics.ts
+++ b/src/sharedHelpers/storageMetrics.ts
@@ -1,0 +1,25 @@
+import RNFS from "react-native-fs";
+import { logFilePath } from "sharedHelpers/logger";
+import zustandMMKVBackingStorage from "stores/zustandMMKVBackingStorage";
+
+export interface StorageMetrics {
+  realmDbBytes: number | "NA";
+  mmkvBytes: number;
+  logFileBytes: number | "NA";
+}
+
+const getStorageMetrics = async ( realmPath?: string | null ): Promise<StorageMetrics> => {
+  const realmBytes = realmPath
+    ? ( await RNFS.stat( realmPath ).catch( () => ( { size: 0 } ) ) ).size
+    : "NA";
+  const logFileBytes = logFilePath
+    ? ( await RNFS.stat( logFilePath ).catch( () => ( { size: 0 } ) ) ).size
+    : "NA";
+  return {
+    realmDbBytes: realmBytes,
+    mmkvBytes: zustandMMKVBackingStorage.size,
+    logFileBytes,
+  };
+};
+
+export default getStorageMetrics;


### PR DESCRIPTION
In this PR:

- On startup, log some persisted data storage
  - I did not include photo storage as that, as near as I could tell, would require relatively expensive reading of the file system