### PR TITLE
Refactor into two workflows

### DIFF
--- a/.github/workflows/e2e_android.new.yml
+++ b/.github/workflows/e2e_android.new.yml
@@ -1,8 +1,16 @@
-name: e2e-Android
+name: e2e-Android-build
+# Untrusted half of the two-workflow e2e pattern.
+# Runs on pull_request (incl. forks). Has NO access to repo secrets.
+# Produces a debug-signed APK + PR metadata that the trusted
+# `e2e-Android-test` workflow consumes via `workflow_run`.
 permissions:
   contents: read
 on:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    # 4-core Ubunutu GitHub Larger Runner
+    # 4-core Ubuntu GitHub Larger Runner
     # https://docs.github.com/en/enterprise-cloud@latest/billing/reference/actions-runner-pricing#x64-powered-larger-runners
     runs-on: ubuntu-24.04-m
 
@@ -18,51 +26,32 @@ jobs:
     - name: Check out Git repository
       uses: actions/checkout@v6
 
-    # Generate the secret files needed for a release build
-    - name: Create .env file
-      env:
-        OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
-        OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
-        E2E_TEST_USERNAME: ${{ secrets.E2E_TEST_USERNAME }}
-        E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-        JWT_ANONYMOUS_API_SECRET: ${{ secrets.JWT_ANONYMOUS_API_SECRET }}
-        GMAPS_API_KEY: ${{ secrets.GMAPS_API_KEY }}
-      run: printf 'API_URL=https://stagingapi.inaturalist.org/v2\nOAUTH_API_URL=https://staging.inaturalist.org\nJWT_ANONYMOUS_API_SECRET=%s\nOAUTH_CLIENT_ID=%s\nOAUTH_CLIENT_SECRET=%s\nE2E_TEST_USERNAME=%s\nE2E_TEST_PASSWORD=%s\nGMAPS_API_KEY=%s\nANDROID_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.tflite\nANDROID_TAXONOMY_FILE_NAME=taxonomy.csv\nANDROID_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.tflite\nIOS_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.mlmodel\nIOS_TAXONOMY_FILE_NAME=taxonomy.json\nIOS_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.mlmodel\nCV_MODEL_VERSION=small_2\n' "$JWT_ANONYMOUS_API_SECRET" "$OAUTH_CLIENT_ID" "$OAUTH_CLIENT_SECRET" "$E2E_TEST_USERNAME" "$E2E_TEST_PASSWORD" "$GMAPS_API_KEY" > .env
-
-    - name: Add secrets to google-services.json
-      env:
-        FIREBASE_PROJECT_NUMBER: ${{ secrets.FIREBASE_PROJECT_NUMBER }}
-        FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-        FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-        FIREBASE_STAGING_GOOGLE_APP_ID: ${{ secrets.FIREBASE_STAGING_GOOGLE_APP_ID }}
-        FIREBASE_STAGING_PACKAGE_NAME: ${{ secrets.FIREBASE_STAGING_PACKAGE_NAME }}
-        FIREBASE_STAGING_API_KEY: ${{ secrets.FIREBASE_STAGING_API_KEY }}
+    # Non-secret .env. Real OAuth / E2E creds are injected by the
+    # trusted test workflow at test-runtime (not baked into the APK).
+    - name: Create placeholder .env file
       run: |
-        cp android/app/google-services.example.json android/app/google-services.json
-        sed -i "s/your_project_number/${FIREBASE_PROJECT_NUMBER//\//\\/}/g" "android/app/google-services.json"
-        sed -i "s/your_project_id/${FIREBASE_PROJECT_ID//\//\\/}/g" "android/app/google-services.json"
-        sed -i "s/your_storage_bucket/${FIREBASE_STORAGE_BUCKET//\//\\/}/g" "android/app/google-services.json"
-        sed -i "s/your_mobilesdk_app_id/${FIREBASE_STAGING_GOOGLE_APP_ID//\//\\/}/g" "android/app/google-services.json"
-        sed -i "s/your_package_name/${FIREBASE_STAGING_PACKAGE_NAME//\//\\/}/g" "android/app/google-services.json"
-        sed -i "s/your_current_key/${FIREBASE_STAGING_API_KEY//\//\\/}/g" "android/app/google-services.json"
+        cat > .env <<'EOF'
+        API_URL=https://stagingapi.inaturalist.org/v2
+        OAUTH_API_URL=https://staging.inaturalist.org
+        JWT_ANONYMOUS_API_SECRET=placeholder
+        OAUTH_CLIENT_ID=placeholder
+        OAUTH_CLIENT_SECRET=placeholder
+        E2E_TEST_USERNAME=placeholder
+        E2E_TEST_PASSWORD=placeholder
+        GMAPS_API_KEY=placeholder
+        ANDROID_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.tflite
+        ANDROID_TAXONOMY_FILE_NAME=taxonomy.csv
+        ANDROID_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.tflite
+        IOS_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.mlmodel
+        IOS_TAXONOMY_FILE_NAME=taxonomy.json
+        IOS_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.mlmodel
+        CV_MODEL_VERSION=small_2
+        EOF
 
-    - name: Create keystore.properties file
-      env:
-        ANDROID_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}
-        ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        ANDROID_ALIAS: ${{ secrets.ANDROID_ALIAS }}
-      run: printf 'storePassword=%s\nkeyPassword=%s\nkeyAlias=%s\nstoreFile=release.keystore' "$ANDROID_KEY_STORE_PASSWORD" "$ANDROID_KEY_PASSWORD" "$ANDROID_ALIAS" > android/keystore.properties
-
-    - name: Generate release keystore
-      env:
-        ANDROID_ALIAS: ${{ secrets.ANDROID_ALIAS }}
-        ANDROID_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}
-        ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-      run: |
-        keytool -genkeypair -v -noprompt -storetype PKCS12 -keystore release.keystore -alias "$ANDROID_ALIAS" -keyalg RSA -keysize 2048 -validity 10000 -storepass "$ANDROID_KEY_STORE_PASSWORD" -keypass "$ANDROID_KEY_PASSWORD" -dname "CN=mqttserver.ibm.com, OU=ID, O=IBM, L=Hursley, S=Hants, C=GB"
-
-    - name: Move keystore
-      run: mv release.keystore android/app/release.keystore
+    # Use the example google-services.json verbatim. No Firebase secrets
+    # are exposed to fork code; staging Firebase isn't exercised by e2e.
+    - name: Use example google-services.json
+      run: cp android/app/google-services.example.json android/app/google-services.json
 
     - uses: actions/setup-node@v6
       with:
@@ -80,129 +69,34 @@ jobs:
         gradle-version: '8.14.1'
 
     - name: Install JS dependencies
-      run: |
-        npm install
+      run: npm install
 
     - name: Download the small example cv and geomodel
-      run: |
-        npm run add-example-model -- -f=main
+      run: npm run add-example-model -- -f=main
 
-    - name: Android Build
+    # Debug build only: avoids needing a release keystore (which is a secret).
+    # Debug-signed APKs install fine on the emulator used by the test workflow.
+    - name: Android Build (debug, x86 only)
       run: |
         cd android
-        # for the CI build, we can just target the x86 build for the emulator
-        # also, we can exclude linting tasks
-        ./gradlew build -PreactNativeArchitectures=x86 -x lint -x lintVitalRelease 
+        ./gradlew assembleDebug -PreactNativeArchitectures=x86 -x lint
 
     - name: Upload APK
       uses: actions/upload-artifact@v6
       with:
         name: release-apk
-        # note: clarifying because this is different from iOS:
-        # {myBuild}.apk is a single file so `release-apk` points to a single file
-        # in contrast, iOS's .ipa is actually a _directory_
-        path: android/app/build/outputs/apk/release/*-release.apk
-    
-  test:
-    # 4-core Ubunutu GitHub Larger Runner
-    # https://docs.github.com/en/enterprise-cloud@latest/billing/reference/actions-runner-pricing#x64-powered-larger-runners
-    # `cores` setting for emulator actions should be updated to reflect changes to this
-    runs-on: ubuntu-24.04-m
-    needs: build
+        path: android/app/build/outputs/apk/debug/*-debug.apk
 
-    steps:
-      # note: this step requires checkout for the test flows, but does _not_ require npm install w/ Maestro
-      - uses: actions/checkout@v6
+    # Persist PR context so the trusted workflow knows what to report on.
+    - name: Save PR metadata
+      run: |
+        mkdir -p pr-metadata
+        echo "${{ github.event.pull_request.number }}" > pr-metadata/pr_number
+        echo "${{ github.event.pull_request.head.sha || github.sha }}" > pr-metadata/head_sha
+        echo "${{ github.event.pull_request.head.repo.full_name || github.repository }}" > pr-metadata/head_repo
 
-      - name: Download APK
-        uses: actions/download-artifact@v7
-        with:
-          name: release-apk
-          # resulting file structure: $GITHUB_HOME/e2e-build/{myBuild}.apk
-          path: e2e-build
-
-      - name: Install Maestro
-        run: |
-          export MAESTRO_VERSION="2.0.8"; curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-
-      # These KVM settings are in support of the android-emulator-runner action that takes advantage of them
-      # Further reading:
-      # - https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
-      # - https://github.com/reactivecircus/android-emulator-runner/tree/v2/?tab=readme-ov-file#github-action---android-emulator-runner
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      # AVD Cache: we can reuse a previously-created AVD to save time and make the test-run start step more dependable
-      # both android-emulator-runner steps should have the same image config for cores, api-level, target
-      - name: Attempt to restore AVD cache
-        uses: actions/cache/restore@v5
-        id: avd-cache-restore
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-29
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache-restore.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          cores: 4
-          api-level: 29
-          target: google_apis
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-      - name: Save AVD cache
-        if: steps.avd-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-29
-
-      - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          MAESTRO_DRIVER_STARTUP_TIMEOUT: 60000
-          MAESTRO_CLI_NO_ANALYTICS: 1
-          # custom ENV var to drive recordings within test flows
-          # see README for details
-          MAESTRO_RECORD: true
-        with:
-          cores: 4
-          api-level: 29
-          target: google_apis
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: |
-            adb install -r e2e-build/*.apk
-            # single exemplary "smoketest" flow for now
-            maestro test --no-ansi e2e/maestro/android/signedOut.yaml
-
-      - name: Upload test video
-        uses: actions/upload-artifact@v6
-        if: ${{ success() || failure() }}
-        with:
-          # single exemplary flow artifact for now, generated by MAESTRO_RECORD configuration
-          path: signedOut.mp4
-          name: Android
-
-  notify:
-    name: Notify Slack
-    needs: test
-    if: ${{ success() || failure() }}
-    runs-on: macos-latest
-    steps:
-      - uses: iRoachie/slack-github-actions@v2.3.0
-        if: env.SLACK_WEBHOOK_URL != null
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILDS_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload PR metadata
+      uses: actions/upload-artifact@v6
+      with:
+        name: pr-metadata
+        path: pr-metadata/

--- a/.github/workflows/e2e_android.new.yml
+++ b/.github/workflows/e2e_android.new.yml
@@ -53,6 +53,12 @@ jobs:
     - name: Use example google-services.json
       run: cp android/app/google-services.example.json android/app/google-services.json
 
+    # build.gradle reads keystore.properties at configuration time even for
+    # debug builds, so write a placeholder. The values are only consumed by
+    # the release signingConfig, which assembleDebug never invokes.
+    - name: Create placeholder keystore.properties
+      run: printf 'storePassword=placeholder\nkeyPassword=placeholder\nkeyAlias=placeholder\nstoreFile=placeholder.keystore' > android/keystore.properties
+
     - uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
@@ -69,16 +75,17 @@ jobs:
         gradle-version: '8.14.1'
 
     - name: Install JS dependencies
-      run: npm install
+      run: npm ci
 
     - name: Download the small example cv and geomodel
       run: npm run add-example-model -- -f=main
 
-    # Debug build only: avoids needing a release keystore (which is a secret).
-    # Debug-signed APKs install fine on the emulator used by the test workflow.
-    - name: Android Build (debug, x86 only)
+    - name: Android Build
       run: |
         cd android
+        # Debug build only: signed with the in-tree debug.keystore that ships
+        # with React Native, so no release keystore / signing secrets needed.
+        # x86-only keeps it small and matches the emulator we test against.
         ./gradlew assembleDebug -PreactNativeArchitectures=x86 -x lint
 
     - name: Upload APK
@@ -87,7 +94,7 @@ jobs:
         name: release-apk
         path: android/app/build/outputs/apk/debug/*-debug.apk
 
-    # Persist PR context so the trusted workflow knows what to report on.
+    # Persist PR context so the trusted test workflow knows what to report on.
     - name: Save PR metadata
       run: |
         mkdir -p pr-metadata

--- a/.github/workflows/e2e_android_test.yml
+++ b/.github/workflows/e2e_android_test.yml
@@ -1,0 +1,146 @@
+name: e2e-Android-test
+# Trusted half of the two-workflow e2e pattern.
+# Runs after `e2e-Android-build` completes. Has access to repo secrets.
+# Never checks out untrusted PR code into a privileged step;
+# it only consumes the prebuilt APK artifact from the build run.
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  checks: write
+
+on:
+  workflow_run:
+    workflows: ["e2e-Android-build"]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04-m
+    # Attach required-reviewer protection to this environment in repo
+    # settings to require human approval before secrets are exposed.
+    environment: e2e
+    steps:
+      # Download the APK and PR metadata from the upstream (untrusted) run.
+      - name: Download APK artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: release-apk
+          path: e2e-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR metadata artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pr-metadata
+          path: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          echo "pr_number=$(cat pr-metadata/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(cat pr-metadata/head_sha)" >> "$GITHUB_OUTPUT"
+          echo "head_repo=$(cat pr-metadata/head_repo)" >> "$GITHUB_OUTPUT"
+
+      # Check out the BASE repo at the workflow_run head_sha (trusted).
+      # We only need the test flow files from the base, not fork JS.
+      - name: Check out base repo at run SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install Maestro
+        run: |
+          export MAESTRO_VERSION="2.0.8"
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Attempt to restore AVD cache
+        uses: actions/cache/restore@v5
+        id: avd-cache-restore
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-29
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache-restore.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          cores: 4
+          api-level: 29
+          target: google_apis
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Save AVD cache
+        if: steps.avd-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-29
+
+      # Secrets are passed to Maestro via env vars, NOT baked into the APK.
+      # Maestro flows should reference these via ${E2E_TEST_USERNAME} etc.
+      # NOTE: anything the app needs at *build* time (e.g. OAUTH_CLIENT_*
+      # via react-native-config) cannot be injected here; flows that
+      # depend on those values will need to be adapted to read from
+      # runtime sources (intent extras, deep links, or a debug menu).
+      - name: Run e2e tests
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: 60000
+          MAESTRO_CLI_NO_ANALYTICS: 1
+          MAESTRO_RECORD: true
+          E2E_TEST_USERNAME: ${{ secrets.E2E_TEST_USERNAME }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        with:
+          cores: 4
+          api-level: 29
+          target: google_apis
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            adb install -r e2e-build/*.apk
+            maestro test --no-ansi e2e/maestro/android/signedOut.yaml
+
+      - name: Upload test video
+        uses: actions/upload-artifact@v6
+        if: ${{ success() || failure() }}
+        with:
+          path: signedOut.mp4
+          name: Android
+
+  notify:
+    name: Notify Slack
+    needs: test
+    if: ${{ success() || failure() }}
+    runs-on: macos-latest
+    steps:
+      - uses: iRoachie/slack-github-actions@v2.3.0
+        if: env.SLACK_WEBHOOK_URL != null
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILDS_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -1,7 +1,12 @@
 ##
-# Run e2e tests
+# Untrusted half of the two-workflow e2e pattern for iOS.
+# Runs on pull_request (incl. forks). Has NO access to repo secrets.
+# Produces a Detox app build + PR metadata that the trusted
+# `e2e-iOS-test` workflow consumes via `workflow_run`.
 ##
-name: e2e-iOS
+name: e2e-iOS-build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:
@@ -12,27 +17,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
-jobs:
-  checksecret:
-    name: check for oauth client
-    runs-on: macos-15
-    outputs:
-      is_SECRETS_PRESENT_set: ${{ steps.checksecret_job.outputs.is_SECRETS_PRESENT_set }}
-    steps:
-      - name: Check whether unity activation requests should be done
-        id: checksecret_job
-        env:
-            SECRETS_PRESENT: ${{ secrets.OAUTH_CLIENT_SECRET }}
-        run: |
-            echo "is_SECRETS_PRESENT_set: ${{ env.SECRETS_PRESENT != '' }}"
-            echo "::set-output name=is_SECRETS_PRESENT_set::${{ env.SECRETS_PRESENT != '' }}"
 
+jobs:
   build:
-    needs: checksecret
-    if: needs.checksecret.outputs.is_SECRETS_PRESENT_set == 'true'
     runs-on: macos-15
-    # Kill the task if not finished after 120 minutes
     timeout-minutes: 120
 
     steps:
@@ -49,7 +37,7 @@ jobs:
     - name: Setup Ruby version according to .ruby-version with cached gems
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true        
+        bundler-cache: true
 
     - name: Cache node modules
       uses: actions/cache@v5
@@ -62,10 +50,8 @@ jobs:
       if: steps.cache.outputs.cache-hit == 'true'
       run: npx detox clean-framework-cache && npx detox build-framework-cache
 
-    # supposedly our current cache includes native modules like Realm
-    # that have compiled binaries specific to the environment where they were installed
-    # which might not be the same as the github actions environment
-    # so we need to rebuild them
+    # Cached node_modules may include native binaries built for a different
+    # environment than this runner, so rebuild them.
     - name: Rebuild native modules
       if: steps.cache.outputs.cache-hit == 'true'
       run: npm rebuild
@@ -86,42 +72,39 @@ jobs:
         gem update cocoapods xcodeproj
         cd ios && pod install && cd ..
 
-    - name: Add secrets to GoogleService-Info.plist
-      env:
-        FIREBASE_STAGING_GOOGLE_APP_ID: ${{ secrets.FIREBASE_STAGING_GOOGLE_APP_ID }}
-        FIREBASE_STAGING_API_KEY: ${{ secrets.FIREBASE_STAGING_API_KEY }}
-      run: |
-        sed -i "" "s/your-google-app-id/${FIREBASE_STAGING_GOOGLE_APP_ID//\//\\/}/g" "ios/GoogleService-Info.example.plist"
-        sed -i "" "s/your-api-key/${FIREBASE_STAGING_API_KEY//\//\\/}/g" "ios/GoogleService-Info.example.plist"
-
+    # Use the example GoogleService-Info.plist verbatim. No Firebase secrets
+    # are exposed to fork code; staging Firebase isn't exercised by e2e.
     - name: Create GoogleService-Info.plist files from example
       run: |
         cp ios/GoogleService-Info.example.plist ios/GoogleService-Info.staging.plist
         cp ios/GoogleService-Info.example.plist ios/GoogleService-Info.production.plist
 
-    # Generate the secret files needed for a test run
-    - name: Create .env file
-      env:
-        OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
-        OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
-        E2E_TEST_USERNAME: ${{ secrets.E2E_TEST_USERNAME }}
-        E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-        JWT_ANONYMOUS_API_SECRET: ${{ secrets.JWT_ANONYMOUS_API_SECRET }}
+    # Non-secret .env. Real OAuth / E2E creds are injected by the
+    # trusted test workflow at test-runtime (not baked into the app).
+    - name: Create placeholder .env file
       run: |
-        printf 'API_URL=https://stagingapi.inaturalist.org/v2\nOAUTH_API_URL=https://staging.inaturalist.org\nJWT_ANONYMOUS_API_SECRET=%s\nOAUTH_CLIENT_ID=%s\nOAUTH_CLIENT_SECRET=%s\nE2E_TEST_USERNAME=%s\nE2E_TEST_PASSWORD=%s\nGMAPS_API_KEY=%s\nANDROID_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.tflite\nANDROID_TAXONOMY_FILE_NAME=taxonomy.csv\nANDROID_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.tflite\nIOS_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.mlmodel\nIOS_TAXONOMY_FILE_NAME=taxonomy.json\nIOS_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.mlmodel\nCV_MODEL_VERSION=small_2\n' \
-        "$JWT_ANONYMOUS_API_SECRET" \
-        "$OAUTH_CLIENT_ID" \
-        "$OAUTH_CLIENT_SECRET" \
-        "$E2E_TEST_USERNAME" \
-        "$E2E_TEST_PASSWORD" \
-        "$GMAPS_API_KEY" > .env
+        cat > .env <<'EOF'
+        API_URL=https://stagingapi.inaturalist.org/v2
+        OAUTH_API_URL=https://staging.inaturalist.org
+        JWT_ANONYMOUS_API_SECRET=placeholder
+        OAUTH_CLIENT_ID=placeholder
+        OAUTH_CLIENT_SECRET=placeholder
+        E2E_TEST_USERNAME=placeholder
+        E2E_TEST_PASSWORD=placeholder
+        GMAPS_API_KEY=placeholder
+        ANDROID_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.tflite
+        ANDROID_TAXONOMY_FILE_NAME=taxonomy.csv
+        ANDROID_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.tflite
+        IOS_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.mlmodel
+        IOS_TAXONOMY_FILE_NAME=taxonomy.json
+        IOS_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.mlmodel
+        CV_MODEL_VERSION=small_2
+        EOF
 
     # Download all linked model files not included in the repository (otherwise build will error out), requires .env file
     - name: Download the example cv model and taxonomy file into the ios folder
       run: npm run add-example-model
 
-    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-    # This will be available for all subsequent steps
     - name: Set MOCK_MODE to e2e
       run: echo "MOCK_MODE=e2e" >> "$GITHUB_ENV"
 
@@ -135,124 +118,17 @@ jobs:
         path: ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app
         retention-days: 5
 
-  test:
-    needs: build
-    runs-on: macos-15
-    # Kill the task if not finished after 120 minutes
-    timeout-minutes: 120
-
-    steps:
-    - name: Check out Git repository
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-
-    - name: Download iOS Detox app build
-      uses: actions/download-artifact@v7
-      with:
-        name: detox_app
-        path: ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app
-
-    - name: Install Node.js, NPM and Yarn
-      uses: actions/setup-node@v6
-      with:
-        node-version: 22
-
-    - name: Cache node modules
-      uses: actions/cache@v5
-      id: cache
-      with:
-        path: node_modules
-        key: node-modules-${{ hashFiles('**/package-lock.json') }}
-
-    - name: Rebuild detox from cache
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npx detox clean-framework-cache && npx detox build-framework-cache
-
-    # supposedly our current cache includes native modules like Realm
-    # that have compiled binaries specific to the environment where they were installed
-    # which might not be the same as the github actions environment
-    # so we need to rebuild them
-    - name: Rebuild native modules
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npm rebuild
-
-    - name: Install Dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: npm install
-
-    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-    # This will be available for all subsequent steps
-    - name: Set MOCK_MODE to e2e
-      run: echo "MOCK_MODE=e2e" >> "$GITHUB_ENV"
-
-    # Generate the secret files needed for a release build
-    - name: Create .env file
-      env:
-        OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
-        OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
-        E2E_TEST_USERNAME: ${{ secrets.E2E_TEST_USERNAME }}
-        E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-        JWT_ANONYMOUS_API_SECRET: ${{ secrets.JWT_ANONYMOUS_API_SECRET }}
+    # Persist PR context so the trusted workflow knows what to report on.
+    - name: Save PR metadata
       run: |
-        printf 'API_URL=https://stagingapi.inaturalist.org/v2\nOAUTH_API_URL=https://staging.inaturalist.org\nJWT_ANONYMOUS_API_SECRET=%s\nOAUTH_CLIENT_ID=%s\nOAUTH_CLIENT_SECRET=%s\nE2E_TEST_USERNAME=%s\nE2E_TEST_PASSWORD=%s\nGMAPS_API_KEY=%s\nANDROID_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.tflite\nANDROID_TAXONOMY_FILE_NAME=taxonomy.csv\nANDROID_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.tflite\nIOS_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.mlmodel\nIOS_TAXONOMY_FILE_NAME=taxonomy.json\nIOS_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.mlmodel\nCV_MODEL_VERSION=small_2\n' \
-        "$JWT_ANONYMOUS_API_SECRET" \
-        "$OAUTH_CLIENT_ID" \
-        "$OAUTH_CLIENT_SECRET" \
-        "$E2E_TEST_USERNAME" \
-        "$E2E_TEST_PASSWORD" \
-        "$GMAPS_API_KEY" > .env
+        mkdir -p pr-metadata
+        echo "${{ github.event.pull_request.number }}" > pr-metadata/pr_number
+        echo "${{ github.event.pull_request.head.sha || github.sha }}" > pr-metadata/head_sha
+        echo "${{ github.event.pull_request.head.repo.full_name || github.repository }}" > pr-metadata/head_repo
 
-    # Install prerequisites for detox and build app, and test
-    - name: Install macOS dependencies
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_NO_INSTALL_CLEANUP: 1
-      run: |
-        brew tap wix/brew
-        brew install applesimutils
-
-    - name: Ensure servers are running
-      id: status_check
-      run: |
-        # is rails running?
-        curl -I --fail "https://staging.inaturalist.org/ping"
-        # is node running & is ES working?
-        curl -I --fail "https://stagingapi.inaturalist.org/v2/taxa"
-
-    - name: Run e2e test
-      # don't mark job as error so that retries so that we can rely on the retry to succeed and mark job & workflow green
-      continue-on-error: true
-      id: first_test_run
-      run: |
-        npm run e2e:test:ios
-
-    - name: Run e2e test (retry, with logs)
-      # if first_test_run fails, but we `continue-on-error`, failure() is false. so we need to check it's specific _outcome_
-      if: ${{ steps.first_test_run.outcome == 'failure' }}
-      run: |
-        # provide more debugging context on retry failure
-        # we're explicitly not using `detox test --retries` because we want to run them w/ different options
-        npm run e2e:test:ios -- --take-screenshots failing --record-videos failing --record-logs all -l trace
-    
-    # The artifacts for the failing tests are available for download on github.com on the page of the individual actions run
-    - name: Store Detox artifacts on test failure
+    - name: Upload PR metadata
       uses: actions/upload-artifact@v6
-      # don't run this if it's status check that failed or if our first test run passes (no first_test_run check needed)
-      if: ${{ failure() && steps.status_check.outcome != 'failure' }}
       with:
-        name: detox-artifacts
-        path: artifacts
+        name: pr-metadata
+        path: pr-metadata/
         retention-days: 5
-
-  notify:
-    name: Notify Slack
-    needs: test
-    if: ${{ success() || failure() }}
-    runs-on: macos-15
-    steps:
-      - uses: iRoachie/slack-github-actions@v2.3.0
-        if: env.SLACK_WEBHOOK_URL != null
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILDS_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e_ios_test.yml
+++ b/.github/workflows/e2e_ios_test.yml
@@ -1,0 +1,157 @@
+##
+# Trusted half of the two-workflow e2e pattern for iOS.
+# Runs after `e2e-iOS-build` completes. Has access to repo secrets.
+# Never checks out untrusted PR code into a privileged step;
+# it only consumes the prebuilt .app artifact from the build run.
+##
+name: e2e-iOS-test
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  checks: write
+
+on:
+  workflow_run:
+    workflows: ["e2e-iOS-build"]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: macos-15
+    timeout-minutes: 120
+    # Attach required-reviewer protection to this environment in repo
+    # settings to require human approval before secrets are exposed.
+    environment: e2e
+
+    steps:
+    # Download the .app and PR metadata from the upstream (untrusted) run.
+    - name: Download iOS Detox app build
+      uses: actions/download-artifact@v7
+      with:
+        name: detox_app
+        path: ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download PR metadata artifact
+      uses: actions/download-artifact@v7
+      with:
+        name: pr-metadata
+        path: pr-metadata
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Read PR metadata
+      id: pr
+      run: |
+        echo "pr_number=$(cat pr-metadata/pr_number)" >> "$GITHUB_OUTPUT"
+        echo "head_sha=$(cat pr-metadata/head_sha)" >> "$GITHUB_OUTPUT"
+        echo "head_repo=$(cat pr-metadata/head_repo)" >> "$GITHUB_OUTPUT"
+
+    # Check out the BASE repo at the workflow_run head_sha (trusted code).
+    # We only need test-runner code (Detox config, e2e specs) from base.
+    - name: Check out base repo at run SHA
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+
+    - name: Install Node.js, NPM and Yarn
+      uses: actions/setup-node@v6
+      with:
+        node-version: 22
+
+    - name: Cache node modules
+      uses: actions/cache@v5
+      id: cache
+      with:
+        path: node_modules
+        key: node-modules-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Rebuild detox from cache
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: npx detox clean-framework-cache && npx detox build-framework-cache
+
+    - name: Rebuild native modules
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: npm rebuild
+
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: npm install
+
+    - name: Set MOCK_MODE to e2e
+      run: echo "MOCK_MODE=e2e" >> "$GITHUB_ENV"
+
+    # Real secrets only on this trusted runner. Detox tests should read
+    # creds from process.env at test time rather than depending on values
+    # baked into the prebuilt .app. Anything the app needs at *build*
+    # time (e.g. OAUTH_CLIENT_* via react-native-config) cannot be
+    # injected here; flows that depend on those values will need to be
+    # adapted to read from runtime sources (launch args, deep links,
+    # or a debug menu).
+    - name: Create .env file with secrets
+      env:
+        OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+        OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        E2E_TEST_USERNAME: ${{ secrets.E2E_TEST_USERNAME }}
+        E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+        JWT_ANONYMOUS_API_SECRET: ${{ secrets.JWT_ANONYMOUS_API_SECRET }}
+        GMAPS_API_KEY: ${{ secrets.GMAPS_API_KEY }}
+      run: |
+        printf 'API_URL=https://stagingapi.inaturalist.org/v2\nOAUTH_API_URL=https://staging.inaturalist.org\nJWT_ANONYMOUS_API_SECRET=%s\nOAUTH_CLIENT_ID=%s\nOAUTH_CLIENT_SECRET=%s\nE2E_TEST_USERNAME=%s\nE2E_TEST_PASSWORD=%s\nGMAPS_API_KEY=%s\nANDROID_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.tflite\nANDROID_TAXONOMY_FILE_NAME=taxonomy.csv\nANDROID_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.tflite\nIOS_MODEL_FILE_NAME=INatVision_Small_2_fact256_8bit.mlmodel\nIOS_TAXONOMY_FILE_NAME=taxonomy.json\nIOS_GEOMODEL_FILE_NAME=INatGeomodel_Small_2_8bit.mlmodel\nCV_MODEL_VERSION=small_2\n' \
+        "$JWT_ANONYMOUS_API_SECRET" \
+        "$OAUTH_CLIENT_ID" \
+        "$OAUTH_CLIENT_SECRET" \
+        "$E2E_TEST_USERNAME" \
+        "$E2E_TEST_PASSWORD" \
+        "$GMAPS_API_KEY" > .env
+
+    - name: Install macOS dependencies
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+      run: |
+        brew tap wix/brew
+        brew install applesimutils
+
+    - name: Ensure servers are running
+      id: status_check
+      run: |
+        curl -I --fail "https://staging.inaturalist.org/ping"
+        curl -I --fail "https://stagingapi.inaturalist.org/v2/taxa"
+
+    - name: Run e2e test
+      continue-on-error: true
+      id: first_test_run
+      run: npm run e2e:test:ios
+
+    - name: Run e2e test (retry, with logs)
+      if: ${{ steps.first_test_run.outcome == 'failure' }}
+      run: |
+        npm run e2e:test:ios -- --take-screenshots failing --record-videos failing --record-logs all -l trace
+
+    - name: Store Detox artifacts on test failure
+      uses: actions/upload-artifact@v6
+      if: ${{ failure() && steps.status_check.outcome != 'failure' }}
+      with:
+        name: detox-artifacts
+        path: artifacts
+        retention-days: 5
+
+  notify:
+    name: Notify Slack
+    needs: test
+    if: ${{ success() || failure() }}
+    runs-on: macos-15
+    steps:
+      - uses: iRoachie/slack-github-actions@v2.3.0
+        if: env.SLACK_WEBHOOK_URL != null
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILDS_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use `on: pull request` trigger to send untrusted code to run in `on: workflow_run` workflow for ios and android.