### PR TITLE
Update react hooks eslint for 19.2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,14 +113,14 @@ module.exports = {
 
     // @FLGMWT 20260427: the following were introduced with `react-hooks/recommended` and represent
     // cases that are very likely to cause bugs and _have definitely_ been the cause of a number of
-    // bugs fixed in the past few months. Ideally, we'll progressively turn these into warnings
-    // and then errors as we fix them : ) noting here in case it ever gets lost in Linear.
-    "react-hooks/static-components": 0,
-    "react-hooks/set-state-in-effect": 0,
-    "react-hooks/refs": 0,
-    "react-hooks/preserve-manual-memoization": 0,
-    "react-hooks/purity": 0,
-    "react-hooks/immutability": 0,
+    // bugs fixed in the past few months. Turning these on as warnings and we can eventually
+    // switch to errors as we fix them : ) noting here in case it ever gets lost in Linear.
+    "react-hooks/static-components": 1,
+    "react-hooks/set-state-in-effect": 1,
+    "react-hooks/refs": 1,
+    "react-hooks/preserve-manual-memoization": 1,
+    "react-hooks/purity": 1,
+    "react-hooks/immutability": 1,
 
     "react-native/no-inline-styles": "error",
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,12 +115,12 @@ module.exports = {
     // cases that are very likely to cause bugs and _have definitely_ been the cause of a number of
     // bugs fixed in the past few months. Ideally, we'll progressively turn these into warnings
     // and then errors as we fix them : ) noting here in case it ever gets lost in Linear.
-    "react-hooks/static-components": 0, // 33
-    "react-hooks/set-state-in-effect": 0, // 31
-    "react-hooks/refs": 0, // 26
-    "react-hooks/preserve-manual-memoization": 0, // 11
-    "react-hooks/purity": 0, // 3
-    "react-hooks/immutability": 0, // 3
+    "react-hooks/static-components": 0,
+    "react-hooks/set-state-in-effect": 0,
+    "react-hooks/refs": 0,
+    "react-hooks/preserve-manual-memoization": 0,
+    "react-hooks/purity": 0,
+    "react-hooks/immutability": 0,
 
     "react-native/no-inline-styles": "error",
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     "airbnb",
     "plugin:i18next/recommended",
     "plugin:@tanstack/query/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:react-native-a11y/ios",
     "plugin:@typescript-eslint/recommended",
   ],
@@ -105,9 +106,21 @@ module.exports = {
 
     // React-Hooks Plugin
     // The following rules are made available via `eslint-plugin-react-hooks`
-    "react-hooks/rules-of-hooks": 2,
     "react-hooks/exhaustive-deps": 2,
-    "react-hooks/react-compiler": "error",
+
+    // React Compiler
+    // These rules are specific to React Compiler.
+
+    // @FLGMWT 20260427: the following were introduced with `react-hooks/recommended` and represent
+    // cases that are very likely to cause bugs and _have definitely_ been the cause of a number of
+    // bugs fixed in the past few months. Ideally, we'll progressively turn these into warnings
+    // and then errors as we fix them : ) noting here in case it ever gets lost in Linear.
+    "react-hooks/static-components": 0, // 33
+    "react-hooks/set-state-in-effect": 0, // 31
+    "react-hooks/refs": 0, // 26
+    "react-hooks/preserve-manual-memoization": 0, // 11
+    "react-hooks/purity": 0, // 3
+    "react-hooks/immutability": 0, // 3
 
     "react-native/no-inline-styles": "error",
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-lodash": "^7.4.0",
         "eslint-plugin-module-resolver": "^1.5.0",
-        "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-native": "^5.0.0",
         "eslint-plugin-react-native-a11y": "^3.5.1",
         "eslint-plugin-simple-import-sort": "^12.0.0",
@@ -6226,20 +6226,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@react-native/virtualized-lists": {
-      "version": "0.72.8",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.72.8.tgz",
-      "integrity": "sha512-J3Q4Bkuo99k7mu+jPS9gSUSgq+lLRSI/+ahXNwV92XgJ/8UgOTxu2LPwhJnBk/sQKxq7E8WkZBnBiozukQMqrw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/@react-navigation/bottom-tabs": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.4.6.tgz",
@@ -7549,18 +7535,6 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
-      }
-    },
-    "node_modules/@types/react-native": {
-      "version": "0.72.8",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.8.tgz",
-      "integrity": "sha512-St6xA7+EoHN5mEYfdWnfYt0e8u6k2FR0P9s2arYgakQGFgU1f9FlPrIEcj0X24pLCF5c5i3WVuLCUdiCYHmOoA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@react-native/virtualized-lists": "^0.72.4",
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-test-renderer": {
@@ -11927,24 +11901,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "6.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-6.0.0-rc1.tgz",
-      "integrity": "sha512-I4ntWyjqgGemGtOU85FUdVo00h0i0Y5xvQ7a8EVxyzjOZsxXaxvkKBcYoXbP97QDvDjMzY/nGIvfdB/WRLTGxQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
-        "@babel/plugin-transform-private-methods": "^7.24.4",
         "hermes-parser": "^0.25.1",
-        "zod": "^3.22.4",
-        "zod-validation-error": "^3.0.3"
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -13655,13 +13628,15 @@
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
       }

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-module-resolver": "^1.5.0",
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-native": "^5.0.0",
     "eslint-plugin-react-native-a11y": "^3.5.1",
     "eslint-plugin-simple-import-sort": "^12.0.0",
@@ -225,7 +225,7 @@
     "yargs": "^17.7.2"
   },
   "overrides": {
-    "eslint-plugin-react-hooks": "^6.0.0-rc.1"
+    "eslint-plugin-react-hooks": "^7.1.1"
   },
   "engines": {
     "node": ">=20"

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -133,7 +133,6 @@ const StandardCamera = ( {
       prepareCamera();
       // TODO: I am not sure how to make the react compiler happy here, so I disabled it
       // for this hook
-      // eslint-disable-next-line react-hooks/react-compiler
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [] ),
   );

--- a/src/components/FullPageWebView/FullPageWebView.tsx
+++ b/src/components/FullPageWebView/FullPageWebView.tsx
@@ -206,7 +206,6 @@ const FullPageWebView = ( ) => {
       }
       // TODO: I am not sure how to make the react compiler happy here, so I disabled it
       // for this hook
-      // eslint-disable-next-line react-hooks/react-compiler
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [navigation, params.loggedIn, params.title] ),
   );


### PR DESCRIPTION
I was thinking that useEffectEvent _may_ be appropriate for the useQuery fixes. I wasn't planning on introducing it yet, but it uncovered that our version of react-hooks linting wasn't "effect event"-aware. Specifically, `exhaustive-deps` should _not_ fire when "effect events" are omitted from the dep array. In fact, it should _stop_ you from using one in the dep array: https://react.dev/reference/react/useEffectEvent#effect-event-in-deps.

Anyway, I'm bumping this so that we can explore that in the future.

Additionally,  new 7.x plugin is more closely aligned with React Compiler and it uncovered some _great_ spots for the stuff we were already fixing in one-offs. I added the `:recommended` and explicitly disabled those with a comment. It'd be nice to set those to warn a bit at a time to start knocking them down.

as of now, the error count is:
```
react-hooks/static-components: 33
react-hooks/set-state-in-effect: 31
react-hooks/refs: 26
react-hooks/preserve-manual-memoization: 11
react-hooks/purity: 3
react-hooks/immutability: 3
```