### PR TITLE
Refactor zustand mmkv direct access mapType

### DIFF
--- a/src/components/LocationPicker/LocationPicker.js
+++ b/src/components/LocationPicker/LocationPicker.js
@@ -26,7 +26,6 @@ type Props = {
   loading: boolean,
   locationName: string,
   initialRegion: Object,
-  mapType: string,
   onCurrentLocationPress: Function,
   onMapReady: Function,
   onRegionChangeComplete: Function,
@@ -45,7 +44,6 @@ const LocationPicker = ( {
   locationName,
   regionToAnimate,
   initialRegion,
-  mapType,
   onCurrentLocationPress,
   onMapReady,
   onRegionChangeComplete,
@@ -113,7 +111,6 @@ const LocationPicker = ( {
           <Map
             className="h-full"
             initialRegion={initialRegion}
-            mapType={mapType}
             onCurrentLocationPress={onCurrentLocationPress}
             onMapReady={onMapReady}
             onRegionChangeComplete={onRegionChangeComplete}

--- a/src/components/LocationPicker/LocationPickerContainer.js
+++ b/src/components/LocationPicker/LocationPickerContainer.js
@@ -75,7 +75,6 @@ const initialState = {
   isFirstMapRender: true,
   loading: true,
   locationName: "",
-  mapType: "standard",
   region: undefined,
   regionToAnimate: undefined,
 };
@@ -120,11 +119,6 @@ const reducer = ( state, action ) => {
         regionToAnimate: action.region,
         loading: true,
       };
-    case "SET_MAP_TYPE":
-      return {
-        ...state,
-        mapType: action.mapType,
-      };
     case "UPDATE_LOCATION_NAME":
       return {
         ...state,
@@ -151,7 +145,6 @@ const LocationPickerContainer = ( ): Node => {
     isFirstMapRender,
     loading,
     locationName,
-    mapType,
     region,
     regionToAnimate,
   } = state;
@@ -254,7 +247,6 @@ const LocationPickerContainer = ( ): Node => {
       loading={loading}
       locationName={locationName}
       initialRegion={initialRegion}
-      mapType={mapType}
       onCurrentLocationPress={onCurrentLocationPress}
       onMapReady={onMapReady}
       onRegionChangeComplete={onRegionChangeComplete}

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -12,7 +12,7 @@ import React, {
 import type { DimensionValue, ViewStyle } from "react-native";
 import { Platform } from "react-native";
 import type {
-  BoundingBox, LatLng, MapType, Region,
+  BoundingBox, LatLng, Region,
 } from "react-native-maps";
 import MapView, { UrlTile } from "react-native-maps";
 import type Observation from "realmModels/Observation";
@@ -20,6 +20,8 @@ import fetchCoarseUserLocation from "sharedHelpers/fetchCoarseUserLocation";
 import mapTracker from "sharedHelpers/mapPerformanceTracker";
 import { useDebugMode, useDeviceOrientation } from "sharedHooks";
 import useLocationPermission from "sharedHooks/useLocationPermission";
+import type { MAP_TYPES } from "stores/createLayoutSlice";
+import useStore from "stores/useStore";
 import colors from "styles/tailwindColors";
 
 import CurrentLocationButton from "./CurrentLocationButton";
@@ -59,7 +61,6 @@ interface Props {
   initialRegion?: Region;
   isLoading?: boolean;
   mapHeight?: DimensionValue; // allows for height to be defined as px or percentage
-  mapType?: MapType;
   mapViewClassName?: string;
   observation?: Observation;
   onCurrentLocationPress?: () => void;
@@ -94,7 +95,6 @@ const Map = ( {
   initialRegion,
   isLoading = true,
   mapHeight,
-  mapType,
   mapViewClassName,
   observation,
   onCurrentLocationPress,
@@ -135,7 +135,7 @@ const Map = ( {
     longitude: number;
   } | undefined | null>( null );
   const mapViewRef = useRef<MapView>( undefined );
-  const [currentMapType, setCurrentMapType] = useState( mapType || "standard" );
+  const mapType: MAP_TYPES = useStore( state => state.layout.mapType );
   const [showsUserLocation, setShowsUserLocation] = useState( showsUserLocationProp );
 
   let defaultInitialRegion = null;
@@ -525,7 +525,7 @@ const Map = ( {
         initialRegion={initialRegion}
         loadingEnabled
         loadingIndicatorColor={colors.inatGreen}
-        mapType={currentMapType}
+        mapType={mapType}
         minZoomLevel={MIN_ZOOM_LEVEL}
         onMapReady={handleMapReady}
         onPanDrag={onPanDrag}
@@ -584,9 +584,7 @@ const Map = ( {
         onPress={handleCurrentLocationPress}
       />
       <SwitchMapTypeButton
-        currentMapType={currentMapType}
         mapType={mapType}
-        setCurrentMapType={setCurrentMapType}
         showSwitchMapTypeButton={showSwitchMapTypeButton}
         switchMapTypeButtonClassName={switchMapTypeButtonClassName}
       />

--- a/src/components/SharedComponents/Map/SwitchMapTypeButton.tsx
+++ b/src/components/SharedComponents/Map/SwitchMapTypeButton.tsx
@@ -1,43 +1,29 @@
 import classnames from "classnames";
 import { INatIconButton } from "components/SharedComponents";
-import React, {
-  useEffect,
-} from "react";
+import React from "react";
 import { useTranslation } from "sharedHooks";
 import { MAP_TYPES } from "stores/createLayoutSlice";
-import { zustandStorage } from "stores/useStore";
+import useStore from "stores/useStore";
 import { getShadow } from "styles/global";
 
 const DROP_SHADOW = getShadow( );
 
 interface Props {
-  currentMapType?: string;
-  mapType?: string;
-  setCurrentMapType: ( mapType: string|number ) => void;
+  mapType?: MAP_TYPES;
   showSwitchMapTypeButton?: boolean;
   switchMapTypeButtonClassName?: string;
 }
 
 const SwitchMapTypeButton = ( {
-  currentMapType,
   mapType,
-  setCurrentMapType,
   showSwitchMapTypeButton,
   switchMapTypeButtonClassName,
 }: Props ) => {
   const { t } = useTranslation( );
-  useEffect( () => {
-    const value = zustandStorage.getItem( "mapType" );
-    if ( value && !mapType ) {
-      // Load last saved map type (unless explicitly overridden by the parent
-      // of the Map component)
-      setCurrentMapType( value );
-    }
-  }, [mapType, setCurrentMapType] );
+  const setMapType = useStore( state => state.layout.setMapType );
 
-  const changeMapType = ( newMapType: string ) => {
-    setCurrentMapType( newMapType );
-    zustandStorage.setItem( "mapType", newMapType );
+  const changeMapType = ( newMapType: MAP_TYPES ) => {
+    setMapType( newMapType );
   };
 
   return showSwitchMapTypeButton && (
@@ -49,13 +35,13 @@ const SwitchMapTypeButton = ( {
       )}
       style={DROP_SHADOW}
       accessibilityLabel={
-        currentMapType === MAP_TYPES.STANDARD
+        mapType === MAP_TYPES.STANDARD
           ? t( "Standard--map-type" )
           : t( "Satellite--map-type" )
       }
       accessibilityHint={t( "Toggle-map-type" )}
       onPress={( ) => {
-        changeMapType( currentMapType === MAP_TYPES.STANDARD
+        changeMapType( mapType === MAP_TYPES.STANDARD
           ? MAP_TYPES.HYBRID
           : MAP_TYPES.STANDARD );
       }}

--- a/src/components/SharedComponents/Map/SwitchMapTypeButton.tsx
+++ b/src/components/SharedComponents/Map/SwitchMapTypeButton.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
 } from "react";
 import { useTranslation } from "sharedHooks";
+import { MAP_TYPES } from "stores/createLayoutSlice";
 import { zustandStorage } from "stores/useStore";
 import { getShadow } from "styles/global";
 
@@ -48,15 +49,15 @@ const SwitchMapTypeButton = ( {
       )}
       style={DROP_SHADOW}
       accessibilityLabel={
-        currentMapType === "standard"
+        currentMapType === MAP_TYPES.STANDARD
           ? t( "Standard--map-type" )
           : t( "Satellite--map-type" )
       }
       accessibilityHint={t( "Toggle-map-type" )}
       onPress={( ) => {
-        changeMapType( currentMapType === "standard"
-          ? "hybrid"
-          : "standard" );
+        changeMapType( currentMapType === MAP_TYPES.STANDARD
+          ? MAP_TYPES.HYBRID
+          : MAP_TYPES.STANDARD );
       }}
     />
   );

--- a/src/stores/createLayoutSlice.ts
+++ b/src/stores/createLayoutSlice.ts
@@ -9,6 +9,11 @@ export enum SCREEN_AFTER_PHOTO_EVIDENCE {
   MATCH = "Match"
 }
 
+export enum MAP_TYPES {
+  STANDARD = "standard",
+  HYBRID = "hybrid",
+}
+
 const createLayoutSlice = set => ( {
   // Vestigial un-namespaced values
   isAdvancedUser: false,
@@ -124,6 +129,14 @@ const createLayoutSlice = set => ( {
       layout: {
         ...state.layout,
         debugModeEnabled: !state.layout.debugModeEnabled,
+      },
+    } ) ),
+    // Last selected map layers type for react-native-maps MapView ("standard" or "hybrid")
+    mapType: MAP_TYPES.STANDARD,
+    setMapType: ( newMapType: MAP_TYPES ) => set( state => ( {
+      layout: {
+        ...state.layout,
+        mapType: newMapType,
       },
     } ) ),
   },


### PR DESCRIPTION
Refactored so that the mapType state is directly read from store in all Map instances (Closes MOB-841), and set from the button switcher (Closes MOB-1377). This removes the need for tracking local state.