### PR TITLE
Show no-evidence state on SavedMatch after deleting media

### DIFF
--- a/src/components/Match/PhotosSection.tsx
+++ b/src/components/Match/PhotosSection.tsx
@@ -2,6 +2,7 @@ import type { ApiPhoto, ApiTaxon } from "api/types";
 import classnames from "classnames";
 import MediaViewerModal from "components/MediaViewer/MediaViewerModal";
 import {
+  IconicTaxonIcon,
   PhotoCount,
 } from "components/SharedComponents";
 import {
@@ -187,6 +188,25 @@ const PhotosSection = ( {
       ) )}
     </View>
   );
+
+  if ( observationPhotos.length === 0 ) {
+    return (
+      <View className="h-[390px]">
+        <IconicTaxonIcon
+          iconicTaxonName={taxon?.iconic_taxon_name}
+          imageClassName={[
+            "grow",
+            "aspect-square",
+            "bg-darkGray",
+            "border-0",
+          ]}
+          white
+          isBackground
+          size={120}
+        />
+      </View>
+    );
+  }
 
   if ( displayPortraitLayout === null ) {
     return (

--- a/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatch.tsx
+++ b/src/components/ObsDetailsDefaultMode/SavedMatch/SavedMatch.tsx
@@ -48,7 +48,7 @@ const SavedMatch = ( {
       />
       <View className={matchCardClassBottom} />
       {
-        isConnected && (
+        taxon && isConnected && (
           <Button
             className="mx-4 mb-[30px]"
             level="primary"


### PR DESCRIPTION
Closes MOB-1297

Also removed the Learn More button if there is no taxon to route to, because it crashes the app.

After
<img width="563" height="1218" alt="IMG_4705" src="https://github.com/user-attachments/assets/fa647b7e-e829-40db-9953-3614b57437cc" />
Before
<img width="563" height="1218" alt="IMG_4707" src="https://github.com/user-attachments/assets/ddb6642c-a7d9-4a30-a853-1522d3bb700d" />

After
<img width="563" height="1218" alt="IMG_4706" src="https://github.com/user-attachments/assets/f2158e0b-67ef-4714-86f4-834bd030cf74" />
Before
<img width="563" height="1218" alt="IMG_4708" src="https://github.com/user-attachments/assets/2c4491c7-2d82-4f51-84a6-72f9fd73add2" />

