### PR TITLE
prevent duplicate photo submissions by disabling checkmark while processing

### DIFF
--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -81,6 +81,7 @@ const AICameraButtons = ( {
         handleZoomButtonPress={handleZoomButtonPress}
         disabled={!modelLoaded || takingPhoto}
         disabledPhotoLibrary={takingPhoto}
+        confirmDisabled={false}
         flipCamera={flipCamera}
         hasFlash={hasFlash}
         hasPhotoLibraryButton

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -81,7 +81,10 @@ const AICameraButtons = ( {
         handleZoomButtonPress={handleZoomButtonPress}
         disabled={!modelLoaded || takingPhoto}
         disabledPhotoLibrary={takingPhoto}
-        confirmDisabled={false}
+        // TODO: once we re-visit tablet views, we'll want to ensure users cannot spam the submit
+        // button while taking photos. see:
+        // https://linear.app/inaturalist/issue/MOB-1084/multicapture-camera-multiple-copies-of-photos-can-be-saved
+        // confirmDisabled={false}
         flipCamera={flipCamera}
         hasFlash={hasFlash}
         hasPhotoLibraryButton

--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -128,6 +128,8 @@ const CameraContainer = ( ) => {
   } as const;
   const [takePhotoOptions, setTakePhotoOptions] = useState<TakePhotoOptions>( initialPhotoOptions );
   const [takingPhoto, setTakingPhoto] = useState( false );
+  const [confirmPhotosInProgress, setconfirmPhotosInProgress] = useState( false );
+  const confirmPhotosInProgressRef = useRef( false );
   const addEvidence = params?.addEvidence;
 
   const camera = useRef<Camera>( null );
@@ -157,24 +159,32 @@ const CameraContainer = ( ) => {
     newPhotoState: PhotoState,
     visionResult?: StoredResult | null,
   ) => {
-    const hasSavePhotoPermission = await hasWriteMediaPermission( );
-    startFirebaseTrace(
-      FIREBASE_TRACES.AI_CAMERA_TO_MATCH,
-      { [FIREBASE_TRACE_ATTRIBUTES.HAS_SAVE_PHOTO_PERMISSION]: `${hasSavePhotoPermission}` },
-    );
-    // fetch accurate user location, with a fallback to a course location
-    // at the time the user taps AI shutter or multicapture checkmark
-    // to create an observation
-    // this handles checking for location, and we do *not* want to show
-    // location permissions in the camera, so we no longer need to check for that
-    const accurateUserLocation = await fetchAccurateUserLocation( );
-    await prepareStoreAndNavigate( {
-      userLocation: accurateUserLocation,
-      newPhotoState,
-      logStageIfAICamera,
-      deleteStageIfAICamera,
-      visionResult,
-    } );
+    if ( confirmPhotosInProgressRef.current ) return;
+    confirmPhotosInProgressRef.current = true;
+    setconfirmPhotosInProgress( true );
+    try {
+      const hasSavePhotoPermission = await hasWriteMediaPermission( );
+      startFirebaseTrace(
+        FIREBASE_TRACES.AI_CAMERA_TO_MATCH,
+        { [FIREBASE_TRACE_ATTRIBUTES.HAS_SAVE_PHOTO_PERMISSION]: `${hasSavePhotoPermission}` },
+      );
+      // fetch accurate user location, with a fallback to a course location
+      // at the time the user taps AI shutter or multicapture checkmark
+      // to create an observation
+      // this handles checking for location, and we do *not* want to show
+      // location permissions in the camera, so we no longer need to check for that
+      const accurateUserLocation = await fetchAccurateUserLocation( );
+      await prepareStoreAndNavigate( {
+        userLocation: accurateUserLocation,
+        newPhotoState,
+        logStageIfAICamera,
+        deleteStageIfAICamera,
+        visionResult,
+      } );
+    } finally {
+      confirmPhotosInProgressRef.current = false;
+      setconfirmPhotosInProgress( false );
+    }
   }, [
     prepareStoreAndNavigate,
     logStageIfAICamera,
@@ -298,6 +308,7 @@ const CameraContainer = ( ) => {
         device={device}
         flipCamera={flipCamera}
         handleCheckmarkPress={handleNavigation}
+        confirmPhotosInProgress={confirmPhotosInProgress}
         toggleFlash={toggleFlash}
         takingPhoto={takingPhoto}
         takePhotoAndStoreUri={takePhotoAndStoreUri}

--- a/src/components/Camera/CameraWithDevice.tsx
+++ b/src/components/Camera/CameraWithDevice.tsx
@@ -16,6 +16,7 @@ interface Props {
   camera: object;
   flipCamera: ( ) => void;
   handleCheckmarkPress: ( ) => void;
+  confirmPhotosInProgress: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   toggleFlash: Function;
   takingPhoto: boolean;
@@ -36,6 +37,7 @@ const CameraWithDevice = ( {
   camera,
   flipCamera,
   handleCheckmarkPress,
+  confirmPhotosInProgress,
   toggleFlash,
   takingPhoto,
   takePhotoAndStoreUri,
@@ -63,6 +65,7 @@ const CameraWithDevice = ( {
             device={device}
             flipCamera={flipCamera}
             handleCheckmarkPress={handleCheckmarkPress}
+            confirmPhotosInProgress={confirmPhotosInProgress}
             isLandscapeMode={isLandscapeMode}
             toggleFlash={toggleFlash}
             takingPhoto={takingPhoto}

--- a/src/components/Camera/StandardCamera/CameraNavButtons.js
+++ b/src/components/Camera/StandardCamera/CameraNavButtons.js
@@ -11,6 +11,7 @@ const isTablet = DeviceInfo.isTablet();
 
 type Props = {
   disabled: boolean,
+  confirmDisabled: boolean,
   handleCheckmarkPress: Function,
   handleClose: Function,
   photosTaken: boolean,
@@ -20,6 +21,7 @@ type Props = {
 
 const CameraNavButtons = ( {
   disabled,
+  confirmDisabled,
   handleCheckmarkPress,
   handleClose,
   photosTaken,
@@ -31,7 +33,7 @@ const CameraNavButtons = ( {
   return (
     <View testID="CameraNavButtons">
       <MediaNavButtons
-        disabled={disabled}
+        disabled={confirmDisabled}
         mediaCaptured={photosTaken}
         onClose={handleClose}
         onConfirm={handleCheckmarkPress}

--- a/src/components/Camera/StandardCamera/CameraOptionsButtons.js
+++ b/src/components/Camera/StandardCamera/CameraOptionsButtons.js
@@ -14,6 +14,7 @@ type Props = {
   takePhoto: () => Promise<void>,
   handleClose: Function,
   disabled: boolean,
+  confirmDisabled: boolean,
   photosTaken: boolean,
   rotatableAnimatedStyle: Object,
   handleCheckmarkPress: Function,
@@ -30,6 +31,7 @@ const CameraOptionsButtons = ( {
   takePhoto,
   handleClose,
   disabled,
+  confirmDisabled,
   photosTaken,
   rotatableAnimatedStyle,
   handleCheckmarkPress,
@@ -70,6 +72,7 @@ const CameraOptionsButtons = ( {
       takePhoto={takePhoto}
       handleClose={handleClose}
       disabled={disabled}
+      confirmDisabled={confirmDisabled}
       photosTaken={photosTaken}
       rotatableAnimatedStyle={rotatableAnimatedStyle}
       handleCheckmarkPress={handleCheckmarkPress}

--- a/src/components/Camera/StandardCamera/CameraOptionsButtons.js
+++ b/src/components/Camera/StandardCamera/CameraOptionsButtons.js
@@ -14,7 +14,6 @@ type Props = {
   takePhoto: () => Promise<void>,
   handleClose: Function,
   disabled: boolean,
-  confirmDisabled: boolean,
   photosTaken: boolean,
   rotatableAnimatedStyle: Object,
   handleCheckmarkPress: Function,
@@ -31,7 +30,6 @@ const CameraOptionsButtons = ( {
   takePhoto,
   handleClose,
   disabled,
-  confirmDisabled,
   photosTaken,
   rotatableAnimatedStyle,
   handleCheckmarkPress,
@@ -72,7 +70,10 @@ const CameraOptionsButtons = ( {
       takePhoto={takePhoto}
       handleClose={handleClose}
       disabled={disabled}
-      confirmDisabled={confirmDisabled}
+      // TODO: once we re-visit tablet views, we'll want to ensure users cannot spam the submit
+      // button while taking photos. see:
+      // https://linear.app/inaturalist/issue/MOB-1084/multicapture-camera-multiple-copies-of-photos-can-be-saved
+      // confirmDisabled={confirmDisabled}
       photosTaken={photosTaken}
       rotatableAnimatedStyle={rotatableAnimatedStyle}
       handleCheckmarkPress={handleCheckmarkPress}

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -48,6 +48,7 @@ type Props = {
   device: Object,
   flipCamera: Function,
   handleCheckmarkPress: Function,
+  confirmPhotosInProgress: boolean,
   isLandscapeMode: boolean,
   toggleFlash: Function,
   takingPhoto: boolean,
@@ -62,6 +63,7 @@ const StandardCamera = ( {
   device,
   flipCamera,
   handleCheckmarkPress,
+  confirmPhotosInProgress,
   isLandscapeMode,
   toggleFlash,
   takingPhoto,
@@ -232,6 +234,7 @@ const StandardCamera = ( {
           flipCamera={onFlipCamera}
           handleCheckmarkPress={handleCheckmarkPress}
           handleClose={handleBackButtonPress}
+          confirmDisabled={takingPhoto || confirmPhotosInProgress}
           hasFlash={hasFlash}
           photosTaken={photosTaken}
           rotatableAnimatedStyle={rotatableAnimatedStyle}
@@ -244,6 +247,7 @@ const StandardCamera = ( {
       </View>
       <CameraNavButtons
         disabled={disallowAddingPhotos || takingPhoto}
+        confirmDisabled={takingPhoto || confirmPhotosInProgress}
         handleCheckmarkPress={handleCheckmarkPress}
         handleClose={handleBackButtonPress}
         photosTaken={photosTaken}

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -234,7 +234,6 @@ const StandardCamera = ( {
           flipCamera={onFlipCamera}
           handleCheckmarkPress={handleCheckmarkPress}
           handleClose={handleBackButtonPress}
-          confirmDisabled={takingPhoto || confirmPhotosInProgress}
           hasFlash={hasFlash}
           photosTaken={photosTaken}
           rotatableAnimatedStyle={rotatableAnimatedStyle}

--- a/src/components/Camera/TabletButtons.tsx
+++ b/src/components/Camera/TabletButtons.tsx
@@ -37,7 +37,6 @@ const cameraOptionsClasses = [
 interface Props {
   handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   disabled: boolean;
-  confirmDisabled: boolean;
   disabledPhotoLibrary: boolean;
   flipCamera: ( _event: GestureResponderEvent ) => void;
   handleCheckmarkPress?: ( _event: GestureResponderEvent ) => void;
@@ -76,7 +75,6 @@ const CameraButtonPlaceholder = ( { extraClassName }: { extraClassName?: string 
 const TabletButtons = ( {
   handleZoomButtonPress,
   disabled,
-  confirmDisabled,
   disabledPhotoLibrary,
   flipCamera,
   handleCheckmarkPress,
@@ -147,7 +145,6 @@ const TabletButtons = ( {
           containerClass={classnames( checkmarkClasses )}
         >
           <GreenCheckmark
-            disabled={confirmDisabled}
             handleCheckmarkPress={handleCheckmarkPress || ( () => null )}
           />
         </RotatableIconWrapper>

--- a/src/components/Camera/TabletButtons.tsx
+++ b/src/components/Camera/TabletButtons.tsx
@@ -37,6 +37,7 @@ const cameraOptionsClasses = [
 interface Props {
   handleZoomButtonPress: ( _event: GestureResponderEvent ) => void;
   disabled: boolean;
+  confirmDisabled: boolean;
   disabledPhotoLibrary: boolean;
   flipCamera: ( _event: GestureResponderEvent ) => void;
   handleCheckmarkPress?: ( _event: GestureResponderEvent ) => void;
@@ -75,6 +76,7 @@ const CameraButtonPlaceholder = ( { extraClassName }: { extraClassName?: string 
 const TabletButtons = ( {
   handleZoomButtonPress,
   disabled,
+  confirmDisabled,
   disabledPhotoLibrary,
   flipCamera,
   handleCheckmarkPress,
@@ -145,6 +147,7 @@ const TabletButtons = ( {
           containerClass={classnames( checkmarkClasses )}
         >
           <GreenCheckmark
+            disabled={confirmDisabled}
             handleCheckmarkPress={handleCheckmarkPress || ( () => null )}
           />
         </RotatableIconWrapper>


### PR DESCRIPTION
closes [MOB-1084](https://linear.app/inaturalist/issue/MOB-1084/multicapture-camera-multiple-copies-of-photos-can-be-saved)