### PR TITLE
Also wrap children in a container if a RotatableIcon is not supposed to rotate

### DIFF
--- a/src/components/Camera/RotatableIconWrapper.tsx
+++ b/src/components/Camera/RotatableIconWrapper.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
 import type { ViewStyle } from "react-native";
+import { View } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import type { AnimatedStyle } from "react-native-reanimated";
 import Animated from "react-native-reanimated";
@@ -18,7 +19,11 @@ const RotatableIconWrapper = ( {
   containerClass,
 }: Props ) => {
   if ( isTablet || !rotatableAnimatedStyle ) {
-    return children;
+    return (
+      <View className={containerClass}>
+        {children}
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
Closes MOB-1243

This repairs a bug introduced with PR #3404 by repairing previous behaviour of always having a container that get's styled with the container class.

Before in ticket. After:
![4711CEF9-7BDE-4C80-96D1-64DFC3F2FFBA_4_5005_c](https://github.com/user-attachments/assets/8d0da2cc-c2e5-4daf-8d9b-a3d19d8113e7)
![6DC2F476-2C04-4053-8556-3164DF66B894_4_5005_c](https://github.com/user-attachments/assets/e3444c39-c79e-415c-9c63-33d8a0791e94)
![6D337B22-2F60-4C93-9710-07AA4A45E581_4_5005_c](https://github.com/user-attachments/assets/89d9bb47-ea4b-4edf-871c-689586aade32)
