### PR TITLE
Use nvmrc to specifiy the version in github actions node setup

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Cache node modules
         uses: actions/cache@v5

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -44,7 +44,8 @@ jobs:
     - name: Install Node.js, NPM and Yarn
       uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version-file: '.nvmrc'
+        cache: 'npm'
 
     - name: Setup Ruby version according to .ruby-version with cached gems
       uses: ruby/setup-ruby@v1
@@ -163,7 +164,8 @@ jobs:
     - name: Install Node.js, NPM and Yarn
       uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version-file: '.nvmrc'
+        cache: 'npm'
 
     - name: Cache node modules
       uses: actions/cache@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install Node.js, NPM and Yarn
       uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version-file: '.nvmrc'
+        cache: 'npm'
 
     - name: Cache node modules
       uses: actions/cache@v5


### PR DESCRIPTION
@FLGMwt I have seen your android e2e test uses this instead of specifying the version in the workflow file. Is this preferred?