### PR TITLE
Add a log for duration of an API call with and without fields

### DIFF
--- a/src/api/observations.js
+++ b/src/api/observations.js
@@ -25,15 +25,21 @@ const searchObservations = async ( params: Object = {}, opts: Object = {} ): Pro
     const startedAt = Date.now( );
     const response = await inatjs.observations.search( params, opts );
     const elapsedMs = Date.now( ) - startedAt;
-    logger.infoWithExtra(
-      "EXPERIMENTAL COMPARISON: querying API v2 with fields",
-      {
-        hasFields: !!params?.fields,
-        durationMs: elapsedMs,
-        // Not sure if asking for smaller page has performance benefits, but log it just in case
-        per_page: params?.per_page,
-      },
-    );
+    // Wrapping this in try/catch just in case something goes wrong with logging,
+    // we don't want to fail the whole request just because of that
+    try {
+      logger.infoWithExtra(
+        "EXPERIMENTAL COMPARISON: querying API v2 with fields",
+        {
+          hasFields: !!params?.fields,
+          durationMs: elapsedMs,
+          // Not sure if asking for smaller page has performance benefits, but log it just in case
+          per_page: params?.per_page,
+        },
+      );
+    } catch ( e ) {
+      logger.error( "Error logging experimental comparison", e );
+    }
     response.results = response.results.map( mapToLocalSchema );
     return response;
   } catch ( e ) {


### PR DESCRIPTION
Closes MOB-1188

I found one API endpoint that in parts of the app we query with fields and in other parts we query the same endpoint without fields. This is just a quick log to compare the turnaround time of the same endpoint with/without fields restriction.

One thought: Do I have to guard against the log call being the culprit of an error and then we are not using the correctly received observation results? Seems unlikely to me to happen but IDK.