### PR TITLE
Flip settings toggle layout

### DIFF
--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -1,7 +1,4 @@
-import {
-  Body1,
-  Body2,
-} from "components/SharedComponents";
+import { Body2 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
 import type { GestureResponderEvent } from "react-native";
@@ -12,10 +9,8 @@ interface Props {
   classNames: string;
   label: string;
   onValueChange: ( newValue: boolean ) => void;
-  smallLabel: boolean;
   testID: string;
   value: boolean;
-  labelComponent?: React.JSX.Element;
   disabled?: boolean;
 }
 
@@ -23,10 +18,8 @@ const SwitchRow = ( {
   classNames,
   label,
   onValueChange,
-  smallLabel = false,
   testID,
   value,
-  labelComponent,
   disabled = false,
 }: Props ) => {
   const handlePress = ( _e: GestureResponderEvent ) => {
@@ -34,10 +27,6 @@ const SwitchRow = ( {
       onValueChange( !value );
     }
   };
-
-  const Label = smallLabel
-    ? Body2
-    : Body1;
 
   return (
     <Pressable
@@ -50,13 +39,11 @@ const SwitchRow = ( {
     >
       <View className="flex-row items-center">
         <View className="mr-3 flex-row flex-1">
-          {labelComponent || (
-            <Label
-              maxFontSizeMultiplier={1.5}
-            >
-              {label}
-            </Label>
-          )}
+          <Body2
+            maxFontSizeMultiplier={1.5}
+          >
+            {label}
+          </Body2>
         </View>
         <Switch
           value={value}

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -55,13 +55,6 @@ const SwitchRow = ( {
       disabled={disabled}
     >
       <View className="flex-row items-center">
-        <Switch
-          value={value}
-          onValueChange={onValueChange}
-          disabled={disabled}
-          color={colors.inatGreen}
-          testID={`${testID || "Toggle"}.switch`}
-        />
         <View className="ml-3 flex-row w-5/6">
           {labelComponent || (
             <Label
@@ -73,6 +66,13 @@ const SwitchRow = ( {
           )}
           {icon && <INatIcon name={icon} size={19} color={colors.inatGreen} />}
         </View>
+        <Switch
+          value={value}
+          onValueChange={onValueChange}
+          disabled={disabled}
+          color={colors.inatGreen}
+          testID={`${testID || "Toggle"}.switch`}
+        />
       </View>
       {description && (
         <List2

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -7,20 +7,20 @@ import colors from "styles/tailwindColors";
 
 interface Props {
   classNames: string;
+  disabled?: boolean;
   label: string;
   onValueChange: ( newValue: boolean ) => void;
   testID: string;
   value: boolean;
-  disabled?: boolean;
 }
 
 const SwitchRow = ( {
   classNames,
+  disabled = false,
   label,
   onValueChange,
   testID,
   value,
-  disabled = false,
 }: Props ) => {
   const handlePress = ( _e: GestureResponderEvent ) => {
     if ( !disabled ) {

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -24,15 +24,15 @@ interface Props {
 }
 
 const SwitchRow = ( {
-  value,
   classNames,
-  description,
-  icon,
   label,
-  labelComponent,
   onValueChange,
   smallLabel = false,
   testID,
+  value,
+  description,
+  icon,
+  labelComponent,
   disabled = false,
 }: Props ) => {
   const handlePress = ( _e: GestureResponderEvent ) => {

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -49,7 +49,7 @@ const SwitchRow = ( {
       disabled={disabled}
     >
       <View className="flex-row items-center">
-        <View className="ml-3 flex-row w-5/6">
+        <View className="mr-3 flex-row flex-1">
           {labelComponent || (
             <Label
               maxFontSizeMultiplier={1.5}

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -2,7 +2,6 @@ import {
   Body1,
   Body2,
   INatIcon,
-  List2,
 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
@@ -17,7 +16,6 @@ interface Props {
   smallLabel: boolean;
   testID: string;
   value: boolean;
-  description?: string;
   icon?: string;
   labelComponent?: React.JSX.Element;
   disabled?: boolean;
@@ -30,7 +28,6 @@ const SwitchRow = ( {
   smallLabel = false,
   testID,
   value,
-  description,
   icon,
   labelComponent,
   disabled = false,
@@ -74,14 +71,6 @@ const SwitchRow = ( {
           testID={`${testID || "Toggle"}.switch`}
         />
       </View>
-      {description && (
-        <List2
-          maxFontSizeMultiplier={1.5}
-          className="ml-[32px] mt-[3px]"
-        >
-          {description}
-        </List2>
-      )}
     </Pressable>
   );
 };

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -1,7 +1,6 @@
 import {
   Body1,
   Body2,
-  INatIcon,
 } from "components/SharedComponents";
 import { Pressable, View } from "components/styledComponents";
 import React from "react";
@@ -16,7 +15,6 @@ interface Props {
   smallLabel: boolean;
   testID: string;
   value: boolean;
-  icon?: string;
   labelComponent?: React.JSX.Element;
   disabled?: boolean;
 }
@@ -28,7 +26,6 @@ const SwitchRow = ( {
   smallLabel = false,
   testID,
   value,
-  icon,
   labelComponent,
   disabled = false,
 }: Props ) => {
@@ -61,7 +58,6 @@ const SwitchRow = ( {
               {label}
             </Label>
           )}
-          {icon && <INatIcon name={icon} size={19} color={colors.inatGreen} />}
         </View>
         <Switch
           value={value}

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -11,15 +11,15 @@ import { Switch } from "react-native-paper";
 import colors from "styles/tailwindColors";
 
 interface Props {
+  classNames: string;
+  label: string;
+  onValueChange: ( newValue: boolean ) => void;
+  smallLabel: boolean;
+  testID: string;
   value: boolean;
-  classNames?: string;
   description?: string;
   icon?: string;
-  label?: string;
   labelComponent?: React.JSX.Element;
-  onValueChange: ( newValue: boolean ) => void;
-  smallLabel?: boolean;
-  testID?: string;
   disabled?: boolean;
 }
 

--- a/src/components/SharedComponents/SwitchRow.tsx
+++ b/src/components/SharedComponents/SwitchRow.tsx
@@ -53,7 +53,6 @@ const SwitchRow = ( {
           {labelComponent || (
             <Label
               maxFontSizeMultiplier={1.5}
-              className="mr-2"
             >
               {label}
             </Label>


### PR DESCRIPTION
Closes MOB-1410

Also, some cleanup of past options to customise this component which are nowhere used in the app. Also, maybe good we start removing some not so often used components from the barrel import/export file?

After:
<img width="563" height="1218" alt="IMG_4635" src="https://github.com/user-attachments/assets/97ad0788-d01e-4d5a-afcf-e649e2435255" />
