### PR TITLE
Add sort button to explore v2

### DIFF
--- a/src/components/Explore/ExploreV2/ExploreV2DebugSheet.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2DebugSheet.tsx
@@ -127,7 +127,7 @@ const ExploreV2DebugSheet = ( ) => {
       <INatIconButton
         icon="triangle-exclamation"
         className={classnames(
-          "absolute bottom-5 right-5",
+          "absolute top-5 right-5",
           "rounded-full",
         )}
         color="white"

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   ViewWrapper,
 } from "components/SharedComponents";
+import SortButton from "components/SharedComponents/Buttons/SortButton";
 import { View } from "components/styledComponents";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React from "react";
@@ -73,6 +74,12 @@ const ExploreResults = ( ) => {
                 testID="ExploreV2ObservationsList"
               />
               <ExploreV2DebugSheet />
+              <SortButton
+                // TODO: wire up onPress to show sort bottom sheet
+                onPress={() => console.log( "onPress SortButton" )}
+                // TODO: add label based on state wether this is sorting species or observations
+                accessibilityLabel={t( "Change-species-sort-order" )}
+              />
             </>
           )}
       </View>

--- a/src/components/SharedComponents/Buttons/SortButton.tsx
+++ b/src/components/SharedComponents/Buttons/SortButton.tsx
@@ -9,7 +9,7 @@ const DROP_SHADOW = getShadow( {
 } );
 
 interface Props {
-  onPress: () => void;
+  onPress: ( ) => void;
   accessibilityLabel: string;
 }
 


### PR DESCRIPTION
Closes MOB-1191

The ticket says nothing about wiring it up, and what it is supposed to do is not yet possible on ExploreV2, so I assume this is purely cosmetic, i.e. to put the button in it's place.
Even that is  a future TODO though because the Results section does not switch between Obs/Species/Users yet, so probably the placement will have to change later as well.