### PR TITLE
don't use problematic useLocalObservations in Notifications

### DIFF
--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -1,11 +1,10 @@
 import { NotificationOnboarding } from "components/OnboardingModal/PivotCards";
 import { Tabs } from "components/SharedComponents";
 import { View } from "components/styledComponents";
+import { RealmContext } from "providers/contexts";
 import React, { useState } from "react";
 import { EventRegister } from "react-native-event-listeners";
-import {
-  useCurrentUser, useLayoutPrefs, useLocalObservations, useTranslation,
-} from "sharedHooks";
+import { useCurrentUser, useLayoutPrefs, useTranslation } from "sharedHooks";
 
 import NotificationsContainer from "./NotificationsContainer";
 import NotificationsTab, {
@@ -13,6 +12,8 @@ import NotificationsTab, {
   OTHER_TAB,
   OWNER_TAB,
 } from "./NotificationsTab";
+
+const { useRealm } = RealmContext;
 
 const OWNER_TAB_PARAMS = { observations_by: "owner" } as const;
 const FOLLOWING_TAB_PARAMS = { observations_by: "following" } as const;
@@ -22,9 +23,9 @@ const Notifications = ( ) => {
   const { t } = useTranslation();
   const { isDefaultMode } = useLayoutPrefs( );
   const currentUser = useCurrentUser( );
-  const {
-    totalResults: totalResultsLocal,
-  } = useLocalObservations( );
+
+  const realm = useRealm();
+  const localObservationCount = realm.objects( "Observation" ).length;
 
   return (
     <View className="flex-1 bg-white">
@@ -60,7 +61,7 @@ const Notifications = ( ) => {
       )}
       <NotificationOnboarding
         triggerCondition={
-          isDefaultMode && !!currentUser && !!totalResultsLocal && totalResultsLocal < 10
+          isDefaultMode && !!currentUser && localObservationCount < 10
         }
       />
     </View>


### PR DESCRIPTION
closes MOB-1420

same concern as #3609. The observation Realm=>pojo mapping that `useLocalObservations` handles is hook-local so both consumers were doing their own expensive mapping.

For users with a non-trivial amount of locally loaded Observations, the app freezes multiple times during upload. The problem gets worse over time as the Realm obs collection grows. 

If a user ever navigates to the Notifications tab, for the reset of the app session, the freezes are twice as long because we are attaching a second mapping listener.

The solution here is to just not use it. We just need to know this is a new user w/ <10 obs to see if we need to prompt them w/ an onboarding modal. We don't need the pojo list, we can just query realm directly.
