### PR TITLE
Adjust radius of circle when selecting a location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.2.0",
+        "haversine-distance": "^1.2.4",
         "i18next": "^26.0.4",
         "i18next-fluent": "^2.0.0",
         "i18next-resources-to-backend": "^1.2.1",
@@ -13648,6 +13649,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/haversine-distance": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/haversine-distance/-/haversine-distance-1.2.4.tgz",
+      "integrity": "sha512-8MHQBQXR7GXZJIvitCf/ux+gwLtWOxmXNNz5dReG+jJbuvaEoj6QIXlaIO3cPr433BFWM4jececJaLYpwxnZhg==",
+      "license": "MIT"
     },
     "node_modules/hermes-compiler": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
+    "haversine-distance": "^1.2.4",
     "i18next": "^26.0.4",
     "i18next-fluent": "^2.0.0",
     "i18next-resources-to-backend": "^1.2.1",

--- a/src/components/LocationPicker/LocationPickerContainer.js
+++ b/src/components/LocationPicker/LocationPickerContainer.js
@@ -2,6 +2,7 @@
 
 import { useNavigation } from "@react-navigation/native";
 import {
+  getGeojsonRadiusMeters,
   latitudeDeltaToMeters,
   metersToLatitudeDelta,
 } from "components/SharedComponents/Map/helpers/mapHelpers";
@@ -201,19 +202,33 @@ const LocationPickerContainer = ( ): Node => {
 
   const selectPlaceResult = place => {
     const { coordinates } = place.point_geojson;
+    const latitude = coordinates[1];
+    const longitude = coordinates[0];
+
+    // Find the smallest circle, centered on point_geojson, which contains the entire
+    // bounding box of the place.
+    const radiusMeters = getGeojsonRadiusMeters(
+      coordinates,
+      place.bounding_box_geojson.coordinates,
+    );
+
+    const latitudeDelta = metersToLatitudeDelta(
+      radiusMeters,
+      latitude,
+    ) / radiusToMapHeight;
+  
+    const newRegion = {
+      latitude,
+      longitude,
+      latitudeDelta,
+      longitudeDelta: latitudeDelta * mapDimensionsRatio,
+    };
+
     dispatch( {
       type: "SELECT_PLACE_RESULT",
       locationName: place.display_name,
-      region: {
-        ...region,
-        latitude: coordinates[1],
-        longitude: coordinates[0],
-      },
-      regionToAnimate: {
-        ...region,
-        latitude: coordinates[1],
-        longitude: coordinates[0],
-      },
+      region: newRegion,
+      regionToAnimate: newRegion,
     } );
   };
 

--- a/src/components/LocationPicker/LocationSearch.tsx
+++ b/src/components/LocationPicker/LocationSearch.tsx
@@ -20,6 +20,9 @@ interface Place {
   point_geojson: {
     coordinates: [number, number];
   };
+  bounding_box_geojson?: {
+    coordinates: number[][][];
+  };
 }
 interface Props {
   locationName: string;
@@ -44,7 +47,7 @@ const LocationSearch = ( {
     ( optsWithAuth: ApiOpts ) => fetchSearchResults( {
       q: locationName,
       sources: "places",
-      fields: "place,place.display_name,place.point_geojson",
+      fields: "place,place.display_name,place.point_geojson,place.bounding_box_geojson",
     }, optsWithAuth ),
   );
 

--- a/src/components/SharedComponents/Map/helpers/mapHelpers.ts
+++ b/src/components/SharedComponents/Map/helpers/mapHelpers.ts
@@ -1,3 +1,4 @@
+import haversineDistance from "haversine-distance";
 import type { MapBoundaries } from "providers/ExploreContext";
 import Config from "react-native-config";
 import type { LatLng, Region } from "react-native-maps";
@@ -72,6 +73,21 @@ export function latitudeDeltaToMeters(
   latitude: number,
 ): number {
   return latitudeDelta * metersPerDegreeLatitude( latitude );
+}
+
+// Compute the distance in meters from center to the furthest point in the geojson.
+export function getGeojsonRadiusMeters(
+  center: [number, number],
+  geojson: number[][][],
+): Number {
+  let radius = 0;
+  for ( const ring of geojson) {
+    for ( const point of ring) {
+      const distance = haversineDistance(center, point);
+      radius = Math.max( radius, distance );
+    }
+  }
+  return radius;
 }
 
 export function getMapRegion( totalBounds: MapBoundaries ): Region {

--- a/tests/unit/components/SharedComponents/Map/mapHelpers.test.js
+++ b/tests/unit/components/SharedComponents/Map/mapHelpers.test.js
@@ -1,0 +1,36 @@
+import {
+  getGeojsonRadiusMeters,
+  latitudeDeltaToMeters,
+} from "components/SharedComponents/Map/helpers/mapHelpers";
+import haversineDistance from "haversine-distance";
+
+describe( "getGeojsonRadiusMeters", ( ) => {
+
+  test( "should give 0 for no bounding box", ( ) => {
+    const radius = getGeojsonRadiusMeters( [0, 0], []);
+    expect( radius ).toBe( 0 );
+  } );
+
+  test( "should give 0 for single point", ( ) => {
+    const radius = getGeojsonRadiusMeters( [0, 0], [[ [0, 0] ]] );
+    expect( radius ).toBe( 0 );
+  } );
+
+  test( "should be correct for 1 degree latitude", ( ) => {
+    const radius = getGeojsonRadiusMeters( [0, 0], [[ [1, 0], [0, 1], [-1, 0], [0, -1] ]] );
+    const expected = haversineDistance( [0, 0], [1, 0] );
+    expect( radius ).toBe( expected );
+  } );
+
+  test( "should be correct for a point other than 0,0", ( ) => {
+    const radius = getGeojsonRadiusMeters( [1, 1], [[ [2, 1], [1, 2] ]] );
+    const expected = haversineDistance( [1, 1], [1, 2] );
+    expect( radius ).toBe( expected );
+  } );
+
+  test( "should be correct for multiple rings", ( ) => {
+    const radius = getGeojsonRadiusMeters( [0, 0], [ [[1, 0]], [[2, 0]] ] );
+    const expected = haversineDistance( [0, 0], [2, 0] );
+    expect( radius ).toBe( expected );
+  } );
+} );


### PR DESCRIPTION
Today, if I type a location into the location selector, it keeps the same radius (several thousand kilometers) even if the location is much more specific. This change looks at the geojson of the place to find the smallest radius which contains the entire place. This saves a lot of manual pinching and zooming, and makes the location selector more useful.

Before:

<img width="603" height="1311" alt="before" src="https://github.com/user-attachments/assets/e393a22f-54bf-4eb3-bd72-f342cb6343cc" />

After:

<img width="603" height="1311" alt="after" src="https://github.com/user-attachments/assets/10157cb1-4226-450a-bdff-0c84ff5b97e3" />

