### PR TITLE
initialize useCurrentUser useState value

### DIFF
--- a/src/sharedHooks/useCurrentUser.ts
+++ b/src/sharedHooks/useCurrentUser.ts
@@ -22,8 +22,11 @@ const useCurrentUser = ( ): User | null => {
       setCurrentUser( User.currentUser( realm ) || null );
     };
 
-    realmResults.addListener( listener );
+    // User could* have been mutated between state initialization and listener setup, resync state
+    // * FLGMwt: if you're reading this and have better knowledge of Realm's lifecycle, speak up!
+    listener();
 
+    realmResults.addListener( listener );
     return ( ) => {
       realmResults.removeListener( listener );
     };

--- a/src/sharedHooks/useCurrentUser.ts
+++ b/src/sharedHooks/useCurrentUser.ts
@@ -1,6 +1,5 @@
 import { RealmContext } from "providers/contexts";
 import { useEffect, useState } from "react";
-import type Realm from "realm";
 import User from "realmModels/User";
 
 const { useRealm } = RealmContext;
@@ -8,41 +7,27 @@ const { useRealm } = RealmContext;
 const useCurrentUser = ( ): User | null => {
   const realm = useRealm( );
   const [currentUser, setCurrentUser] = useState<User | null>( null );
+
   useEffect( ( ) => {
     const realmResults = realm.objects( User ).filtered( "signedIn == true" );
 
-    // Sets the current user if one is detected, unsets it if not
-    const listener = (
-      collection: Realm.OrderedCollection<User>,
-      changes: Realm.CollectionChangeSet,
-    ) => {
-      if (
-        ( changes.deletions && changes.deletions.length > 0 )
-        || !collection[0]?.isValid( )
-      ) {
-        setCurrentUser( null );
-      } else {
-        setCurrentUser( collection[0] );
-      }
+    // when the signedIn User collection changes, update state to latest currentUser or null.
+    // We don't need to handles changes in the listener because we only ever care about the
+    // single result (or lack of)
+    const listener = () => {
+      setCurrentUser( User.currentUser( realm ) || null );
     };
 
-    // Run the listener on the results for the first time
-    listener( realmResults, {
-      insertions: [],
-      deletions: [],
-      newModifications: [],
-      oldModifications: [],
-    } );
+    realmResults.addListener( listener );
 
-    // Add the listener
-    realmResults?.addListener( listener );
-
-    // Remove the listener when this dismounts
     return ( ) => {
-      realmResults?.removeListener( listener );
+      realmResults.removeListener( listener );
     };
   }, [realm] );
 
+  // isValid() here _only_ protects an invalid Realm being used in the one render pass between
+  // the listener firing on logout and currentUser being setStat'd to null.
+  // async callbacks referencing this `currentUser` return still need to `isValid()`.
   return currentUser?.isValid( )
     ? currentUser
     : null;

--- a/src/sharedHooks/useCurrentUser.ts
+++ b/src/sharedHooks/useCurrentUser.ts
@@ -6,7 +6,11 @@ const { useRealm } = RealmContext;
 
 const useCurrentUser = ( ): User | null => {
   const realm = useRealm( );
-  const [currentUser, setCurrentUser] = useState<User | null>( null );
+
+  // use a state initializer for the initial value from Realm
+  const [currentUser, setCurrentUser] = useState<User | null>(
+    () => User.currentUser( realm ) || null,
+  );
 
   useEffect( ( ) => {
     const realmResults = realm.objects( User ).filtered( "signedIn == true" );

--- a/src/sharedHooks/useCurrentUser.ts
+++ b/src/sharedHooks/useCurrentUser.ts
@@ -16,7 +16,7 @@ const useCurrentUser = ( ): User | null => {
     const realmResults = realm.objects( User ).filtered( "signedIn == true" );
 
     // when the signedIn User collection changes, update state to latest currentUser or null.
-    // We don't need to handles changes in the listener because we only ever care about the
+    // We don't need to handle changes in the listener because we only ever care about the
     // single result (or lack of)
     const listener = () => {
       setCurrentUser( User.currentUser( realm ) || null );


### PR DESCRIPTION
Sample problem this fixes (that I introduced):

```js
const currentUser = useCurrentUser();

useEffect(() => {
  const announcements = !!currentUser
    ? await authenticatedAnnouncements() // API A
    : await unauthenticatedAnnouncements(); // API B
}, [currentUser]);
```

Given a logged in user, this triggers an incorrect call to `API B` right before `API A`. The first effect is triggered on the initial state of `null` and only corrected to `currentUser` on the hook's effect run & listener setup call to `setState`.

Fix: initialize the hook's state (with an [initializer function](https://react.dev/reference/react/useState#parameters) so we're not adding realm hits past the first render).

I also simplified the listener logic in a separate commit. This collection only really cares if it changes and then we want to get the latest correct value. The result is equivalent.

closes MOB-1431