### PR TITLE
Fix: Media deletion was operating with stale data

### DIFF
--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -157,14 +157,15 @@ const EvidenceList = ( {
     </Pressable>
   ), [handleAddEvidence, t] );
 
-  const afterMediaDeleted = useCallback( ( ) => {
+  const afterMediaDeleted = useCallback( deletedUri => {
     // If there was was only one item and it was deleted, close the modal by
     // nullifying the selected media URI. Otherwise, choose the last
     // remaining item.
-    if ( mediaUris.length === 1 ) {
+    const remainingMediaUris = mediaUris.filter( uri => uri !== deletedUri );
+    if ( remainingMediaUris.length === 0 ) {
       setSelectedMediaUri( null );
     } else {
-      setSelectedMediaUri( mediaUris[mediaUris.length - 1] );
+      setSelectedMediaUri( remainingMediaUris[remainingMediaUris.length - 1] );
     }
     setDeleting( false );
   }, [mediaUris, setSelectedMediaUri] );
@@ -176,7 +177,7 @@ const EvidenceList = ( {
   const onDeletePhoto = useCallback( async uriToDelete => {
     await ObservationPhoto.deletePhoto( uriToDelete, currentObservation );
     deletePhotoFromObservation( uriToDelete );
-    afterMediaDeleted( );
+    afterMediaDeleted( uriToDelete );
   }, [afterMediaDeleted, currentObservation, deletePhotoFromObservation] );
 
   const onDeleteSound = useCallback( async uriToDelete => {
@@ -188,7 +189,7 @@ const EvidenceList = ( {
         uriToDelete,
         currentObservation.uuid,
       );
-      afterMediaDeleted( );
+      afterMediaDeleted( uriToDelete );
     }
     setDeleting( true );
     // If sound was synced, delete the remote copy immediately and then remove

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -25,6 +25,7 @@ import colors from "styles/tailwindColors";
 const ALLOWED_TAGS = ( `
   a
   abbr
+  asd
   acronym
   b
   blockquote

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -25,7 +25,6 @@ import colors from "styles/tailwindColors";
 const ALLOWED_TAGS = ( `
   a
   abbr
-  asd
   acronym
   b
   blockquote


### PR DESCRIPTION
Closes MOB-1392

`mediaUris` is referencing the state before the media was deleted, so we have to select the new state after deletion based on mediaUris filtered by the just deleted uri. Or we could update the callback to work with non-stale data, but I don't think a callback is needed here anyway. We are just calling a function in the media viewer modal.