### PR TITLE
Update iOS e2e tests to macos-26 runner

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -34,7 +34,7 @@ module.exports = {
         "ios/build/Build/Products/Debug-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
     },
     "ios.release": {
       type: "ios.app",
@@ -42,7 +42,7 @@ module.exports = {
         "ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
     },
     "android.debug": {
       type: "android.apk",

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -34,7 +34,7 @@ module.exports = {
         "ios/build/Build/Products/Debug-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
     },
     "ios.release": {
       type: "ios.app",
@@ -42,7 +42,7 @@ module.exports = {
         "ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
     },
     "android.debug": {
       type: "android.apk",

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -65,8 +65,7 @@ module.exports = {
     simulator: {
       type: "ios.simulator",
       device: {
-        type: "iPhone 16 Pro",
-        os: "iOS 18.6",
+        type: "iPhone 17 Pro",
       },
     },
     emulator: {

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -34,7 +34,7 @@ module.exports = {
         "ios/build/Build/Products/Debug-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
     },
     "ios.release": {
       type: "ios.app",
@@ -42,7 +42,7 @@ module.exports = {
         "ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
     },
     "android.debug": {
       type: "android.apk",

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -34,7 +34,7 @@ module.exports = {
         "ios/build/Build/Products/Debug-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64",
     },
     "ios.release": {
       type: "ios.app",
@@ -42,7 +42,7 @@ module.exports = {
         "ios/build/Build/Products/Release-iphonesimulator/iNaturalistReactNative.app",
       build:
         /* eslint-disable-next-line max-len */
-        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES",
+        "xcodebuild -workspace ios/iNaturalistReactNative.xcworkspace -scheme iNaturalistReactNative -configuration Release -sdk iphonesimulator -derivedDataPath ios/build ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64",
     },
     "android.debug": {
       type: "android.apk",

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   checksecret:
     name: check for oauth client
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       is_SECRETS_PRESENT_set: ${{ steps.checksecret_job.outputs.is_SECRETS_PRESENT_set }}
     steps:
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: checksecret
     if: needs.checksecret.outputs.is_SECRETS_PRESENT_set == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     # Kill the task if not finished after 120 minutes
     timeout-minutes: 120
 
@@ -137,7 +137,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: macos-15
+    runs-on: macos-26
     # Kill the task if not finished after 120 minutes
     timeout-minutes: 120
 
@@ -249,7 +249,7 @@ jobs:
     name: Notify Slack
     needs: test
     if: ${{ success() || failure() }}
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: iRoachie/slack-github-actions@v2.3.0
         if: env.SLACK_WEBHOOK_URL != null

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -49,7 +49,14 @@ jobs:
     - name: Setup Ruby version according to .ruby-version with cached gems
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true        
+        bundler-cache: true
+
+    # Required workaround for Firebase & XCode >26.0.1
+    # https://github.com/actions/runner-images/issues/13135#issuecomment-3397914993
+    - name: Set Xcode Toolchain
+      shell: bash
+      run: |
+        echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
 
     - name: Cache node modules
       uses: actions/cache@v5


### PR DESCRIPTION
XCode 26 has mostly been working for me locally since 26.4 which is now also the default on the macos-26 runners. So, I did a PR to update to the 26 runners, and apart from one new command to deal with some problems in building we seem to be fine here.
https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md