### PR TITLE
MOB-168: set needLocation to false when navigating to locationPicker

### DIFF
--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -294,7 +294,6 @@ const MatchContainer = ( ) => {
 
   const navToLocationPicker = useCallback( ( ) => {
     stopWatch( subscriptionId );
-    setNeedLocation( false );
     navigation.navigate( "LocationPicker" );
   }, [stopWatch, subscriptionId, navigation] );
 

--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -294,6 +294,7 @@ const MatchContainer = ( ) => {
 
   const navToLocationPicker = useCallback( ( ) => {
     stopWatch( subscriptionId );
+    setNeedLocation( false );
     navigation.navigate( "LocationPicker" );
   }, [stopWatch, subscriptionId, navigation] );
 

--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -499,6 +499,7 @@ const MatchContainer = ( ) => {
           // we want to start watching the location no matter how the observation
           // was created (camera, sound recorder, etc.)
           onPermissionGranted: () => {
+            setNeedLocation( true );
             getCurrentUserPlaceName( );
           },
           // If the user does not give location permissions in any form,

--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -500,7 +500,6 @@ const MatchContainer = ( ) => {
           // we want to start watching the location no matter how the observation
           // was created (camera, sound recorder, etc.)
           onPermissionGranted: () => {
-            setNeedLocation( true );
             getCurrentUserPlaceName( );
           },
           // If the user does not give location permissions in any form,

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -87,6 +87,7 @@ const ObsEdit = ( ): Node => {
 
   const navToLocationPicker = useCallback( ( ) => {
     stopWatch( subscriptionId );
+    setNeedLocation( false );
     navigation.navigate( "LocationPicker" );
   }, [stopWatch, subscriptionId, navigation] );
 


### PR DESCRIPTION
Repro is not consistent but this definitely fixes it for me.

Only downside I can see is this will stop the location fetching even if a user doesn't actually select a location from the LocationPicker. I think it's worth the tradeoff for simplicity's sake