### PR TITLE
do not fail lint-staged on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --cache --fix --max-warnings=0 --cache-location .eslintcache"
+      "eslint --cache --fix --cache-location .eslintcache"
     ],
     "*.rb": [
       "bundle exec rubocop --force-exclusion --parallel"


### PR DESCRIPTION
We intentionally introduced warnings in #3574. I missed that we _were_ preventing commits on warnings, we just happened to be warning free. Team consensus on that issue was that we desired the warnings. Discussion w/ @jtklein this week confirmed that we feel safe _allowing_ warnings to exist and not preventing commits.