### PR TITLE
Replace a useEffect with a useFocusEffect

### DIFF
--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -1,10 +1,10 @@
 import {
   useNetInfo,
 } from "@react-native-community/netinfo";
-import { useNavigation } from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import type { ApiObservationsUpdatesParams } from "api/types";
 import NotificationsList from "components/Notifications/NotificationsList";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import type { RealmUser } from "realmModels/types";
 import { log } from "sharedHelpers/logger";
 import {
@@ -26,7 +26,6 @@ const NotificationsContainer = ( {
   notificationParams,
   onRefresh: onRefreshProp,
 }: Props ) => {
-  const navigation = useNavigation( );
   const { isConnected } = useNetInfo( );
   const [refreshing, setRefreshing] = useState( false );
 
@@ -47,14 +46,13 @@ const NotificationsContainer = ( {
     logger.info( loadTime );
   }
 
-  useEffect( ( ) => {
-    const unsubscribe = navigation.addListener( "focus", ( ) => {
+  useFocusEffect(
+    useCallback( ( ) => {
       if ( isConnected && currentUser ) {
-        refetch();
+        refetch( );
       }
-    } );
-    return unsubscribe;
-  }, [isConnected, currentUser, navigation, refetch] );
+    }, [isConnected, currentUser, refetch] ),
+  );
 
   const onRefresh = async () => {
     if ( currentUser ) {


### PR DESCRIPTION
useNavigation replaced with useFocusEffect: focus handling uses the navigation hook meant for screen focus.