### PR TITLE
Remove TODO

### DIFF
--- a/src/components/Settings/LanguageSetting.tsx
+++ b/src/components/Settings/LanguageSetting.tsx
@@ -43,8 +43,6 @@ const LanguageSetting = ( { onChange }: Props ) => {
         : [] );
 
       const apiToken = await getJWT( );
-      // TODO: enable fields if it makes sense? Idk if it helps with this endpoint
-      // https://linear.app/inaturalist/issue/MOB-1367/enable-fields-for-available-locales-in-languagesetting
       const locales = await fetchAvailableLocales( {}, { api_token: apiToken } );
       zustandStorage.setItem( "availableLocales", JSON.stringify( locales ) );
       setWebLocales( locales as LocalesResponse );


### PR DESCRIPTION
Closes MOB-1367
It does not make sense to restrict fields here. There is only a low set of values fetched here, with only 2 fields when we request all fields.