### PR TITLE
memoize extraData to flashlist

### DIFF
--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -255,10 +255,10 @@ const ObservationsFlashList = ( {
     t,
   ] );
 
-  const extraData = {
+  const extraData = useMemo( () => ( {
     gridItemWidth,
     numColumns,
-  };
+  } ), [gridItemWidth, numColumns] );
 
   // only used id as a fallback key because after upload
   // react thinks we've rendered a second item w/ a duplicate key

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -114,7 +114,6 @@ const ObservationsFlashList = ( {
   const {
     flashListStyle,
     gridItemStyle,
-    gridItemWidth,
     numColumns,
   } = useGridLayout( layout );
   const { t } = useTranslation( );
@@ -255,11 +254,6 @@ const ObservationsFlashList = ( {
     t,
   ] );
 
-  const extraData = useMemo( () => ( {
-    gridItemWidth,
-    numColumns,
-  } ), [gridItemWidth, numColumns] );
-
   // only used id as a fallback key because after upload
   // react thinks we've rendered a second item w/ a duplicate key
   const keyExtractor = item => item.uuid || item.id;
@@ -301,7 +295,6 @@ const ObservationsFlashList = ( {
       ListHeaderComponent={listHeaderContent}
       contentContainerStyle={contentContainerStyle}
       data={data}
-      extraData={extraData}
       ref={ref}
       key={numColumns}
       keyExtractor={keyExtractor}


### PR DESCRIPTION
came up in discovery of MOB-1458 / MOB-1447. PR-ing separately. Closes MOB-1459, my description copied from there:

> Moving from non-stable pojos to string primitives as list data highlighted an optimization opportunity: we were creating a non-stable reference to extraData which invalidates every render optimization that FlashList might attempt.
> 
> Even if a pojo reference was stable or a uuid identity was stable, we were forcing FlashList to renderItem again because extraData (which informs renderItem) was unstable.
> 
> These need to be wrapped in an object for the FlashList prop so this is a clear case where a memo object wrapper of two separate primitives is warranted.