### PR TITLE
Fix list component remounting in Projects.tsx

### DIFF
--- a/src/components/ProjectList/ProjectList.tsx
+++ b/src/components/ProjectList/ProjectList.tsx
@@ -11,6 +11,8 @@ import {
 
 import ProjectListItem from "./ProjectListItem";
 
+const ItemSeparator = () => <View className="border-b border-lightGray" />;
+
 interface Props {
   projects: ApiProject[];
   ListEmptyComponent?: React.ReactElement;
@@ -50,13 +52,9 @@ const ProjectList = ( {
     </Pressable>
   );
 
-  const renderItemSeparator = () => (
-    <View className="border-b border-lightGray" />
-  );
-
   return (
     <CustomFlashList
-      ItemSeparatorComponent={renderItemSeparator}
+      ItemSeparatorComponent={ItemSeparator}
       ListEmptyComponent={ListEmptyComponent}
       ListFooterComponent={ListFooterComponent}
       data={projects}

--- a/src/components/ProjectList/ProjectList.tsx
+++ b/src/components/ProjectList/ProjectList.tsx
@@ -15,7 +15,7 @@ const ItemSeparator = () => <View className="border-b border-lightGray" />;
 
 interface Props {
   projects: ApiProject[];
-  ListEmptyComponent?: React.ReactElement;
+  ListEmptyComponent?: React.ReactElement | null;
   ListFooterComponent?: React.ReactElement;
   onEndReached?: ( ) => void;
   onPress?: ( project: ApiProject ) => void;

--- a/src/components/ProjectList/ProjectList.tsx
+++ b/src/components/ProjectList/ProjectList.tsx
@@ -13,8 +13,8 @@ import ProjectListItem from "./ProjectListItem";
 
 interface Props {
   projects: ApiProject[];
-  ListEmptyComponent?: React.JSX.Element;
-  ListFooterComponent?: React.JSX.Element;
+  ListEmptyComponent?: React.ReactElement;
+  ListFooterComponent?: React.ReactElement;
   onEndReached?: ( ) => void;
   onPress?: ( project: ApiProject ) => void;
   accessibilityLabel?: string;

--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -16,7 +16,7 @@ import {
 } from "components/SharedComponents";
 import type { Tab } from "components/SharedComponents/Tabs/Tabs";
 import { View } from "components/styledComponents";
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import {
   useTranslation,
 } from "sharedHooks";
@@ -76,14 +76,14 @@ const Projects = ( {
     } );
   }, [navigation, t] );
 
-  const renderFooter = useCallback( ( ) => (
+  const footerComponent = useMemo( ( ) => (
     <InfiniteScrollLoadingWheel
       hideLoadingWheel={hideLoadingWheel}
       isConnected={isConnected}
     />
   ), [hideLoadingWheel, isConnected] );
 
-  const renderEmptyList = ( ) => {
+  const emptyListComponent = useMemo( ( ) => {
     if ( isLoading ) {
       <ActivityIndicator size={50} />;
     } else {
@@ -119,7 +119,14 @@ const Projects = ( {
     }
 
     return null;
-  };
+  }, [
+    isLoading,
+    searchInput,
+    currentTabId,
+    memberId,
+    t,
+    setSearchInput,
+  ] );
 
   const renderList = ( ) => {
     // hasPermission undefined means we haven't checked for location permissions yet
@@ -148,8 +155,8 @@ const Projects = ( {
     return (
       <ProjectList
         projects={projects}
-        ListEmptyComponent={renderEmptyList}
-        ListFooterComponent={renderFooter}
+        ListEmptyComponent={emptyListComponent}
+        ListFooterComponent={footerComponent}
         onEndReached={fetchNextPage}
       />
     );


### PR DESCRIPTION
Closes [MOB-1204](https://linear.app/inaturalist/issue/MOB-1204)

Projects now passes memoized elements (useMemo) to ProjectList for ListEmptyComponent and ListFooterComponent instead of useCallback render functions (same approach as [MOB-717](https://linear.app/inaturalist/issue/MOB-717) / https://github.com/inaturalist/iNaturalistReactNative/pull/3383).
Also refactored out ItemSeparator in ProjectsList following the same PR as an example.