### PR TITLE
retrigger notification query on effect rather than new query

### DIFF
--- a/src/components/Notifications/NotificationsTab.tsx
+++ b/src/components/Notifications/NotificationsTab.tsx
@@ -23,9 +23,6 @@ const NotificationsTab = ( { id, text }: TabComponentProps ) => {
     [
       "NotificationsTab",
       "notificationsCount",
-      // We want to check for notifications when the user views an
-      // observation, because that might make the indicator go away
-      observationMarkedAsViewedAt,
       id,
     ],
     ( optsWithAuth: ApiOpts ) => fetchUnviewedObservationUpdatesCount(
@@ -40,6 +37,10 @@ const NotificationsTab = ( { id, text }: TabComponentProps ) => {
       enabled: !!( currentUser ),
     },
   );
+
+  useEffect( () => {
+    refetch();
+  }, [observationMarkedAsViewedAt, refetch] );
 
   useEffect( ( ) => {
     const listener = EventRegister.addEventListener(

--- a/src/navigation/BottomTabNavigator/NotificationsIconContainer.tsx
+++ b/src/navigation/BottomTabNavigator/NotificationsIconContainer.tsx
@@ -23,7 +23,7 @@ const NotificationsIconContainer = ( {
 
   // TODO: enable fields if it makes sense
   // https://linear.app/inaturalist/issue/MOB-1362/enable-fields-for-unviewed-updates-count-in-notificationsicon
-  const { data: unviewedUpdatesCount, refetch } = useAuthenticatedQuery(        
+  const { data: unviewedUpdatesCount, refetch } = useAuthenticatedQuery(
     [
       "notificationsCount",
     ],

--- a/src/navigation/BottomTabNavigator/NotificationsIconContainer.tsx
+++ b/src/navigation/BottomTabNavigator/NotificationsIconContainer.tsx
@@ -1,6 +1,6 @@
 import { fetchUnviewedObservationUpdatesCount } from "api/observations";
 import NotificationsIcon from "navigation/BottomTabNavigator/NotificationsIcon";
-import React from "react";
+import React, { useEffect } from "react";
 import {
   useAuthenticatedQuery,
   useCurrentUser,
@@ -21,12 +21,9 @@ const NotificationsIconContainer = ( {
   const currentUser = useCurrentUser( );
   const observationMarkedAsViewedAt = useStore( state => state.observationMarkedAsViewedAt );
 
-  const { data: unviewedUpdatesCount } = useAuthenticatedQuery(
+  const { data: unviewedUpdatesCount, refetch } = useAuthenticatedQuery(
     [
       "notificationsCount",
-      // We want to check for notifications when the user views an
-      // observation, because that might make the indicator go away
-      observationMarkedAsViewedAt,
     ],
     optsWithAuth => fetchUnviewedObservationUpdatesCount( {}, optsWithAuth ),
     {
@@ -36,6 +33,10 @@ const NotificationsIconContainer = ( {
       refetchInterval: 60_000,
     },
   );
+
+  useEffect( () => {
+    refetch();
+  }, [observationMarkedAsViewedAt, refetch] );
 
   const hasUnread = ( unviewedUpdatesCount ?? 0 ) > 0;
 

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -27,6 +27,7 @@ jest.mock( "sharedHooks/useAuthenticatedQuery", () => ( {
   __esModule: true,
   default: () => ( {
     data: 0,
+    refetch: () => undefined,
   } ),
 } ) );
 


### PR DESCRIPTION
closes MOB-1382

Highlighting the distinction between:
- API call
- Query: instance of a React Query returned from `useQuery`, one instance per `queryKey`. maintains its own request state and cache entry. triggering a query's queryFn usually results in an API call

before: every new "viewed at" timestamp update would trigger a new Query (and API call)
after: every new "viewed at" timestamp update will trigger the same Query's `refetch` (and API call)

here's the only place that's set w/ a `new Date()`
https://github.com/inaturalist/iNaturalistReactNative/blob/26d89434d0799afa3cb509868e31799fb9ce61e3/src/components/ObsDetailsSharedComponents/hooks/useMarkViewedMutation.js#L45-L47 