### PR TITLE
Observation flash list render defined component

### DIFF
--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -236,7 +236,7 @@ const MyObservationsSimple = ( {
     />
   );
 
-  const observationsHeader = ( ) => {
+  const observationsHeader = useMemo( ( ) => {
     if ( layout !== "grid" ) {
       return (
         <SimpleHeader
@@ -267,7 +267,7 @@ const MyObservationsSimple = ( {
         />
       </View>
     );
-  };
+  }, [flashListStyle, isConnected, layout, numTotalObservations, obsMissingBasicsExist] );
 
   const dataFilledWithEmptyBoxes = useMemo( ( ) => {
     const data = observations;
@@ -381,7 +381,7 @@ const MyObservationsSimple = ( {
               showObservationsEmptyScreen
               showNoResults={showNoResults}
               testID="MyObservationsAnimatedList"
-              renderHeader={observationsHeader}
+              listHeaderContent={observationsHeader}
             />
             <ObservationsViewBar
               hideMap

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -34,6 +34,9 @@ const { useRealm } = RealmContext;
 
 const AnimatedFlashList = Animated.createAnimatedComponent( CustomFlashList );
 
+// unlike the other FlashList Component props, Separator does _not_ accept an Element
+const ItemSeparator = () => <View className="border-b border-lightGray" />;
+
 interface Props {
   contentContainerStyle?: StyleProp<ViewStyle>;
   // TODO: type data / observations
@@ -198,11 +201,11 @@ const ObservationsFlashList = ( {
     uploadQueue,
   ] );
 
-  const renderItemSeparator = useCallback( ( ) => {
+  const itemSeparatorComponent = useMemo( ( ) => {
     if ( layout === "grid" ) {
       return null;
     }
-    return <View className="border-b border-lightGray" />;
+    return ItemSeparator;
   }, [layout] );
 
   const renderFooter = useCallback( ( ) => (
@@ -293,7 +296,7 @@ const ObservationsFlashList = ( {
 
   return (
     <AnimatedFlashList
-      ItemSeparatorComponent={renderItemSeparator}
+      ItemSeparatorComponent={itemSeparatorComponent}
       ListEmptyComponent={renderEmptyComponent}
       ListFooterComponent={renderFooter}
       ListHeaderComponent={renderHeader}

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -59,8 +59,7 @@ interface Props {
   onLayout?: ( event: LayoutChangeEvent ) => void;
   onScroll?: ( event: NativeSyntheticEvent<NativeScrollEvent> ) => void;
   // this ref is being forwarded to the underlying CustomFlashList and used as an imperative handle
-  // so the parent can control behavior like scrolling; it's typed as Function because there's not
-  // a good way to capture this otherwise with Flow.
+  // so the parent can control behavior like scrolling
   // TODO: type data / observations
   ref?: React.Ref<FlashListRef<unknown>>;
   listHeaderContent?: React.ReactElement | null;

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -1,5 +1,5 @@
-// @flow
 import { useNavigation } from "@react-navigation/native";
+import type { FlashListRef } from "@shopify/flash-list";
 import {
   ActivityIndicator,
   Body3,
@@ -9,12 +9,14 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import { RealmContext } from "providers/contexts";
-import type { Node } from "react";
 import React, {
   useCallback,
   useMemo,
   useState,
 } from "react";
+import type {
+  LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent, StyleProp, ViewStyle,
+} from "react-native";
 import { Animated } from "react-native";
 import RealmObservation from "realmModels/Observation";
 import {
@@ -32,37 +34,39 @@ const { useRealm } = RealmContext;
 
 const AnimatedFlashList = Animated.createAnimatedComponent( CustomFlashList );
 
-type Props = {
-  contentContainerStyle?: Object,
-  data: Object[],
-  dataCanBeFetched?: boolean,
-  fetchFromLastObservation?: Function,
-  explore: boolean,
-  handlePullToRefresh: Function,
-  handleIndividualUploadPress: Function,
-  hideLoadingWheel?: boolean,
-  hideMetadata?: boolean,
-  hideObsUploadStatus?: boolean,
-  hideObsStatus?: boolean,
-  isSimpleObsStatus?: boolean,
-  hideRGLabel?: boolean,
-  isConnected: boolean,
-  layout: "list" | "grid",
-  obsListKey: string,
-  onEndReached: Function,
-  onLayout?: Function,
-  onScroll?: Function,
+interface Props {
+  contentContainerStyle?: StyleProp<ViewStyle>;
+  // TODO: type data / observations
+  data: unknown[];
+  dataCanBeFetched?: boolean;
+  fetchFromLastObservation?: ( observationId?: number ) => Promise<void>;
+  explore: boolean;
+  handlePullToRefresh: () => Promise<void>;
+  handleIndividualUploadPress: ( observationUuid: string ) => Promise<void>;
+  hideLoadingWheel?: boolean;
+  hideMetadata?: boolean;
+  hideObsUploadStatus?: boolean;
+  hideObsStatus?: boolean;
+  isSimpleObsStatus?: boolean;
+  hideRGLabel?: boolean;
+  isConnected: boolean;
+  layout: "list" | "grid";
+  obsListKey: string;
+  onEndReached: () => Promise<void>;
+  onLayout?: ( event: LayoutChangeEvent ) => void;
+  onScroll?: ( event: NativeSyntheticEvent<NativeScrollEvent> ) => void;
   // this ref is being forwarded to the underlying CustomFlashList and used as an imperative handle
   // so the parent can control behavior like scrolling; it's typed as Function because there's not
   // a good way to capture this otherwise with Flow.
-  ref?: Function,
-  renderHeader?: Function,
-  showNoResults?: boolean,
-  showObservationsEmptyScreen?: boolean,
-  testID: string
-};
+  // TODO: type data / observations
+  ref?: React.Ref<FlashListRef<unknown>>;
+  renderHeader?: () => React.ReactElement | null;
+  showNoResults?: boolean;
+  showObservationsEmptyScreen?: boolean;
+  testID: string;
+}
 
-const ObservationsFlashList: Function = ( {
+const ObservationsFlashList = ( {
   contentContainerStyle: contentContainerStyleProp = {},
   data,
   dataCanBeFetched,
@@ -87,7 +91,7 @@ const ObservationsFlashList: Function = ( {
   showNoResults,
   showObservationsEmptyScreen,
   testID,
-}: Props ): Node => {
+}: Props ) => {
   const {
     isDefaultMode,
   } = useLayoutPrefs( );
@@ -113,6 +117,7 @@ const ObservationsFlashList: Function = ( {
   } = useGridLayout( layout );
   const { t } = useTranslation( );
 
+  // TODO: type data / observation
   const renderItem = useCallback( ( { item: observation } ) => {
     // Empty box
     if ( observation.empty ) {

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -63,7 +63,7 @@ interface Props {
   // a good way to capture this otherwise with Flow.
   // TODO: type data / observations
   ref?: React.Ref<FlashListRef<unknown>>;
-  renderHeader?: () => React.ReactElement | null;
+  listHeaderContent?: React.ReactElement | null;
   showNoResults?: boolean;
   showObservationsEmptyScreen?: boolean;
   testID: string;
@@ -90,7 +90,7 @@ const ObservationsFlashList = ( {
   onLayout,
   onScroll,
   ref,
-  renderHeader,
+  listHeaderContent,
   showNoResults,
   showObservationsEmptyScreen,
   testID,
@@ -299,7 +299,7 @@ const ObservationsFlashList = ( {
       ItemSeparatorComponent={itemSeparatorComponent}
       ListEmptyComponent={emptyContent}
       ListFooterComponent={footerContent}
-      ListHeaderComponent={renderHeader}
+      ListHeaderComponent={listHeaderContent}
       contentContainerStyle={contentContainerStyle}
       data={data}
       extraData={extraData}

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -208,7 +208,7 @@ const ObservationsFlashList = ( {
     return ItemSeparator;
   }, [layout] );
 
-  const renderFooter = useCallback( ( ) => (
+  const footerContent = useMemo( ( ) => (
     <InfiniteScrollLoadingWheel
       explore={explore}
       hideLoadingWheel={hideLoadingWheel}
@@ -234,7 +234,7 @@ const ObservationsFlashList = ( {
     layout,
   ] );
 
-  const renderEmptyComponent = useCallback( ( ) => {
+  const emptyContent = useMemo( ( ) => {
     const showEmptyScreen = showObservationsEmptyScreen
       ? null
       : (
@@ -297,8 +297,8 @@ const ObservationsFlashList = ( {
   return (
     <AnimatedFlashList
       ItemSeparatorComponent={itemSeparatorComponent}
-      ListEmptyComponent={renderEmptyComponent}
-      ListFooterComponent={renderFooter}
+      ListEmptyComponent={emptyContent}
+      ListFooterComponent={footerContent}
       ListHeaderComponent={renderHeader}
       contentContainerStyle={contentContainerStyle}
       data={data}

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -39,10 +39,10 @@ interface Props {
   // TODO: type data / observations
   data: unknown[];
   dataCanBeFetched?: boolean;
-  fetchFromLastObservation?: ( observationId?: number ) => Promise<void>;
+  fetchFromLastObservation?: ( observationId?: number ) => void;
   explore: boolean;
-  handlePullToRefresh: () => Promise<void>;
-  handleIndividualUploadPress: ( observationUuid: string ) => Promise<void>;
+  handlePullToRefresh: () => void;
+  handleIndividualUploadPress: ( observationUuid: string ) => void;
   hideLoadingWheel?: boolean;
   hideMetadata?: boolean;
   hideObsUploadStatus?: boolean;
@@ -52,7 +52,7 @@ interface Props {
   isConnected: boolean;
   layout: "list" | "grid";
   obsListKey: string;
-  onEndReached: () => Promise<void>;
+  onEndReached: () => void;
   onLayout?: ( event: LayoutChangeEvent ) => void;
   onScroll?: ( event: NativeSyntheticEvent<NativeScrollEvent> ) => void;
   // this ref is being forwarded to the underlying CustomFlashList and used as an imperative handle


### PR DESCRIPTION
This is an additional case of a class of issue discovered in #3383: `<FlashList HeaderComponent={() => <View />} />` or its equivalent of defining a `*Component` prop in render is Bad.

In this case, I believe it's causing `Announcements`, which loads dynamic html into a WebView on mount, to unnecessarily mount/remount (not just rerender).

UPDATE: 

1) After testing, that doesn't seem to be the case. This is still a desired change following the pattern of #3383.
2) Related we _are_ getting two calls to announcements whenever we render it, introduced when we added unauth'd announcements. This is due to an issue with how we check "is user authenticated". MOB-1431 to track this

----

Looking at this class of issue again here, I'm realizing now that we should probably _never_ pass a `useCallback`'d prop to one of FlashList's `*Component` props. At best, with no props, it's identical to passing a useMemo()'d Element. W/ props, it's strictly worse because we mount/unmount instead of just re-rendering. I think we can also _test_ removing the memos as well. They probably aren't having the impact we think they're having and they complicate the code.

^not suggesting that immediately but mentioning while we're here. For this PR, I kept us to using the pattern of useMemo'd elements we've stuck to since #3383.