### PR TITLE
MOB-1329 ExploreV2 state and initial obs fetching

### DIFF
--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -14,7 +14,6 @@ const ExploreV2WithProvider = ( ) => {
   const { state, dispatch } = useExploreV2( );
   const {
     hasPermissions,
-    renderPermissionsGate,
   } = useLocationPermission( );
   const previousHasPermissions = useRef<boolean | undefined>( undefined );
 
@@ -53,10 +52,7 @@ const ExploreV2WithProvider = ( ) => {
   }, [hasPermissions] );
 
   return (
-    <>
-      <ExploreStackNavigator />
-      {renderPermissionsGate( undefined )}
-    </>
+    <ExploreStackNavigator />
   );
 };
 

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -19,11 +19,7 @@ const ExploreV2WithProvider = ( ) => {
   const previousHasPermissions = useRef<boolean | undefined>( undefined );
 
   const onPermissionsGained = useEffectEvent( async ( ) => {
-    // State not empty. Do nothing
-    if (
-      state.placeMode !== EXPLORE_V2_PLACE_MODE.NEARBY
-      || state.lat !== undefined
-    ) return;
+    if ( state.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) return;
 
     const next = await defaultExploreV2Location( );
     if ( next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY ) {
@@ -51,7 +47,7 @@ const ExploreV2WithProvider = ( ) => {
   useEffect( ( ) => {
     if (
       hasPermissions === false
-      && state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
+      && state.placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED
     ) {
       dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
     }

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -7,7 +7,7 @@ import {
   ExploreV2Provider,
   useExploreV2,
 } from "providers/ExploreV2Context";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useEffectEvent, useRef } from "react";
 import useLocationPermission from "sharedHooks/useLocationPermission";
 
 const ExploreV2WithProvider = ( ) => {
@@ -18,42 +18,33 @@ const ExploreV2WithProvider = ( ) => {
   } = useLocationPermission( );
   const previousHasPermissions = useRef<boolean | undefined>( undefined );
 
-  // Resolve initial location once we know permission state. NEARBY with no
-  // coords means we haven't fetched the user's coarse location yet.
-  useEffect( ( ) => {
-    let cancelled = false;
-    async function resolveLocation( ) {
-      if (
-        hasPermissions
-        && !previousHasPermissions.current
-        && state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
-        && state.lat === undefined
-      ) {
-        const next = await defaultExploreV2Location( );
-        if ( cancelled ) return;
-        if (
-          next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
-          && next.lat !== undefined
-          && next.lng !== undefined
-          && next.radius !== undefined
-        ) {
-          dispatch( {
-            type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
-            lat: next.lat,
-            lng: next.lng,
-            radius: next.radius,
-          } );
-        } else {
-          dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
-        }
-      }
-      previousHasPermissions.current = hasPermissions;
+  const onPermissionsGained = useEffectEvent( async ( ) => {
+    // State not empty. No op
+    if (
+      state.placeMode !== EXPLORE_V2_PLACE_MODE.NEARBY
+      || state.lat !== undefined
+    ) return;
+
+    const next = await defaultExploreV2Location( );
+    if ( next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY ) {
+      dispatch( {
+        type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
+        lat: next.lat,
+        lng: next.lng,
+        radius: next.radius,
+      } );
+    } else {
+      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
     }
-    resolveLocation( );
-    return ( ) => {
-      cancelled = true;
-    };
-  }, [hasPermissions, state.placeMode, state.lat, dispatch] );
+  } );
+
+  // handle granting location permissions on Explore
+  useEffect( ( ) => {
+    if ( hasPermissions && !previousHasPermissions.current ) {
+      onPermissionsGained( );
+    }
+    previousHasPermissions.current = hasPermissions;
+  }, [hasPermissions] );
 
   // Per the ticket: default to "Worldwide" when location is denied (or blocked).
   // Once permission state is known to be false, fall back from NEARBY.

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -1,0 +1,83 @@
+import ExploreStackNavigator
+  from "navigation/StackNavigators/ExploreStackNavigator";
+import {
+  defaultExploreV2Location,
+  EXPLORE_V2_ACTION,
+  EXPLORE_V2_PLACE_MODE,
+  ExploreV2Provider,
+  useExploreV2,
+} from "providers/ExploreV2Context";
+import React, { useEffect, useRef } from "react";
+import useLocationPermission from "sharedHooks/useLocationPermission";
+
+const ExploreV2WithProvider = ( ) => {
+  const { state, dispatch } = useExploreV2( );
+  const {
+    hasPermissions,
+    renderPermissionsGate,
+  } = useLocationPermission( );
+  const previousHasPermissions = useRef<boolean | undefined>( undefined );
+
+  // Resolve initial location once we know permission state. NEARBY with no
+  // coords means we haven't fetched the user's coarse location yet.
+  useEffect( ( ) => {
+    let cancelled = false;
+    async function resolveLocation( ) {
+      if (
+        hasPermissions
+        && !previousHasPermissions.current
+        && state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
+        && state.lat === undefined
+      ) {
+        const next = await defaultExploreV2Location( );
+        if ( cancelled ) return;
+        if (
+          next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
+          && next.lat !== undefined
+          && next.lng !== undefined
+          && next.radius !== undefined
+        ) {
+          dispatch( {
+            type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
+            lat: next.lat,
+            lng: next.lng,
+            radius: next.radius,
+          } );
+        } else {
+          dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
+        }
+      }
+      previousHasPermissions.current = hasPermissions;
+    }
+    resolveLocation( );
+    return ( ) => {
+      cancelled = true;
+    };
+  }, [hasPermissions, state.placeMode, state.lat, dispatch] );
+
+  // Per the ticket: default to "Worldwide" when location is denied (or blocked).
+  // Once permission state is known to be false, fall back from NEARBY.
+  useEffect( ( ) => {
+    if (
+      hasPermissions === false
+      && state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
+    ) {
+      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
+    }
+  }, [hasPermissions, state.placeMode, dispatch] );
+
+  return (
+    <>
+      <ExploreStackNavigator />
+      {renderPermissionsGate( undefined )}
+    </>
+  );
+};
+
+const ExploreV2Container = ( ) => (
+  <ExploreV2Provider>
+    <ExploreV2WithProvider />
+  </ExploreV2Provider>
+);
+
+export default ExploreV2Container;

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -34,24 +34,23 @@ const ExploreV2WithProvider = ( ) => {
     }
   } );
 
-  // handle granting location permissions on Explore
+  // default to "Worldwide" when location is denied
+  // hasPermissions === false always means permission has been denied or blocked
+  const onPermissionsDenied = useEffectEvent( ( ) => {
+    if ( state.placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) {
+      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
+    }
+  } );
+
+  // handle location permission changes on Explore
   useEffect( ( ) => {
-    if ( hasPermissions && !previousHasPermissions.current ) {
+    if ( hasPermissions === true && previousHasPermissions.current !== true ) {
       onPermissionsGained( );
+    } else if ( hasPermissions === false && previousHasPermissions.current !== false ) {
+      onPermissionsDenied( );
     }
     previousHasPermissions.current = hasPermissions;
   }, [hasPermissions] );
-
-  // default to "Worldwide" when location is denied
-  // hasPermissions === false always means permission has been denied or blocked
-  useEffect( ( ) => {
-    if (
-      hasPermissions === false
-      && state.placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED
-    ) {
-      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
-    }
-  }, [hasPermissions, state.placeMode, dispatch] );
 
   return (
     <>

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -19,7 +19,7 @@ const ExploreV2WithProvider = ( ) => {
   const previousHasPermissions = useRef<boolean | undefined>( undefined );
 
   const onPermissionsGained = useEffectEvent( async ( ) => {
-    // State not empty. No op
+    // State not empty. Do nothing
     if (
       state.placeMode !== EXPLORE_V2_PLACE_MODE.NEARBY
       || state.lat !== undefined
@@ -46,8 +46,8 @@ const ExploreV2WithProvider = ( ) => {
     previousHasPermissions.current = hasPermissions;
   }, [hasPermissions] );
 
-  // Per the ticket: default to "Worldwide" when location is denied (or blocked).
-  // Once permission state is known to be false, fall back from NEARBY.
+  // default to "Worldwide" when location is denied
+  // hasPermissions === false always means permission has been denied or blocked
   useEffect( ( ) => {
     if (
       hasPermissions === false

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -19,7 +19,7 @@ const ExploreV2WithProvider = ( ) => {
   const previousHasPermissions = useRef<boolean | undefined>( undefined );
 
   const onPermissionsGained = useEffectEvent( async ( ) => {
-    if ( state.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) return;
+    if ( state.location.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) return;
 
     const next = await defaultExploreV2Location( );
     if ( next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY ) {
@@ -37,7 +37,7 @@ const ExploreV2WithProvider = ( ) => {
   // default to "Worldwide" when location is denied
   // hasPermissions === false always means permission has been denied or blocked
   const onPermissionsDenied = useEffectEvent( ( ) => {
-    if ( state.placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) {
+    if ( state.location.placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) {
       dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
     }
   } );

--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -7,7 +7,7 @@ import {
   ExploreV2Provider,
   useExploreV2,
 } from "providers/ExploreV2Context";
-import React, { useEffect, useEffectEvent, useRef } from "react";
+import React, { useEffect, useEffectEvent } from "react";
 import useLocationPermission from "sharedHooks/useLocationPermission";
 
 const ExploreV2WithProvider = ( ) => {
@@ -15,8 +15,8 @@ const ExploreV2WithProvider = ( ) => {
   const {
     hasPermissions,
   } = useLocationPermission( );
-  const previousHasPermissions = useRef<boolean | undefined>( undefined );
-
+  // useEffectEvent is a new pattern for us, which we are adding only to new code for the moment
+  // https://github.com/inaturalist/iNaturalistReactNative/pull/3585#discussion_r3220223241
   const onPermissionsGained = useEffectEvent( async ( ) => {
     if ( state.location.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) return;
 
@@ -43,12 +43,11 @@ const ExploreV2WithProvider = ( ) => {
 
   // handle location permission changes on Explore
   useEffect( ( ) => {
-    if ( hasPermissions === true && previousHasPermissions.current !== true ) {
+    if ( hasPermissions === true ) {
       onPermissionsGained( );
-    } else if ( hasPermissions === false && previousHasPermissions.current !== false ) {
+    } else if ( hasPermissions === false ) {
       onPermissionsDenied( );
     }
-    previousHasPermissions.current = hasPermissions;
   }, [hasPermissions] );
 
   return (

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -40,12 +40,18 @@ const buildExploreV2QueryParams = (
     ...sortToOrder[state.sortBy],
   };
 
-  if ( state.subjectType === "taxon" && state.taxon ) {
-    params.taxon_id = state.taxon.id;
-  } else if ( state.subjectType === "user" && state.user ) {
-    params.user_id = state.user.id;
-  } else if ( state.subjectType === "project" && state.project ) {
-    params.project_id = state.project.id;
+  switch ( state.subject?.type ) {
+    case "taxon":
+      params.taxon_id = state.subject.taxon.id;
+      break;
+    case "user":
+      params.user_id = state.subject.user.id;
+      break;
+    case "project":
+      params.project_id = state.subject.project.id;
+      break;
+    default:
+      break;
   }
 
   if (

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -58,9 +58,9 @@ const buildExploreV2QueryParams = (
     params.radius = state.radius;
   } else if (
     state.placeMode === EXPLORE_V2_PLACE_MODE.PLACE
-    && state.placeId !== null
+    && state.place
   ) {
-    params.place_id = state.placeId;
+    params.place_id = state.place.id;
   }
 
   return params;

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -55,20 +55,22 @@ const buildExploreV2QueryParams = (
       break;
   }
 
-  switch ( state.placeMode ) {
+  const { location } = state;
+  switch ( location.placeMode ) {
     case EXPLORE_V2_PLACE_MODE.NEARBY:
-      params.lat = state.lat;
-      params.lng = state.lng;
-      params.radius = state.radius;
+      params.lat = location.lat;
+      params.lng = location.lng;
+      params.radius = location.radius;
       break;
     case EXPLORE_V2_PLACE_MODE.PLACE:
-      params.place_id = state.place.id;
+      params.place_id = location.place.id;
       break;
     case EXPLORE_V2_PLACE_MODE.WORLDWIDE:
     case EXPLORE_V2_PLACE_MODE.UNINITIALIZED:
       break;
     default: {
-      const _exhaustive: never = state;
+      // Exhaustiveness check: ts fails if a new placeMode is added without a case.
+      const _exhaustive: never = location;
       return _exhaustive;
     }
   }

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -55,19 +55,22 @@ const buildExploreV2QueryParams = (
       break;
   }
 
-  if (
-    state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
-    && state.lat !== undefined
-    && state.lng !== undefined
-  ) {
-    params.lat = state.lat;
-    params.lng = state.lng;
-    params.radius = state.radius;
-  } else if (
-    state.placeMode === EXPLORE_V2_PLACE_MODE.PLACE
-    && state.place
-  ) {
-    params.place_id = state.place.id;
+  switch ( state.placeMode ) {
+    case EXPLORE_V2_PLACE_MODE.NEARBY:
+      params.lat = state.lat;
+      params.lng = state.lng;
+      params.radius = state.radius;
+      break;
+    case EXPLORE_V2_PLACE_MODE.PLACE:
+      params.place_id = state.place.id;
+      break;
+    case EXPLORE_V2_PLACE_MODE.WORLDWIDE:
+    case EXPLORE_V2_PLACE_MODE.UNINITIALIZED:
+      break;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
   }
 
   return params;

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -1,0 +1,69 @@
+import type { ExploreV2State } from "providers/ExploreV2Context";
+import {
+  EXPLORE_V2_PLACE_MODE,
+  EXPLORE_V2_SORT,
+} from "providers/ExploreV2Context";
+
+const PER_PAGE = 20;
+
+export interface ExploreV2QueryParams {
+  per_page: number;
+  order_by: "created_at" | "observed_on" | "votes";
+  order: "asc" | "desc";
+  taxon_id?: number;
+  user_id?: number;
+  project_id?: number;
+  lat?: number;
+  lng?: number;
+  radius?: number;
+  place_id?: number;
+  verifiable?: boolean;
+}
+
+const sortToOrder: Record<
+  EXPLORE_V2_SORT,
+  { order_by: "created_at" | "observed_on" | "votes"; order: "asc" | "desc" }
+> = {
+  [EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST]: { order_by: "created_at", order: "desc" },
+  [EXPLORE_V2_SORT.DATE_UPLOADED_OLDEST]: { order_by: "created_at", order: "asc" },
+  [EXPLORE_V2_SORT.DATE_OBSERVED_NEWEST]: { order_by: "observed_on", order: "desc" },
+  [EXPLORE_V2_SORT.DATE_OBSERVED_OLDEST]: { order_by: "observed_on", order: "asc" },
+  [EXPLORE_V2_SORT.MOST_FAVED]: { order_by: "votes", order: "desc" },
+};
+
+const buildExploreV2QueryParams = (
+  state: ExploreV2State,
+): ExploreV2QueryParams => {
+  const params: ExploreV2QueryParams = {
+    per_page: PER_PAGE,
+    verifiable: true,
+    ...sortToOrder[state.sortBy],
+  };
+
+  if ( state.entityType === "taxon" && state.taxon ) {
+    params.taxon_id = state.taxon.id;
+  } else if ( state.entityType === "user" && state.user ) {
+    params.user_id = state.user.id;
+  } else if ( state.entityType === "project" && state.project ) {
+    params.project_id = state.project.id;
+  }
+
+  if (
+    state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
+    && state.lat !== undefined
+    && state.lng !== undefined
+  ) {
+    params.lat = state.lat;
+    params.lng = state.lng;
+    params.radius = state.radius;
+  } else if (
+    state.placeMode === EXPLORE_V2_PLACE_MODE.PLACE
+    && state.placeId !== null
+  ) {
+    params.place_id = state.placeId;
+  }
+
+  return params;
+};
+
+export default buildExploreV2QueryParams;

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -40,11 +40,11 @@ const buildExploreV2QueryParams = (
     ...sortToOrder[state.sortBy],
   };
 
-  if ( state.entityType === "taxon" && state.taxon ) {
+  if ( state.subjectType === "taxon" && state.taxon ) {
     params.taxon_id = state.taxon.id;
-  } else if ( state.entityType === "user" && state.user ) {
+  } else if ( state.subjectType === "user" && state.user ) {
     params.user_id = state.user.id;
-  } else if ( state.entityType === "project" && state.project ) {
+  } else if ( state.subjectType === "project" && state.project ) {
     params.project_id = state.project.id;
   }
 

--- a/src/components/Explore/ExploreV2/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/buildQueryParams.ts
@@ -40,6 +40,7 @@ const buildExploreV2QueryParams = (
     ...sortToOrder[state.sortBy],
   };
 
+  // this might warrant moving into a selector function at some point
   switch ( state.subject?.type ) {
     case "taxon":
       params.taxon_id = state.subject.taxon.id;

--- a/src/components/Explore/ExploreV2/screens/AdvancedSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/AdvancedSearch.tsx
@@ -1,0 +1,18 @@
+import { Body2, ViewWrapper } from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import { useExploreV2 } from "providers/ExploreV2Context";
+import React from "react";
+
+const AdvancedSearch = ( ) => {
+  useExploreV2( );
+  return (
+    <ViewWrapper testID="AdvancedSearch">
+      <View className="flex-1 items-center justify-center p-4">
+        {/* eslint-disable-next-line i18next/no-literal-string */}
+        <Body2>TODO: Advanced Search — MOB-1346</Body2>
+      </View>
+    </ViewWrapper>
+  );
+};
+
+export default AdvancedSearch;

--- a/src/components/Explore/ExploreV2/screens/AdvancedSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/AdvancedSearch.tsx
@@ -1,18 +1,14 @@
 import { Body2, ViewWrapper } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { useExploreV2 } from "providers/ExploreV2Context";
 import React from "react";
 
-const AdvancedSearch = ( ) => {
-  useExploreV2( );
-  return (
-    <ViewWrapper testID="AdvancedSearch">
-      <View className="flex-1 items-center justify-center p-4">
-        {/* eslint-disable-next-line i18next/no-literal-string */}
-        <Body2>TODO: Advanced Search — MOB-1346</Body2>
-      </View>
-    </ViewWrapper>
-  );
-};
+const AdvancedSearch = ( ) => (
+  <ViewWrapper testID="AdvancedSearch">
+    <View className="flex-1 items-center justify-center p-4">
+      {/* eslint-disable-next-line i18next/no-literal-string */}
+      <Body2>TODO: Advanced Search — MOB-1346</Body2>
+    </View>
+  </ViewWrapper>
+);
 
 export default AdvancedSearch;

--- a/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
@@ -1,6 +1,4 @@
 import { useNetInfo } from "@react-native-community/netinfo";
-import { useNavigation } from "@react-navigation/native";
-import classnames from "classnames";
 import buildExploreV2QueryParams
   from "components/Explore/ExploreV2/buildQueryParams";
 import useInfiniteExploreScroll
@@ -8,18 +6,15 @@ import useInfiniteExploreScroll
 import ObservationsFlashList from "components/ObservationsFlashList/ObservationsFlashList";
 import {
   Body2,
-  INatIconButton,
   ViewWrapper,
 } from "components/SharedComponents";
-import { Pressable, View } from "components/styledComponents";
+import { View } from "components/styledComponents";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React, { useMemo } from "react";
-import { Alert } from "react-native";
 
 const OBS_LIST_CONTAINER_STYLE = { paddingTop: 50 };
 
 const ExploreObservations = ( ) => {
-  const navigation = useNavigation( );
   const { state } = useExploreV2( );
   const { isConnected } = useNetInfo( );
 
@@ -38,13 +33,8 @@ const ExploreObservations = ( ) => {
   return (
     <ViewWrapper testID="ExploreObservations" wrapperClassName="overflow-hidden">
       <View className="flex-1 overflow-hidden">
-        <Pressable
-          accessibilityRole="button"
-          onPress={() => navigation.navigate( "UniversalSearch" )}
-        >
-          {/* eslint-disable-next-line i18next/no-literal-string */}
-          <Body2>TODO: Header — MOB-1327 (tap to open Universal Search)</Body2>
-        </Pressable>
+        {/* eslint-disable-next-line i18next/no-literal-string */}
+        <Body2>TODO: Header — MOB-1327 (tap to open Universal Search)</Body2>
         <ObservationsFlashList
           contentContainerStyle={OBS_LIST_CONTAINER_STYLE}
           data={observations}
@@ -60,31 +50,6 @@ const ExploreObservations = ( ) => {
           showNoResults={!canFetch || totalResults === 0}
           testID="ExploreV2ObservationsList"
         />
-        <INatIconButton
-          icon="triangle-exclamation"
-          className={classnames(
-            "absolute",
-            "bg-white",
-            "bottom-[100px]",
-            "h-[55px]",
-            "right-5",
-            "rounded-full",
-            "w-[55px]",
-            "z-10",
-          )}
-          color="white"
-          size={27}
-          accessibilityLabel="Diagnostics"
-          onPress={() => {
-            Alert.alert(
-              "ExploreV2 Info",
-              `state: ${JSON.stringify( state, null, 2 )}\n\nqueryParams: ${
-                JSON.stringify( queryParams, null, 2 )
-              }`,
-            );
-          }}
-        />
-
       </View>
     </ViewWrapper>
   );

--- a/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
@@ -15,13 +15,6 @@ import { Pressable, View } from "components/styledComponents";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React, { useMemo } from "react";
 import { Alert } from "react-native";
-import useDebugMode from "sharedHooks/useDebugMode";
-import { getShadow } from "styles/global";
-
-const DROP_SHADOW = getShadow( {
-  offsetHeight: 4,
-  elevation: 6,
-} );
 
 const OBS_LIST_CONTAINER_STYLE = { paddingTop: 50 };
 
@@ -29,21 +22,10 @@ const ExploreObservations = ( ) => {
   const navigation = useNavigation( );
   const { state } = useExploreV2( );
   const { isConnected } = useNetInfo( );
-  const { isDebug } = useDebugMode( );
 
   const queryParams = useMemo( () => buildExploreV2QueryParams( state ), [state] );
 
-  // Don't fetch until placeMode has resolved to something usable: worldwide
-  // (no coords needed), nearby with coords, or a specific place.
-  const canFetch = state.placeMode === EXPLORE_V2_PLACE_MODE.WORLDWIDE
-    || (
-      state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
-      && queryParams.lat !== undefined
-    )
-    || (
-      state.placeMode === EXPLORE_V2_PLACE_MODE.PLACE
-      && queryParams.place_id !== undefined
-    );
+  const canFetch = state.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED;
 
   const {
     fetchNextPage,
@@ -78,37 +60,31 @@ const ExploreObservations = ( ) => {
           showNoResults={!canFetch || totalResults === 0}
           testID="ExploreV2ObservationsList"
         />
-        {isDebug && (
-          <INatIconButton
-            icon="triangle-exclamation"
-            className={classnames(
-              "absolute",
-              "bg-white",
-              "bottom-[100px]",
-              "h-[55px]",
-              "right-5",
-              "rounded-full",
-              "w-[55px]",
-              "z-10",
-            )}
-            color="white"
-            size={27}
-            style={[
-              DROP_SHADOW,
-              // eslint-disable-next-line react-native/no-inline-styles
-              { backgroundColor: "deeppink" },
-            ]}
-            accessibilityLabel="Diagnostics"
-            onPress={() => {
-              Alert.alert(
-                "ExploreV2 Info",
-                `state: ${JSON.stringify( state, null, 2 )}\n\nqueryParams: ${
-                  JSON.stringify( queryParams, null, 2 )
-                }`,
-              );
-            }}
-          />
-        )}
+        <INatIconButton
+          icon="triangle-exclamation"
+          className={classnames(
+            "absolute",
+            "bg-white",
+            "bottom-[100px]",
+            "h-[55px]",
+            "right-5",
+            "rounded-full",
+            "w-[55px]",
+            "z-10",
+          )}
+          color="white"
+          size={27}
+          accessibilityLabel="Diagnostics"
+          onPress={() => {
+            Alert.alert(
+              "ExploreV2 Info",
+              `state: ${JSON.stringify( state, null, 2 )}\n\nqueryParams: ${
+                JSON.stringify( queryParams, null, 2 )
+              }`,
+            );
+          }}
+        />
+
       </View>
     </ViewWrapper>
   );

--- a/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
@@ -1,0 +1,117 @@
+import { useNetInfo } from "@react-native-community/netinfo";
+import { useNavigation } from "@react-navigation/native";
+import classnames from "classnames";
+import buildExploreV2QueryParams
+  from "components/Explore/ExploreV2/buildQueryParams";
+import useInfiniteExploreScroll
+  from "components/Explore/hooks/useInfiniteExploreScroll";
+import ObservationsFlashList from "components/ObservationsFlashList/ObservationsFlashList";
+import {
+  Body2,
+  INatIconButton,
+  ViewWrapper,
+} from "components/SharedComponents";
+import { Pressable, View } from "components/styledComponents";
+import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
+import React, { useMemo } from "react";
+import { Alert } from "react-native";
+import useDebugMode from "sharedHooks/useDebugMode";
+import { getShadow } from "styles/global";
+
+const DROP_SHADOW = getShadow( {
+  offsetHeight: 4,
+  elevation: 6,
+} );
+
+const OBS_LIST_CONTAINER_STYLE = { paddingTop: 50 };
+
+const ExploreObservations = ( ) => {
+  const navigation = useNavigation( );
+  const { state } = useExploreV2( );
+  const { isConnected } = useNetInfo( );
+  const { isDebug } = useDebugMode( );
+
+  const queryParams = useMemo( () => buildExploreV2QueryParams( state ), [state] );
+
+  // Don't fetch until placeMode has resolved to something usable: worldwide
+  // (no coords needed), nearby with coords, or a specific place.
+  const canFetch = state.placeMode === EXPLORE_V2_PLACE_MODE.WORLDWIDE
+    || (
+      state.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY
+      && queryParams.lat !== undefined
+    )
+    || (
+      state.placeMode === EXPLORE_V2_PLACE_MODE.PLACE
+      && queryParams.place_id !== undefined
+    );
+
+  const {
+    fetchNextPage,
+    isFetchingNextPage,
+    handlePullToRefresh,
+    observations,
+    totalResults,
+  } = useInfiniteExploreScroll( { params: queryParams, enabled: canFetch } );
+
+  return (
+    <ViewWrapper testID="ExploreObservations" wrapperClassName="overflow-hidden">
+      <View className="flex-1 overflow-hidden">
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => navigation.navigate( "UniversalSearch" )}
+        >
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          <Body2>TODO: Header — MOB-1327 (tap to open Universal Search)</Body2>
+        </Pressable>
+        <ObservationsFlashList
+          contentContainerStyle={OBS_LIST_CONTAINER_STYLE}
+          data={observations}
+          dataCanBeFetched={canFetch}
+          explore
+          handlePullToRefresh={handlePullToRefresh}
+          hideLoadingWheel={!isFetchingNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          isConnected={isConnected}
+          layout="list"
+          obsListKey="ExploreV2Observations"
+          onEndReached={fetchNextPage}
+          showNoResults={!canFetch || totalResults === 0}
+          testID="ExploreV2ObservationsList"
+        />
+        {isDebug && (
+          <INatIconButton
+            icon="triangle-exclamation"
+            className={classnames(
+              "absolute",
+              "bg-white",
+              "bottom-[100px]",
+              "h-[55px]",
+              "right-5",
+              "rounded-full",
+              "w-[55px]",
+              "z-10",
+            )}
+            color="white"
+            size={27}
+            style={[
+              DROP_SHADOW,
+              // eslint-disable-next-line react-native/no-inline-styles
+              { backgroundColor: "deeppink" },
+            ]}
+            accessibilityLabel="Diagnostics"
+            onPress={() => {
+              Alert.alert(
+                "ExploreV2 Info",
+                `state: ${JSON.stringify( state, null, 2 )}\n\nqueryParams: ${
+                  JSON.stringify( queryParams, null, 2 )
+                }`,
+              );
+            }}
+          />
+        )}
+      </View>
+    </ViewWrapper>
+  );
+};
+
+export default ExploreObservations;

--- a/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
@@ -25,7 +25,7 @@ const ExploreObservations = ( ) => {
 
   const queryParams = useMemo( () => buildExploreV2QueryParams( state ), [state] );
 
-  const canFetch = state.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED;
+  const canFetch = state.location.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED;
 
   const {
     fetchNextPage,

--- a/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreObservations.tsx
@@ -12,8 +12,6 @@ import { View } from "components/styledComponents";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React, { useMemo } from "react";
 
-const OBS_LIST_CONTAINER_STYLE = { paddingTop: 50 };
-
 const ExploreObservations = ( ) => {
   const { state } = useExploreV2( );
   const { isConnected } = useNetInfo( );
@@ -34,9 +32,8 @@ const ExploreObservations = ( ) => {
     <ViewWrapper testID="ExploreObservations" wrapperClassName="overflow-hidden">
       <View className="flex-1 overflow-hidden">
         {/* eslint-disable-next-line i18next/no-literal-string */}
-        <Body2>TODO: Header — MOB-1327 (tap to open Universal Search)</Body2>
+        <Body2>TODO: Header — MOB-1327</Body2>
         <ObservationsFlashList
-          contentContainerStyle={OBS_LIST_CONTAINER_STYLE}
           data={observations}
           dataCanBeFetched={canFetch}
           explore

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -12,7 +12,7 @@ import { View } from "components/styledComponents";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React, { useMemo } from "react";
 
-const ExploreObservations = ( ) => {
+const ExploreResults = ( ) => {
   const { state } = useExploreV2( );
   const { isConnected } = useNetInfo( );
 
@@ -29,7 +29,7 @@ const ExploreObservations = ( ) => {
   } = useInfiniteExploreScroll( { params: queryParams, enabled: canFetch } );
 
   return (
-    <ViewWrapper testID="ExploreObservations" wrapperClassName="overflow-hidden">
+    <ViewWrapper testID="ExploreResults" wrapperClassName="overflow-hidden">
       <View className="flex-1 overflow-hidden">
         {/* eslint-disable-next-line i18next/no-literal-string */}
         <Body2>TODO: Header — MOB-1327</Body2>
@@ -52,4 +52,4 @@ const ExploreObservations = ( ) => {
   );
 };
 
-export default ExploreObservations;
+export default ExploreResults;

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -10,13 +10,13 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
-import React, { useMemo } from "react";
+import React from "react";
 
 const ExploreResults = ( ) => {
   const { state } = useExploreV2( );
   const { isConnected } = useNetInfo( );
 
-  const queryParams = useMemo( () => buildExploreV2QueryParams( state ), [state] );
+  const queryParams = buildExploreV2QueryParams( state );
 
   const canFetch = state.location.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED;
 

--- a/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
@@ -1,0 +1,18 @@
+import { Body2, ViewWrapper } from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import { useExploreV2 } from "providers/ExploreV2Context";
+import React from "react";
+
+const UniversalSearch = ( ) => {
+  useExploreV2( );
+  return (
+    <ViewWrapper testID="UniversalSearch">
+      <View className="flex-1 items-center justify-center p-4">
+        {/* eslint-disable-next-line i18next/no-literal-string */}
+        <Body2>TODO: Universal Search — MOB-1338</Body2>
+      </View>
+    </ViewWrapper>
+  );
+};
+
+export default UniversalSearch;

--- a/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
@@ -1,18 +1,14 @@
 import { Body2, ViewWrapper } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import { useExploreV2 } from "providers/ExploreV2Context";
 import React from "react";
 
-const UniversalSearch = ( ) => {
-  useExploreV2( );
-  return (
-    <ViewWrapper testID="UniversalSearch">
-      <View className="flex-1 items-center justify-center p-4">
-        {/* eslint-disable-next-line i18next/no-literal-string */}
-        <Body2>TODO: Universal Search — MOB-1338</Body2>
-      </View>
-    </ViewWrapper>
-  );
-};
+const UniversalSearch = ( ) => (
+  <ViewWrapper testID="UniversalSearch">
+    <View className="flex-1 items-center justify-center p-4">
+      {/* eslint-disable-next-line i18next/no-literal-string */}
+      <Body2>TODO: Universal Search — MOB-1338</Body2>
+    </View>
+  </ViewWrapper>
+);
 
 export default UniversalSearch;

--- a/src/navigation/StackNavigators/ExploreStackNavigator.tsx
+++ b/src/navigation/StackNavigators/ExploreStackNavigator.tsx
@@ -8,34 +8,28 @@ import UniversalSearch
 import { hideHeader } from "navigation/navigationOptions";
 import type { ExploreStackParamList } from "navigation/types";
 import React from "react";
-import colors from "styles/tailwindColors";
 
-const BASE_SCREEN_OPTIONS = {
-  headerBackButtonDisplayMode: "minimal",
-  headerTintColor: colors.darkGray,
-} as const;
-
+// When navigating out of this stack, useNavigation should be typed like:
+// useNavigation<ExploreStackScreenProps<"ExploreObservations">["navigation"]>( );
 const Stack = createNativeStackNavigator<ExploreStackParamList>( );
 
 const ExploreStackNavigator = ( ) => (
-  <Stack.Navigator
-    initialRouteName="ExploreObservations"
-    screenOptions={BASE_SCREEN_OPTIONS}
-  >
-    <Stack.Group screenOptions={hideHeader}>
-      <Stack.Screen
-        name="ExploreObservations"
-        component={ExploreObservations}
-      />
-      <Stack.Screen
-        name="UniversalSearch"
-        component={UniversalSearch}
-      />
-      <Stack.Screen
-        name="AdvancedSearch"
-        component={AdvancedSearch}
-      />
-    </Stack.Group>
+  <Stack.Navigator initialRouteName="ExploreObservations">
+    <Stack.Screen
+      name="ExploreObservations"
+      component={ExploreObservations}
+      options={hideHeader}
+    />
+    <Stack.Screen
+      name="UniversalSearch"
+      component={UniversalSearch}
+      options={hideHeader}
+    />
+    <Stack.Screen
+      name="AdvancedSearch"
+      component={AdvancedSearch}
+      options={hideHeader}
+    />
   </Stack.Navigator>
 );
 

--- a/src/navigation/StackNavigators/ExploreStackNavigator.tsx
+++ b/src/navigation/StackNavigators/ExploreStackNavigator.tsx
@@ -1,0 +1,42 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import AdvancedSearch
+  from "components/Explore/ExploreV2/screens/AdvancedSearch";
+import ExploreObservations
+  from "components/Explore/ExploreV2/screens/ExploreObservations";
+import UniversalSearch
+  from "components/Explore/ExploreV2/screens/UniversalSearch";
+import { hideHeader } from "navigation/navigationOptions";
+import type { ExploreStackParamList } from "navigation/types";
+import React from "react";
+import colors from "styles/tailwindColors";
+
+const BASE_SCREEN_OPTIONS = {
+  headerBackButtonDisplayMode: "minimal",
+  headerTintColor: colors.darkGray,
+} as const;
+
+const Stack = createNativeStackNavigator<ExploreStackParamList>( );
+
+const ExploreStackNavigator = ( ) => (
+  <Stack.Navigator
+    initialRouteName="ExploreObservations"
+    screenOptions={BASE_SCREEN_OPTIONS}
+  >
+    <Stack.Group screenOptions={hideHeader}>
+      <Stack.Screen
+        name="ExploreObservations"
+        component={ExploreObservations}
+      />
+      <Stack.Screen
+        name="UniversalSearch"
+        component={UniversalSearch}
+      />
+      <Stack.Screen
+        name="AdvancedSearch"
+        component={AdvancedSearch}
+      />
+    </Stack.Group>
+  </Stack.Navigator>
+);
+
+export default ExploreStackNavigator;

--- a/src/navigation/StackNavigators/ExploreStackNavigator.tsx
+++ b/src/navigation/StackNavigators/ExploreStackNavigator.tsx
@@ -1,8 +1,8 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import AdvancedSearch
   from "components/Explore/ExploreV2/screens/AdvancedSearch";
-import ExploreObservations
-  from "components/Explore/ExploreV2/screens/ExploreObservations";
+import ExploreResults
+  from "components/Explore/ExploreV2/screens/ExploreResults";
 import UniversalSearch
   from "components/Explore/ExploreV2/screens/UniversalSearch";
 import { hideHeader } from "navigation/navigationOptions";
@@ -10,14 +10,14 @@ import type { ExploreStackParamList } from "navigation/types";
 import React from "react";
 
 // When navigating out of this stack, useNavigation should be typed like:
-// useNavigation<ExploreStackScreenProps<"ExploreObservations">["navigation"]>( );
+// useNavigation<ExploreStackScreenProps<"ExploreResults">["navigation"]>( );
 const Stack = createNativeStackNavigator<ExploreStackParamList>( );
 
 const ExploreStackNavigator = ( ) => (
-  <Stack.Navigator initialRouteName="ExploreObservations">
+  <Stack.Navigator initialRouteName="ExploreResults">
     <Stack.Screen
-      name="ExploreObservations"
-      component={ExploreObservations}
+      name="ExploreResults"
+      component={ExploreResults}
       options={hideHeader}
     />
     <Stack.Screen

--- a/src/navigation/StackNavigators/TabStackNavigator.tsx
+++ b/src/navigation/StackNavigators/TabStackNavigator.tsx
@@ -9,6 +9,7 @@ import Donate from "components/Donate/Donate";
 import ExploreContainer from "components/Explore/ExploreContainer";
 import ExploreFiltersContainer from "components/Explore/ExploreFiltersContainer";
 import ExploreSearchContainer from "components/Explore/ExploreSearchContainer";
+import ExploreV2Container from "components/Explore/ExploreV2/ExploreV2Container";
 import RootExploreContainer from "components/Explore/RootExploreContainer";
 import Help from "components/Help/Help";
 import Menu from "components/Menu/Menu";
@@ -45,6 +46,8 @@ import React from "react";
 import {
   useLayoutPrefs,
 } from "sharedHooks";
+import useFeatureFlag from "sharedHooks/useFeatureFlag";
+import { FeatureFlag } from "stores/createFeatureFlagSlice";
 import colors from "styles/tailwindColors";
 
 import SharedStackScreens from "./SharedStackScreens";
@@ -172,6 +175,7 @@ const TabStackNavigator = ( { route }: BottomTabProps ) => {
   const {
     isDefaultMode,
   } = useLayoutPrefs( );
+  const exploreV2Enabled = useFeatureFlag( FeatureFlag.ExploreV2Enabled );
   return (
     <Stack.Navigator
       initialRouteName={initialRouteName}
@@ -199,7 +203,9 @@ const TabStackNavigator = ( { route }: BottomTabProps ) => {
         />
         <Stack.Screen
           name={SCREEN_NAME_ROOT_EXPLORE}
-          component={RootExploreContainer}
+          component={exploreV2Enabled
+            ? ExploreV2Container
+            : RootExploreContainer}
           options={{
             ...preventSwipeToGoBack,
             animation: "none",

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -186,6 +186,15 @@ export type OnboardingStackParamList = {
   Onboarding: undefined;
 };
 
+// Screens hosted by ExploreStackNavigator (ExploreV2)
+// The type containing the mapping must be a type alias. It cannot be an interface.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ExploreStackParamList = {
+  ExploreObservations: undefined;
+  UniversalSearch: undefined;
+  AdvancedSearch: undefined;
+};
+
 // Tab-only routes (not from SharedStackScreens). Intersected with SharedStackParamList
 // so TabStackParamList matches TabStackNavigator + SharedStackScreens.
 // Note from the documentation:

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -391,6 +391,14 @@ export type TabStackScreenProps<T extends keyof TabStackParamList> =
     BottomTabProps
   >;
 
+// ExploreStackNavigator is nested inside RootExplore. This composite type
+// acknowledges ExploreV2 screens access to outer-stack routes
+export type ExploreStackScreenProps<T extends keyof ExploreStackParamList> =
+  CompositeScreenProps<
+    NativeStackScreenProps<ExploreStackParamList, T>,
+    TabStackScreenProps<"RootExplore">
+  >;
+
 export type NoBottomTabStackScreenProps<T extends keyof NoBottomTabStackParamList> =
   CompositeScreenProps<
     NativeStackScreenProps<NoBottomTabStackParamList, T>,

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -190,7 +190,7 @@ export type OnboardingStackParamList = {
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ExploreStackParamList = {
-  ExploreObservations: undefined;
+  ExploreResults: undefined;
   UniversalSearch: undefined;
   AdvancedSearch: undefined;
 };

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+// Please don't change this to an aliased path or the e2e mock will not get
+// used in our e2e tests on Github Actions
 import fetchCoarseUserLocation from "../sharedHelpers/fetchCoarseUserLocation";
 
 export enum EXPLORE_V2_ACTION {

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -3,8 +3,8 @@ import * as React from "react";
 import fetchCoarseUserLocation from "../sharedHelpers/fetchCoarseUserLocation";
 
 export enum EXPLORE_V2_ACTION {
-  SET_ENTITY = "SET_ENTITY",
-  CLEAR_ENTITY = "CLEAR_ENTITY",
+  SET_SUBJECT = "SET_SUBJECT",
+  CLEAR_SUBJECT = "CLEAR_SUBJECT",
   SET_LOCATION_NEARBY = "SET_LOCATION_NEARBY",
   SET_LOCATION_WORLDWIDE = "SET_LOCATION_WORLDWIDE",
   SET_LOCATION_PLACE = "SET_LOCATION_PLACE",
@@ -30,7 +30,7 @@ export enum EXPLORE_V2_SORT {
   MOST_FAVED = "MOST_FAVED"
 }
 
-export type ExploreV2EntityType = "taxon" | "user" | "project";
+export type ExploreV2SubjectType = "taxon" | "user" | "project";
 
 interface Place {
   id: number;
@@ -59,7 +59,7 @@ export interface ExploreV2Filters {
 }
 
 export interface ExploreV2State {
-  entityType: ExploreV2EntityType | null;
+  subjectType: ExploreV2SubjectType | null;
   taxon: Taxon | null;
   user: User | null;
   project: Project | null;
@@ -76,21 +76,21 @@ export interface ExploreV2State {
 
 export type ExploreV2Action =
   | {
-    type: EXPLORE_V2_ACTION.SET_ENTITY;
-    entityType: "taxon";
+    type: EXPLORE_V2_ACTION.SET_SUBJECT;
+    subjectType: "taxon";
     taxon: Taxon;
   }
   | {
-    type: EXPLORE_V2_ACTION.SET_ENTITY;
-    entityType: "user";
+    type: EXPLORE_V2_ACTION.SET_SUBJECT;
+    subjectType: "user";
     user: User;
   }
   | {
-    type: EXPLORE_V2_ACTION.SET_ENTITY;
-    entityType: "project";
+    type: EXPLORE_V2_ACTION.SET_SUBJECT;
+    subjectType: "project";
     project: Project;
   }
-  | { type: EXPLORE_V2_ACTION.CLEAR_ENTITY }
+  | { type: EXPLORE_V2_ACTION.CLEAR_SUBJECT }
   | {
     type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY;
     lat: number;
@@ -110,7 +110,7 @@ export type ExploreV2Action =
 type Dispatch = ( action: ExploreV2Action ) => void;
 
 export const initialExploreV2State: ExploreV2State = {
-  entityType: null,
+  subjectType: null,
   taxon: null,
   user: null,
   project: null,
@@ -132,27 +132,27 @@ export function exploreV2Reducer(
   action: ExploreV2Action,
 ): ExploreV2State {
   switch ( action.type ) {
-    case EXPLORE_V2_ACTION.SET_ENTITY: {
-      // Universal search: only one entity type is active at a time.
+    case EXPLORE_V2_ACTION.SET_SUBJECT: {
+      // Universal search: only one subject type is active at a time.
       const cleared = {
         ...state,
-        entityType: action.entityType,
+        subjectType: action.subjectType,
         taxon: null,
         user: null,
         project: null,
       };
-      if ( action.entityType === "taxon" ) {
+      if ( action.subjectType === "taxon" ) {
         return { ...cleared, taxon: action.taxon };
       }
-      if ( action.entityType === "user" ) {
+      if ( action.subjectType === "user" ) {
         return { ...cleared, user: action.user };
       }
       return { ...cleared, project: action.project };
     }
-    case EXPLORE_V2_ACTION.CLEAR_ENTITY:
+    case EXPLORE_V2_ACTION.CLEAR_SUBJECT:
       return {
         ...state,
-        entityType: null,
+        subjectType: null,
         taxon: null,
         user: null,
         project: null,

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -59,12 +59,6 @@ export interface ExploreV2Filters {
   [key: string]: unknown;
 }
 
-interface ExploreV2BaseState {
-  subject: ExploreV2Subject | null;
-  sortBy: EXPLORE_V2_SORT;
-  filters: ExploreV2Filters;
-}
-
 export type ExploreV2LocationState =
   | { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED }
   | { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE }
@@ -76,7 +70,12 @@ export type ExploreV2LocationState =
   }
   | { placeMode: EXPLORE_V2_PLACE_MODE.PLACE; place: Place };
 
-export type ExploreV2State = ExploreV2BaseState & ExploreV2LocationState;
+export interface ExploreV2State {
+  subject: ExploreV2Subject | null;
+  location: ExploreV2LocationState;
+  sortBy: EXPLORE_V2_SORT;
+  filters: ExploreV2Filters;
+}
 
 export type ExploreV2Action =
   | { type: EXPLORE_V2_ACTION.SET_SUBJECT; subject: ExploreV2Subject }
@@ -98,18 +97,10 @@ export type ExploreV2Action =
 
 export const initialExploreV2State: ExploreV2State = {
   subject: null,
-  placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED,
+  location: { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED },
   sortBy: EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST,
   filters: {},
 };
-
-function baseFields( state: ExploreV2State ): ExploreV2BaseState {
-  return {
-    subject: state.subject,
-    sortBy: state.sortBy,
-    filters: state.filters,
-  };
-}
 
 export function exploreV2Reducer(
   state: ExploreV2State,
@@ -122,22 +113,26 @@ export function exploreV2Reducer(
       return { ...state, subject: null };
     case EXPLORE_V2_ACTION.SET_LOCATION_NEARBY:
       return {
-        ...baseFields( state ),
-        placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-        lat: action.lat,
-        lng: action.lng,
-        radius: action.radius,
+        ...state,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+          lat: action.lat,
+          lng: action.lng,
+          radius: action.radius,
+        },
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE:
       return {
-        ...baseFields( state ),
-        placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE,
+        ...state,
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE },
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_PLACE:
       return {
-        ...baseFields( state ),
-        placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
-        place: action.place,
+        ...state,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
+          place: action.place,
+        },
       };
     case EXPLORE_V2_ACTION.SET_SORT:
       return { ...state, sortBy: action.sortBy };

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -28,8 +28,6 @@ export enum EXPLORE_V2_SORT {
   MOST_FAVED = "MOST_FAVED"
 }
 
-export type ExploreV2SubjectType = "taxon" | "user" | "project";
-
 interface Place {
   id: number;
   display_name?: string;
@@ -50,18 +48,18 @@ interface Project {
   title: string;
 }
 
+export type ExploreV2Subject =
+  | { type: "taxon"; taxon: Taxon }
+  | { type: "user"; user: User }
+  | { type: "project"; project: Project };
+
 // To be added to in MOB-1346
 export interface ExploreV2Filters {
   [key: string]: unknown;
 }
 
 export interface ExploreV2State {
-  subjectType: ExploreV2SubjectType | null;
-  // In theory I prefer separate properties for taxon, user, project so it's very clear
-  // which we're dealing with in later logic but I think this could change to a single property
-  taxon: Taxon | null;
-  user: User | null;
-  project: Project | null;
+  subject: ExploreV2Subject | null;
   placeMode: EXPLORE_V2_PLACE_MODE;
   lat?: number;
   lng?: number;
@@ -72,21 +70,7 @@ export interface ExploreV2State {
 }
 
 export type ExploreV2Action =
-  | {
-    type: EXPLORE_V2_ACTION.SET_SUBJECT;
-    subjectType: "taxon";
-    taxon: Taxon;
-  }
-  | {
-    type: EXPLORE_V2_ACTION.SET_SUBJECT;
-    subjectType: "user";
-    user: User;
-  }
-  | {
-    type: EXPLORE_V2_ACTION.SET_SUBJECT;
-    subjectType: "project";
-    project: Project;
-  }
+  | { type: EXPLORE_V2_ACTION.SET_SUBJECT; subject: ExploreV2Subject }
   | { type: EXPLORE_V2_ACTION.CLEAR_SUBJECT }
   | {
     type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY;
@@ -104,10 +88,7 @@ export type ExploreV2Action =
   | { type: EXPLORE_V2_ACTION.RESET };
 
 export const initialExploreV2State: ExploreV2State = {
-  subjectType: null,
-  taxon: null,
-  user: null,
-  project: null,
+  subject: null,
   placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
   lat: undefined,
   lng: undefined,
@@ -122,31 +103,10 @@ export function exploreV2Reducer(
   action: ExploreV2Action,
 ): ExploreV2State {
   switch ( action.type ) {
-    case EXPLORE_V2_ACTION.SET_SUBJECT: {
-      // Universal search: only one subject type is active at a time.
-      const cleared = {
-        ...state,
-        subjectType: action.subjectType,
-        taxon: null,
-        user: null,
-        project: null,
-      };
-      if ( action.subjectType === "taxon" ) {
-        return { ...cleared, taxon: action.taxon };
-      }
-      if ( action.subjectType === "user" ) {
-        return { ...cleared, user: action.user };
-      }
-      return { ...cleared, project: action.project };
-    }
+    case EXPLORE_V2_ACTION.SET_SUBJECT:
+      return { ...state, subject: action.subject };
     case EXPLORE_V2_ACTION.CLEAR_SUBJECT:
-      return {
-        ...state,
-        subjectType: null,
-        taxon: null,
-        user: null,
-        project: null,
-      };
+      return { ...state, subject: null };
     case EXPLORE_V2_ACTION.SET_LOCATION_NEARBY:
       return {
         ...state,

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -14,6 +14,7 @@ export enum EXPLORE_V2_ACTION {
 }
 
 export enum EXPLORE_V2_PLACE_MODE {
+  UNINITIALIZED = "UNINITIALIZED",
   NEARBY = "NEARBY",
   WORLDWIDE = "WORLDWIDE",
   PLACE = "PLACE"
@@ -58,16 +59,24 @@ export interface ExploreV2Filters {
   [key: string]: unknown;
 }
 
-export interface ExploreV2State {
+interface ExploreV2BaseState {
   subject: ExploreV2Subject | null;
-  placeMode: EXPLORE_V2_PLACE_MODE;
-  lat?: number;
-  lng?: number;
-  radius?: number;
-  place: Place | null;
   sortBy: EXPLORE_V2_SORT;
   filters: ExploreV2Filters;
 }
+
+export type ExploreV2LocationState =
+  | { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED }
+  | { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE }
+  | {
+    placeMode: EXPLORE_V2_PLACE_MODE.NEARBY;
+    lat: number;
+    lng: number;
+    radius: number;
+  }
+  | { placeMode: EXPLORE_V2_PLACE_MODE.PLACE; place: Place };
+
+export type ExploreV2State = ExploreV2BaseState & ExploreV2LocationState;
 
 export type ExploreV2Action =
   | { type: EXPLORE_V2_ACTION.SET_SUBJECT; subject: ExploreV2Subject }
@@ -89,14 +98,18 @@ export type ExploreV2Action =
 
 export const initialExploreV2State: ExploreV2State = {
   subject: null,
-  placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-  lat: undefined,
-  lng: undefined,
-  radius: undefined,
-  place: null,
+  placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED,
   sortBy: EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST,
   filters: {},
 };
+
+function baseFields( state: ExploreV2State ): ExploreV2BaseState {
+  return {
+    subject: state.subject,
+    sortBy: state.sortBy,
+    filters: state.filters,
+  };
+}
 
 export function exploreV2Reducer(
   state: ExploreV2State,
@@ -109,29 +122,21 @@ export function exploreV2Reducer(
       return { ...state, subject: null };
     case EXPLORE_V2_ACTION.SET_LOCATION_NEARBY:
       return {
-        ...state,
+        ...baseFields( state ),
         placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
         lat: action.lat,
         lng: action.lng,
         radius: action.radius,
-        place: null,
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE:
       return {
-        ...state,
+        ...baseFields( state ),
         placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE,
-        lat: undefined,
-        lng: undefined,
-        radius: undefined,
-        place: null,
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_PLACE:
       return {
-        ...state,
+        ...baseFields( state ),
         placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
-        lat: undefined,
-        lng: undefined,
-        radius: undefined,
         place: action.place,
       };
     case EXPLORE_V2_ACTION.SET_SORT:

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -19,9 +19,7 @@ export enum EXPLORE_V2_PLACE_MODE {
   PLACE = "PLACE"
 }
 
-// Sort options. The full Observations sort enum (Taxonomy, Alphabetical, etc.)
-// is owned by MOB-1333; for now we cover the four date-sort cases plus most-faved
-// which is what searchObservations supports today.
+// more options to be potentially added in MOB-1333
 export enum EXPLORE_V2_SORT {
   DATE_UPLOADED_NEWEST = "DATE_UPLOADED_NEWEST",
   DATE_UPLOADED_OLDEST = "DATE_UPLOADED_OLDEST",
@@ -39,27 +37,28 @@ interface Place {
 
 interface Taxon {
   id: number;
-  name?: string;
+  name: string;
 }
 
 interface User {
   id: number;
-  login?: string;
+  login: string;
 }
 
 interface Project {
   id: number;
-  title?: string;
+  title: string;
 }
 
-// Filter scaffold. MOB-1346 (Advanced Search) populates this. Kept open-ended
-// so sibling tickets can extend without a context migration.
+// To be added to in MOB-1346
 export interface ExploreV2Filters {
   [key: string]: unknown;
 }
 
 export interface ExploreV2State {
   subjectType: ExploreV2SubjectType | null;
+  // In theory I prefer separate properties for taxon, user, project so it's very clear
+  // which we're dealing with in later logic but I think this could change to a single property
   taxon: Taxon | null;
   user: User | null;
   project: Project | null;
@@ -68,8 +67,6 @@ export interface ExploreV2State {
   lng?: number;
   radius?: number;
   place: Place | null;
-  placeId: number | null;
-  placeGuess: string;
   sortBy: EXPLORE_V2_SORT;
   filters: ExploreV2Filters;
 }
@@ -101,28 +98,21 @@ export type ExploreV2Action =
   | {
     type: EXPLORE_V2_ACTION.SET_LOCATION_PLACE;
     place: Place;
-    placeGuess?: string;
   }
   | { type: EXPLORE_V2_ACTION.SET_SORT; sortBy: EXPLORE_V2_SORT }
   | { type: EXPLORE_V2_ACTION.SET_FILTERS; filters: ExploreV2Filters }
   | { type: EXPLORE_V2_ACTION.RESET };
-
-type Dispatch = ( action: ExploreV2Action ) => void;
 
 export const initialExploreV2State: ExploreV2State = {
   subjectType: null,
   taxon: null,
   user: null,
   project: null,
-  // Initial placeMode is NEARBY; the container resolves to coords (granted) or
-  // WORLDWIDE (denied/blocked) once permission state is known.
   placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
   lat: undefined,
   lng: undefined,
   radius: undefined,
   place: null,
-  placeId: null,
-  placeGuess: "",
   sortBy: EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST,
   filters: {},
 };
@@ -165,8 +155,6 @@ export function exploreV2Reducer(
         lng: action.lng,
         radius: action.radius,
         place: null,
-        placeId: null,
-        placeGuess: "",
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE:
       return {
@@ -176,8 +164,6 @@ export function exploreV2Reducer(
         lng: undefined,
         radius: undefined,
         place: null,
-        placeId: null,
-        placeGuess: "",
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_PLACE:
       return {
@@ -187,8 +173,6 @@ export function exploreV2Reducer(
         lng: undefined,
         radius: undefined,
         place: action.place,
-        placeId: action.place.id,
-        placeGuess: action.placeGuess ?? action.place.display_name ?? "",
       };
     case EXPLORE_V2_ACTION.SET_SORT:
       return { ...state, sortBy: action.sortBy };
@@ -227,7 +211,7 @@ export async function defaultExploreV2Location( ): Promise<DefaultExploreV2Locat
 
 interface ExploreV2ContextValue {
   state: ExploreV2State;
-  dispatch: Dispatch;
+  dispatch: ( action: ExploreV2Action ) => void;
 }
 
 const ExploreV2Context = React.createContext<ExploreV2ContextValue | undefined>(
@@ -255,6 +239,7 @@ export const ExploreV2Provider = ( { children }: ExploreV2ProviderProps ) => {
 
 export function useExploreV2( ): ExploreV2ContextValue {
   const context = React.useContext( ExploreV2Context );
+  // Pattern from https://kentcdodds.com/blog/how-to-use-react-context-effectively
   if ( context === undefined ) {
     throw new Error( "useExploreV2 must be used within an ExploreV2Provider" );
   }

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -143,6 +143,7 @@ export function exploreV2Reducer(
     case EXPLORE_V2_ACTION.RESET:
       return initialExploreV2State;
     default: {
+      // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
       const _exhaustive: never = action;
       return _exhaustive;
     }

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -203,12 +203,14 @@ export function exploreV2Reducer(
   }
 }
 
-export interface DefaultExploreV2Location {
-  placeMode: EXPLORE_V2_PLACE_MODE;
-  lat?: number;
-  lng?: number;
-  radius?: number;
-}
+export type DefaultExploreV2Location =
+  | { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE }
+  | {
+    placeMode: EXPLORE_V2_PLACE_MODE.NEARBY;
+    lat: number;
+    lng: number;
+    radius: number;
+  };
 
 export async function defaultExploreV2Location( ): Promise<DefaultExploreV2Location> {
   const location = await fetchCoarseUserLocation( );

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -1,0 +1,260 @@
+import * as React from "react";
+
+import fetchCoarseUserLocation from "../sharedHelpers/fetchCoarseUserLocation";
+
+export enum EXPLORE_V2_ACTION {
+  SET_ENTITY = "SET_ENTITY",
+  CLEAR_ENTITY = "CLEAR_ENTITY",
+  SET_LOCATION_NEARBY = "SET_LOCATION_NEARBY",
+  SET_LOCATION_WORLDWIDE = "SET_LOCATION_WORLDWIDE",
+  SET_LOCATION_PLACE = "SET_LOCATION_PLACE",
+  SET_SORT = "SET_SORT",
+  SET_FILTERS = "SET_FILTERS",
+  RESET = "RESET"
+}
+
+export enum EXPLORE_V2_PLACE_MODE {
+  NEARBY = "NEARBY",
+  WORLDWIDE = "WORLDWIDE",
+  PLACE = "PLACE"
+}
+
+// Sort options. The full Observations sort enum (Taxonomy, Alphabetical, etc.)
+// is owned by MOB-1333; for now we cover the four date-sort cases plus most-faved
+// which is what searchObservations supports today.
+export enum EXPLORE_V2_SORT {
+  DATE_UPLOADED_NEWEST = "DATE_UPLOADED_NEWEST",
+  DATE_UPLOADED_OLDEST = "DATE_UPLOADED_OLDEST",
+  DATE_OBSERVED_NEWEST = "DATE_OBSERVED_NEWEST",
+  DATE_OBSERVED_OLDEST = "DATE_OBSERVED_OLDEST",
+  MOST_FAVED = "MOST_FAVED"
+}
+
+export type ExploreV2EntityType = "taxon" | "user" | "project";
+
+interface Place {
+  id: number;
+  display_name?: string;
+}
+
+interface Taxon {
+  id: number;
+  name?: string;
+}
+
+interface User {
+  id: number;
+  login?: string;
+}
+
+interface Project {
+  id: number;
+  title?: string;
+}
+
+// Filter scaffold. MOB-1346 (Advanced Search) populates this. Kept open-ended
+// so sibling tickets can extend without a context migration.
+export interface ExploreV2Filters {
+  [key: string]: unknown;
+}
+
+export interface ExploreV2State {
+  entityType: ExploreV2EntityType | null;
+  taxon: Taxon | null;
+  user: User | null;
+  project: Project | null;
+  placeMode: EXPLORE_V2_PLACE_MODE;
+  lat?: number;
+  lng?: number;
+  radius?: number;
+  place: Place | null;
+  placeId: number | null;
+  placeGuess: string;
+  sortBy: EXPLORE_V2_SORT;
+  filters: ExploreV2Filters;
+}
+
+export type ExploreV2Action =
+  | {
+    type: EXPLORE_V2_ACTION.SET_ENTITY;
+    entityType: "taxon";
+    taxon: Taxon;
+  }
+  | {
+    type: EXPLORE_V2_ACTION.SET_ENTITY;
+    entityType: "user";
+    user: User;
+  }
+  | {
+    type: EXPLORE_V2_ACTION.SET_ENTITY;
+    entityType: "project";
+    project: Project;
+  }
+  | { type: EXPLORE_V2_ACTION.CLEAR_ENTITY }
+  | {
+    type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY;
+    lat: number;
+    lng: number;
+    radius: number;
+  }
+  | { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE }
+  | {
+    type: EXPLORE_V2_ACTION.SET_LOCATION_PLACE;
+    place: Place;
+    placeGuess?: string;
+  }
+  | { type: EXPLORE_V2_ACTION.SET_SORT; sortBy: EXPLORE_V2_SORT }
+  | { type: EXPLORE_V2_ACTION.SET_FILTERS; filters: ExploreV2Filters }
+  | { type: EXPLORE_V2_ACTION.RESET };
+
+type Dispatch = ( action: ExploreV2Action ) => void;
+
+export const initialExploreV2State: ExploreV2State = {
+  entityType: null,
+  taxon: null,
+  user: null,
+  project: null,
+  // Initial placeMode is NEARBY; the container resolves to coords (granted) or
+  // WORLDWIDE (denied/blocked) once permission state is known.
+  placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+  lat: undefined,
+  lng: undefined,
+  radius: undefined,
+  place: null,
+  placeId: null,
+  placeGuess: "",
+  sortBy: EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST,
+  filters: {},
+};
+
+export function exploreV2Reducer(
+  state: ExploreV2State,
+  action: ExploreV2Action,
+): ExploreV2State {
+  switch ( action.type ) {
+    case EXPLORE_V2_ACTION.SET_ENTITY: {
+      // Universal search: only one entity type is active at a time.
+      const cleared = {
+        ...state,
+        entityType: action.entityType,
+        taxon: null,
+        user: null,
+        project: null,
+      };
+      if ( action.entityType === "taxon" ) {
+        return { ...cleared, taxon: action.taxon };
+      }
+      if ( action.entityType === "user" ) {
+        return { ...cleared, user: action.user };
+      }
+      return { ...cleared, project: action.project };
+    }
+    case EXPLORE_V2_ACTION.CLEAR_ENTITY:
+      return {
+        ...state,
+        entityType: null,
+        taxon: null,
+        user: null,
+        project: null,
+      };
+    case EXPLORE_V2_ACTION.SET_LOCATION_NEARBY:
+      return {
+        ...state,
+        placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+        lat: action.lat,
+        lng: action.lng,
+        radius: action.radius,
+        place: null,
+        placeId: null,
+        placeGuess: "",
+      };
+    case EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE:
+      return {
+        ...state,
+        placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE,
+        lat: undefined,
+        lng: undefined,
+        radius: undefined,
+        place: null,
+        placeId: null,
+        placeGuess: "",
+      };
+    case EXPLORE_V2_ACTION.SET_LOCATION_PLACE:
+      return {
+        ...state,
+        placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
+        lat: undefined,
+        lng: undefined,
+        radius: undefined,
+        place: action.place,
+        placeId: action.place.id,
+        placeGuess: action.placeGuess ?? action.place.display_name ?? "",
+      };
+    case EXPLORE_V2_ACTION.SET_SORT:
+      return { ...state, sortBy: action.sortBy };
+    case EXPLORE_V2_ACTION.SET_FILTERS:
+      return { ...state, filters: action.filters };
+    case EXPLORE_V2_ACTION.RESET:
+      return initialExploreV2State;
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}
+
+export interface DefaultExploreV2Location {
+  placeMode: EXPLORE_V2_PLACE_MODE;
+  lat?: number;
+  lng?: number;
+  radius?: number;
+}
+
+export async function defaultExploreV2Location( ): Promise<DefaultExploreV2Location> {
+  const location = await fetchCoarseUserLocation( );
+  if ( !location || !location.latitude ) {
+    return { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE };
+  }
+  return {
+    placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+    lat: location.latitude,
+    lng: location.longitude,
+    radius: 1,
+  };
+}
+
+interface ExploreV2ContextValue {
+  state: ExploreV2State;
+  dispatch: Dispatch;
+}
+
+const ExploreV2Context = React.createContext<ExploreV2ContextValue | undefined>(
+  undefined,
+);
+
+interface ExploreV2ProviderProps {
+  children: React.ReactNode;
+}
+
+export const ExploreV2Provider = ( { children }: ExploreV2ProviderProps ) => {
+  const [state, dispatch] = React.useReducer( exploreV2Reducer, initialExploreV2State );
+
+  const value = React.useMemo(
+    () => ( { state, dispatch } ),
+    [state],
+  );
+
+  return (
+    <ExploreV2Context.Provider value={value}>
+      {children}
+    </ExploreV2Context.Provider>
+  );
+};
+
+export function useExploreV2( ): ExploreV2ContextValue {
+  const context = React.useContext( ExploreV2Context );
+  if ( context === undefined ) {
+    throw new Error( "useExploreV2 must be used within an ExploreV2Provider" );
+  }
+  return context;
+}

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -194,9 +194,9 @@ export const ExploreV2Provider = ( { children }: ExploreV2ProviderProps ) => {
   );
 
   return (
-    <ExploreV2Context.Provider value={value}>
+    <ExploreV2Context value={value}>
       {children}
-    </ExploreV2Context.Provider>
+    </ExploreV2Context>
   );
 };
 

--- a/tests/unit/components/Explore/ExploreV2/buildQueryParams.test.js
+++ b/tests/unit/components/Explore/ExploreV2/buildQueryParams.test.js
@@ -1,0 +1,167 @@
+import buildExploreV2QueryParams
+  from "components/Explore/ExploreV2/buildQueryParams";
+import {
+  EXPLORE_V2_PLACE_MODE,
+  EXPLORE_V2_SORT,
+  initialExploreV2State,
+} from "providers/ExploreV2Context";
+
+describe( "buildExploreV2QueryParams", ( ) => {
+  describe( "subject filter", ( ) => {
+    it( "maps a selected taxon to taxon_id", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        subject: { type: "taxon", taxon: { id: 42 } },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.taxon_id ).toBe( 42 );
+      expect( params.user_id ).toBeUndefined( );
+      expect( params.project_id ).toBeUndefined( );
+    } );
+
+    it( "maps a selected user to user_id", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        subject: { type: "user", user: { id: 7 } },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.user_id ).toBe( 7 );
+      expect( params.taxon_id ).toBeUndefined( );
+    } );
+
+    it( "maps a selected project to project_id", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        subject: { type: "project", project: { id: 12 } },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.project_id ).toBe( 12 );
+    } );
+  } );
+
+  describe( "location", ( ) => {
+    it( "includes lat/lng/radius in NEARBY mode with coords", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+          lat: 37.5,
+          lng: -122.1,
+          radius: 1,
+        },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.lat ).toBe( 37.5 );
+      expect( params.lng ).toBe( -122.1 );
+      expect( params.radius ).toBe( 1 );
+      expect( params.place_id ).toBeUndefined( );
+    } );
+
+    it( "omits coords and place in WORLDWIDE mode", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.lat ).toBeUndefined( );
+      expect( params.place_id ).toBeUndefined( );
+    } );
+
+    it( "uses place_id in PLACE mode", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
+          place: { id: 5 },
+        },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.place_id ).toBe( 5 );
+      expect( params.lat ).toBeUndefined( );
+    } );
+  } );
+
+  describe( "sort", ( ) => {
+    it( "DATE_UPLOADED_NEWEST → created_at desc", ( ) => {
+      const params = buildExploreV2QueryParams( {
+        ...initialExploreV2State,
+        sortBy: EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST,
+      } );
+      expect( params.order_by ).toBe( "created_at" );
+      expect( params.order ).toBe( "desc" );
+    } );
+
+    it( "DATE_UPLOADED_OLDEST → created_at asc", ( ) => {
+      const params = buildExploreV2QueryParams( {
+        ...initialExploreV2State,
+        sortBy: EXPLORE_V2_SORT.DATE_UPLOADED_OLDEST,
+      } );
+      expect( params.order_by ).toBe( "created_at" );
+      expect( params.order ).toBe( "asc" );
+    } );
+
+    it( "DATE_OBSERVED_NEWEST → observed_on desc", ( ) => {
+      const params = buildExploreV2QueryParams( {
+        ...initialExploreV2State,
+        sortBy: EXPLORE_V2_SORT.DATE_OBSERVED_NEWEST,
+      } );
+      expect( params.order_by ).toBe( "observed_on" );
+      expect( params.order ).toBe( "desc" );
+    } );
+
+    it( "DATE_OBSERVED_OLDEST → observed_on asc", ( ) => {
+      const params = buildExploreV2QueryParams( {
+        ...initialExploreV2State,
+        sortBy: EXPLORE_V2_SORT.DATE_OBSERVED_OLDEST,
+      } );
+      expect( params.order_by ).toBe( "observed_on" );
+      expect( params.order ).toBe( "asc" );
+    } );
+
+    it( "MOST_FAVED → votes desc", ( ) => {
+      const params = buildExploreV2QueryParams( {
+        ...initialExploreV2State,
+        sortBy: EXPLORE_V2_SORT.MOST_FAVED,
+      } );
+      expect( params.order_by ).toBe( "votes" );
+      expect( params.order ).toBe( "desc" );
+    } );
+  } );
+
+  it( "always sets per_page to 20 and verifiable to true", ( ) => {
+    const params = buildExploreV2QueryParams( initialExploreV2State );
+    expect( params.per_page ).toBe( 20 );
+    expect( params.verifiable ).toBe( true );
+  } );
+
+  it( "applies sort order to the default state", ( ) => {
+    const params = buildExploreV2QueryParams( initialExploreV2State );
+    expect( params.order_by ).toBe( "created_at" );
+    expect( params.order ).toBe( "desc" );
+  } );
+
+  it( "combines subject, location, and sort into a single query", ( ) => {
+    const state = {
+      subject: { type: "taxon", taxon: { id: 42 } },
+      location: {
+        placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+        lat: 37.5,
+        lng: -122.1,
+        radius: 1,
+      },
+      sortBy: EXPLORE_V2_SORT.MOST_FAVED,
+      filters: {},
+    };
+    const params = buildExploreV2QueryParams( state );
+    expect( params ).toEqual( {
+      per_page: 20,
+      verifiable: true,
+      order_by: "votes",
+      order: "desc",
+      taxon_id: 42,
+      lat: 37.5,
+      lng: -122.1,
+      radius: 1,
+    } );
+  } );
+} );

--- a/tests/unit/providers/ExploreV2Context.test.js
+++ b/tests/unit/providers/ExploreV2Context.test.js
@@ -1,0 +1,226 @@
+import {
+  defaultExploreV2Location,
+  EXPLORE_V2_ACTION,
+  EXPLORE_V2_PLACE_MODE,
+  EXPLORE_V2_SORT,
+  exploreV2Reducer,
+  initialExploreV2State,
+} from "providers/ExploreV2Context";
+import fetchCoarseUserLocation from "sharedHelpers/fetchCoarseUserLocation";
+
+jest.mock( "sharedHelpers/fetchCoarseUserLocation", ( ) => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+
+describe( "initialExploreV2State", ( ) => {
+  it( "starts with no subject, UNINITIALIZED placeMode, newest-upload sort, empty filters", ( ) => {
+    expect( initialExploreV2State.subject ).toBeNull( );
+    expect( initialExploreV2State.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.UNINITIALIZED );
+    expect( initialExploreV2State.sortBy ).toBe( EXPLORE_V2_SORT.DATE_UPLOADED_NEWEST );
+    expect( initialExploreV2State.filters ).toEqual( {} );
+  } );
+} );
+
+describe( "exploreV2Reducer", ( ) => {
+  describe( EXPLORE_V2_ACTION.SET_SUBJECT, ( ) => {
+    it( "sets a taxon subject, replacing any prior subject", ( ) => {
+      const taxon = { id: 42, name: "Foo" };
+      const state = {
+        ...initialExploreV2State,
+        subject: { type: "user", user: { id: 1 } },
+      };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_SUBJECT,
+        subject: { type: "taxon", taxon },
+      } );
+      expect( next.subject ).toEqual( { type: "taxon", taxon } );
+    } );
+
+    it( "preserves location, sortBy, and filters when changing subject", ( ) => {
+      const state = {
+        subject: null,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+          lat: 1,
+          lng: 2,
+          radius: 3,
+        },
+        sortBy: EXPLORE_V2_SORT.MOST_FAVED,
+        filters: { quality_grade: "research" },
+      };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_SUBJECT,
+        subject: { type: "taxon", taxon: { id: 1 } },
+      } );
+      expect( next.location ).toEqual( state.location );
+      expect( next.sortBy ).toBe( state.sortBy );
+      expect( next.filters ).toEqual( state.filters );
+    } );
+  } );
+
+  describe( EXPLORE_V2_ACTION.CLEAR_SUBJECT, ( ) => {
+    it( "clears the selected subject", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        subject: { type: "taxon", taxon: { id: 99 } },
+      };
+      const next = exploreV2Reducer( state, { type: EXPLORE_V2_ACTION.CLEAR_SUBJECT } );
+      expect( next.subject ).toBeNull( );
+    } );
+  } );
+
+  describe( "location actions", ( ) => {
+    it( "SET_LOCATION_NEARBY transitions from PLACE and drops place", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
+          place: { id: 1 },
+        },
+      };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
+        lat: 37.5,
+        lng: -122.1,
+        radius: 1,
+      } );
+      expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.NEARBY );
+      expect( next.location.lat ).toBe( 37.5 );
+      expect( next.location.lng ).toBe( -122.1 );
+      expect( next.location.radius ).toBe( 1 );
+      expect( next.location.place ).toBeUndefined( );
+    } );
+
+    it( "SET_LOCATION_WORLDWIDE transitions from NEARBY and drops coords", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+          lat: 1,
+          lng: 1,
+          radius: 1,
+        },
+      };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE,
+      } );
+      expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.WORLDWIDE );
+      expect( next.location.lat ).toBeUndefined( );
+      expect( next.location.lng ).toBeUndefined( );
+      expect( next.location.radius ).toBeUndefined( );
+    } );
+
+    it( "SET_LOCATION_PLACE transitions from NEARBY and drops coords", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+          lat: 1,
+          lng: 1,
+          radius: 1,
+        },
+      };
+      const place = { id: 5, display_name: "Oakland" };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_LOCATION_PLACE,
+        place,
+      } );
+      expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.PLACE );
+      expect( next.location.place ).toEqual( place );
+      expect( next.location.lat ).toBeUndefined( );
+    } );
+
+    it( "SET_LOCATION_PLACE replaces an existing place", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: {
+          placeMode: EXPLORE_V2_PLACE_MODE.PLACE,
+          place: { id: 1, display_name: "Oakland" },
+        },
+      };
+      const place = { id: 2, display_name: "Berkeley" };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_LOCATION_PLACE,
+        place,
+      } );
+      expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.PLACE );
+      expect( next.location.place ).toEqual( place );
+    } );
+
+    it( "preserves subject, sortBy, and filters when changing location", ( ) => {
+      const state = {
+        subject: { type: "taxon", taxon: { id: 42 } },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED },
+        sortBy: EXPLORE_V2_SORT.MOST_FAVED,
+        filters: { quality_grade: "research" },
+      };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE,
+      } );
+      expect( next.subject ).toEqual( state.subject );
+      expect( next.sortBy ).toBe( state.sortBy );
+      expect( next.filters ).toEqual( state.filters );
+    } );
+  } );
+
+  describe( EXPLORE_V2_ACTION.SET_SORT, ( ) => {
+    it( "updates sortBy", ( ) => {
+      const next = exploreV2Reducer( initialExploreV2State, {
+        type: EXPLORE_V2_ACTION.SET_SORT,
+        sortBy: EXPLORE_V2_SORT.DATE_OBSERVED_NEWEST,
+      } );
+      expect( next.sortBy ).toBe( EXPLORE_V2_SORT.DATE_OBSERVED_NEWEST );
+    } );
+  } );
+
+  describe( EXPLORE_V2_ACTION.SET_FILTERS, ( ) => {
+    it( "replaces filters with the provided object", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        filters: { quality_grade: "research" },
+      };
+      const filters = { quality_grade: "needs_id", iconic_taxa: ["Aves"] };
+      const next = exploreV2Reducer( state, {
+        type: EXPLORE_V2_ACTION.SET_FILTERS,
+        filters,
+      } );
+      expect( next.filters ).toEqual( filters );
+    } );
+  } );
+
+  describe( EXPLORE_V2_ACTION.RESET, ( ) => {
+    it( "returns initial state", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        subject: { type: "taxon", taxon: { id: 1 } },
+        sortBy: EXPLORE_V2_SORT.MOST_FAVED,
+      };
+      const next = exploreV2Reducer( state, { type: EXPLORE_V2_ACTION.RESET } );
+      expect( next ).toEqual( initialExploreV2State );
+    } );
+  } );
+} );
+
+describe( "defaultExploreV2Location", ( ) => {
+  beforeEach( ( ) => {
+    fetchCoarseUserLocation.mockReset( );
+  } );
+
+  it( "returns NEARBY with radius 1 when a location is available", async ( ) => {
+    fetchCoarseUserLocation.mockResolvedValueOnce( { latitude: 37.5, longitude: -122.1 } );
+    const result = await defaultExploreV2Location( );
+    expect( result ).toEqual( {
+      placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
+      lat: 37.5,
+      lng: -122.1,
+      radius: 1,
+    } );
+  } );
+
+  it( "returns WORLDWIDE when fetchCoarseUserLocation returns null", async ( ) => {
+    fetchCoarseUserLocation.mockResolvedValueOnce( null );
+    const result = await defaultExploreV2Location( );
+    expect( result ).toEqual( { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } );
+  } );
+} );


### PR DESCRIPTION
In this PR:
- Navigator for ExploreV2
- Context/Provider for ExploreV2
- Query building for ExploreV2
- Stub screens for ExploreObservations, UniversalSearch, and AdvancedSearch

I also have a funky lil modal for debugging in the branch `mob-1329-debug`

https://github.com/user-attachments/assets/817abdd2-7f60-48b6-95ac-b1f99e7b83e8

