### PR TITLE
MOB-1185 additional device runtime and install context for feedback

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -240,7 +240,7 @@ const Menu = ( ) => {
         remoteObservations: "loggedout",
       };
     const storageMetrics = await getStorageMetrics( realm?.path ).catch( () => ( {} ) );
-    const deviceMetrics = await getDeviceMetricsForFeedback();
+    const deviceMetrics = await getDeviceMetricsForFeedback().catch( () => ( {} ) );
     const feedbackContext = {
       ...modeContext,
       ...loggedInContext,


### PR DESCRIPTION
I validated that these are trivially inexpensive calls that should be fine to make on the exceptional user action of providing feedback ([test harness for this output](https://gist.github.com/FLGMwt/633b149ff8497cfee92ea30e6d52b689)): 

<img width="1134" height="167" alt="image" src="https://github.com/user-attachments/assets/e13c7e26-f328-4f8c-89a9-ccc62fddd07e" />

w/ that, I went ahead and made the awaits serial for readability.

closes MOB-1185