### PR TITLE
Omit fields if not given

### DIFF
--- a/src/api/observations.js
+++ b/src/api/observations.js
@@ -15,8 +15,16 @@ function mapObsPhotoToLocalSchema( obsPhoto ) {
   return obsPhoto;
 }
 function mapToLocalSchema( observation ) {
-  observation.observationPhotos = observation?.observationPhotos?.map( mapObsPhotoToLocalSchema );
-  observation.observation_photos = observation?.observation_photos?.map( mapObsPhotoToLocalSchema );
+  // eslint-disable-next-line camelcase
+  const { observationPhotos, observation_photos } = observation;
+  if ( observationPhotos != null ) {
+    observation.observationPhotos = observationPhotos.map( mapObsPhotoToLocalSchema );
+  }
+  // eslint-disable-next-line camelcase
+  if ( observation_photos != null ) {
+    // eslint-disable-next-line camelcase
+    observation.observation_photos = observation_photos.map( mapObsPhotoToLocalSchema );
+  }
   return observation;
 }
 


### PR DESCRIPTION
While looking at query results from useLinking, I have seen that we are handling a response that looks like this: `{ uuid: xy, observation_photos: undefined, observationPhotos: undefined }`. This changes so that an observations without photos does not add those fields when mapped to local schema.