### PR TITLE
reduce rework in use local observations, improve locking UI thread

### DIFF
--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -75,12 +75,14 @@ const useLocalObservations = ( ): Object => {
           // Mode change requires full remap
           mappedObservations = Array.from( filteredObservations )
             .filter( obs => obs.isValid() )
-            .map( obs => mapObservation( obs, isDefaultMode ) );
+            .map( mapObservation );
         } else {
-          const modifiedUuids = newModifications
-            .map( index => localObservations[index] )
-            .filter( obs => obs?.isValid() )
-            .map( obs => obs.uuid );
+          const modifiedUuids = new Set(
+            newModifications
+              .map( index => localObservations[index] )
+              .filter( obs => obs?.isValid() )
+              .map( obs => obs.uuid ),
+          );
 
           const previousObsByUuid = Object.fromEntries(
             prevListRef.current.list.map( obs => [obs.uuid, obs] ),
@@ -89,7 +91,7 @@ const useLocalObservations = ( ): Object => {
           mappedObservations = Array.from( filteredObservations )
             .filter( obs => obs.isValid() )
             .map( obs => {
-              if ( modifiedUuids.includes( obs.uuid ) ) {
+              if ( modifiedUuids.has( obs.uuid ) ) {
                 return mapObservation( obs, currentIsDefaultMode );
               }
               return previousObsByUuid[obs.uuid] ?? mapObservation( obs, currentIsDefaultMode );

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -7,6 +7,7 @@ import {
 } from "react";
 import Observation from "realmModels/Observation";
 import useStore from "stores/useStore";
+import { v4 as uuidv4 } from "uuid";
 
 function isDefaultMode( ) {
   return useStore.getState( ).layout.isDefaultMode === true;
@@ -18,12 +19,6 @@ const deletionFilters
   = "_deleted_at == nil OR _pending_deletion == false OR _pending_deletion == nil";
 
 const sortedFilters = [["needs_sync", true], ["_created_at", true]];
-
-const mapObservations = ( observations, isDefault ) => ( isDefault
-  ? observations
-    .map( observation => Observation.mapObservationForMyObsDefaultMode( observation ) )
-  : observations
-    .map( observation => Observation.mapObservationForMyObsAdvancedMode( observation ) ) );
 
 const useLocalObservations = ( ): Object => {
   const setNumUnuploadedObservations = useStore( state => state.setNumUnuploadedObservations );
@@ -65,29 +60,58 @@ const useLocalObservations = ( ): Object => {
         || unsyncedCount !== prevListRef.current.unsyncedCount
         || currentIsDefaultMode !== prevListRef.current.isDefaultMode
       ) {
+        const transactionId = uuidv4();
+        performance.mark( "start", {
+          detail: {
+            transactionId,
+            insertions: insertions.length,
+            modifications: newModifications.length,
+            deletions: deletions.length,
+          },
+        } );
         // amanda 20250522: React Native works best when minimal data is passed to components,
         // so there aren't costly rerenders. these data transformations ensure the UI is getting
         // exactly what it needs to display and that we're not passing around larger objects
         // or actual Realm objects, which is especially helpful since we're doing an absurd amount
         // of prop drilling in MyObservations
 
-        let mappedObservations = [];
+        const mapObservation = currentIsDefaultMode
+          ? Observation.mapObservationForMyObsDefaultMode
+          : Observation.mapObservationForMyObsAdvancedMode;
 
-        if ( insertions.length > 0
-            && newModifications.length === 0
-            && deletions.length === 0
-            && currentIsDefaultMode === prevListRef.current.isDefaultMode ) {
-          const newObservations = insertions.map( index => filteredObservations[index] )
-            .filter( o => o.isValid() );
+        let mappedObservations;
 
-          const newMappedObservations = mapObservations( newObservations, currentIsDefaultMode );
+        if ( currentIsDefaultMode !== prevListRef.current.isDefaultMode ) {
+          performance.mark( "start-rebuild", { detail: { transactionId } } );
 
-          mappedObservations = [...prevListRef.current.list, ...newMappedObservations];
+          // Mode change requires full remap
+          mappedObservations = Array.from( filteredObservations )
+            .filter( obs => obs.isValid() )
+            .map( obs => mapObservation( obs, isDefaultMode ) );
+
+          performance.mark( "end-rebuild", { detail: { transactionId } } );
         } else {
-          // Full rebuild needed (modifications, deletions, or mode change)
-          const validObservations = Array.from( filteredObservations ).filter( o => o.isValid() );
+          performance.mark( "start-inplace", { detail: { transactionId } } );
 
-          mappedObservations = mapObservations( validObservations, currentIsDefaultMode );
+          const modifiedUuids = newModifications
+            .map( index => localObservations[index] )
+            .filter( obs => obs?.isValid() )
+            .map( obs => obs.uuid );
+
+          const previousObsByUuid = Object.fromEntries(
+            prevListRef.current.list.map( obs => [obs.uuid, obs] ),
+          );
+
+          mappedObservations = Array.from( filteredObservations )
+            .filter( obs => obs.isValid() )
+            .map( obs => {
+              if ( modifiedUuids.includes( obs.uuid ) ) {
+                return mapObservation( obs, currentIsDefaultMode );
+              }
+              return previousObsByUuid[obs.uuid] ?? mapObservation( obs, currentIsDefaultMode );
+            } );
+
+          performance.mark( "end-inplace", { detail: { transactionId } } );
         }
 
         setObservationList( mappedObservations );
@@ -99,6 +123,7 @@ const useLocalObservations = ( ): Object => {
           unsyncedCount,
           isDefaultMode: currentIsDefaultMode,
         };
+        performance.mark( "end", { detail: { transactionId } } );
       }
     };
 

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -8,9 +8,7 @@ import {
 import Observation from "realmModels/Observation";
 import useStore from "stores/useStore";
 
-function isDefaultMode( ) {
-  return useStore.getState( ).layout.isDefaultMode === true;
-}
+import useLayoutPrefs from "./useLayoutPrefs";
 
 const { useRealm } = RealmContext;
 
@@ -21,9 +19,6 @@ const sortedFilters = [["needs_sync", true], ["_created_at", true]];
 
 const useLocalObservations = ( ): Object => {
   const setNumUnuploadedObservations = useStore( state => state.setNumUnuploadedObservations );
-  // Use refs to maintain state without triggering re-renders of hook consumers
-  // when they have lost focus, which prevents other
-  // views from rendering when they have focus.
   const [observationList, setObservationList] = useState( [] );
 
   const prevListRef = useRef( {
@@ -32,6 +27,8 @@ const useLocalObservations = ( ): Object => {
     unsyncedCount: 0,
     isDefaultMode: null,
   } );
+
+  const { isDefaultMode } = useLayoutPrefs();
 
   const realm = useRealm( );
 
@@ -49,7 +46,6 @@ const useLocalObservations = ( ): Object => {
         .sorted( sortedFilters );
 
       const unsyncedCount = Observation.filterUnsyncedObservations( realm ).length;
-      const currentIsDefaultMode = isDefaultMode( );
 
       // limit list updates to when there are actual realm changes
       if ( ( insertions.length > 0
@@ -57,7 +53,7 @@ const useLocalObservations = ( ): Object => {
           || deletions.length > 0 )
         || filteredObservations.length !== prevListRef.current.count
         || unsyncedCount !== prevListRef.current.unsyncedCount
-        || currentIsDefaultMode !== prevListRef.current.isDefaultMode
+        || isDefaultMode !== prevListRef.current.isDefaultMode
       ) {
         // amanda 20250522: React Native works best when minimal data is passed to components,
         // so there aren't costly rerenders. these data transformations ensure the UI is getting
@@ -65,13 +61,13 @@ const useLocalObservations = ( ): Object => {
         // or actual Realm objects, which is especially helpful since we're doing an absurd amount
         // of prop drilling in MyObservations
 
-        const mapObservation = currentIsDefaultMode
+        const mapObservation = isDefaultMode
           ? Observation.mapObservationForMyObsDefaultMode
           : Observation.mapObservationForMyObsAdvancedMode;
 
         let mappedObservations;
 
-        if ( currentIsDefaultMode !== prevListRef.current.isDefaultMode ) {
+        if ( isDefaultMode !== prevListRef.current.isDefaultMode ) {
           // Mode change requires full remap
           mappedObservations = Array.from( filteredObservations )
             .filter( obs => obs.isValid() )
@@ -92,9 +88,9 @@ const useLocalObservations = ( ): Object => {
             .filter( obs => obs.isValid() )
             .map( obs => {
               if ( modifiedUuids.has( obs.uuid ) ) {
-                return mapObservation( obs, currentIsDefaultMode );
+                return mapObservation( obs );
               }
-              return previousObsByUuid[obs.uuid] ?? mapObservation( obs, currentIsDefaultMode );
+              return previousObsByUuid[obs.uuid] ?? mapObservation( obs );
             } );
         }
 
@@ -105,7 +101,7 @@ const useLocalObservations = ( ): Object => {
           list: mappedObservations,
           count: filteredObservations.length,
           unsyncedCount,
-          isDefaultMode: currentIsDefaultMode,
+          isDefaultMode,
         };
       }
     };
@@ -117,7 +113,7 @@ const useLocalObservations = ( ): Object => {
         localObservations?.removeAllListeners( );
       }
     };
-  }, [realm, setNumUnuploadedObservations] );
+  }, [isDefaultMode, realm, setNumUnuploadedObservations] );
 
   return {
     observationList,

--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -7,7 +7,6 @@ import {
 } from "react";
 import Observation from "realmModels/Observation";
 import useStore from "stores/useStore";
-import { v4 as uuidv4 } from "uuid";
 
 function isDefaultMode( ) {
   return useStore.getState( ).layout.isDefaultMode === true;
@@ -60,15 +59,6 @@ const useLocalObservations = ( ): Object => {
         || unsyncedCount !== prevListRef.current.unsyncedCount
         || currentIsDefaultMode !== prevListRef.current.isDefaultMode
       ) {
-        const transactionId = uuidv4();
-        performance.mark( "start", {
-          detail: {
-            transactionId,
-            insertions: insertions.length,
-            modifications: newModifications.length,
-            deletions: deletions.length,
-          },
-        } );
         // amanda 20250522: React Native works best when minimal data is passed to components,
         // so there aren't costly rerenders. these data transformations ensure the UI is getting
         // exactly what it needs to display and that we're not passing around larger objects
@@ -82,17 +72,11 @@ const useLocalObservations = ( ): Object => {
         let mappedObservations;
 
         if ( currentIsDefaultMode !== prevListRef.current.isDefaultMode ) {
-          performance.mark( "start-rebuild", { detail: { transactionId } } );
-
           // Mode change requires full remap
           mappedObservations = Array.from( filteredObservations )
             .filter( obs => obs.isValid() )
             .map( obs => mapObservation( obs, isDefaultMode ) );
-
-          performance.mark( "end-rebuild", { detail: { transactionId } } );
         } else {
-          performance.mark( "start-inplace", { detail: { transactionId } } );
-
           const modifiedUuids = newModifications
             .map( index => localObservations[index] )
             .filter( obs => obs?.isValid() )
@@ -110,8 +94,6 @@ const useLocalObservations = ( ): Object => {
               }
               return previousObsByUuid[obs.uuid] ?? mapObservation( obs, currentIsDefaultMode );
             } );
-
-          performance.mark( "end-inplace", { detail: { transactionId } } );
         }
 
         setObservationList( mappedObservations );
@@ -123,7 +105,6 @@ const useLocalObservations = ( ): Object => {
           unsyncedCount,
           isDefaultMode: currentIsDefaultMode,
         };
-        performance.mark( "end", { detail: { transactionId } } );
       }
     };
 


### PR DESCRIPTION
MyObsContainer and Notifications call useLocalObservations. This hook returns Realm Observations mapped to pojos. It attaches listeners to the realm.objects( "Observation" ) collection to keep this list up to date. Aside: each use of hook maintains its own state / change handlers.

As far as mapping goes, this is a pretty expensive due to Realm objects being "live" managed objects (sort of like js Proxies).  

With the exception of insertion-only, this function was reacting to changes by remapping the entire collection. This becomes an issue because `realm.objects( "Observation" )` grows as the app is used: every time an Obs is loaded from the API, including during infinite scroll, it is added to Realm, increasing the amount of work this function needs to do.

**This change:**

instead of rebuilding and remapping all entities on handleChange, this change uses the previously built list and `newModifications` to only remap what is necessary. Note that additions and deletions are handled implicitly.

Other opportunities:
- consolidating the state / listeners so we're not doing duplicate work in notifs & myobs
- improve and/or defer initial build. we currently lock the UI thread with this so we may need to manually chunk it to
- reduce reliance on a full build at all
- garbage collect `realm.objects( "Observation" )`. This may be an opportunity w/ MyObs search work.

closes MOB-1384 (more tickets to come)