### PR TITLE
fix UiLibrary fast refresh

### DIFF
--- a/src/components/Developer/UiLibraryItem.js
+++ b/src/components/Developer/UiLibraryItem.js
@@ -36,13 +36,12 @@ const UiLibraryItem = ( ) => {
     [navigation, params.title],
   );
 
-  // For reasons I don't understand hot reload doesn't work with this LIBRARY
-  // approach, so if you want that you might just need to render the
-  // component explicitly here. ~~~~kueda20240613
-  // return <ObsGridItemDemo />;
-  return typeof ( LIBRARY[params.component] ) === "function"
-    ? LIBRARY[params.component]()
-    : <ActivityIndicator />;
+  const Component = LIBRARY[params.component];
+  if ( typeof Component !== "function" ) {
+    return <ActivityIndicator />;
+  }
+
+  return <Component />;
 };
 
 export default UiLibraryItem;


### PR DESCRIPTION
this happens to be a very similar concern to the `<FlashList ItemSeparatorComponent={???} />` thing. I think it manages specifically to break Fast Refresh because it _happens_ to cross a module boundary at the same time we're treating the components as render helpers: `return MyComponent()` is very different than `return <MyComponent />`. React can't help you with the former _if_ the render helper definition lives outside the render tree.

idk how much we use this but this should make it nicer. just saw the kueda comment and made the fix while I was here.