### PR TITLE
Re-use our user agent string in netinfo config

### DIFF
--- a/src/components/StartupService.tsx
+++ b/src/components/StartupService.tsx
@@ -1,6 +1,7 @@
 import Geolocation from "@react-native-community/geolocation";
 import NetInfo from "@react-native-community/netinfo";
 import { onlineManager } from "@tanstack/react-query";
+import { getUserAgent } from "api/userAgent";
 import { signOut } from "components/LoginSignUp/AuthenticationService";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
@@ -32,6 +33,9 @@ Realm.setLogLevel( "warn" );
 // with no rendering required, per issue #1770
 NetInfo.configure( {
   reachabilityUrl: "https://www.inaturalist.org/ping",
+  reachabilityHeaders: {
+    "User-Agent": getUserAgent( ),
+  },
 } );
 
 const isTablet = DeviceInfo.isTablet( );


### PR DESCRIPTION
This is used to send a head request to our own ping url. This was a bit confusing because it got parsed as coming from iNaturalistiOS server-side.