### PR TITLE
Fix extra rotation when taking photos on android

### DIFF
--- a/src/components/Camera/helpers/savePhotoToDocumentsDirectory.ts
+++ b/src/components/Camera/helpers/savePhotoToDocumentsDirectory.ts
@@ -12,7 +12,7 @@ const savePhotoToDocumentsDirectory = async (
   const path = rotatedOriginalPhotosPath;
   await RNFS.mkdir( path );
   const filename = cameraPhoto.path.split( "/" ).at( -1 );
-  const newPath = `${path}/${filename}`;
+  const newPath = `file://${path}/${filename}`;
   await RNFS.moveFile( cameraPhoto.path, newPath );
   return newPath;
 };


### PR DESCRIPTION
Closes MOB-982

Photos taken with the in-app camera on Android were displayed with an extra rotation. The root cause is @bam.tech/react-native-image-resizer handling of EXIF orientation on Android as described here: https://github.com/bamlab/react-native-image-resizer/issues/402. 

I replaced the unnecessary "legacy" resize pass in `savePhotoToDocumentsDirectory` with a simple file move. Have checked in the debugger that after the other passes through resizeImages images get uploaded correct-side-up and sent to offline cv model correct-side-up as well. 