### PR TITLE
Toggle advanced mode for users that have 100 obs while logging in

### DIFF
--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -542,7 +542,9 @@ async function verifyCredentials(
   return afterVerifyCredentials( tokenResponse, apiClient );
 }
 
-export interface AuthenticateUserResult { success: boolean }
+export type AuthenticateUserResult =
+| { success: true; observationsCount?: number }
+| { success: false };
 
 async function afterAuthenticateUser(
   userDetails: UserDetails | null,
@@ -593,6 +595,7 @@ async function afterAuthenticateUser(
   clearAuthCache( );
   return {
     success: true,
+    observationsCount: remoteUser?.observations_count,
   };
 }
 

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -542,14 +542,19 @@ async function verifyCredentials(
   return afterVerifyCredentials( tokenResponse, apiClient );
 }
 
-async function afterAuthenticateUser( userDetails: UserDetails | null, realm: Realm ) {
+export interface AuthenticateUserResult { success: boolean }
+
+async function afterAuthenticateUser(
+  userDetails: UserDetails | null,
+  realm: Realm,
+): Promise<AuthenticateUserResult> {
   if ( !userDetails ) {
-    return false;
+    return { success: false };
   }
 
   const { userId, username: remoteUsername, accessToken } = userDetails;
   if ( !userId ) {
-    return false;
+    return { success: false };
   }
 
   // Save authentication details to secure storage
@@ -586,7 +591,9 @@ async function afterAuthenticateUser( userDetails: UserDetails | null, realm: Re
     realm.create( "User", localUser, UpdateMode.Modified );
   }, "saving current user in AuthenticationService" );
   clearAuthCache( );
-  return true;
+  return {
+    success: true,
+  };
 }
 
 /**
@@ -601,7 +608,7 @@ const authenticateUser = async (
   username: string,
   password: string,
   realm: Realm,
-): Promise<boolean> => {
+): Promise<AuthenticateUserResult> => {
   const userDetails = await verifyCredentials( username, password );
 
   return afterAuthenticateUser( userDetails, realm );
@@ -611,7 +618,7 @@ async function authenticateUserByAssertion(
   assertionType: "apple" | "google",
   assertion: string,
   realm: Realm,
-) {
+): Promise<AuthenticateUserResult> {
   const apiClient = createAPI( { Accept: "application/json" } );
   const formData = {
     client_id: Config.OAUTH_CLIENT_ID,

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -120,7 +120,7 @@ const LoginForm = ( {
         params: {
           screen: "ProjectDetails",
           params: {
-            id: params?.projectId,
+            id: params.projectId,
           },
         },
       } );

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -35,7 +35,7 @@ interface Props {
 const LoginForm = ( {
   scrollViewRef,
 }: Props ) => {
-  const navigation = useNavigation( );
+  const navigation = useNavigation<LoginStackScreenProps<"Login">["navigation"]>( );
   const { params } = useRoute<LoginStackScreenProps<"Login">["route"]>();
   const emailConfirmed = params?.emailConfirmed;
   // For debug reasons, we can send the user here to log in again, but we must ensure

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import classnames from "classnames";
+import type { AuthenticateUserResult } from "components/LoginSignUp/AuthenticationService";
 import { authenticateUser, signOut } from "components/LoginSignUp/AuthenticationService";
 import {
   Body1, Body2, Button, CloseButton, Heading4, INatIcon, INatIconButton, List2,
@@ -99,11 +100,11 @@ const LoginForm = ( {
     return unsubscrubeTransition;
   }, [navigation] );
 
-  const logIn = React.useCallback( async ( logInCallback: () => Promise<boolean> ) => {
+  const logIn = useCallback( async ( logInCallback: () => Promise<AuthenticateUserResult> ) => {
     setLoading( true );
-    const success = await logInCallback( );
+    const result = await logInCallback( );
 
-    if ( !success ) {
+    if ( !result.success ) {
       setError( t( "Failed-to-log-in" ) );
       setLoading( false );
       return;

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -127,6 +127,7 @@ const LoginForm = ( {
       // we assume they are an advanced user and switch them to advanced mode.
       setIsDefaultMode( false );
     } else {
+      // Set a state to zustand that we just logged in while in default mode
       setLoggedInWhileInDefaultMode( isDefaultMode );
     }
     if ( params?.prevScreen && params?.projectId ) {

--- a/src/components/LoginSignUp/LoginForm.tsx
+++ b/src/components/LoginSignUp/LoginForm.tsx
@@ -33,6 +33,12 @@ interface Props {
   scrollViewRef?: React.Ref<ScrollView>;
 }
 
+/**
+ * If a user loggs in and their account has at least this many
+ * uploaded observations, auto-switch to advanced mode
+ */
+export const AUTO_ADVANCED_MODE_OBSERVATION_THRESHOLD = 100;
+
 const LoginForm = ( {
   scrollViewRef,
 }: Props ) => {
@@ -45,7 +51,8 @@ const LoginForm = ( {
   const currentUser = useCurrentUser( );
   const loginAgain = !!currentUser && !!currentUser?.login;
   const realm = useRealm( );
-  const { isDefaultMode, setLoggedInWhileInDefaultMode } = useLayoutPrefs( );
+  const { isDefaultMode, setIsDefaultMode, setLoggedInWhileInDefaultMode }
+    = useLayoutPrefs();
   const firstInputFieldRef = useRef( null );
   const emailRef = useRef<TextInput>( null );
   const passwordRef = useRef<TextInput>( null );
@@ -112,8 +119,16 @@ const LoginForm = ( {
 
     setLoading( false );
 
-    // Set a state to zustand that we just logged in while in default mode
-    setLoggedInWhileInDefaultMode( isDefaultMode );
+    if (
+      result.observationsCount
+      && result.observationsCount >= AUTO_ADVANCED_MODE_OBSERVATION_THRESHOLD
+    ) {
+      // If a user that just logged in already has more than the threshold number of observations,
+      // we assume they are an advanced user and switch them to advanced mode.
+      setIsDefaultMode( false );
+    } else {
+      setLoggedInWhileInDefaultMode( isDefaultMode );
+    }
     if ( params?.prevScreen && params?.projectId ) {
       navigation.navigate( "TabNavigator", {
         screen: "ObservationsTab",
@@ -131,6 +146,7 @@ const LoginForm = ( {
     navigation,
     params,
     isDefaultMode,
+    setIsDefaultMode,
     setLoggedInWhileInDefaultMode,
   ] );
 

--- a/src/components/LoginSignUp/SignUpConfirmationForm.tsx
+++ b/src/components/LoginSignUp/SignUpConfirmationForm.tsx
@@ -98,9 +98,9 @@ const SignUpConfirmationForm = ( ) => {
       setLoading( false );
       return;
     }
-    const success = await authenticateUser( processedUser.login, processedUser.password, realm );
+    const result = await authenticateUser( processedUser.login, processedUser.password, realm );
     setLoading( false );
-    if ( !success ) {
+    if ( !result.success ) {
       navigation.navigate( "Login" );
       return;
     }

--- a/src/components/LoginSignUp/SignUpConfirmationForm.tsx
+++ b/src/components/LoginSignUp/SignUpConfirmationForm.tsx
@@ -26,7 +26,7 @@ const { useRealm } = RealmContext;
 
 const SignUpConfirmationForm = ( ) => {
   const realm = useRealm( );
-  const navigation = useNavigation( );
+  const navigation = useNavigation<LoginStackScreenProps<"SignUpConfirmation">["navigation"]>( );
   const { params } = useRoute<LoginStackScreenProps<"SignUpConfirmation">["route"]>();
   const { user } = params;
 

--- a/src/components/LoginSignUp/loginFormHelpers.ts
+++ b/src/components/LoginSignUp/loginFormHelpers.ts
@@ -12,6 +12,7 @@ import Config from "react-native-config";
 import type Realm from "realm";
 import { log } from "sharedHelpers/logger";
 
+import type { AuthenticateUserResult } from "./AuthenticationService";
 import {
   authenticateUserByAssertion,
 } from "./AuthenticationService";
@@ -29,7 +30,7 @@ function showSignInWithAppleFailed() {
   );
 }
 
-async function signInWithApple( realm: Realm ) {
+async function signInWithApple( realm: Realm ): Promise<AuthenticateUserResult> {
   // Request sign in w/ apple. This should pop up some system UI for signing
   // in
   let appleAuthRequestResponse;
@@ -42,11 +43,11 @@ async function signInWithApple( realm: Realm ) {
   } catch ( appleAuthRequestError ) {
     if ( ( appleAuthRequestError as AppleAuthError ).code === appleAuth.Error.CANCELED ) {
       // The user canceled sign in, no need to log
-      return false;
+      return { success: false };
     }
     logger.error( "Apple auth request failed", appleAuthRequestError );
     showSignInWithAppleFailed();
-    return false;
+    return { success: false };
   }
 
   // Check if auth was successful
@@ -74,19 +75,20 @@ async function signInWithApple( realm: Realm ) {
       } ),
     } );
     try {
+      // return await authenticateUserByAssertion( "apple", assertion, realm );
       await authenticateUserByAssertion( "apple", assertion, realm );
     } catch ( authenticateUserByAssertionError ) {
       logger.error( "Assertion with Apple token failed", authenticateUserByAssertionError );
       showSignInWithAppleFailed();
-      return false;
+      return { success: false };
     }
-    return true;
+    return { success: true };
   }
   // We only get here if the user does not grant access... I think, so no need
   // to log an error
   logger.info( "Apple auth failed, credentialState: ", credentialState );
   showSignInWithAppleFailed();
-  return false;
+  return { success: false };
 }
 
 GoogleSignin.configure( {
@@ -124,33 +126,33 @@ function showSignInWithGoogleFailed() {
   );
 }
 
-async function signInWithGoogle( realm: Realm ) {
+async function signInWithGoogle( realm: Realm ): Promise<AuthenticateUserResult> {
   const hasPlayServices = await confirmGooglePlayServices( );
-  if ( !hasPlayServices ) return false;
+  if ( !hasPlayServices ) return { success: false };
   let signInResp;
   try {
     signInResp = await GoogleSignin.signIn();
   } catch ( signInError ) {
     logger.error( "Failed to sign in with Google", signInError );
-    return false;
+    return { success: false };
   }
-  if ( signInResp.type === "cancelled" ) return false;
+  if ( signInResp.type === "cancelled" ) return { success: false };
   let tokens;
   try {
     tokens = await GoogleSignin.getTokens();
   } catch ( getTokensError ) {
     logger.error( "Failed to get tokens from Google", getTokensError );
-    return false;
+    return { success: false };
   }
-  if ( !tokens?.accessToken ) return false;
+  if ( !tokens?.accessToken ) return { success: false };
   try {
     await authenticateUserByAssertion( "google", tokens.accessToken, realm );
   } catch ( authenticateUserByAssertionError ) {
     logger.error( "Assertion with Google token failed", authenticateUserByAssertionError );
     showSignInWithGoogleFailed();
-    return false;
+    return { success: false };
   }
-  return true;
+  return { success: true };
 }
 
 export {

--- a/src/components/LoginSignUp/loginFormHelpers.ts
+++ b/src/components/LoginSignUp/loginFormHelpers.ts
@@ -75,14 +75,12 @@ async function signInWithApple( realm: Realm ): Promise<AuthenticateUserResult> 
       } ),
     } );
     try {
-      // return await authenticateUserByAssertion( "apple", assertion, realm );
-      await authenticateUserByAssertion( "apple", assertion, realm );
+      return await authenticateUserByAssertion( "apple", assertion, realm );
     } catch ( authenticateUserByAssertionError ) {
       logger.error( "Assertion with Apple token failed", authenticateUserByAssertionError );
       showSignInWithAppleFailed();
       return { success: false };
     }
-    return { success: true };
   }
   // We only get here if the user does not grant access... I think, so no need
   // to log an error
@@ -146,13 +144,12 @@ async function signInWithGoogle( realm: Realm ): Promise<AuthenticateUserResult>
   }
   if ( !tokens?.accessToken ) return { success: false };
   try {
-    await authenticateUserByAssertion( "google", tokens.accessToken, realm );
+    return await authenticateUserByAssertion( "google", tokens.accessToken, realm );
   } catch ( authenticateUserByAssertionError ) {
     logger.error( "Assertion with Google token failed", authenticateUserByAssertionError );
     showSignInWithGoogleFailed();
     return { success: false };
   }
-  return { success: true };
 }
 
 export {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -332,11 +332,13 @@ export type NoBottomTabStackParamList = BaseNoBottomTabStackParamList &
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type LoginStackParamList = {
+  // From SignUpConfirmationForm
+  // no params
   Login: {
     emailConfirmed?: boolean;
     prevScreen?: string;
     projectId?: number;
-  };
+  } | undefined;
   SignUp: undefined;
   ForgotPassword: undefined;
   LearnMore: undefined;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -214,7 +214,9 @@ export type BaseTabStackParamList = {
   };
   DataQualityAssessment: undefined;
   Projects: undefined;
-  ProjectDetails: undefined;
+  // From LoginForm
+  // { id: params.projectId }
+  ProjectDetails: { id: number };
   ProjectRequirements: undefined;
   ProjectMembers: undefined;
   // From ProjectButton, ProjectSection

--- a/tests/unit/components/LoginSignUp/AuthenticationService.test.js
+++ b/tests/unit/components/LoginSignUp/AuthenticationService.test.js
@@ -44,7 +44,9 @@ test( "authenticates user", async ( ) => {
 
   // Authenticate the user
   await expect( isLoggedIn() ).resolves.toEqual( false );
-  await expect( authenticateUser( USERNAME, PASSWORD, global.realm ) ).resolves.toEqual( true );
+  await expect( authenticateUser( USERNAME, PASSWORD, global.realm ) ).resolves.toEqual( {
+    success: true,
+  } );
 
   // Make sure user is logged in
   await expect( isCurrentUser( USERNAME ) ).resolves.toEqual( true );
@@ -72,7 +74,9 @@ test( "registers user", async ( ) => {
   await expect( registerUser( "some@mail.com", USERNAME, PASSWORD ) ).resolves.toBeNull( );
 
   // Log back in
-  await expect( authenticateUser( USERNAME, PASSWORD, global.realm ) ).resolves.toEqual( true );
+  await expect( authenticateUser( USERNAME, PASSWORD, global.realm ) ).resolves.toEqual( {
+    success: true,
+  } );
 
   // Make sure user is logged in
   await expect( isCurrentUser( USERNAME ) ).resolves.toEqual( true );

--- a/tests/unit/components/LoginSignUp/AuthenticationService.test.js
+++ b/tests/unit/components/LoginSignUp/AuthenticationService.test.js
@@ -8,9 +8,11 @@ import {
   registerUser,
   signOut,
 } from "components/LoginSignUp/AuthenticationService";
+import inatjs from "inaturalistjs";
 import { navigationRef } from "navigation/navigationUtils";
 import nock from "nock";
 import RNSInfo from "react-native-sensitive-info";
+import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 
 jest.mock( "navigation/navigationUtils", ( ) => ( {
@@ -27,7 +29,21 @@ const ACCESS_TOKEN_AUTHORIZATION_HEADER = `Bearer ${ACCESS_TOKEN}`;
 const JWT = "jwt_token";
 const USERID = 113113;
 
+const mockUserWithUploadedObs = factory( "RemoteUser", {
+  id: USERID,
+  login: USERNAME,
+  observations_count: 5,
+} );
+
+const mockUserWithoutUploadedObs = factory( "RemoteUser", {
+  id: USERID,
+  login: USERNAME,
+  observations_count: 0,
+} );
+
 test( "authenticates user", async ( ) => {
+  inatjs.users.me.mockResolvedValue( makeResponse( [mockUserWithUploadedObs] ) );
+
   const scope = nock( API_HOST )
     .post( "/oauth/token" )
     .reply( 200, { access_token: ACCESS_TOKEN } )
@@ -46,6 +62,7 @@ test( "authenticates user", async ( ) => {
   await expect( isLoggedIn() ).resolves.toEqual( false );
   await expect( authenticateUser( USERNAME, PASSWORD, global.realm ) ).resolves.toEqual( {
     success: true,
+    observationsCount: 5,
   } );
 
   // Make sure user is logged in
@@ -61,6 +78,8 @@ test( "authenticates user", async ( ) => {
 } );
 
 test( "registers user", async ( ) => {
+  inatjs.users.me.mockResolvedValue( makeResponse( [mockUserWithoutUploadedObs] ) );
+
   const scope = nock( API_HOST )
     .post( "/oauth/token" )
     .reply( 200, { access_token: ACCESS_TOKEN } )
@@ -76,6 +95,7 @@ test( "registers user", async ( ) => {
   // Log back in
   await expect( authenticateUser( USERNAME, PASSWORD, global.realm ) ).resolves.toEqual( {
     success: true,
+    observationsCount: 0,
   } );
 
   // Make sure user is logged in


### PR DESCRIPTION
Closes MOB-1309

We are already fetching the remote user after authentication, so all I did there was to refactor the return type to also return the number of already uploaded observations (`observations_count` from API). We save the info to realm as well but we do need the count immediately from the caller.

I did not take into consideration a way to manipulate the actual threshold at runtime, as we are not really setup for that yet. So, currently a hard-coded const of 100 obs.

Since we already have the number of obs setting the boolean zustand that is "Advanced mode" is already done before we navigate away from the login screen, so there should be no awkward switch when on the Me tab. (Or do we need to "await" setIsDefaultMode?)

Some things to note for the logic part: if the app is in default or advanced mode before pressing "Log in" shouldn't matter for this bit because we want to enforce isDefaultMode to false when >100 obs and do not change it when <100 obs.

One open question I had: Why is the remote user typed so defensively with some fields being undefined?

PS: Sorry, couldn't help myself and added some navigation types. Bad example because they should be in a separate PR.