### PR TITLE
Increase maximum zoom in the media viewer

### DIFF
--- a/src/components/MediaViewer/CustomImageZoom.tsx
+++ b/src/components/MediaViewer/CustomImageZoom.tsx
@@ -9,7 +9,7 @@ import React, {
 import useDeviceOrientation from "sharedHooks/useDeviceOrientation";
 
 const MIN_SCALE = 0.5;
-const MAX_SCALE = 5;
+const MAX_SCALE = 50;
 
 interface Props {
   uri: string;


### PR DESCRIPTION
There are many images in iNaturalist where the subject is very small in the frame. Particularly when ID'ing, 5x zoom is often not enough. Increasing this value is a simple enough change, and aligns with the [2026H1 goal](https://www.inaturalist.org/blog/123394-our-product-goals-for-january-june-2026) of building the identifier community. The mobile app has huge potential to make it easier for identifiers to spend a few minutes doing it on the go.

This is also a good feature for accessibility - I don't have great eyesight, and I imagine I'm not alone among iNaturalist users.

cc @FLGMwt @albullington - seems like you do work here. It seems I don't have permission to add reviewers to a PR?