### PR TITLE
Use zustand for debug mode state

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -13,6 +13,7 @@ import { t } from "i18next";
 import React, { useState } from "react";
 import { getBuildNumber, getVersion } from "react-native-device-info";
 import { useDebugMode } from "sharedHooks";
+import useStore from "stores/useStore";
 
 const aboutID = "about";
 const teamID = "team";
@@ -23,7 +24,8 @@ const About = ( ) => {
   const [count, setCount] = useState( 0 );
   const appVersion = getVersion();
   const buildVersion = getBuildNumber();
-  const { isDebug, toggleDebug } = useDebugMode( );
+  const { isDebug } = useDebugMode( );
+  const toggleDebug = useStore( state => state.layout.toggleDebugMode );
 
   const onTermsPressed = async () => {
     const url = "https://www.inaturalist.org/pages/terms";

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,14 +3,14 @@
 import { useNavigation } from "@react-navigation/native";
 import RootStackNavigator from "navigation/RootStackNavigator";
 import type { Node } from "react";
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { log } from "sharedHelpers/logger";
 import {
   useCurrentUser,
   usePerformance,
   useShare,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 
 import AppStateListener from "./AppStateListener";
 import useDeferredStartup from "./hooks/useDeferredStartup";
@@ -58,9 +58,12 @@ const App = ( { children }: Props ): Node => {
   const { loadTime } = usePerformance( {
     screenName: "App",
   } );
-  if ( isDebugMode( ) ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode();
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   // attempting to make sure that navigation is only called once
   // for performance reasons

--- a/src/components/AppStateListener.ts
+++ b/src/components/AppStateListener.ts
@@ -6,7 +6,7 @@ import { log } from "sharedHelpers/logger";
 import {
   usePerformance,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 
 const logger = log.extend( "AppStateListener" );
 
@@ -15,9 +15,12 @@ const AppStateListener = ( ) => {
     screenName: "AppStateListener",
     isLoading: false,
   } );
-  if ( isDebugMode( ) ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode();
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
   const { deviceStorageFull, showStorageFullAlert } = useDeviceStorageFull( );
   const [deviceStorageFullShown, setDeviceStorageFullShown] = useState( false );
 

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -123,7 +123,7 @@ const AICamera = ( {
   const changeDebugFormat = ( ) => {
     setDebugFormatIndex( prev => ( prev + 1 ) % device.formats.length );
   };
-  const debugFormat = isDebugMode()
+  const debugFormat = isDebug
     ? device.formats[debugFormatIndex]
     : undefined;
 

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -23,7 +23,6 @@ import {
   usePerformance,
   useTranslation,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
 import useStore from "stores/useStore";
 import colors from "styles/tailwindColors";
 
@@ -146,9 +145,11 @@ const AICamera = ( {
   const { loadTime } = usePerformance( {
     isLoading: camera?.current !== null,
   } );
-  if ( isDebugMode( ) && loadTime ) {
-    logger.info( loadTime );
-  }
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   const resetCameraOnFocus = useCallback( ( ) => {
     setResult( null );

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -22,7 +22,7 @@ import ObservationPhoto from "realmModels/ObservationPhoto";
 import { BREAKPOINTS } from "sharedHelpers/breakpoint";
 import { log } from "sharedHelpers/logger";
 import { useDeviceOrientation, usePerformance } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 import useStore from "stores/useStore";
 
 import {
@@ -94,9 +94,12 @@ const StandardCamera = ( {
   const { loadTime } = usePerformance( {
     isLoading: camera?.current !== null,
   } );
-  if ( isDebugMode( ) && loadTime ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode();
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   const cameraUris = useStore( state => state.cameraUris );
   const prepareCamera = useStore( state => state.prepareCamera );

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -30,8 +30,12 @@ import removeAllFilesFromDirectory from "sharedHelpers/removeAllFilesFromDirecto
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { setFirebaseDataCollectionEnabled } from "sharedHelpers/tracking";
 import { unlink } from "sharedHelpers/util";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useStore from "stores/useStore";
 import zustandMMKVBackingStorage from "stores/zustandMMKVBackingStorage";
+
+function isDebugModeSync( ): boolean {
+  return useStore.getState().layout.debugModeEnabled === true;
+}
 
 const logger = log.extend( "AuthenticationService" );
 // The remote transport in the default logger uses many of the methods in this
@@ -98,7 +102,7 @@ async function getSensitiveItem(
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const getItemError = e as SensitiveInfoError;
-      if ( isDebugMode() ) {
+      if ( isDebugModeSync() ) {
         switch ( getItemError.code ) {
           case ErrorCode.NOT_FOUND:
             // Value doesn't exist
@@ -129,7 +133,7 @@ async function setSensitiveItem( key: string, value: string, options = {} ) {
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const setItemError = e as SensitiveInfoError;
-      if ( isDebugMode( ) ) {
+      if ( isDebugModeSync( ) ) {
         localLogger.info(
           `RNSInfo.setItem error for ${key}, ${setItemError.code} ${setItemError.message}`,
         );
@@ -152,7 +156,7 @@ async function deleteSensitiveItem(
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const deleteItemError = e as SensitiveInfoError;
-      if ( isDebugMode() ) {
+      if ( isDebugModeSync() ) {
         localLogger.info(
           `RNSInfo.deleteItem error for ${key}, ${deleteItemError.code} ${deleteItemError.message}`,
         );

--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -29,7 +29,7 @@ import shouldFetchObservationLocation from "sharedHelpers/shouldFetchObservation
 import {
   useExitObservationFlow, useLocationPermission, useSuggestions, useWatchPosition,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 import {
   internalUseSuggestionsInitialSuggestions,
 } from "sharedHooks/useSuggestions/filterSuggestions";
@@ -119,7 +119,7 @@ const { useRealm } = RealmContext;
 
 const MatchContainer = ( ) => {
   const hasLoadedRef = useRef( false );
-  const isDebug = isDebugMode( );
+  const { isDebug } = useDebugMode( );
   const scrollRef = useRef<ScrollView>( null );
   const currentObservation = useStore( state => state.currentObservation );
   const getCurrentObservation = useStore( state => state.getCurrentObservation );

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -22,8 +22,10 @@ import User from "realmModels/User";
 import { valueToBreakpoint } from "sharedHelpers/breakpoint";
 import { log } from "sharedHelpers/logger";
 import getStorageMetrics from "sharedHelpers/storageMetrics";
-import { useCurrentUser, useLayoutPrefs, useTranslation } from "sharedHooks";
-import { zustandStorage } from "stores/useStore";
+import {
+  useCurrentUser, useDebugMode,
+  useLayoutPrefs, useTranslation,
+} from "sharedHooks";
 import colors from "styles/tailwindColors";
 
 import MenuItem from "./MenuItem";
@@ -96,7 +98,7 @@ const getDeviceMetricsForFeedback = async () => {
 };
 
 const Menu = ( ) => {
-  const isDebug = zustandStorage.getItem( "debugMode" ) === "true";
+  const { isDebug } = useDebugMode();
   const realm = useRealm( );
   const navigation = useNavigation( );
   const queryClient = useQueryClient( );

--- a/src/components/NetworkService.ts
+++ b/src/components/NetworkService.ts
@@ -1,9 +1,10 @@
+import { useEffect } from "react";
 import { log } from "sharedHelpers/logger";
 import {
   useIconicTaxa,
   useObservationUpdatesWhenFocused, usePerformance,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 
 import useTaxonCommonNames from "./hooks/useTaxonCommonNames";
 import useWorkQueue from "./hooks/useWorkQueue";
@@ -15,9 +16,12 @@ const NetworkService = ( ) => {
     screenName: "NetworkService",
     isLoading: false,
   } );
-  if ( isDebugMode( ) ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode();
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   useObservationUpdatesWhenFocused( );
 

--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -4,14 +4,14 @@ import {
 import { useFocusEffect } from "@react-navigation/native";
 import type { ApiObservationsUpdatesParams } from "api/types";
 import NotificationsList from "components/Notifications/NotificationsList";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import type { RealmUser } from "realmModels/types";
 import { log } from "sharedHelpers/logger";
 import {
   useInfiniteNotificationsScroll,
   usePerformance,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 
 const logger = log.extend( "NotificationsContainer" );
 
@@ -42,9 +42,12 @@ const NotificationsContainer = ( {
   const { loadTime } = usePerformance( {
     isLoading: isInitialLoading,
   } );
-  if ( isDebugMode( ) ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode( );
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   useFocusEffect(
     useCallback( ( ) => {

--- a/src/components/StartupService.tsx
+++ b/src/components/StartupService.tsx
@@ -12,7 +12,7 @@ import { IS_FRESH_INSTALL, store } from "sharedHelpers/installData";
 import { log } from "sharedHelpers/logger";
 import { addARCameraFiles } from "sharedHelpers/mlModel";
 import { usePerformance } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 
 Realm.setLogLevel( "warn" );
 
@@ -42,9 +42,12 @@ const StartupService = ( ) => {
     screenName: "StartupService",
     isLoading: false,
   } );
-  if ( isDebugMode( ) ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode();
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   useEffect( ( ) => {
     const initializeApp = async ( ) => {

--- a/src/components/Suggestions/SuggestionsContainer.tsx
+++ b/src/components/Suggestions/SuggestionsContainer.tsx
@@ -18,7 +18,7 @@ import {
   usePerformance,
   useSuggestions,
 } from "sharedHooks";
-import { isDebugMode } from "sharedHooks/useDebugMode";
+import useDebugMode from "sharedHooks/useDebugMode";
 import {
   internalUseSuggestionsInitialSuggestions,
 } from "sharedHooks/useSuggestions/filterSuggestions";
@@ -289,9 +289,12 @@ const SuggestionsContainer = ( ) => {
   const { loadTime } = usePerformance( {
     isLoading,
   } );
-  if ( isDebugMode( ) && loadTime ) {
-    logger.info( loadTime );
-  }
+  const { isDebug } = useDebugMode();
+  useEffect( () => {
+    if ( isDebug && loadTime ) {
+      logger.info( loadTime );
+    }
+  }, [isDebug, loadTime] );
 
   const toggleLocation = useCallback( async ( { showLocation }: { showLocation: boolean } ) => {
     const newImageParams = await createUploadParams( selectedPhotoUri, showLocation );

--- a/src/sharedHooks/useDebugMode.ts
+++ b/src/sharedHooks/useDebugMode.ts
@@ -1,25 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
-import { zustandStorage } from "stores/useStore";
+import useStore, { zustandStorage } from "stores/useStore";
 
 const DEBUG_MODE = "debugMode";
 
 const useDebugMode = ( ): { isDebug: boolean; toggleDebug: () => void } => {
-  const [isDebug, setDebug] = useState( false );
-
-  useEffect( ( ) => {
-    const readDebugModeFromStorage = ( ) => {
-      const storedDebugMode = zustandStorage.getItem( DEBUG_MODE );
-      setDebug( storedDebugMode === "true" );
-    };
-
-    readDebugModeFromStorage( );
-  }, [] );
-
-  const toggleDebug = useCallback( ( ) => {
-    zustandStorage.setItem( DEBUG_MODE, ( !isDebug ).toString( ) );
-    setDebug( !isDebug );
-  }, [isDebug] );
-
+  const isDebug = useStore( state => state.layout.debugModeEnabled );
+  const toggleDebug = useStore( state => state.layout.toggleDebugMode );
   return {
     isDebug,
     toggleDebug,

--- a/src/sharedHooks/useDebugMode.ts
+++ b/src/sharedHooks/useDebugMode.ts
@@ -1,6 +1,4 @@
-import useStore, { zustandStorage } from "stores/useStore";
-
-const DEBUG_MODE = "debugMode";
+import useStore from "stores/useStore";
 
 const useDebugMode = ( ): { isDebug: boolean } => {
   const isDebug = useStore( state => state.layout.debugModeEnabled );
@@ -8,9 +6,5 @@ const useDebugMode = ( ): { isDebug: boolean } => {
     isDebug,
   };
 };
-
-export function isDebugMode( ): boolean {
-  return zustandStorage.getItem( DEBUG_MODE ) === "true";
-}
 
 export default useDebugMode;

--- a/src/sharedHooks/useDebugMode.ts
+++ b/src/sharedHooks/useDebugMode.ts
@@ -2,12 +2,10 @@ import useStore, { zustandStorage } from "stores/useStore";
 
 const DEBUG_MODE = "debugMode";
 
-const useDebugMode = ( ): { isDebug: boolean; toggleDebug: () => void } => {
+const useDebugMode = ( ): { isDebug: boolean } => {
   const isDebug = useStore( state => state.layout.debugModeEnabled );
-  const toggleDebug = useStore( state => state.layout.toggleDebugMode );
   return {
     isDebug,
-    toggleDebug,
   };
 };
 

--- a/src/stores/createLayoutSlice.ts
+++ b/src/stores/createLayoutSlice.ts
@@ -110,6 +110,14 @@ const createLayoutSlice = set => ( {
         dismissedAnnouncementIds: [],
       },
     } ) ),
+    // State to control debug mode
+    debugModeEnabled: false,
+    toggleDebugMode: () => set( state => ( {
+      layout: {
+        ...state.layout,
+        debugModeEnabled: !state.layout.debugModeEnabled,
+      },
+    } ) ),
   },
 } );
 


### PR DESCRIPTION
We were using our mmkv store _directly_ instead of using the zustand store. This meant that react wasn't aware of updates to it. This adds that key to the persisted layout slice and updates all usages to a zustand-aware hook with two changes:
- the hook no longer returns the "toggle" function. This is _only_ used in one place and shouldn't be "accidentally" importable.
- the hook file no longer exports an imperative "get value". Again, this is only used in one place so is now defined in that one place (AuthenticationService). It still uses the store w/ an imperative `useStore.getState()` (specifically to _not_ call functions on mmkv)

We do have a TODO "don't do this" against this exact thing, I think we just hadn't noticed the impact.
```ts
// TODO do *not* export this. This allows any consumer to overwrite *any* part
// of state, circumventing any getter/setter logic we have in the stores. If
// you need to modify state, you should be doing so through a store.
export const zustandStorage = {
```

This instance has marginal user impact but I noticed it looking at obs counts / upload workflow which is bugged partially because we do this thing. I'll get to those next and we _might_ be able to remove the `export`.

A few remaining "violators" I'll fix:
- "numOfUserObservations" / "numOfUserSpecies": is set and read from `layout`, should _definitely_ be fixed, causes actual bugs
- `useStoredLayout`: I think this just shouldn't exist and can all be moved to `layout`
- "mapType": isolated but impact UI & easily ported to `layout`

Skipping
- "lastDeletedSyncTime": isolated, I'll leave this alone
- "LAST_CRASH_DATA": isolated, I'll leave this alone
- "availableLocales": isolated, I'll leave this alone
