### PR TITLE
fix useLocalObservation regression: set listener on filtered 'desired' realm collection

### DIFF
--- a/src/sharedHooks/useLocalObservations.js
+++ b/src/sharedHooks/useLocalObservations.js
@@ -37,13 +37,12 @@ const useLocalObservations = ( ): Object => {
       // Satisfy the useEffect return type by returning a destructor function.
       return () => {};
     }
-    const localObservations = realm.objects( "Observation" );
+    const filteredObservations = realm.objects( "Observation" )
+      .filtered( deletionFilters )
+      .sorted( sortedFilters );
 
-    const handleChange = ( collection, changes ) => {
+    const handleChange = ( _collection, changes ) => {
       const { insertions, newModifications, deletions } = changes;
-      const filteredObservations = localObservations
-        .filtered( deletionFilters )
-        .sorted( sortedFilters );
 
       const unsyncedCount = Observation.filterUnsyncedObservations( realm ).length;
 
@@ -75,7 +74,7 @@ const useLocalObservations = ( ): Object => {
         } else {
           const modifiedUuids = new Set(
             newModifications
-              .map( index => localObservations[index] )
+              .map( index => filteredObservations[index] )
               .filter( obs => obs?.isValid() )
               .map( obs => obs.uuid ),
           );
@@ -106,11 +105,11 @@ const useLocalObservations = ( ): Object => {
       }
     };
 
-    localObservations.addListener( handleChange );
+    filteredObservations.addListener( handleChange );
     return ( ) => {
       // remember to remove listeners to avoid async updates
-      if ( localObservations && !realm.isClosed ) {
-        localObservations?.removeAllListeners( );
+      if ( filteredObservations && !realm.isClosed ) {
+        filteredObservations?.removeAllListeners( );
       }
     };
   }, [isDefaultMode, realm, setNumUnuploadedObservations] );


### PR DESCRIPTION
I noticed a mistake I made with this. We discussed the collection fidelity here https://github.com/inaturalist/iNaturalistReactNative/pull/3609#discussion_r3229917873 and while that's still correct about `localObservations` / `collection`, the _returned_ & cached mapping is based on a different collection, `filteredObs` which is the result of a filter & sort. 

As a result, a `changes` that references `obs[0]` would, in this case, incorrectly target a `needs_sync` obs sorted to the top of `filteredResults`.

The fix:

We don't actually need to deal with `observations` and `filteredObservations` separately. We can just make `filteredObservations` the "primary" collection and add a listener to that. This keeps us from having to manually reconcile the two.