### PR TITLE
Add realm to signOut options

### DIFF
--- a/src/components/StartupService.tsx
+++ b/src/components/StartupService.tsx
@@ -83,7 +83,7 @@ const StartupService = ( ) => {
         if ( isFreshInstall ) {
           store.set( IS_FRESH_INSTALL, false );
           if ( !currentUser ) {
-            await signOut( { clearRealm: true } );
+            await signOut( { realm, clearRealm: true } );
           }
         } else {
           // make sure the MMKV store has been created on a previous installation


### PR DESCRIPTION
Looking at the code of `signOut` it is clear that a deletion of realm only happens when we pass the Realm instance in as an option, otherwise it just passes over the code in this if block: https://github.com/inaturalist/iNaturalistReactNative/blob/0480fc8b4ace10526fec3b17cfb20dcc980e75d3/src/components/LoginSignUp/AuthenticationService.ts#L229-L245 So, since the call site here is clear that it wants to clearRealm inside of signOut, adding the realm instance leads to actually deleting realm which is I think what was intended here.