### PR TITLE
add worklets patch for extra react native host preventing profiling

### DIFF
--- a/patches/react-native-worklets+0.7.4.patch
+++ b/patches/react-native-worklets+0.7.4.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.cpp b/node_modules/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.cpp
+index 22388b6..48fe9ae 100644
+--- a/node_modules/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.cpp
++++ b/node_modules/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.cpp
+@@ -63,8 +63,11 @@ WorkletHermesRuntime::WorkletHermesRuntime(
+     const std::string &name)
+     : jsi::WithRuntimeDecorator<WorkletsReentrancyCheck>(*runtime, reentrancyCheck_), runtime_(std::move(runtime)) {
+ #if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
+-  auto adapter = std::make_unique<HermesExecutorRuntimeAdapter>(*runtime_, jsQueue);
+-  debugToken_ = chrome::enableDebugging(std::move(adapter), name);
++  // Skip worklet debug target registration to avoid RN 0.83.5+ false-positive
++  // "multiple React Native hosts" in DevTools, which disables Network and
++  // Performance tabs. See react-native-community/discussions-and-proposals#954.
++  (void)jsQueue;
++  (void)name;
+ #endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
+ 
+ #ifndef NDEBUG
+@@ -92,8 +95,7 @@ WorkletHermesRuntime::WorkletHermesRuntime(
+ 
+ WorkletHermesRuntime::~WorkletHermesRuntime() {
+ #if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
+-  // We have to disable debugging before the runtime is destroyed.
+-  chrome::disableDebugging(debugToken_);
++  // Paired with skipped enableDebugging above.
+ #endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
+ }
+ 


### PR DESCRIPTION
The Profiling Dev Tools tab is disabled with message "Multiple React Native hosts not supported". This is related to us seeing two duplicate attach options when launching the dev tools through the dev server.

Issue: https://github.com/react-native-community/discussions-and-proposals/discussions/954

Comment w/ patch:https://github.com/react-native-community/discussions-and-proposals/discussions/954#discussioncomment-16707157

As I understand, this change only affects users debugging _against_ worklets itself.

With this, I am able to start and stop a profiling session and get a result.

Pretty much anything "useful", even a couple taps in under 5s results in the dev tools hanging and becoming unresponsive. I discovered that it _eventually_ completes processing, even if the device's connection with dev tools times out. Once it's done, you get the pop up of "dev tools disconnected. Reconnect? Dismiss?" <- you have to dismiss to get to the actual results or you'll lose the profiling session.

EDIT: it took a while for me to trust that it actually eventually worked consistently. I now trust that it does, one just has to be patient.

Would welcome anyone trying this out!

fixes MOB-1407
