### PR TITLE
Fix: Navigation issue in useExitObservationFlow, migrate to TS

### DIFF
--- a/src/components/AddObsBottomSheet/AddObsButton.js
+++ b/src/components/AddObsBottomSheet/AddObsButton.js
@@ -115,7 +115,8 @@ const AddObsButton = ( ): React.Node => {
     logger.info( `isAdvancedUser: ${isAllAddObsOptionsMode}` );
   }, [isAllAddObsOptionsMode] );
 
-  const navAndCloseBottomSheet = ( screen, params ) => {
+  type Screen = "ObsEdit" | "Camera" | "PhotoLibrary" | "SoundRecorder";
+  const navAndCloseBottomSheet = ( screen: Screen, params ) => {
     if ( screen !== "ObsEdit" ) {
       resetObservationFlowSlice( );
     }

--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -6,6 +6,7 @@ import {
 } from "components/Camera/helpers/visionCameraWrapper";
 import { ActivityIndicator } from "components/SharedComponents";
 import { View } from "components/styledComponents";
+import type { NoBottomTabStackScreenProps } from "navigation/types";
 import React, {
   useCallback,
   useEffect,
@@ -70,7 +71,8 @@ const CameraContainer = ( ) => {
   const addCameraRollUris = useStore( state => state.addCameraRollUris );
   const startFirebaseTrace = useStore( state => state.startFirebaseTrace );
 
-  const { params } = useRoute( );
+  const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>();
+  const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
   const cameraType = params?.camera;
 
   const logStageIfAICamera = useCallback( async (
@@ -96,7 +98,6 @@ const CameraContainer = ( ) => {
   // will not reflect when they actually took the photo
   const [userLocationForGeomodel, setUserLocationForGeomodel] = useState( null );
 
-  const navigation = useNavigation( );
   const { t } = useTranslation( );
 
   const [cameraPosition, setCameraPosition] = useState<"front" | "back">( "back" );

--- a/src/components/Camera/CameraWithDevice.tsx
+++ b/src/components/Camera/CameraWithDevice.tsx
@@ -11,7 +11,7 @@ import StandardCamera from "./StandardCamera/StandardCamera";
 const isTablet = DeviceInfo.isTablet( );
 
 interface Props {
-  cameraType: string;
+  cameraType: "AI" | "Standard";
   device: CameraDevice;
   camera: object;
   flipCamera: ( ) => void;

--- a/src/components/Camera/StandardCamera/hooks/useBackPress.ts
+++ b/src/components/Camera/StandardCamera/hooks/useBackPress.ts
@@ -1,5 +1,6 @@
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import { getCurrentRoute } from "navigation/navigationUtils";
+import type { NoBottomTabStackScreenProps } from "navigation/types";
 import {
   useCallback,
   useState,
@@ -10,7 +11,7 @@ import {
 import useExitObservationFlow from "sharedHooks/useExitObservationFlow";
 
 const useBackPress = ( shouldShowDiscardSheet: boolean ) => {
-  const navigation = useNavigation( );
+  const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>( );
   const exitObservationFlow = useExitObservationFlow( );
 
   const [showDiscardSheet, setShowDiscardSheet] = useState( false );

--- a/src/components/Camera/StandardCamera/hooks/useBackPress.ts
+++ b/src/components/Camera/StandardCamera/hooks/useBackPress.ts
@@ -1,5 +1,4 @@
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
-import { getCurrentRoute } from "navigation/navigationUtils";
+import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
 import type { NoBottomTabStackScreenProps } from "navigation/types";
 import {
   useCallback,
@@ -12,6 +11,7 @@ import useExitObservationFlow from "sharedHooks/useExitObservationFlow";
 
 const useBackPress = ( shouldShowDiscardSheet: boolean ) => {
   const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>( );
+  const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
   const exitObservationFlow = useExitObservationFlow( );
 
   const [showDiscardSheet, setShowDiscardSheet] = useState( false );
@@ -19,17 +19,15 @@ const useBackPress = ( shouldShowDiscardSheet: boolean ) => {
   const handleBackButtonPress = useCallback( ( ) => {
     if ( shouldShowDiscardSheet ) {
       setShowDiscardSheet( true );
+    } else if ( params?.addEvidence ) {
+      navigation.navigate( "ObsEdit" );
     } else {
-      const currentRoute = getCurrentRoute();
-      if ( currentRoute?.params?.addEvidence ) {
-        navigation.navigate( "ObsEdit" );
-      } else {
-        exitObservationFlow( );
-      }
+      exitObservationFlow( );
     }
   }, [
     exitObservationFlow,
     navigation,
+    params?.addEvidence,
     setShowDiscardSheet,
     shouldShowDiscardSheet,
   ] );

--- a/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
+++ b/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
@@ -1,5 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import useDeviceStorageFull from "components/Camera/hooks/useDeviceStorageFull";
+import type { NoBottomTabStackScreenProps } from "navigation/types";
 import {
   useCallback,
 } from "react";
@@ -15,8 +16,8 @@ import useStore from "stores/useStore";
 import savePhotosToPhotoLibrary from "../helpers/savePhotosToPhotoLibrary";
 
 const usePrepareStoreAndNavigate = ( ) => {
-  const navigation = useNavigation( );
-  const { params } = useRoute( );
+  const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>( );
+  const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
   const addEvidence = params?.addEvidence;
   const setObservations = useStore( state => state.setObservations );
   const updateObservations = useStore( state => state.updateObservations );

--- a/src/components/Explore/ExploreSearchContainer.tsx
+++ b/src/components/Explore/ExploreSearchContainer.tsx
@@ -1,7 +1,7 @@
-import type { RouteProp } from "@react-navigation/native";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import type { ApiPlace, ApiProject, ApiTaxon } from "api/types";
 import { View } from "components/styledComponents";
+import type { TabStackScreenProps } from "navigation/types";
 import {
   ExploreProvider,
 } from "providers/ExploreContext";
@@ -15,8 +15,8 @@ import ExploreTaxonSearch from "./SearchScreens/ExploreTaxonSearch";
 import ExploreUserSearch from "./SearchScreens/ExploreUserSearch";
 
 const ExploreSearchContainerWithContext = () => {
-  const navigation = useNavigation();
-  const { params } = useRoute<RouteProp<Record<string, { initialSearchMode?: string }>, string>>( );
+  const navigation = useNavigation<TabStackScreenProps<"ExploreSearch">["navigation"]>();
+  const { params } = useRoute<TabStackScreenProps<"ExploreSearch">["route"]>();
 
   const {
     hasPermissions,

--- a/src/components/Explore/Modals/ExploreTaxonSearchModal.tsx
+++ b/src/components/Explore/Modals/ExploreTaxonSearchModal.tsx
@@ -7,7 +7,6 @@ import type { RealmTaxon } from "realmModels/types";
 
 interface Props {
   closeModal: ( ) => void;
-  hideInfoButton?: boolean;
   onPressInfo?: ( ) => void;
   showModal: boolean;
   updateTaxon: ( taxon: RealmTaxon | null ) => void;
@@ -15,7 +14,6 @@ interface Props {
 
 const ExploreTaxonSearchModal = ( {
   closeModal,
-  hideInfoButton,
   onPressInfo,
   showModal,
   updateTaxon,
@@ -30,7 +28,6 @@ const ExploreTaxonSearchModal = ( {
       modal={(
         <ExploreTaxonSearch
           closeModal={closeModal}
-          hideInfoButton={hideInfoButton}
           onPressInfo={( taxon: RealmTaxon | ApiTaxon ) => {
             navigation.push( "TaxonDetails", { id: taxon.id } );
             closeModal();

--- a/src/components/Explore/SearchScreens/ExploreTaxonSearch.js
+++ b/src/components/Explore/SearchScreens/ExploreTaxonSearch.js
@@ -17,14 +17,12 @@ import ExploreSearchHeader from "./ExploreSearchHeader";
 
 type Props = {
   closeModal: Function,
-  hideInfoButton?: boolean,
   onPressInfo?: Function,
   updateTaxon: Function
 };
 
 const ExploreTaxonSearch = ( {
   closeModal,
-  hideInfoButton,
   onPressInfo,
   updateTaxon,
 }: Props ): Node => {
@@ -55,14 +53,12 @@ const ExploreTaxonSearch = ( {
       first={index === 0}
       fetchRemote={false}
       handleTaxonOrEditPress={() => onTaxonSelected( taxon )}
-      hideInfoButton={hideInfoButton}
       onPressInfo={onPressInfo}
       showCheckmark={false}
       taxon={taxon}
       testID={`Search.taxa.${taxon.id}`}
     />
   ), [
-    hideInfoButton,
     onPressInfo,
     onTaxonSelected,
   ] );

--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -2,7 +2,6 @@ import {
   useNetInfo,
 } from "@react-native-community/netinfo";
 import { useNavigation } from "@react-navigation/native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { ApiPhoto, ApiSuggestion } from "api/types";
 import { Body3, Heading4, ViewWrapper } from "components/SharedComponents";
 import { View } from "components/styledComponents";
@@ -12,6 +11,11 @@ import {
 } from "components/Suggestions/SuggestionsContainer";
 import { isEqual } from "lodash";
 import orderBy from "lodash/orderBy";
+import type {
+  NoBottomTabStackScreenProps,
+  SharedStackParamList,
+  TabStackScreenProps,
+} from "navigation/types";
 import { RealmContext } from "providers/contexts";
 import React, {
   useCallback,
@@ -45,12 +49,6 @@ interface ImageParamsType {
   };
   lat?: number;
   lng?: number;
-}
-
-interface NavParams {
-  id?: number | string;
-  firstPhotoID?: number | string;
-  representativePhoto?: { isRepresentativeButOtherTaxon?: boolean; id?: number | string };
 }
 
 interface State {
@@ -127,7 +125,11 @@ const MatchContainer = ( ) => {
   const getCurrentObservation = useStore( state => state.getCurrentObservation );
   const cameraRollUris = useStore( state => state.cameraRollUris );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );
-  const navigation = useNavigation<NativeStackNavigationProp<Record<string, NavParams>>>( );
+  const navigation = useNavigation<
+    NoBottomTabStackScreenProps<"Match">["navigation"] &
+    TabStackScreenProps<"Match">["navigation"]
+  >( );
+
   const {
     hasPermissions,
     renderPermissionsGate,
@@ -443,7 +445,7 @@ const MatchContainer = ( ) => {
 
   const navToTaxonDetails
   = ( photo?: ApiPhoto | RealmPhoto ) => {
-    const navParams: NavParams = { id: taxonId };
+    const navParams: SharedStackParamList["TaxonDetails"] = { id: taxonId };
     if ( !photo?.isRepresentativeButOtherTaxon ) {
       navParams.firstPhotoID = photo?.id;
     } else {

--- a/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatchContainer.tsx
+++ b/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatchContainer.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import SavedMatch from "components/ObsDetailsDefaultMode/SavedMatch/SavedMatch";
+import type { TabStackScreenProps } from "navigation/types";
 import React from "react";
 import type { RealmObservation } from "realmModels/types";
 
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const SavedMatchContainer = ( { observation }: Props ) => {
-  const navigation = useNavigation<NativeStackNavigationProp<Record<string, { id?: number }>>>( );
+  const navigation = useNavigation<TabStackScreenProps<"ObsDetails">["navigation"]>( );
 
   const navToTaxonDetails = () => {
     const navParams = { id: observation.taxon?.id };

--- a/src/components/ObsDetailsSharedComponents/hooks/useObsDetailsSharedLogic.ts
+++ b/src/components/ObsDetailsSharedComponents/hooks/useObsDetailsSharedLogic.ts
@@ -179,6 +179,7 @@ const useObsDetailsSharedLogic = ( {
   refetchRemoteObservation,
 }: UseObsDetailsSharedLogicParams ): UseObsDetailsSharedLogicReturn => {
   const setObservations = useStore( state => state.setObservations );
+  // TODO: replace with central types
   const navigation = useNavigation<NavigationProp<ParamListBase>>( );
   const realm = useRealm( );
   const [state, dispatch] = useReducer( reducer, initialState );

--- a/src/components/PhotoImporter/PhotoLibrary.tsx
+++ b/src/components/PhotoImporter/PhotoLibrary.tsx
@@ -184,7 +184,6 @@ const PhotoLibrary = ( ) => {
         navToObsEdit();
 
         // Determine if we need to go back to ObsList or ObsDetails screen
-      // TODO: the typing of params seems correct to me, so we might never hit this case here?
       } else if ( params && params.previousScreen && params.previousScreen.name === "ObsDetails" ) {
         // If the uuid is undefined we need to error out here or ObsDetails doesn't work
         if ( !params.previousScreen.params?.uuid ) {

--- a/src/components/PhotoImporter/PhotoLibrary.tsx
+++ b/src/components/PhotoImporter/PhotoLibrary.tsx
@@ -184,6 +184,7 @@ const PhotoLibrary = ( ) => {
         navToObsEdit();
 
         // Determine if we need to go back to ObsList or ObsDetails screen
+      // TODO: the typing of params seems correct to me, so we might never hit this case here?
       } else if ( params && params.previousScreen && params.previousScreen.name === "ObsDetails" ) {
         // If the uuid is undefined we need to error out here or ObsDetails doesn't work
         if ( !params.previousScreen.params?.uuid ) {

--- a/src/components/PhotoImporter/PhotoLibrary.tsx
+++ b/src/components/PhotoImporter/PhotoLibrary.tsx
@@ -72,6 +72,7 @@ const PhotoLibrary = ( ) => {
 
   const navBasedOnUserSettings = useCallback( async ( ) => {
     if ( isDefaultMode ) {
+      // TODO: why do we need to define higher navigator here
       return navigation.navigate( "NoBottomTabStackNavigator", {
         screen: "Match",
         params: {

--- a/src/components/PhotoImporter/PhotoLibrary.tsx
+++ b/src/components/PhotoImporter/PhotoLibrary.tsx
@@ -1,5 +1,4 @@
 import { mkdir, moveFile, TemporaryDirectoryPath } from "@dr.pogodin/react-native-fs";
-import type { Route, RouteProp } from "@react-navigation/native";
 import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
 import {
   photoLibraryPhotosPath,
@@ -7,6 +6,7 @@ import {
 import navigateToObsDetails from "components/ObsDetails/helpers/navigateToObsDetails";
 import { ActivityAnimation, ViewWrapper } from "components/SharedComponents";
 import { t } from "i18next";
+import type { NoBottomTabStackScreenProps } from "navigation/types";
 import React, {
   useCallback,
   useState,
@@ -36,23 +36,13 @@ const MAX_PHOTOS_ALLOWED = Platform.select( {
 
 const FROM_AICAMERA_MAX_PHOTOS_ALLOWED = 1;
 
-interface PreviousScreenParams {
-  uuid?: string;
-}
-
-interface RouteParams {
-  skipGroupPhotos?: boolean;
-  fromGroupPhotos?: boolean;
-  fromAICamera?: boolean;
-  cmonBack?: boolean;
-  previousScreen?: Route<string, PreviousScreenParams> | null;
-}
-
 const PhotoLibrary = ( ) => {
   const {
     screenAfterPhotoEvidence, isDefaultMode,
   } = useLayoutPrefs( );
-  const navigation = useNavigation( );
+  const navigation = useNavigation<NoBottomTabStackScreenProps<"PhotoLibrary">["navigation"]>();
+  const { params } = useRoute<NoBottomTabStackScreenProps<"PhotoLibrary">["route"]>();
+
   const [photoLibraryShown, setPhotoLibraryShown] = useState( false );
   const setPhotoImporterState = useStore( state => state.setPhotoImporterState );
   const setGroupedPhotos = useStore( state => state.setGroupedPhotos );
@@ -65,8 +55,6 @@ const PhotoLibrary = ( ) => {
   const observations = useStore( state => state.observations );
   const numOfObsPhotos: number = currentObservation?.observationPhotos?.length || 0;
   const exitObservationsFlow = useExitObservationsFlow( );
-
-  const { params } = useRoute<RouteProp<Record<string, RouteParams>, string>>( );
 
   const skipGroupPhotos = params
     ? params.skipGroupPhotos

--- a/src/components/PhotoImporter/PhotoLibrary.tsx
+++ b/src/components/PhotoImporter/PhotoLibrary.tsx
@@ -24,7 +24,7 @@ import fetchPlaceName from "sharedHelpers/fetchPlaceName";
 import { log } from "sharedHelpers/logger";
 import { sleep } from "sharedHelpers/util";
 import { useLayoutPrefs } from "sharedHooks";
-import useExitObservationsFlow from "sharedHooks/useExitObservationFlow";
+import useExitObservationFlow from "sharedHooks/useExitObservationFlow";
 import useStore from "stores/useStore";
 
 const logger = log.extend( "PhotoLibrary" );
@@ -54,7 +54,7 @@ const PhotoLibrary = ( ) => {
   const currentObservationIndex = useStore( state => state.currentObservationIndex );
   const observations = useStore( state => state.observations );
   const numOfObsPhotos: number = currentObservation?.observationPhotos?.length || 0;
-  const exitObservationsFlow = useExitObservationsFlow( );
+  const exitObservationFlow = useExitObservationFlow( );
 
   const skipGroupPhotos = params
     ? params.skipGroupPhotos
@@ -163,7 +163,7 @@ const PhotoLibrary = ( ) => {
     } catch ( launchError ) {
       logger.error( "launchImageLibrary threw unexpectedly", launchError );
       setPhotoLibraryShown( false );
-      exitObservationsFlow();
+      exitObservationFlow();
       return;
     }
 
@@ -194,7 +194,7 @@ const PhotoLibrary = ( ) => {
       } else if ( params?.cmonBack && navigation.canGoBack() ) {
         navigation.goBack();
       } else {
-        exitObservationsFlow();
+        exitObservationFlow();
       }
       setPhotoLibraryShown( false );
       return;
@@ -277,13 +277,13 @@ const PhotoLibrary = ( ) => {
     } catch ( error ) {
       logger.error( "Error importing photos from library", error );
       setPhotoLibraryShown( false );
-      exitObservationsFlow();
+      exitObservationFlow();
     }
   }, [
     currentObservation,
     currentObservationIndex,
     evidenceToAdd,
-    exitObservationsFlow,
+    exitObservationFlow,
     fromGroupPhotos,
     photoLibraryUris,
     groupedPhotos,

--- a/src/components/PhotoImporter/PhotoLibrary.tsx
+++ b/src/components/PhotoImporter/PhotoLibrary.tsx
@@ -163,7 +163,7 @@ const PhotoLibrary = ( ) => {
     } catch ( launchError ) {
       logger.error( "launchImageLibrary threw unexpectedly", launchError );
       setPhotoLibraryShown( false );
-      exitObservationFlow();
+      exitObservationFlow( );
       return;
     }
 
@@ -194,7 +194,7 @@ const PhotoLibrary = ( ) => {
       } else if ( params?.cmonBack && navigation.canGoBack() ) {
         navigation.goBack();
       } else {
-        exitObservationFlow();
+        exitObservationFlow( );
       }
       setPhotoLibraryShown( false );
       return;
@@ -277,7 +277,7 @@ const PhotoLibrary = ( ) => {
     } catch ( error ) {
       logger.error( "Error importing photos from library", error );
       setPhotoLibraryShown( false );
-      exitObservationFlow();
+      exitObservationFlow( );
     }
   }, [
     currentObservation,

--- a/src/components/PhotoSharing.tsx
+++ b/src/components/PhotoSharing.tsx
@@ -16,7 +16,10 @@ const PhotoSharing = ( ) => {
     NoBottomTabStackScreenProps<"PhotoSharing">["navigation"] &
     TabStackScreenProps<"PhotoSharing">["navigation"]
   >( );
-  const { params } = useRoute( );
+  const { params } = useRoute<
+    NoBottomTabStackScreenProps<"PhotoSharing">["route"] &
+    TabStackScreenProps<"PhotoSharing">["route"]
+  >( );
   const { item } = params;
   const sharedText = item.extraData?.userInput;
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );

--- a/src/components/PhotoSharing.tsx
+++ b/src/components/PhotoSharing.tsx
@@ -21,6 +21,7 @@ const PhotoSharing = ( ) => {
     TabStackScreenProps<"PhotoSharing">["route"]
   >( );
   const { item } = params;
+  // TODO: seems expected here but not actually defined in App.js the only start point
   const sharedText = item.extraData?.userInput;
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
@@ -28,7 +29,9 @@ const PhotoSharing = ( ) => {
   const { screenAfterPhotoEvidence, isDefaultMode } = useLayoutPrefs();
   const [navigationHandled, setNavigationHandled] = useState( null );
 
-  const resetNavigator = useCallback( screen => navigation.dispatch(
+  const resetNavigator = useCallback( (
+    screen: "Match" | "ObsEdit" | "Suggestions",
+  ) => navigation.dispatch(
     CommonActions.reset( {
       index: 0,
       routes: [

--- a/src/components/PhotoSharing.tsx
+++ b/src/components/PhotoSharing.tsx
@@ -1,6 +1,7 @@
 import { CommonActions, useNavigation, useRoute } from "@react-navigation/native";
 import { ActivityAnimation, ViewWrapper } from "components/SharedComponents";
 import { View } from "components/styledComponents";
+import type { NoBottomTabStackScreenProps, TabStackScreenProps } from "navigation/types";
 import React, {
   useCallback, useEffect, useRef, useState,
 } from "react";
@@ -11,7 +12,10 @@ import useStore from "stores/useStore";
 
 const PhotoSharing = ( ) => {
   const previousItem = useRef( null );
-  const navigation = useNavigation( );
+  const navigation = useNavigation<
+    NoBottomTabStackScreenProps<"PhotoSharing">["navigation"] &
+    TabStackScreenProps<"PhotoSharing">["navigation"]
+  >( );
   const { params } = useRoute( );
   const { item } = params;
   const sharedText = item.extraData?.userInput;

--- a/src/components/PhotoSharing.tsx
+++ b/src/components/PhotoSharing.tsx
@@ -30,7 +30,7 @@ const PhotoSharing = ( ) => {
   const [navigationHandled, setNavigationHandled] = useState( null );
 
   const resetNavigator = useCallback( (
-    screen: "Match" | "ObsEdit" | "Suggestions",
+    screen: "Match" | "ObsEdit" | "Suggestions" | "GroupPhotos",
   ) => navigation.dispatch(
     CommonActions.reset( {
       index: 0,
@@ -76,6 +76,7 @@ const PhotoSharing = ( ) => {
     // navigating through the AddObsBottomSheet
     resetObservationFlowSlice( );
 
+    // TODO: fix TS of the share item
     const photoUris = data
       .filter( x => x.mimeType && x.mimeType.startsWith( "image/" ) )
       .map( x => ( { image: { uri: x.data } } ) );

--- a/src/components/SharedComponents/ObsDetails/HeaderEditIcon.tsx
+++ b/src/components/SharedComponents/ObsDetails/HeaderEditIcon.tsx
@@ -13,7 +13,7 @@ import colors from "styles/tailwindColors";
 
 interface Props {
   observation: RealmObservation;
-  lastScreen?: string;
+  lastScreen?: "Match";
   taxon?: ApiTaxon | RealmTaxon;
 }
 

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -10,6 +10,7 @@ import {
 import { Pressable, View } from "components/styledComponents";
 import type {
   NoBottomTabStackScreenProps,
+  SharedStackParamList,
   TabStackScreenProps,
 } from "navigation/types";
 import type { PropsWithChildren } from "react";
@@ -138,7 +139,7 @@ const TaxonResult = ( {
     );
 
   const navToTaxonDetails = React.useCallback( ( ) => {
-    const params = {
+    const params: SharedStackParamList["TaxonDetails"] = {
       id: usableTaxon?.id,
       hideNavButtons,
       lastScreen,

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -8,6 +8,10 @@ import {
   INatIconButton,
 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
+import type {
+  NoBottomTabStackScreenProps,
+  TabStackScreenProps,
+} from "navigation/types";
 import type { PropsWithChildren } from "react";
 import React from "react";
 import type { GestureResponderEvent } from "react-native";
@@ -79,7 +83,25 @@ const TaxonResult = ( {
   white = false,
 }: TaxonResultProps ) => {
   const { t } = useTranslation( );
-  const navigation = useNavigation( );
+  // TaxonResult is imported in
+  // AICamera
+  // ExploreTaxonSearch
+  // MatchTaxonSearch
+  // IdentificationSection
+  // Suggestion
+  // SuggestionsTaxonSearch
+  // However, navigation is only used if
+  // unpressable is false and hideInfoButton is false and onPressInfo is not provided
+  // or
+  // unpressable is false and handleTaxonOrEditPress is not provided
+  const navigation = useNavigation<
+    TabStackScreenProps<
+      "MatchTaxonSearchScreen" | "Suggestions" | "SuggestionsTaxonSearch"
+    >["navigation"] &
+    NoBottomTabStackScreenProps<
+      "MatchTaxonSearchScreen" | "Suggestions" | "SuggestionsTaxonSearch"
+    >["navigation"]
+  >( );
 
   const currentUser = useCurrentUser( );
 

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -38,7 +38,7 @@ interface TaxonResultProps {
   handleTaxonOrEditPress?: ( _event?: GestureResponderEvent ) => void;
   hideInfoButton?: boolean;
   hideNavButtons?: boolean;
-  lastScreen?: string | null;
+  lastScreen?: "Suggestions";
   onPressInfo?: ( taxon: object ) => void;
   showCheckmark?: boolean;
   showEditButton?: boolean;
@@ -70,7 +70,7 @@ const TaxonResult = ( {
   handleTaxonOrEditPress,
   hideInfoButton = false,
   hideNavButtons = false,
-  lastScreen = null,
+  lastScreen,
   onPressInfo,
   retryQuery = true,
   showCheckmark = true,

--- a/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts
+++ b/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts
@@ -1,4 +1,5 @@
 import { StackActions, useNavigation, useRoute } from "@react-navigation/native";
+import type { NoBottomTabStackScreenProps, TabStackScreenProps } from "navigation/types";
 import { useCallback } from "react";
 import useStore from "stores/useStore";
 
@@ -7,8 +8,17 @@ const useNavigateWithTaxonSelected = (
     vision: boolean;
   },
 ) => {
-  const navigation = useNavigation( );
-  const { params } = useRoute( );
+  // This hook is used in SuggestionsTaxonSearch and SuggestionsContainer.
+  // Both screens are in the SharedStackNavigator.
+  // So the navigation types here are possible from TabStack or NoBottomTabStack
+  const navigation = useNavigation<
+    NoBottomTabStackScreenProps<"Suggestions" | "SuggestionsTaxonSearch">["navigation"] &
+    TabStackScreenProps<"Suggestions" | "SuggestionsTaxonSearch">["navigation"]
+  >( );
+  const { params } = useRoute<
+    NoBottomTabStackScreenProps<"Suggestions" | "SuggestionsTaxonSearch">["route"] &
+    TabStackScreenProps<"Suggestions" | "SuggestionsTaxonSearch">["route"]
+  >( );
   const { entryScreen, lastScreen } = params || {};
   const currentObservation = useStore( state => state.currentObservation );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );

--- a/src/components/TaxonDetails/Taxonomy.tsx
+++ b/src/components/TaxonDetails/Taxonomy.tsx
@@ -4,6 +4,7 @@ import {
   Heading4,
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
+import type { NoBottomTabStackScreenProps, TabStackScreenProps } from "navigation/types";
 import React, { useState } from "react";
 import { useCurrentUser, useTranslation } from "sharedHooks";
 
@@ -16,7 +17,10 @@ interface Props {
 
 const Taxonomy = ( { taxon: currentTaxon, hideNavButtons }: Props ) => {
   const [viewChildren, setViewChildren] = useState( false );
-  const navigation = useNavigation( );
+  const navigation = useNavigation<
+    NoBottomTabStackScreenProps<"TaxonDetails">["navigation"] &
+    TabStackScreenProps<"TaxonDetails">["navigation"]
+  >( );
   const { t } = useTranslation( );
   const currentUser = useCurrentUser( );
   const scientificNameFirst = currentUser?.prefers_scientific_name_first;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -32,6 +32,8 @@ export type SharedStackParamList = {
   Match: {
     entryScreen: "CameraWithDevice";
     lastScreen: "CameraWithDevice";
+  } | {
+    lastScreen: "PhotoLibrary";
   };
   Suggestions: {
     entryScreen: "CameraWithDevice";
@@ -42,6 +44,8 @@ export type SharedStackParamList = {
     hideSkip: boolean;
   } | {
     lastScreen: "ObsEdit";
+  } | {
+    lastScreen: "PhotoLibrary";
   };
   SuggestionsTaxonSearch: {
     entryScreen: "ObsEdit";

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -36,10 +36,17 @@ export type SharedStackParamList = {
   // { lastScreen: "Suggestions" }
   // From useNavigateToObsEdit.ts
   // { lastScreen: "Match" }
+    // From PhotoSharing
+  // { lastScreen: "PhotoSharing" }
   // From useBackPress.ts; SoundRecorder.js; useNavigateWithTaxonSelected.ts; TaxonDetails.js
   // undefined
   ObsEdit: {
-    lastScreen?: "Camera" | "CameraWithDevice" | "PhotoLibrary" | "Suggestions" | "Match";
+    lastScreen?: "Camera" |
+      "CameraWithDevice" |
+      "PhotoLibrary" |
+      "Suggestions" |
+      "Match" |
+      "PhotoSharing";
     entryScreen?: "CameraWithDevice";
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;
@@ -96,9 +103,11 @@ export type SharedStackParamList = {
   // {
   //   lastScreen: "PhotoLibrary";
   // }
+  // From PhotoSharing
+  // { lastScreen: "PhotoSharing" }
   Match: {
     entryScreen?: "CameraWithDevice";
-    lastScreen: "CameraWithDevice" | "PhotoLibrary";
+    lastScreen: "CameraWithDevice" | "PhotoLibrary" | "PhotoSharing";
   };
   // From usePrepareStoreAndNavigate.ts
   // {
@@ -125,9 +134,11 @@ export type SharedStackParamList = {
   //   lastScreen: "ObsDetails",
   //   hideSkip: true,
   // }
+  // From PhotoSharing
+  // { lastScreen: "PhotoSharing" }
   Suggestions: {
     entryScreen?: "CameraWithDevice" | "ObsEdit" | "ObsDetails";
-    lastScreen?: "CameraWithDevice" | "ObsEdit" | "PhotoLibrary" | "ObsDetails";
+    lastScreen?: "CameraWithDevice" | "ObsEdit" | "PhotoLibrary" | "ObsDetails" | "PhotoSharing";
     hideSkip?: boolean;
   };
   SuggestionsTaxonSearch: {
@@ -250,8 +261,10 @@ export type BaseNoBottomTabStackParamList = {
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;
   };
-  GroupPhotos: undefined;
   SoundRecorder: undefined;
+  // From PhotoSharing
+  // { lastScreen: "PhotoSharing" }
+  GroupPhotos: { lastScreen: "PhotoSharing" };
 };
 
 export type NoBottomTabStackParamList = BaseNoBottomTabStackParamList &

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -38,7 +38,7 @@ export type SharedStackParamList = {
   // { lastScreen: "Match" }
   // From PhotoSharing
   // { lastScreen: "PhotoSharing" }
-  // From GroupPhotos
+  // From GroupPhotosContainer
   // { lastScreen: "GroupPhotos" }
   // {
   //   entryScreen: "GroupPhotos",
@@ -119,7 +119,7 @@ export type SharedStackParamList = {
   // }
   // From PhotoSharing
   // { lastScreen: "PhotoSharing" }
-  // From GroupPhotos
+  // From GroupPhotosContainer
   // {
   //   entryScreen: "GroupPhotos",
   //   lastScreen: "GroupPhotos",
@@ -155,7 +155,7 @@ export type SharedStackParamList = {
   // }
   // From PhotoSharing
   // { lastScreen: "PhotoSharing" }
-  // From GroupPhotos
+  // From GroupPhotosContainer
   // {
   //   entryScreen: "GroupPhotos",
   //   lastScreen: "GroupPhotos",

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -32,10 +32,12 @@ export type SharedStackParamList = {
   // {
   //   previousScreen: ParamListRoute<RootStackParamList>;
   // };
-  // From useBackPress.ts
+  // From useNavigateWithTaxonSelected.ts
+  // { lastScreen: "Suggestions" }
+  // From useBackPress.ts; SoundRecorder.js; useNavigateWithTaxonSelected.ts
   // undefined
   ObsEdit: {
-    lastScreen?: "Camera" | "CameraWithDevice" | "PhotoLibrary";
+    lastScreen?: "Camera" | "CameraWithDevice" | "PhotoLibrary" | "Suggestions";
     entryScreen?: "CameraWithDevice";
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -193,9 +193,22 @@ export type BaseNoBottomTabStackParamList = {
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;
   };
+  // From AddObsButton
+  // {
+  //   previousScreen: ParamListRoute<RootStackParamList>;
+  // };
+  // From MyObservationsEmptySimple.js
+  // { camera: "AI" }
+  // From AddEvidenceSheet.js
+  // {
+  //   addEvidence: true,
+  //   camera: "Standard",
+  // }
   Camera: {
     addEvidence?: boolean;
     camera?: "AI" | "Standard";
+    // eslint-disable-next-line no-use-before-define
+    previousScreen?: ParamListRoute<RootStackParamList>;
   };
   GroupPhotos: undefined;
   SoundRecorder: undefined;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -16,7 +16,7 @@ export type SharedStackParamList = {
   } | {
     entryScreen: "CameraWithDevice";
     lastScreen: "CameraWithDevice";
-  };
+  } | undefined;
   LocationPicker: undefined;
   TaxonDetails: undefined;
   PhotoSharing: undefined;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -11,12 +11,23 @@ import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SharedStackParamList = {
-  ObsEdit: undefined;
+  ObsEdit: {
+    lastScreen: "Camera";
+  } | {
+    entryScreen: "CameraWithDevice";
+    lastScreen: "CameraWithDevice";
+  };
   LocationPicker: undefined;
   TaxonDetails: undefined;
   PhotoSharing: undefined;
-  Match: undefined;
-  Suggestions: undefined;
+  Match: {
+    entryScreen: "CameraWithDevice";
+    lastScreen: "CameraWithDevice";
+  };
+  Suggestions: {
+    entryScreen: "CameraWithDevice";
+    lastScreen: "CameraWithDevice";
+  };
   SuggestionsTaxonSearch: undefined;
   MatchTaxonSearchScreen: undefined;
   FullPageWebView: undefined;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -65,6 +65,12 @@ export type SharedStackParamList = {
   //   vision,
   //   firstPhotoID
   // }
+  // From Taxonomy
+  // {
+  //   id: taxonId,
+  //   hideNavButtons,
+  //   usesVision: false,
+  // }
   TaxonDetails: {
     // TODO: how can this be string?
     id?: number | string;
@@ -76,7 +82,9 @@ export type SharedStackParamList = {
     };
     hideNavButtons?: boolean;
     lastScreen?: "Suggestions";
+    // TODO: do we really use both?
     vision?: boolean;
+    usesVision?: boolean;
   };
   PhotoSharing: undefined;
   // From usePrepareStoreAndNavigate.ts

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -36,8 +36,14 @@ export type SharedStackParamList = {
   // { lastScreen: "Suggestions" }
   // From useNavigateToObsEdit.ts
   // { lastScreen: "Match" }
-    // From PhotoSharing
+  // From PhotoSharing
   // { lastScreen: "PhotoSharing" }
+  // From GroupPhotos
+  // { lastScreen: "GroupPhotos" }
+  // {
+  //   entryScreen: "GroupPhotos",
+  //   lastScreen: "GroupPhotos",
+  // }
   // From useBackPress.ts; SoundRecorder.js; useNavigateWithTaxonSelected.ts; TaxonDetails.js
   // undefined
   ObsEdit: {
@@ -46,8 +52,9 @@ export type SharedStackParamList = {
       "PhotoLibrary" |
       "Suggestions" |
       "Match" |
-      "PhotoSharing";
-    entryScreen?: "CameraWithDevice";
+      "PhotoSharing" |
+      "GroupPhotos";
+    entryScreen?: "CameraWithDevice" | "GroupPhotos";
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;
   } | undefined;
@@ -112,9 +119,14 @@ export type SharedStackParamList = {
   // }
   // From PhotoSharing
   // { lastScreen: "PhotoSharing" }
+  // From GroupPhotos
+  // {
+  //   entryScreen: "GroupPhotos",
+  //   lastScreen: "GroupPhotos",
+  // }
   Match: {
-    entryScreen?: "CameraWithDevice";
-    lastScreen: "CameraWithDevice" | "PhotoLibrary" | "PhotoSharing";
+    entryScreen?: "CameraWithDevice" | "GroupPhotos";
+    lastScreen: "CameraWithDevice" | "PhotoLibrary" | "PhotoSharing" | "GroupPhotos";
   };
   // From usePrepareStoreAndNavigate.ts
   // {
@@ -143,9 +155,19 @@ export type SharedStackParamList = {
   // }
   // From PhotoSharing
   // { lastScreen: "PhotoSharing" }
+  // From GroupPhotos
+  // {
+  //   entryScreen: "GroupPhotos",
+  //   lastScreen: "GroupPhotos",
+  // }
   Suggestions: {
-    entryScreen?: "CameraWithDevice" | "ObsEdit" | "ObsDetails";
-    lastScreen?: "CameraWithDevice" | "ObsEdit" | "PhotoLibrary" | "ObsDetails" | "PhotoSharing";
+    entryScreen?: "CameraWithDevice" | "ObsEdit" | "ObsDetails" | "GroupPhotos";
+    lastScreen?: "CameraWithDevice" |
+      "ObsEdit" |
+      "PhotoLibrary" |
+      "ObsDetails" |
+      "PhotoSharing" |
+      "GroupPhotos";
     hideSkip?: boolean;
   };
   SuggestionsTaxonSearch: {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -44,11 +44,26 @@ export type SharedStackParamList = {
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;
   } | undefined;
+  // From MatchContainer
+  // undefined
   LocationPicker: undefined;
   // From ExploreSearchContainer, ExploreTaxonSearchModal
   // { id: taxon.id }
+  // From MatchContainer
+  // {
+  //   id?: number | string;
+  //   firstPhotoID?: number | string;
+  //   representativePhoto?: { isRepresentativeButOtherTaxon?: boolean; id?: number | string };
+  // };
   TaxonDetails: {
-    id?: number;
+    // TODO: how can this be string?
+    id?: number | string;
+    // TODO: how can this be string?
+    firstPhotoID?: number | string;
+    representativePhoto?: {
+      isRepresentativeButOtherTaxon?: boolean;
+      id?: number | string;
+    };
   };
   PhotoSharing: undefined;
   // From usePrepareStoreAndNavigate.ts

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -34,8 +34,17 @@ export type SharedStackParamList = {
   Suggestions: {
     entryScreen: "CameraWithDevice";
     lastScreen: "CameraWithDevice";
+  } | {
+    entryScreen: "ObsEdit";
+    lastScreen: "ObsEdit";
+    hideSkip: boolean;
+  } | {
+    lastScreen: "ObsEdit";
   };
-  SuggestionsTaxonSearch: undefined;
+  SuggestionsTaxonSearch: {
+    entryScreen: "ObsEdit";
+    lastScreen: "ObsEdit";
+  };
   MatchTaxonSearchScreen: undefined;
   FullPageWebView: undefined;
 };

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -118,7 +118,38 @@ export type BottomTabParamList = {
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type BaseNoBottomTabStackParamList = {
-  PhotoLibrary: undefined;
+  // PhotoLibrary param options:
+  // Being set on PhotoLibrary:
+  // {
+  //   fromGroupPhotos: false;
+  // }
+  // From GroupPhotos
+  // {
+  //   fromGroupPhotos: true;
+  // }
+  // From PhotoLibraryIcon
+  // {
+  //   cmonBack: true;
+  //   lastScreen: "Camera";
+  //   fromAICamera: true;
+  // }
+  // From AddEvidenceSheet
+  // {
+  //   skipGroupPhotos: true;
+  // }
+  // From AddObsButton
+  // {
+  //   previousScreen: ParamListRoute<RootStackParamList>;
+  // };
+  PhotoLibrary: {
+    fromGroupPhotos?: boolean;
+    cmonBack?: boolean;
+    lastScreen?: "Camera";
+    fromAICamera?: boolean;
+    skipGroupPhotos?: boolean;
+    // eslint-disable-next-line no-use-before-define
+    previousScreen?: ParamListRoute<RootStackParamList>;
+  };
   Camera: {
     addEvidence?: boolean;
     camera?: "AI" | "Standard";

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -15,16 +15,30 @@ import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SharedStackParamList = {
+  // From usePrepareStoreAndNavigate.ts
+  // {
+  //   entryScreen: "Camera";
+  // }
+  // From usePrepareStoreAndNavigate.ts
+  // {
+  //   entryScreen: "CameraWithDevice";
+  //   lastScreen: "CameraWithDevice";
+  // }
+  // From PhotoLibrary
+  // {
+  //   lastScreen: "PhotoLibrary";
+  // }
+  // From AddObsButton
+  // {
+  //   previousScreen: ParamListRoute<RootStackParamList>;
+  // };
+  // From useBackPress.ts
+  // undefined
   ObsEdit: {
-    lastScreen: "Camera";
-  } | {
-    entryScreen: "CameraWithDevice";
-    lastScreen: "CameraWithDevice";
-  } | {
+    lastScreen?: "Camera" | "CameraWithDevice" | "PhotoLibrary";
+    entryScreen?: "CameraWithDevice";
     // eslint-disable-next-line no-use-before-define
-    previousScreen: ParamListRoute<RootStackParamList>;
-  } | {
-    lastScreen: "PhotoLibrary";
+    previousScreen?: ParamListRoute<RootStackParamList>;
   } | undefined;
   LocationPicker: undefined;
   TaxonDetails: undefined;
@@ -174,7 +188,9 @@ export type BaseNoBottomTabStackParamList = {
     camera?: "AI" | "Standard";
   };
   GroupPhotos: undefined;
-  SoundRecorder: undefined;
+  SoundRecorder: {
+    addEvidence?: boolean;
+  } | undefined;
 };
 
 export type NoBottomTabStackParamList = BaseNoBottomTabStackParamList &

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -35,17 +35,29 @@ export type SharedStackParamList = {
   } | {
     lastScreen: "PhotoLibrary";
   };
+  // From usePrepareStoreAndNavigate.ts
+  // {
+  //   entryScreen: "CameraWithDevice";
+  //   lastScreen: "CameraWithDevice";
+  // }
+  // From IdentificationSection.js
+  // {
+  //   entryScreen: "ObsEdit";
+  //   lastScreen: "ObsEdit";
+  //   hideSkip: boolean;
+  // }
+  // From ObsEditHeader
+  // {
+  //   lastScreen: "ObsEdit";
+  // }
+  // From PhotoLibrary
+  // {
+  //   lastScreen: "PhotoLibrary";
+  // }
   Suggestions: {
-    entryScreen: "CameraWithDevice";
-    lastScreen: "CameraWithDevice";
-  } | {
-    entryScreen: "ObsEdit";
-    lastScreen: "ObsEdit";
-    hideSkip: boolean;
-  } | {
-    lastScreen: "ObsEdit";
-  } | {
-    lastScreen: "PhotoLibrary";
+    entryScreen?: "CameraWithDevice" | "ObsEdit";
+    lastScreen?: "CameraWithDevice" | "ObsEdit" | "PhotoLibrary";
+    hideSkip?: boolean;
   };
   SuggestionsTaxonSearch: {
     entryScreen: "ObsEdit";

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -23,6 +23,8 @@ export type SharedStackParamList = {
   } | {
     // eslint-disable-next-line no-use-before-define
     previousScreen: ParamListRoute<RootStackParamList>;
+  } | {
+    lastScreen: "PhotoLibrary";
   } | undefined;
   LocationPicker: undefined;
   TaxonDetails: undefined;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -47,7 +47,9 @@ export type SharedStackParamList = {
   // From MatchContainer
   // undefined
   LocationPicker: undefined;
-  // From ExploreSearchContainer, ExploreTaxonSearchModal
+  // From ExploreSearchContainer, ExploreTaxonSearchModal, MyObservationsSimple,
+  // ObsDetailsOverview, CommunityTaxon, SavedMatchContainer, ActivityItem, ProjectRequirements
+  // TaxonGridItem
   // { id: taxon.id }
   // From MatchContainer
   // {
@@ -55,6 +57,14 @@ export type SharedStackParamList = {
   //   firstPhotoID?: number | string;
   //   representativePhoto?: { isRepresentativeButOtherTaxon?: boolean; id?: number | string };
   // };
+  // From TaxonResult
+  // {
+  //   id: usableTaxon?.id,
+  //   hideNavButtons,
+  //   lastScreen,
+  //   vision,
+  //   firstPhotoID
+  // }
   TaxonDetails: {
     // TODO: how can this be string?
     id?: number | string;
@@ -64,6 +74,9 @@ export type SharedStackParamList = {
       isRepresentativeButOtherTaxon?: boolean;
       id?: number | string;
     };
+    hideNavButtons?: boolean;
+    lastScreen?: "Suggestions";
+    vision?: boolean;
   };
   PhotoSharing: undefined;
   // From usePrepareStoreAndNavigate.ts

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -85,8 +85,11 @@ export type BottomTabParamList = {
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type BaseNoBottomTabStackParamList = {
-  Camera: undefined;
   PhotoLibrary: undefined;
+  Camera: {
+    addEvidence?: boolean;
+    camera?: "AI" | "Standard";
+  };
   GroupPhotos: undefined;
   SoundRecorder: undefined;
 };

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -45,7 +45,11 @@ export type SharedStackParamList = {
     previousScreen?: ParamListRoute<RootStackParamList>;
   } | undefined;
   LocationPicker: undefined;
-  TaxonDetails: undefined;
+  // From ExploreSearchContainer, ExploreTaxonSearchModal
+  // { id: taxon.id }
+  TaxonDetails: {
+    id?: number;
+  };
   PhotoSharing: undefined;
   // From usePrepareStoreAndNavigate.ts
   // {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -188,9 +188,7 @@ export type BaseNoBottomTabStackParamList = {
     camera?: "AI" | "Standard";
   };
   GroupPhotos: undefined;
-  SoundRecorder: {
-    addEvidence?: boolean;
-  } | undefined;
+  SoundRecorder: undefined;
 };
 
 export type NoBottomTabStackParamList = BaseNoBottomTabStackParamList &

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -93,7 +93,14 @@ export type SharedStackParamList = {
     vision?: boolean;
     usesVision?: boolean;
   };
-  PhotoSharing: undefined;
+  // From App.js
+  // item is SharedItem
+  PhotoSharing: {
+    item: {
+      mimeType: string;
+      data: string | string[];
+    };
+  };
   // From usePrepareStoreAndNavigate.ts
   // {
   //   entryScreen: "CameraWithDevice";

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -29,11 +29,18 @@ export type SharedStackParamList = {
   LocationPicker: undefined;
   TaxonDetails: undefined;
   PhotoSharing: undefined;
+  // From usePrepareStoreAndNavigate.ts
+  // {
+  //   entryScreen: "CameraWithDevice";
+  //   lastScreen: "CameraWithDevice";
+  // }
+  // From PhotoLibrary
+  // {
+  //   lastScreen: "PhotoLibrary";
+  // }
   Match: {
-    entryScreen: "CameraWithDevice";
-    lastScreen: "CameraWithDevice";
-  } | {
-    lastScreen: "PhotoLibrary";
+    entryScreen?: "CameraWithDevice";
+    lastScreen: "CameraWithDevice" | "PhotoLibrary";
   };
   // From usePrepareStoreAndNavigate.ts
   // {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -77,9 +77,15 @@ export type SharedStackParamList = {
   // {
   //   lastScreen: "PhotoLibrary";
   // }
+  // From useObsDetailsSharedLogic.ts
+  // {
+  //   entryScreen: "ObsDetails",
+  //   lastScreen: "ObsDetails",
+  //   hideSkip: true,
+  // }
   Suggestions: {
-    entryScreen?: "CameraWithDevice" | "ObsEdit";
-    lastScreen?: "CameraWithDevice" | "ObsEdit" | "PhotoLibrary";
+    entryScreen?: "CameraWithDevice" | "ObsEdit" | "ObsDetails";
+    lastScreen?: "CameraWithDevice" | "ObsEdit" | "PhotoLibrary" | "ObsDetails";
     hideSkip?: boolean;
   };
   SuggestionsTaxonSearch: {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -4,7 +4,11 @@
  */
 
 import type { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
-import type { CompositeScreenProps, NavigatorScreenParams } from "@react-navigation/native";
+import type {
+  CompositeScreenProps,
+  NavigatorScreenParams,
+  ParamListRoute,
+} from "@react-navigation/native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 // Note from the documentation:
@@ -16,6 +20,9 @@ export type SharedStackParamList = {
   } | {
     entryScreen: "CameraWithDevice";
     lastScreen: "CameraWithDevice";
+  } | {
+    // eslint-disable-next-line no-use-before-define
+    previousScreen: ParamListRoute<RootStackParamList>;
   } | undefined;
   LocationPicker: undefined;
   TaxonDetails: undefined;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -34,10 +34,12 @@ export type SharedStackParamList = {
   // };
   // From useNavigateWithTaxonSelected.ts
   // { lastScreen: "Suggestions" }
-  // From useBackPress.ts; SoundRecorder.js; useNavigateWithTaxonSelected.ts
+  // From useNavigateToObsEdit.ts
+  // { lastScreen: "Match" }
+  // From useBackPress.ts; SoundRecorder.js; useNavigateWithTaxonSelected.ts; TaxonDetails.js
   // undefined
   ObsEdit: {
-    lastScreen?: "Camera" | "CameraWithDevice" | "PhotoLibrary" | "Suggestions";
+    lastScreen?: "Camera" | "CameraWithDevice" | "PhotoLibrary" | "Suggestions" | "Match";
     entryScreen?: "CameraWithDevice";
     // eslint-disable-next-line no-use-before-define
     previousScreen?: ParamListRoute<RootStackParamList>;

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -43,7 +43,7 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
 
     if ( typeof ( options.navigate ) === "function" ) {
       // This seems only to be used in ObsEditHeader in a few cases of backing out
-      options.navigate();
+      options.navigate( );
     } else {
       navigation.navigate( "TabNavigator", {
         screen: "ObservationsTab",

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -28,7 +28,12 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
     >["navigation"] &
     TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["navigation"]
   >( );
-  const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
+  const { params } = useRoute<
+    NoBottomTabStackScreenProps<
+      "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
+    >["route"] &
+    TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["route"]
+  >( );
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
 
   return useCallback( ( options: Options = {} ) => {

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -3,7 +3,7 @@
 // state
 import { useNavigation, useRoute } from "@react-navigation/native";
 import navigateToObsDetails from "components/ObsDetails/helpers/navigateToObsDetails";
-import type { NoBottomTabStackScreenProps } from "navigation/types";
+import type { NoBottomTabStackScreenProps, TabStackScreenProps } from "navigation/types";
 import { useCallback } from "react";
 import useStore from "stores/useStore";
 
@@ -17,7 +17,11 @@ interface Options {
 export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
   // This hook is used in:
   // - useBackPress.ts
-  const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>( );
+  // - MatchContainer.js
+  const navigation = useNavigation<
+    NoBottomTabStackScreenProps<"Camera">["navigation"] &
+    TabStackScreenProps<"Match">["navigation"]
+  >( );
   const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
 

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -18,9 +18,15 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
   // This hook is used in:
   // - useBackPress.ts
   // - MatchContainer.js
+  // - BottomButtonsContainer.tsx
+  // - ObsEditHeader.js
+  // - PhotoLibrary.tsx
+  // - TaxonDetails.tsx
   const navigation = useNavigation<
-    NoBottomTabStackScreenProps<"Camera">["navigation"] &
-    TabStackScreenProps<"Match">["navigation"]
+    NoBottomTabStackScreenProps<
+      "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
+    >["navigation"] &
+    TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["navigation"]
   >( );
   const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -1,22 +1,11 @@
 // Trying to consolidate cleanup and nav logic when exiting the obs create /
 // edit flow, so basically nav to MyObs by default and clean up the zustand
 // state
-import type { RouteProp } from "@react-navigation/native";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import navigateToObsDetails from "components/ObsDetails/helpers/navigateToObsDetails";
+import type { NoBottomTabStackScreenProps } from "navigation/types";
 import { useCallback } from "react";
 import useStore from "stores/useStore";
-
-interface ObsFlowParams {
-  [name: string]: {
-    previousScreen?: {
-      name: string;
-      params: {
-        uuid?: string;
-      };
-    };
-  };
-}
 
 interface ExitOptions {
   skipStoreReset?: boolean;
@@ -26,8 +15,10 @@ interface Options {
 }
 
 export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
-  const navigation = useNavigation( );
-  const { params } = useRoute<RouteProp<ObsFlowParams, string>>( );
+  // This hook is used in:
+  // - useBackPress.ts
+  const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>( );
+  const { params } = useRoute<NoBottomTabStackScreenProps<"Camera">["route"]>( );
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
 
   return useCallback( ( options: Options = {} ) => {

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -1,8 +1,7 @@
 // Trying to consolidate cleanup and nav logic when exiting the obs create /
 // edit flow, so basically nav to MyObs by default and clean up the zustand
 // state
-import { useNavigation, useRoute } from "@react-navigation/native";
-import navigateToObsDetails from "components/ObsDetails/helpers/navigateToObsDetails";
+import { useNavigation } from "@react-navigation/native";
 import type { NoBottomTabStackScreenProps, TabStackScreenProps } from "navigation/types";
 import { useCallback } from "react";
 import useStore from "stores/useStore";
@@ -28,12 +27,6 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
     >["navigation"] &
     TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["navigation"]
   >( );
-  const { params } = useRoute<
-    NoBottomTabStackScreenProps<
-      "Match" | "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
-    >["route"] &
-    TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["route"]
-  >( );
   const resetObservationFlowSlice = useStore( state => state.resetObservationFlowSlice );
 
   return useCallback( ( options: Options = {} ) => {
@@ -48,14 +41,7 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
       resetObservationFlowSlice( );
     }
 
-    // Only in those screens can we have a previousScreen param:
-    // "ObsEdit" | "Camera" | "PhotoLibrary" | "SoundRecorder"
-    const previousScreen = params && params.previousScreen
-      ? params.previousScreen
-      : null;
-    if ( previousScreen && previousScreen.name === "ObsDetails" ) {
-      navigateToObsDetails( navigation, previousScreen.params.uuid );
-    } else if ( typeof ( options.navigate ) === "function" ) {
+    if ( typeof ( options.navigate ) === "function" ) {
       // This seems only to be used in ObsEditHeader in a few cases of backing out
       options.navigate();
     } else {
@@ -68,7 +54,6 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
     }
   }, [
     navigation,
-    params,
     resetObservationFlowSlice,
     exitOptions,
   ] );

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -1,7 +1,7 @@
 // Trying to consolidate cleanup and nav logic when exiting the obs create /
 // edit flow, so basically nav to MyObs by default and clean up the zustand
 // state
-import { useNavigation } from "@react-navigation/native";
+import { CommonActions, useNavigation } from "@react-navigation/native";
 import type { NoBottomTabStackScreenProps, TabStackScreenProps } from "navigation/types";
 import { useCallback } from "react";
 import useStore from "stores/useStore";
@@ -45,12 +45,30 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
       // This seems only to be used in ObsEditHeader in a few cases of backing out
       options.navigate( );
     } else {
-      navigation.navigate( "TabNavigator", {
-        screen: "ObservationsTab",
-        params: {
-          screen: "ObsList",
-        },
-      } );
+      // Use a reset (not navigate) to avoid piling up screen instances
+      navigation.dispatch(
+        CommonActions.reset( {
+          index: 0,
+          routes: [
+            {
+              name: "TabNavigator",
+              state: {
+                routes: [
+                  {
+                    name: "ObservationsTab",
+                    state: {
+                      index: 0,
+                      routes: [
+                        { name: "ObsList" },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        } ),
+      );
     }
   }, [
     navigation,

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -24,13 +24,13 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
   // - TaxonDetails.tsx
   const navigation = useNavigation<
     NoBottomTabStackScreenProps<
-      "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
+      "Match" | "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
     >["navigation"] &
     TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["navigation"]
   >( );
   const { params } = useRoute<
     NoBottomTabStackScreenProps<
-      "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
+      "Match" | "Camera" | "ObsEdit" | "PhotoLibrary" | "TaxonDetails"
     >["route"] &
     TabStackScreenProps<"Match" | "ObsEdit" | "TaxonDetails">["route"]
   >( );

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -54,6 +54,7 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
     if ( previousScreen && previousScreen.name === "ObsDetails" ) {
       navigateToObsDetails( navigation, previousScreen.params.uuid );
     } else if ( typeof ( options.navigate ) === "function" ) {
+      // This seems only to be used in ObsEditHeader in a few cases of backing out
       options.navigate();
     } else {
       navigation.navigate( "TabNavigator", {

--- a/src/sharedHooks/useExitObservationFlow.ts
+++ b/src/sharedHooks/useExitObservationFlow.ts
@@ -48,6 +48,8 @@ export default function useExitObservationFlow( exitOptions?: ExitOptions ) {
       resetObservationFlowSlice( );
     }
 
+    // Only in those screens can we have a previousScreen param:
+    // "ObsEdit" | "Camera" | "PhotoLibrary" | "SoundRecorder"
     const previousScreen = params && params.previousScreen
       ? params.previousScreen
       : null;

--- a/src/sharedHooks/useNavigateToObsEdit.ts
+++ b/src/sharedHooks/useNavigateToObsEdit.ts
@@ -19,7 +19,7 @@ function useNavigateToObsEdit() {
 
   function navigateToObsEdit(
     localObservation: RealmObservation,
-    lastScreen?: string,
+    lastScreen?: "Match",
     taxon?: ApiTaxon | RealmTaxon,
   ) {
     prepareObsEdit( localObservation );

--- a/src/sharedHooks/useNavigateToObsEdit.ts
+++ b/src/sharedHooks/useNavigateToObsEdit.ts
@@ -1,12 +1,18 @@
-import type { ParamListBase } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { ApiTaxon } from "api/types";
+import type { TabStackScreenProps } from "navigation/types";
 import type { RealmObservation, RealmTaxon } from "realmModels/types";
 import useStore from "stores/useStore";
 
 function useNavigateToObsEdit() {
-  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  // This hook is used in
+  // MyObservationsContainer
+  // ObsDetailsDefaultModeHeaderRight
+  // ObservationsFlashList
+  // HeaderEditIcon
+  const navigation = useNavigation<TabStackScreenProps<
+  "ObsList" | "ObsDetails" | "RootExplore" | "Explore" | "Match"
+  >["navigation"]>( );
   const prepareObsEdit = useStore( state => state.prepareObsEdit );
   const setMyObsOffsetToRestore = useStore( state => state.setMyObsOffsetToRestore );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );


### PR DESCRIPTION
Closes MOB-1316

Sorry for the huge PR but the TS migrations were very helpful in isolating the issue.
In terms of TS I was trying to stick to only type the navigation of screens that useExitObservationFlow is imported in, and the screens that route to those screens (because in the beginning useExitObservationFlow also had a useRoute and params check which I needed to see typed before I removed it).

The actual performance fix is [the last commit](https://github.com/inaturalist/iNaturalistReactNative/pull/3541/commits/cb76191195b58fe790d56c34ec8d43380bf5f028):
This is a fix for a performance issue we have seen where saving multiple observations and editing them leads to a slow app.
What is the problem? As the migration to TS made more clear, this hook is imported in screens in both the NoBottomTabStack and the TabStack.
Before: if you hit this navigation action in a screen in the NoBottomTabStack it works fine, the app navigates to the TabNavigator here and loads ObsList as the first screen. However, if you call it while already being in the TabNavigator it just pushes another ObsList unto the stack and not removing any previous screens (even though they are UI wise essentially unreachable).
After: Every time we hit this action we just reset the entire navigation to only show the Me tab with ObsList loaded. This frees up all accumulated screens in either the NoBottomTabStack or the TabStack (depending on from which one it is called in).

This PR also [removes one of the navigation flows](https://github.com/inaturalist/iNaturalistReactNative/pull/3541/commits/92e41df22cb2944b6f9c66ac0b57386d005db8b8) of the useExitObservationFlow, why?
1.) To remove some level of complexity in our navigation flows.
2.) Migrating all to TypeScript reveals that, this is an edge case for a user being on an ObsDetails screen and then starting a new obs from the AddObsButton. This has nothing to do with a user being on ObsDetails for an observation and starting to edit this same observation. In other words, this navigation flow meant that when a user starts a new obs and saves it, we navigate them back to the ObDetails they were on when starting to create a new obs.
3.) This is actually kind of buggy: If a user is in the Notifications tab looking at an ObsDetails of someone else's observation, then starting a new observation and finishing it, we are resetting the navigation to be in the Me tab looking at the same ObsDetails of someone else, which doesn't make a lot of sense.

Before this PR, for a flow of new install - import 3 photos from gallery - Save all - For each of the three new obs: One by one go into 1) ObsDetails - 2) ObsEdit - 3) Suggestions (select a taxon) - 4) ObsEdit (Save) - repeat for next one:
<img width="507" height="402" alt="Screenshot 2026-04-15 at 23 10 35" src="https://github.com/user-attachments/assets/e1aa55c0-373d-4d4d-8446-09a741bbc973" />
Memory usage is only accumulating
After: Same flow
<img width="516" height="417" alt="Screenshot 2026-04-15 at 22 47 57" src="https://github.com/user-attachments/assets/7c26de74-7740-4df3-a5a8-ddedf5e5cb3b" />
Several cleanups hit

Before: Same flow as above but only 2 observations:
<img width="506" height="910" alt="Screenshot 2026-04-15 at 21 34 49" src="https://github.com/user-attachments/assets/ccd61d3f-0b40-45f6-9bc7-ba7db2cce1d3" />
Navigation state accumulated screens
After: Same flow as above but only 2 observations:
<img width="514" height="171" alt="Screenshot 2026-04-15 at 21 37 02" src="https://github.com/user-attachments/assets/0ad81b49-d000-43a0-8429-1007fdb66b82" />
Navigation reset after last obs Saved (Note that also the NoBottomTab has disappeared because after the import of 3 photos has finished with all being saved, the navigation is already reset once.
