### PR TITLE
Fix list component remounting in ProjectMembers.tsx

### DIFF
--- a/src/components/ProjectDetails/ProjectMembers.tsx
+++ b/src/components/ProjectDetails/ProjectMembers.tsx
@@ -8,7 +8,7 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import UserList from "components/UserList/UserList";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import User from "realmModels/User";
 import { useInfiniteScroll, useTranslation } from "sharedHooks";
 
@@ -49,7 +49,7 @@ const ProjectMembers = ( ) => {
     } ),
   } ), [title, totalMembers, t] );
 
-  const renderFooter = useCallback( ( ) => (
+  const footerComponent = useMemo( ( ) => (
     <InfiniteScrollLoadingWheel
       hideLoadingWheel={!isFetchingNextPage}
       layout="list"
@@ -61,7 +61,7 @@ const ProjectMembers = ( ) => {
     navigation.setOptions( headerOptions );
   }, [navigation, headerOptions] );
 
-  const renderEmptyComponent = useCallback( ( ) => (
+  const emptyComponent = useMemo( ( ) => (
     <ActivityIndicator size={50} />
   ), [] );
 
@@ -71,8 +71,8 @@ const ProjectMembers = ( ) => {
         users={projectMembers}
         onEndReached={fetchNextPage}
         refreshing={isFetchingNextPage}
-        ListEmptyComponent={renderEmptyComponent}
-        ListFooterComponent={renderFooter}
+        ListEmptyComponent={emptyComponent}
+        ListFooterComponent={footerComponent}
       />
     </View>
   );

--- a/src/components/SharedComponents/FlashList/CustomFlashList.tsx
+++ b/src/components/SharedComponents/FlashList/CustomFlashList.tsx
@@ -1,10 +1,11 @@
+import type { FlashListProps, FlashListRef, ViewToken } from "@shopify/flash-list";
 import { FlashList } from "@shopify/flash-list";
 import React, {
   useCallback,
   useEffect,
   useRef,
 } from "react";
-import type { ViewabilityConfig } from "react-native";
+import type { NativeScrollEvent, NativeSyntheticEvent, ViewabilityConfig } from "react-native";
 import flashListTracker from "sharedHelpers/flashListPerformanceTracker";
 
 const defaultViewabilityConfig: ViewabilityConfig = {
@@ -13,7 +14,7 @@ const defaultViewabilityConfig: ViewabilityConfig = {
   waitForInteraction: false,
 };
 
-const CustomFlashList = props => {
+const CustomFlashList = <T, >( props: FlashListProps<T> & { ref?: React.Ref<FlashListRef<T>>} ) => {
   const isFirstRender = useRef( true );
   const lastContentOffset = useRef( 0 );
 
@@ -23,7 +24,7 @@ const CustomFlashList = props => {
   const ignoreInitialEvents = useRef( true );
   const fetchInProgress = useRef( false );
 
-  const internalRef = useRef( null );
+  const internalRef = useRef<FlashListRef<T> | null>( null );
 
   const {
     ref,
@@ -39,73 +40,88 @@ const CustomFlashList = props => {
       flashListTracker.reset( );
       isFirstRender.current = false;
 
-      const timer = setTimeout( () => {
+      const timer = setTimeout( ( ) => {
         ignoreInitialEvents.current = false;
       }, 1000 );
 
-      return () => clearTimeout( timer );
+      return ( ) => clearTimeout( timer );
     }
     return ( ) => undefined;
   }, [] );
 
-  const handleViewableItemsChanged = useCallback( info => {
-    if ( info.viewableItems.length > 0 ) {
-      flashListTracker.markItemsVisible( );
-    }
+  const handleViewableItemsChanged = useCallback(
+    ( info: { viewableItems: ViewToken<T>[]; changed: ViewToken<T>[] } ) => {
+      if ( info.viewableItems.length > 0 ) {
+        flashListTracker.markItemsVisible( );
+      }
 
-    if ( onViewableItemsChanged ) {
-      onViewableItemsChanged( info );
-    }
-  }, [onViewableItemsChanged] );
+      if ( onViewableItemsChanged ) {
+        onViewableItemsChanged( info );
+      }
+    },
+    [onViewableItemsChanged],
+  );
 
-  const handleScroll = useCallback( event => {
-    lastContentOffset.current = event.nativeEvent.contentOffset.y;
+  const handleScroll = useCallback(
+    ( event: NativeSyntheticEvent<NativeScrollEvent> ) => {
+      lastContentOffset.current = event.nativeEvent.contentOffset.y;
 
-    if ( onScroll ) {
-      onScroll( event );
-    }
-  }, [onScroll] );
+      if ( onScroll ) {
+        onScroll( event );
+      }
+    },
+    [onScroll],
+  );
 
-  const handleScrollBeginDrag = useCallback( event => {
-    if ( ignoreInitialEvents.current ) return;
+  const handleScrollBeginDrag = useCallback(
+    ( event: NativeSyntheticEvent<NativeScrollEvent> ) => {
+      if ( ignoreInitialEvents.current ) return;
 
-    const { y } = event.nativeEvent.contentOffset;
-
-    scrollStartPosition.current = y;
-    scrollStartTime.current = Date.now();
-    isUserScrolling.current = true;
-
-    flashListTracker.beginScrollEvent( y );
-  }, [] );
-
-  const handleScrollEndDrag = useCallback( event => {
-    if ( ignoreInitialEvents.current || !isUserScrolling.current ) return;
-
-    const { y } = event.nativeEvent.contentOffset;
-
-    isUserScrolling.current = false;
-    flashListTracker.endScrollEvent( y );
-
-    fetchInProgress.current = true;
-    flashListTracker.beginDataFetch( );
-  }, [] );
-
-  const handleMomentumScrollEnd = useCallback( event => {
-    if ( onMomentumScrollEnd ) {
-      onMomentumScrollEnd( event );
-    }
-
-    if ( isUserScrolling.current && !ignoreInitialEvents.current ) {
       const { y } = event.nativeEvent.contentOffset;
+
+      scrollStartPosition.current = y;
+      scrollStartTime.current = Date.now( );
+      isUserScrolling.current = true;
+
+      flashListTracker.beginScrollEvent( y );
+    },
+    [],
+  );
+
+  const handleScrollEndDrag = useCallback(
+    ( event: NativeSyntheticEvent<NativeScrollEvent> ) => {
+      if ( ignoreInitialEvents.current || !isUserScrolling.current ) return;
+
+      const { y } = event.nativeEvent.contentOffset;
+
       isUserScrolling.current = false;
       flashListTracker.endScrollEvent( y );
 
-      if ( !fetchInProgress.current ) {
-        fetchInProgress.current = true;
-        flashListTracker.beginDataFetch();
+      fetchInProgress.current = true;
+      flashListTracker.beginDataFetch( );
+    },
+    [],
+  );
+
+  const handleMomentumScrollEnd = useCallback(
+    ( event: NativeSyntheticEvent<NativeScrollEvent> ) => {
+      if ( onMomentumScrollEnd ) {
+        onMomentumScrollEnd( event );
       }
-    }
-  }, [onMomentumScrollEnd] );
+
+      if ( isUserScrolling.current && !ignoreInitialEvents.current ) {
+        const { y } = event.nativeEvent.contentOffset;
+        isUserScrolling.current = false;
+        flashListTracker.endScrollEvent( y );
+
+        if ( !fetchInProgress.current ) {
+          fetchInProgress.current = true;
+          flashListTracker.beginDataFetch( );
+        }
+      }
+    },
+    [onMomentumScrollEnd],
+  );
 
   const handleEndReached = useCallback( ( ) => {
     if ( ignoreInitialEvents.current ) return;
@@ -122,17 +138,17 @@ const CustomFlashList = props => {
 
   // To be called when new data is received
   // This needs to be exposed so it can be called from parent component
-  React.useImperativeHandle( ref, () => {
+  React.useImperativeHandle( ref, ( ) => {
     const flashListMethods = internalRef.current || {};
 
     return {
       ...flashListMethods,
-      notifyDataFetched: itemsCount => {
+      notifyDataFetched: ( itemsCount: number ) => {
         if ( fetchInProgress.current ) {
           flashListTracker.endDataFetch( itemsCount );
           fetchInProgress.current = false;
         } else {
-          flashListTracker.beginDataFetch();
+          flashListTracker.beginDataFetch( );
           flashListTracker.endDataFetch( itemsCount );
         }
       },

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -14,8 +14,8 @@ const CONTAINER_STYLE = {
 };
 
 interface Props {
-  ListEmptyComponent?: React.JSX.Element;
-  ListFooterComponent?: React.JSX.Element;
+  ListEmptyComponent?: React.ReactElement;
+  ListFooterComponent?: React.ReactElement;
   onEndReached?: ( ) => void;
   refreshing?: boolean;
   users: object[];

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -19,9 +19,9 @@ interface Props {
   onEndReached?: ( ) => void;
   refreshing?: boolean;
   users: object[];
-  onPress?: ( ) => void;
+  onPress?: ( item: object ) => void;
   accessibilityLabel?: string;
-  keyboardShouldPersistTaps?: string;
+  keyboardShouldPersistTaps?: "handled";
   contentContainerStyle?: ViewStyle;
 }
 


### PR DESCRIPTION
Closes MOB-1202

ProjectMembers now passes memoized elements (useMemo) to UserList for ListEmptyComponent and ListFooterComponent instead of useCallback render functions, so FlashList doesn’t remount those subtrees when deps change (same approach as MOB-717 / #3383).

Also added types for CustomFlashList.