### PR TITLE
Switch to @native-html/render to support markdown again

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,7 @@ module.exports = {
   presets: ["module:@react-native/babel-preset"],
   plugins: [
     "babel-plugin-react-compiler", // must run first!
+    "@babel/plugin-transform-export-namespace-from",
     "react-native-worklets-core/plugin",
     "transform-inline-environment-variables",
     "nativewind/babel",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2258,8 +2258,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-render-html (6.3.4):
-    - React-Core
   - react-native-restart (0.0.27):
     - React-Core
   - react-native-safe-area-context (5.6.2):
@@ -3813,7 +3811,6 @@ DEPENDENCIES:
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-orientation-locker (from `../node_modules/react-native-orientation-locker`)
   - react-native-performance (from `../node_modules/react-native-performance`)
-  - react-native-render-html (from `../node_modules/react-native-render-html`)
   - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
@@ -4024,8 +4021,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-orientation-locker"
   react-native-performance:
     :path: "../node_modules/react-native-performance"
-  react-native-render-html:
-    :path: "../node_modules/react-native-render-html"
   react-native-restart:
     :path: "../node_modules/react-native-restart"
   react-native-safe-area-context:
@@ -4237,7 +4232,6 @@ SPEC CHECKSUMS:
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-orientation-locker: dbd3f6ddbe9e62389cb0807dc2af63f6c36dec36
   react-native-performance: a7a65d0b0f3055c5db33e1433e4345143ef6a100
-  react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
   react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
   react-native-safe-area-context: 0a3b034bb63a5b684dd2f5fffd3c90ef6ed41ee8
   react-native-slider: 05e7080478df08489251c2a6739a0d5628b7c198

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@invertase/react-native-apple-authentication": "^2.4.0",
         "@likashefqet/react-native-image-zoom": "^4.2.0",
         "@lodev09/react-native-exify": "^1.0.3",
+        "@native-html/render": "^1.0.2",
         "@react-native-camera-roll/camera-roll": "^7.10.2",
         "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native-community/datetimepicker": "^8.4.4",
@@ -96,7 +97,6 @@
         "react-native-permissions": "^4.1.5",
         "react-native-reanimated": "^4.2.2",
         "react-native-reanimated-carousel": "^4.0.3",
-        "react-native-render-html": "^6.3.4",
         "react-native-restart": "^0.0.27",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "4.15.4",
@@ -120,6 +120,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@babel/node": "^7.25.2",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-react": "^7.24.1",
         "@babel/runtime": "^7.25.0",
@@ -4408,36 +4409,195 @@
         "react-native": "*"
       }
     },
-    "node_modules/@native-html/css-processor": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@native-html/css-processor/-/css-processor-1.11.0.tgz",
-      "integrity": "sha512-NnhBEbJX5M2gBGltPKOetiLlKhNf3OHdRafc8//e2ZQxXN8JaSW/Hy8cm94pnIckQxwaMKxrtaNT3x4ZcffoNQ==",
+    "node_modules/@native-html/render": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@native-html/render/-/render-1.0.2.tgz",
+      "integrity": "sha512-6vFHGETCVYAr7qvYN/6vF73Ru7dl6kbFCV5pHQMGOEA4lIjXSTjzUBWG0vUaTwojiQOOdY7x1OpcCxoIqrvUkQ==",
+      "license": "MIT",
       "dependencies": {
-        "css-to-react-native": "^3.0.0",
-        "csstype": "^3.0.8"
+        "@jsamr/counter-style": "^2.0.2",
+        "@jsamr/react-native-li": "^2.3.1",
+        "@native-html/transient-render-engine": "12.0.0",
+        "@types/ramda": "^0.31.1",
+        "@types/urijs": "^1.19.25",
+        "prop-types": "^15.8.1",
+        "ramda": "^0.32.0",
+        "stringify-entities": "^4.0.4",
+        "urijs": "^1.19.11"
       },
       "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-native": "*"
+        "react": "*",
+        "react-native": "*"
       }
     },
-    "node_modules/@native-html/transient-render-engine": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/@native-html/transient-render-engine/-/transient-render-engine-11.2.3.tgz",
-      "integrity": "sha512-zXwgA3gPUEmFs3I3syfnvDvS6WiUHXEE6jY09OBzK+trq7wkweOSFWIoyXiGkbXrozGYG0KY90YgPyr8Tg8Uyg==",
+    "node_modules/@native-html/render/node_modules/@native-html/css-processor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@native-html/css-processor/-/css-processor-2.0.0.tgz",
+      "integrity": "sha512-kAFfpas0PsJtZJGRPmFO3XNvqW9yQt016kBTLehLQV80zrH5DbjU+MkfHZVBbx7v5Zl0fyH+j1YiwUT0Fp5N9g==",
+      "license": "MIT",
       "dependencies": {
-        "@native-html/css-processor": "1.11.0",
-        "@types/ramda": "^0.27.44",
-        "csstype": "^3.0.9",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "htmlparser2": "^7.1.2",
-        "ramda": "^0.27.2"
+        "css-to-react-native": "^3.2.0",
+        "csstype": "^3.1.3"
       },
       "peerDependencies": {
-        "@types/react-native": "*",
-        "react-native": "^*"
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/@native-html/transient-render-engine": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@native-html/transient-render-engine/-/transient-render-engine-12.0.0.tgz",
+      "integrity": "sha512-SUJ8XLQ0vFR4ITLJ1Cey/o0QhVo/bn3PiGgqnQIhCJjEsdzwYJ1/HfAXIUVZND9Fz5AYQzB6X9T6mwkSekgCzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@native-html/css-processor": "2.0.0",
+        "csstype": "^3.1.3",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "htmlparser2": "^10.0.0",
+        "ramda": "^0.32.0"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/@types/ramda": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.31.0"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/ramda": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/@native-html/render/node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -6097,6 +6257,7 @@
       "version": "0.72.8",
       "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.72.8.tgz",
       "integrity": "sha512-J3Q4Bkuo99k7mu+jPS9gSUSgq+lLRSI/+ahXNwV92XgJ/8UgOTxu2LPwhJnBk/sQKxq7E8WkZBnBiozukQMqrw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
@@ -7399,14 +7560,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
       "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q=="
     },
-    "node_modules/@types/ramda": {
-      "version": "0.27.66",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.66.tgz",
-      "integrity": "sha512-i2YW+E2U6NfMt3dp0RxNcejox+bxJUNDjB7BpYuRuoHIzv5juPHkJkNgcUOu+YSQEmaWu8cnAo/8r63C0NnuVA==",
-      "dependencies": {
-        "ts-toolbelt": "^6.15.1"
-      }
-    },
     "node_modules/@types/react": {
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
@@ -7429,6 +7582,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.8.tgz",
       "integrity": "sha512-St6xA7+EoHN5mEYfdWnfYt0e8u6k2FR0P9s2arYgakQGFgU1f9FlPrIEcj0X24pLCF5c5i3WVuLCUdiCYHmOoA==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@react-native/virtualized-lists": "^0.72.4",
@@ -7559,9 +7713,10 @@
       "license": "MIT"
     },
     "node_modules/@types/urijs": {
-      "version": "1.19.19",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
-      "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
+      "version": "1.19.26",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.26.tgz",
+      "integrity": "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -9268,24 +9423,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/character-entities-html4": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
-      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -10009,9 +10146,10 @@
       }
     },
     "node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -10083,9 +10221,10 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -10948,19 +11087,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -10992,33 +11118,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-case": {
@@ -11163,14 +11262,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -13614,35 +13705,6 @@
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "dependencies": {
         "void-elements": "3.1.0"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-errors": {
@@ -19197,11 +19259,6 @@
         }
       ]
     },
-    "node_modules/ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -19839,26 +19896,6 @@
         "react-native": "*",
         "react-native-gesture-handler": "*",
         "react-native-reanimated": ">=2.0.0"
-      }
-    },
-    "node_modules/react-native-render-html": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/react-native-render-html/-/react-native-render-html-6.3.4.tgz",
-      "integrity": "sha512-H2jSMzZjidE+Wo3qCWPUMU1nm98Vs2SGCvQCz/i6xf0P3Y9uVtG/b0sDbG/cYFir2mSYBYCIlS1Dv0WC1LjYig==",
-      "dependencies": {
-        "@jsamr/counter-style": "^2.0.1",
-        "@jsamr/react-native-li": "^2.3.0",
-        "@native-html/transient-render-engine": "11.2.3",
-        "@types/ramda": "^0.27.40",
-        "@types/urijs": "^1.19.15",
-        "prop-types": "^15.5.7",
-        "ramda": "^0.27.2",
-        "stringify-entities": "^3.1.0",
-        "urijs": "^1.19.6"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-restart": {
@@ -21630,20 +21667,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/stringify-entities": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
-      "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
-      "dependencies": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -22331,11 +22354,6 @@
         "node": ">= 18.0.0"
       }
     },
-    "node_modules/ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -22519,6 +22537,21 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/types-ramda": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
+    },
+    "node_modules/types-ramda/node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "license": "Apache-2.0"
     },
     "node_modules/typescript": {
       "version": "5.8.3",
@@ -23203,6 +23236,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@invertase/react-native-apple-authentication": "^2.4.0",
     "@likashefqet/react-native-image-zoom": "^4.2.0",
     "@lodev09/react-native-exify": "^1.0.3",
+    "@native-html/render": "^1.0.2",
     "@react-native-camera-roll/camera-roll": "^7.10.2",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/datetimepicker": "^8.4.4",
@@ -132,7 +133,6 @@
     "react-native-permissions": "^4.1.5",
     "react-native-reanimated": "^4.2.2",
     "react-native-reanimated-carousel": "^4.0.3",
-    "react-native-render-html": "^6.3.4",
     "react-native-restart": "^0.0.27",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "4.15.4",
@@ -156,6 +156,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/node": "^7.25.2",
+    "@babel/plugin-transform-export-namespace-from": "^7.27.1",
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-react": "^7.24.1",
     "@babel/runtime": "^7.25.0",

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -145,8 +145,8 @@ const UserText = ( {
   };
   const tagsStyles: TRenderEngineConfig["tagsStyles"] = {
     a: {
-      textDecorationLine: "underline",
       color: colors.inatGreen,
+      textDecorationColor: colors.inatGreen,
     },
   };
   const fonts = [fontRegular, ...defaultSystemFonts];

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -63,7 +63,6 @@ const ALLOWED_TAGS = ( `
   th
   thead
   tr
-  tt
   ul
 ` ).split( /\s+/m ).filter( e => e !== "" );
 

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -148,6 +148,46 @@ const UserText = ( {
       color: colors.inatGreen,
       textDecorationColor: colors.inatGreen,
     },
+    h1: {
+      fontSize: 25,
+      letterSpacing: -0.25,
+      lineHeight: 30,
+      marginBottom: 8,
+      marginTop: 8,
+    },
+    h2: {
+      fontSize: 21,
+      lineHeight: 25.2,
+      marginBottom: 8,
+      marginTop: 8,
+    },
+    h3: {
+      fontSize: 18,
+      lineHeight: 21.6,
+      marginBottom: 8,
+      marginTop: 8,
+    },
+    h4: {
+      fontSize: 15,
+      letterSpacing: 2,
+      lineHeight: 18,
+      marginBottom: 8,
+      marginTop: 8,
+    },
+    h5: {
+      fontSize: 11,
+      letterSpacing: 2,
+      lineHeight: 13.2,
+      marginBottom: 6,
+      marginTop: 6,
+    },
+    h6: {
+      fontSize: 8,
+      letterSpacing: 0.65,
+      lineHeight: 9.6,
+      marginBottom: 6,
+      marginTop: 6,
+    },
   };
   const fonts = [fontRegular, ...defaultSystemFonts];
 

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -20,6 +20,8 @@ import type { IOptions } from "sanitize-html";
 import sanitizeHtml from "sanitize-html";
 import colors from "styles/tailwindColors";
 
+// Keep aligned with Post::ALLOWED_TAGS in inaturalist/inaturalist (Rails);
+// omit iframe/embed/audio so mobile sanitization is a tad stricter than web
 const ALLOWED_TAGS = ( `
   a
   abbr
@@ -57,7 +59,7 @@ const ALLOWED_TAGS = ( `
   table
   tbody
   td
-  t
+  tfoot
   th
   thead
   tr

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -104,16 +104,7 @@ interface Props extends React.PropsWithChildren {
   htmlStyle?: object;
 }
 
-const UserText = ( {
-  children,
-  htmlStyle,
-  text: textProp,
-} : Props ) => {
-  const navigation = useNavigation( );
-
-  // Allow stringified children to serve as text if no prop provided
-  const text = textProp || children?.toString( ) || "";
-  const { width } = useWindowDimensions( );
+export function buildUserTextHtml( text: string ): string {
   let html = trim( text );
 
   // replace ampersands in URL params with entities so they don't get
@@ -136,6 +127,22 @@ const UserText = ( {
   // <code>
 
   html = linkifyHtml( html, LINKIFY_OPTIONS );
+  return html;
+}
+
+const UserText = ( {
+  children,
+  htmlStyle,
+  text: textProp,
+} : Props ) => {
+  const navigation = useNavigation( );
+
+  // Allow stringified children to serve as text if no prop provided
+  const text = textProp || children?.toString( ) || "";
+  const { width } = useWindowDimensions( );
+
+  const html = buildUserTextHtml( text );
+
   const baseStyle: MixedStyleDeclaration = {
     fontFamily: fontRegular,
     fontSize: 16,

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -1,5 +1,11 @@
 import "linkify-plugin-mention";
 
+import type {
+  MixedStyleDeclaration,
+  RenderersProps,
+  TRenderEngineConfig,
+} from "@native-html/render";
+import RenderHtml, { defaultSystemFonts } from "@native-html/render";
 import { useNavigation } from "@react-navigation/native";
 import { fontRegular } from "appConstants/fontFamilies";
 import linkifyHtml from "linkify-html";
@@ -9,12 +15,6 @@ import trim from "lodash/trim";
 import MarkdownIt from "markdown-it";
 import * as React from "react";
 import { Linking, useWindowDimensions } from "react-native";
-import type {
-  MixedStyleDeclaration, RenderersProps, TRenderEngineConfig,
-} from "react-native-render-html";
-import HTML, {
-  defaultSystemFonts,
-} from "react-native-render-html";
 import WebView from "react-native-webview";
 import type { IOptions } from "sanitize-html";
 import sanitizeHtml from "sanitize-html";
@@ -171,7 +171,7 @@ const UserText = ( {
   };
 
   return (
-    <HTML
+    <RenderHtml
       baseStyle={baseStyle}
       tagsStyles={tagsStyles}
       contentWidth={width}

--- a/src/components/SharedComponents/index.ts
+++ b/src/components/SharedComponents/index.ts
@@ -87,5 +87,5 @@ export { default as UnderlinedLink } from "./Typography/UnderlinedLink";
 export { default as UploadProgressBar } from "./UploadProgressBar";
 export { default as UploadStatus } from "./UploadStatus/UploadStatus";
 export { default as UserIcon } from "./UserIcon";
-export { default as UserText } from "./UserText";
+export { buildUserTextHtml, default as UserText } from "./UserText";
 export { default as ViewWrapper } from "./ViewWrapper";

--- a/src/components/TaxonDetails/Wikipedia.tsx
+++ b/src/components/TaxonDetails/Wikipedia.tsx
@@ -1,3 +1,4 @@
+import RenderHtml, { defaultSystemFonts } from "@native-html/render";
 import { fontRegular } from "appConstants/fontFamilies";
 import {
   Body2,
@@ -5,7 +6,6 @@ import {
 } from "components/SharedComponents";
 import * as React from "react";
 import { useWindowDimensions } from "react-native";
-import HTML, { defaultSystemFonts } from "react-native-render-html";
 import { openExternalWebBrowser } from "sharedHelpers/util";
 import useTranslation from "sharedHooks/useTranslation";
 import colors from "styles/tailwindColors";
@@ -38,7 +38,7 @@ const Wikipedia = ( { taxon }: Props ) => {
   return (
     <>
       <Heading4 className="mb-3">{t( "WIKIPEDIA" )}</Heading4>
-      <HTML
+      <RenderHtml
         contentWidth={width}
         source={{ html: taxon.wikipedia_summary }}
         systemFonts={FONTS}

--- a/tests/unit/components/UserText/__snapshots__/buildUserTextHtml.test.js.snap
+++ b/tests/unit/components/UserText/__snapshots__/buildUserTextHtml.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`building HTML for userText fixture matches HTML snapshot 1`] = `
+"<p><strong>bold</strong><br />
+<a href="https://staging.inaturalist.org/observations/350544545">An observation with id</a><br />
+<em>italics</em></p>
+<blockquote>
+<p>blockquote<br />
+<a href="https://staging.inaturalist.org/projects/3545">A project with id</a></p>
+</blockquote>
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h3>
+<h4>Heading 4</h4>
+<h5>Heading 5</h5>
+<h6>Heading 6</h6>
+<hr />
+<ul>
+<li>unordered list</li>
+<li>second item</li>
+</ul>
+<p>Normal text before</p>
+<p>Paragraph</p>
+Normal text after
+<ol>
+<li>Ordered list</li>
+<li>Second item</li>
+</ol>
+<table class="table">
+<thead>
+<tr>
+<th>table</th>
+<th>up</th>
+<th>top!</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>foo</td>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+<p>Choice lines of fine words<br />
+Separated by line breaks<br />
+Should look just fine, k?</p>
+<ol>
+<li>An escaped</li>
+<li>List</li>
+<li>is possible</li>
+</ol>
+<p><abbr title="Abbreviation abbreviation">HTML</abbr> is still <del>possible</del><ins>probable</ins>!</p>
+"
+`;

--- a/tests/unit/components/UserText/buildUserTextHtml.test.js
+++ b/tests/unit/components/UserText/buildUserTextHtml.test.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-useless-escape */
+import { buildUserTextHtml } from "components/SharedComponents/UserText";
+
+// Frozen copy of userText fixture.
+// Update fixture + snapshot if expanding coverage.
+const TEST_USER_TEXT_FIXTURE = `
+**bold**
+[An observation with id](https://staging.inaturalist.org/observations/350544545)
+*italics*
+
+> blockquote
+[A project with id](https://staging.inaturalist.org/projects/3545)
+
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+
+---
+
+* unordered list
+* second item
+
+Normal text before
+<p>Paragraph</p>
+Normal text after
+
+1. Ordered list
+1. Second item
+
+|table|up|top!|
+|-|-|-|
+|foo|bar|baz|
+
+Choice lines of fine words
+Separated by line breaks
+Should look just fine, k?
+
+1\. An escaped
+13\. List
+33\. is possible
+
+<abbr title="Abbreviation abbreviation">HTML</abbr> is still <del>possible</del><ins>probable</ins>!
+`;
+
+describe( "building HTML for userText fixture", () => {
+  it( "matches HTML snapshot", () => {
+    expect( buildUserTextHtml( TEST_USER_TEXT_FIXTURE ) ).toMatchSnapshot( );
+  } );
+} );


### PR DESCRIPTION
Closes MOB-1197

The previously used library is no longer maintained and has a migration notice to this new package: https://github.com/meliorence/react-native-render-html/issues/674

Just swapping out the library meant we already get back to supporting all markdown elements I checked for (didn't check for all in the list of supported html tags).
Added a snapshot test for the part that takes user text and generates html.

