### PR TITLE
Guard observation update against stale connection

### DIFF
--- a/src/sharedHooks/useLocalObservation.ts
+++ b/src/sharedHooks/useLocalObservation.ts
@@ -46,12 +46,16 @@ const useLocalObservation = ( uuid: string ): UseLocalObservation => {
   }
 
   const markDeletedLocally = ( ) => {
+    if ( realm.isClosed ) return;
+    if ( !observation || !observation.isValid() ) return;
     safeRealmWrite( realm, ( ) => {
       observation._deleted_at = new Date( );
     }, "adding _deleted_at date in ObsDetailsContainer" );
   };
 
   const markViewedLocally = ( ) => {
+    if ( realm.isClosed ) return;
+    if ( !observation || !observation.isValid() ) return;
     safeRealmWrite( realm, ( ) => {
       // Flags if all comments and identifications have been viewed
       observation.comments_viewed = true;


### PR DESCRIPTION
Closes MOB-1320

From what I can see, the crash comes from this flow in the "observation was remotely deleted" WarningSheet:

1. User taps OK on the sheet `confirmRemoteObsWasDeleted` runs:
calls markDeletedLocally() which writes observation._deleted_at = new Date()
calls navigation.goBack() which unmounts the ObsDetails screen
2. The unmount causes @gorhom/bottom-sheet to fire onDismiss -> handleClose in `BottomSheet` -> `onPressClose`, which in `IdentificationSheets` is also confirmRemoteObsWasDeleted
3. On the second invocation, the observation in `useLocalObservation` is no longer valid (screen unmounted, Realm handle being released), so observation._deleted_at = new Date() throws.

@sepeterson this is another one of those issues were the BottomSheet's onPress is called for the button press but also for the sheet dismiss. I remember you had a similar fix not long ago. Should I change something in this PR to what you introduced?

Actual fix: Do not try to update the observation if realm is already closed, or the object is invalid.