### PR TITLE
PotentialDisagreementSheet not allowing you to choose first value

### DIFF
--- a/src/components/Explore/Explore.js
+++ b/src/components/Explore/Explore.js
@@ -197,31 +197,31 @@ const Explore = ( {
     }
     const values = {
       species: {
-        label: t( "Species" ),
-        text: t( "Organisms-that-are-identified-to-species" ),
         buttonText: t( "EXPLORE-SPECIES" ),
         icon: "species",
+        label: t( "Species" ),
+        text: t( "Organisms-that-are-identified-to-species" ),
         value: "species",
       },
       observations: {
-        label: t( "Observations" ),
-        text: t( "Individual-encounters-with-organisms" ),
         buttonText: t( "EXPLORE-OBSERVATIONS" ),
         icon: "observations",
+        label: t( "Observations" ),
+        text: t( "Individual-encounters-with-organisms" ),
         value: "observations",
       },
       observers: {
-        label: t( "Observers" ),
-        text: t( "iNaturalist-users-who-have-observed" ),
         buttonText: t( "EXPLORE-OBSERVERS" ),
         icon: "observers",
+        label: t( "Observers" ),
+        text: t( "iNaturalist-users-who-have-observed" ),
         value: "observers",
       },
       identifiers: {
-        label: t( "Identifiers" ),
-        text: t( "iNaturalist-users-who-have-left-an-identification" ),
         buttonText: t( "EXPLORE-IDENTIFIERS" ),
         icon: "identifiers",
+        label: t( "Identifiers" ),
+        text: t( "iNaturalist-users-who-have-left-an-identification" ),
         value: "identifiers",
       },
     };

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -133,14 +133,14 @@ const MyObservationsSimple = ( {
 
   const taxaSortOptions = {
     [SPECIES_SORT_BY.COUNT_DESC]: {
-      value: SPECIES_SORT_BY.COUNT_DESC,
       label: t( "Most-Observed-Default" ),
       text: t( "Species-with-the-most-observations-appear-first" ),
+      value: SPECIES_SORT_BY.COUNT_DESC,
     },
     [SPECIES_SORT_BY.COUNT_ASC]: {
-      value: SPECIES_SORT_BY.COUNT_ASC,
       label: t( "Least-Observed" ),
       text: t( "Species-with-the-least-observations-appear-first" ),
+      value: SPECIES_SORT_BY.COUNT_ASC,
     },
   };
 

--- a/src/components/ObsDetailsSharedComponents/Sheets/PotentialDisagreementSheet.tsx
+++ b/src/components/ObsDetailsSharedComponents/Sheets/PotentialDisagreementSheet.tsx
@@ -98,6 +98,7 @@ const PotentialDisagreementSheet = ( {
       confirmText={t( "SUBMIT-ID-SUGGESTION" )}
       onPressClose={onPressClose}
       radioValues={radioValues}
+      requireSelectionChange={false}
       selectedValue={radioValues.unsure.value}
       topDescriptionText={topDescriptionText}
       bottomComponent={bottomComponent}

--- a/src/components/ObsDetailsSharedComponents/Sheets/PotentialDisagreementSheet.tsx
+++ b/src/components/ObsDetailsSharedComponents/Sheets/PotentialDisagreementSheet.tsx
@@ -2,7 +2,8 @@ import type { ApiTaxon } from "api/types";
 import {
   Body1,
   DisplayTaxon,
-  DisplayTaxonName, List2,
+  DisplayTaxonName,
+  List2,
   RadioButtonSheet,
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
@@ -14,7 +15,7 @@ import { useCurrentUser, useTranslation } from "sharedHooks";
 interface Props {
   loading?: boolean;
   onPressClose: () => void;
-  onPotentialDisagreePressed: ( _checkedValue: string ) => void;
+  onPotentialDisagreePressed: ( _checkedValue: boolean ) => void;
   newTaxon: RealmTaxon | ApiTaxon;
   oldTaxon: RealmTaxon | ApiTaxon;
 }

--- a/src/components/ObsEdit/Sheets/WildStatusSheet.tsx
+++ b/src/components/ObsEdit/Sheets/WildStatusSheet.tsx
@@ -1,23 +1,20 @@
-// @flow
-
 import {
   RadioButtonSheet,
 } from "components/SharedComponents";
-import type { Node } from "react";
 import React from "react";
 import useTranslation from "sharedHooks/useTranslation";
 
-type Props = {
-  onPressClose: Function,
-  selectedValue: boolean,
-  updateCaptiveStatus: Function
+interface Props {
+  onPressClose: ( ) => void;
+  selectedValue: boolean;
+  updateCaptiveStatus: ( _status: boolean ) => void;
 }
 
 const WildStatusSheet = ( {
   onPressClose,
   selectedValue,
   updateCaptiveStatus,
-}: Props ): Node => {
+}: Props ) => {
   const { t } = useTranslation( );
 
   const radioValues = {
@@ -37,7 +34,7 @@ const WildStatusSheet = ( {
     <RadioButtonSheet
       headerText={t( "WILD-STATUS" )}
       confirm={checkBoxValue => {
-        updateCaptiveStatus( checkBoxValue );
+        updateCaptiveStatus( checkBoxValue as boolean );
         onPressClose( );
       }}
       onPressClose={onPressClose}

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -25,7 +25,7 @@ interface Props {
     label?: string;
     text?: string;
     buttonText?: string;
-    labelComponent?: React.ReactNode;
+    labelComponent?: React.JSX.Element;
   }>;
   selectedValue?: RadioSheetPrimitive;
   testID?: string;

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -7,23 +7,25 @@ import { View } from "components/styledComponents";
 import React, { useState } from "react";
 import useTranslation from "sharedHooks/useTranslation";
 
+type RadioSheetPrimitive = boolean | number | string;
+
 interface Props {
   bottomComponent?: React.JSX.Element;
   buttonRowClassName?: string;
-  confirm: ( _checkedValue: string ) => void;
+  confirm: ( _checkedValue: RadioSheetPrimitive ) => void;
   confirmText?: string;
   headerText: string;
   insideModal?: boolean;
   loading?: boolean;
   onPressClose?: ( ) => void;
   radioValues: Record<string, {
-    value: string;
+    value: RadioSheetPrimitive;
     icon?: string;
     label: string;
     text?: string;
     buttonText?: string;
   }>;
-  selectedValue?: string;
+  selectedValue?: RadioSheetPrimitive;
   testID?: string;
   topDescriptionText?: React.JSX.Element;
 }

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -57,7 +57,7 @@ const RadioButtonSheet = ( {
     <View key={radioRow} className="pb-4">
       <RadioButtonRow
         classNames={buttonRowClassName}
-        value={radioValues[radioRow].value}
+        value={radioValues[radioRow].value.toString( )}
         icon={radioValues[radioRow].icon}
         checked={checkedValue === radioValues[radioRow].value}
         onPress={() => setCheckedValue( radioValues[radioRow].value )}

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -18,6 +18,7 @@ interface Props {
   insideModal?: boolean;
   loading?: boolean;
   onPressClose?: ( ) => void;
+  requireSelectionChange?: boolean;
   radioValues: Record<string, {
     value: RadioSheetPrimitive;
     icon?: string;
@@ -41,6 +42,7 @@ const RadioButtonSheet = ( {
   loading,
   onPressClose,
   radioValues,
+  requireSelectionChange = true,
   selectedValue = "none",
   testID,
   topDescriptionText,
@@ -49,6 +51,7 @@ const RadioButtonSheet = ( {
   const [checkedValue, setCheckedValue] = useState( selectedValue );
 
   const isDirty = checkedValue !== selectedValue;
+  const confirmBlockedByDirtyCheck = requireSelectionChange && !isDirty;
 
   const radioButtonRow = ( radioRow: string ) => (
     <View key={radioRow} className="pb-4">
@@ -86,7 +89,7 @@ const RadioButtonSheet = ( {
           onPress={( ) => {
             confirm( checkedValue );
           }}
-          disabled={!isDirty || loading}
+          disabled={confirmBlockedByDirtyCheck || loading}
           loading={loading}
           text={radioValues[checkedValue]?.buttonText ?? confirmLabel}
           accessibilityLabel={radioValues[checkedValue]?.buttonText ?? confirmLabel}

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -20,12 +20,13 @@ interface Props {
   onPressClose?: ( ) => void;
   requireSelectionChange?: boolean;
   radioValues: Record<string, {
-    value: RadioSheetPrimitive;
+    buttonText?: string;
     icon?: string;
     label?: string;
-    text?: string;
-    buttonText?: string;
+    labelCaps?: string;
     labelComponent?: React.JSX.Element;
+    text?: string;
+    value: RadioSheetPrimitive;
   }>;
   selectedValue?: RadioSheetPrimitive;
   testID?: string;

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -23,7 +23,6 @@ interface Props {
     buttonText?: string;
     icon?: string;
     label?: string;
-    labelCaps?: string;
     labelComponent?: React.JSX.Element;
     text?: string;
     value: RadioSheetPrimitive;

--- a/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
+++ b/src/components/SharedComponents/Sheets/RadioButtonSheet.tsx
@@ -21,9 +21,10 @@ interface Props {
   radioValues: Record<string, {
     value: RadioSheetPrimitive;
     icon?: string;
-    label: string;
+    label?: string;
     text?: string;
     buttonText?: string;
+    labelComponent?: React.ReactNode;
   }>;
   selectedValue?: RadioSheetPrimitive;
   testID?: string;

--- a/tests/unit/components/SharedComponents/Sheets/RadioButtonSheet.test.js
+++ b/tests/unit/components/SharedComponents/Sheets/RadioButtonSheet.test.js
@@ -1,5 +1,7 @@
+import { fireEvent, screen } from "@testing-library/react-native";
 import { RadioButtonSheet } from "components/SharedComponents";
 import React from "react";
+import { renderComponent } from "tests/helpers/render";
 
 const mockHandleClose = jest.fn( );
 const mockConfirm = jest.fn( );
@@ -18,6 +20,10 @@ const mockRadioValues = {
 };
 
 describe( "RadioButtonSheet", () => {
+  beforeEach( () => {
+    jest.clearAllMocks( );
+  } );
+
   it( "should not have accessibility errors", () => {
     const sheet = (
       <RadioButtonSheet
@@ -31,5 +37,58 @@ describe( "RadioButtonSheet", () => {
     // TODO: this errors because RadioButton from react-native-paper is not accessible
     console.log( "typeof sheet :>> ", typeof sheet );
     // expect( sheet ).toBeAccessible();
+  } );
+
+  it( "disables confirm when unchanged and requireSelectionChange is default", () => {
+    renderComponent(
+      <RadioButtonSheet
+        onPressClose={mockHandleClose}
+        confirm={mockConfirm}
+        headerText="header text"
+        radioValues={mockRadioValues}
+        selectedValue={mockRadioValues.first.value}
+      />,
+    );
+
+    const button = screen.getByText( "CONFIRM" );
+
+    expect( button ).toBeDisabled( );
+  } );
+
+  it( "enables confirm on initial render when requireSelectionChange is false", () => {
+    renderComponent(
+      <RadioButtonSheet
+        onPressClose={mockHandleClose}
+        confirm={mockConfirm}
+        headerText="header text"
+        radioValues={mockRadioValues}
+        requireSelectionChange={false}
+        selectedValue={mockRadioValues.first.value}
+      />,
+    );
+
+    const button = screen.getByText( "CONFIRM" );
+
+    expect( button ).toBeEnabled( );
+  } );
+
+  it( "enables confirm after changing option when requireSelectionChange is default", () => {
+    renderComponent(
+      <RadioButtonSheet
+        onPressClose={mockHandleClose}
+        confirm={mockConfirm}
+        headerText="header text"
+        radioValues={mockRadioValues}
+        selectedValue={mockRadioValues.first.value}
+      />,
+    );
+    const label2 = screen.getByText( "label 2" );
+    const button = screen.getByText( "CONFIRM" );
+
+    fireEvent.press( label2 );
+    expect( button ).toBeEnabled();
+    fireEvent.press( button );
+
+    expect( mockConfirm ).toHaveBeenCalledWith( "value-2" );
   } );
 } );

--- a/tests/unit/components/SharedComponents/Sheets/RadioButtonSheet.test.js
+++ b/tests/unit/components/SharedComponents/Sheets/RadioButtonSheet.test.js
@@ -3,18 +3,19 @@ import React from "react";
 
 const mockHandleClose = jest.fn( );
 const mockConfirm = jest.fn( );
-const mockValues = [
-  {
-    value: "value 1",
+
+const mockRadioValues = {
+  first: {
+    value: "value-1",
     label: "label 1",
-    description: "description 1",
+    text: "description 1",
   },
-  {
-    value: "value 2",
+  second: {
+    value: "value-2",
     label: "label 2",
-    description: "description 2",
+    text: "description 2",
   },
-];
+};
 
 describe( "RadioButtonSheet", () => {
   it( "should not have accessibility errors", () => {
@@ -23,7 +24,7 @@ describe( "RadioButtonSheet", () => {
         onPressClose={mockHandleClose}
         confirm={mockConfirm}
         headerText="header text"
-        radioValues={mockValues}
+        radioValues={mockRadioValues}
       />
     );
 


### PR DESCRIPTION
Closes MOB-1395.

Added a new prop `requireSelectionChange` to be able to not consider the default value being "dirty" so that the user can already submit the radio button sheet with the default value.

Also updated types to reflect current real usage.