### PR TITLE
Smaller project icon

### DIFF
--- a/src/components/ProjectDetails/ProjectDetails.js
+++ b/src/components/ProjectDetails/ProjectDetails.js
@@ -153,14 +153,6 @@ const ProjectDetails = ( {
           {displayProjectIcon( project?.icon )}
         </ImageBackground>
       </View>
-
-      {/* <Image
-          source={{ uri: project.icon }}
-          className="h-[70px] w-[70px] rounded-full bottom-6 z-100 bg-white"
-          testID="ProjectDetails.projectIcon"
-          accessibilityIgnoresInvertColors
-        /> */}
-      {/* </ImageBackground> */}
       <View className="mx-4 pb-8">
         <Heading1 className="shrink mt-4">{project.title}</Heading1>
         <Subheading1>


### PR DESCRIPTION
On project details we show the project.icon (the round image above the background image). The only relevant sizes for this image we can get from the server are 70x70px or 1024x1024px. For this round image on screen we specify 134x134px, so, in most projects this image is a bit blurry on screen.
This PR makes the container a bit smaller so images should be a bit less blurry.