### PR TITLE
MOB-882: popto when selecting taxon from taxon details

### DIFF
--- a/src/components/TaxonDetails/TaxonDetails.js
+++ b/src/components/TaxonDetails/TaxonDetails.js
@@ -1,7 +1,12 @@
 // @flow
 
 import { refresh, useNetInfo } from "@react-native-community/netinfo";
-import { useNavigation, useNavigationState, useRoute } from "@react-navigation/native";
+import {
+  StackActions,
+  useNavigation,
+  useNavigationState,
+  useRoute,
+} from "@react-navigation/native";
 import { fetchSpeciesCounts } from "api/observations";
 import MatchSaveDiscardButtons from "components/Match/SaveDiscardButtons";
 import MediaViewerModal from "components/MediaViewer/MediaViewerModal";
@@ -476,14 +481,15 @@ const TaxonDetails = ( ): Node => {
               } else {
                 updateTaxon( );
                 if ( fromObsDetails ) {
-                  const obsDetailsParam = {
-                    uuid: obsUuid,
-                    identTaxonId: taxon?.id,
-                    identAt: Date.now(),
-                  };
-                  navigation.navigate( "ObsDetails", obsDetailsParam );
+                  navigation.dispatch(
+                    StackActions.popTo( "ObsDetails", {
+                      uuid: obsUuid,
+                      identTaxonId: taxon?.id,
+                      identAt: Date.now(),
+                    } ),
+                  );
                 } else {
-                  navigation.navigate( "ObsEdit" );
+                  navigation.dispatch( StackActions.popTo( "ObsEdit" ) );
                 }
               }
             }}


### PR DESCRIPTION
Closes [MOB-882](https://linear.app/inaturalist/issue/MOB-882/explore-swiping-back-after-adding-id-from-taxon-page-not-working)

Instead of adding a new screen to the stack, return to a previous one. Mirrors the approach in useNavigateWithTaxonSelected here https://github.com/inaturalist/iNaturalistReactNative/blob/ea5e4bb20bdc6bdedf4c95914d5f46fd14b11915/src/components/Suggestions/hooks/useNavigateWithTaxonSelected.ts#L47