### PR TITLE
MOB-1322: rm removeBottomBorder from stack group

### DIFF
--- a/src/navigation/StackNavigators/SharedStackScreens.tsx
+++ b/src/navigation/StackNavigators/SharedStackScreens.tsx
@@ -15,7 +15,6 @@ import {
   blankHeaderTitle,
   fadeInComponent,
   hideHeader,
-  removeBottomBorder,
   showHeader,
   showSimpleCustomHeader,
 } from "navigation/navigationOptions";
@@ -87,7 +86,6 @@ const SharedStackScreens = ( ) => (
     {/* Screens with centered header */}
     <Stack.Group
       screenOptions={{
-        ...removeBottomBorder,
         ...showHeader,
         headerTitleAlign: "center",
         headerBackButtonDisplayMode: "minimal",


### PR DESCRIPTION
Fixes not being able to tap the Match screen header edit icon on android.

As near as I can tell the background component added with removeBottomBorder was blocking taps to the edit button. It also seems not to be needed any longer.

<details>
  <summary>Screenies for visual comparison (they're the same)</summary>

  Android before

<img width="216" height="126" alt="116" src="https://github.com/user-attachments/assets/423329f0-cdbe-4735-8053-22b4166d06c2" />

  <img width="216" height="123" alt="118" src="https://github.com/user-attachments/assets/66590acc-8680-46b3-96a8-35852783a4e7" />

  <img width="216" height="64" alt="117" src="https://github.com/user-attachments/assets/686a59f6-85ba-4beb-800f-bce5e7a995bd" />
  
  Android after

  <img width="216" height="130" alt="120" src="https://github.com/user-attachments/assets/2d123f80-ddce-4f6b-abb6-fc91ecef26b1" />

  <img width="216" height="112" alt="121" src="https://github.com/user-attachments/assets/22383010-7f81-4f6c-aa0a-11842abf69b0" />

  <img width="216" height="173" alt="123" src="https://github.com/user-attachments/assets/d678cd35-60cd-4a78-9a33-f57c97796de4" />

  iOS after
  
  <img width="236" height="134" alt="IMG_0169" src="https://github.com/user-attachments/assets/329fb269-02fa-4d9e-8bf7-399900c3394e" />

  <img width="236" height="125" alt="IMG_0171" src="https://github.com/user-attachments/assets/ac675b80-822d-43f9-9b14-778ad1ffe4b7" />

  <img width="236" height="77" alt="IMG_0170" src="https://github.com/user-attachments/assets/b9d764e1-b5a4-4e80-9e05-abd3a4a3e192" />


  </details>