### PR TITLE
Show iconic taxon in obs list

### DIFF
--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -328,7 +328,7 @@ class Observation extends Realm.Object {
           preferred_common_name: obs?.taxon?.preferred_common_name,
           rank: obs?.taxon?.rank,
           rank_level: obs?.taxon?.rank_level,
-          iconic_taxon_name: obs?.taxon.iconic_taxon_name,
+          iconic_taxon_name: obs?.taxon?.iconic_taxon_name,
         }
         : null,
       comments_viewed: obs.comments_viewed,

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -328,6 +328,7 @@ class Observation extends Realm.Object {
           preferred_common_name: obs?.taxon?.preferred_common_name,
           rank: obs?.taxon?.rank,
           rank_level: obs?.taxon?.rank_level,
+          iconic_taxon_name: obs?.taxon.iconic_taxon_name,
         }
         : null,
       comments_viewed: obs.comments_viewed,


### PR DESCRIPTION
When there is no media for an observation but a taxon is assigned, the fallback UI should show the iconic taxon. So, when mapping realm obs for the list we also need to get the iconic_taxon_name value.

Have found this while doing sth else, and I don't think there is a ticket for this.

Before
<img width="563" height="1218" alt="IMG_4709" src="https://github.com/user-attachments/assets/9d4051cc-36da-4199-8614-4937ef043b50" />
After
<img width="563" height="1218" alt="IMG_4704" src="https://github.com/user-attachments/assets/b0cf5900-9b86-4f42-8345-93672df837b9" />
