### PR TITLE
Add fetchPlaceName mock

### DIFF
--- a/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
+++ b/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
@@ -6,7 +6,6 @@ import {
 } from "react";
 import Observation from "realmModels/Observation";
 import ObservationPhoto from "realmModels/ObservationPhoto";
-import fetchPlaceName from "sharedHelpers/fetchPlaceName";
 import { log } from "sharedHelpers/logger";
 import {
   useLayoutPrefs,
@@ -14,6 +13,8 @@ import {
 import { SCREEN_AFTER_PHOTO_EVIDENCE } from "stores/createLayoutSlice";
 import useStore from "stores/useStore";
 
+// Relative import so MOCK_MODE=e2e resolves fetchPlaceName.e2e-mock (Metro sourceExts).
+import fetchPlaceName from "../../../sharedHelpers/fetchPlaceName";
 import savePhotosToPhotoLibrary from "../helpers/savePhotosToPhotoLibrary";
 
 const logger = log.extend( "usePrepareStoreAndNavigate" );

--- a/src/sharedHelpers/fetchPlaceName.e2e-mock
+++ b/src/sharedHelpers/fetchPlaceName.e2e-mock
@@ -1,0 +1,11 @@
+// Skip geocoding during e2e tests. This is a legit failure of the Android e2e tests. Because we are
+// testing on an AOSP emulator, we do not have Play Services to geocode with. Mocking this out here is
+// one way to get the tests to pass.
+// This is also a real production bug though for users on phones that do not have Play Services.
+// Consider this a temporary workaround until this is done: https://linear.app/inaturalist/issue/MOB-1433/unhandled-promise-rejection-geocoder-not-available-for-this-platform
+const fetchPlaceName = async (
+  _lat?: number,
+  _lng?: number,
+): Promise<string | null> => null;
+
+export default fetchPlaceName;

--- a/tests/vision-camera/vision-camera.js
+++ b/tests/vision-camera/vision-camera.js
@@ -64,7 +64,7 @@ export class mockCamera extends React.PureComponent {
       /*
         On Android, copyAssetsFileIOS is not available. Instead, copy the test
         image that was pushed to the app's external files directory by
-        iNatE2eBeforeAll (via `adb push e2e/maestro/android/test.jpg`).
+        iNatE2eBeforeAll (via `adb push e2e/animal.jpg`).
         ExternalDirectoryPath = /sdcard/Android/data/<package>/files/
         which is accessible by the app without extra permissions.
       */

--- a/tests/vision-camera/vision-camera.js
+++ b/tests/vision-camera/vision-camera.js
@@ -127,7 +127,7 @@ export class mockCamera extends React.PureComponent {
   }
 
   render() {
-    return <View style={style} />;
+    return <View style={style} collapsable={false} />;
   }
 }
 


### PR DESCRIPTION
Part of MOB-939.

This fixes a fail in the AI camera e2e test. The reason for the fail is an unhandled promise rejection on using geocoding, which I have now mocked away. This is a legit bug for users on Android phones without Play Services, so we should at one point fix the source of the bug and remove this mock. Follow-up ticket here MOB-1433.

This PR makes the aiCamera.e2e.js test pass for me locally.