### PR TITLE
Update MatchContainer to import loads function directly

### DIFF
--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -10,7 +10,7 @@ import flattenUploadParams from "components/Suggestions/helpers/flattenUploadPar
 import {
   FETCH_STATUSES,
 } from "components/Suggestions/SuggestionsContainer";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import orderBy from "lodash/orderBy";
 import { RealmContext } from "providers/contexts";
 import React, {


### PR DESCRIPTION
This way we don't need to require the entire lodash package.