### PR TITLE
ObsImagePreview: inline render helpers

### DIFF
--- a/src/components/ObservationsFlashList/ObsImagePreview.tsx
+++ b/src/components/ObservationsFlashList/ObsImagePreview.tsx
@@ -119,31 +119,6 @@ const ObsImagePreview = ( {
     obsPhotosCount,
   ] );
 
-  const renderSelectable = useCallback( ( ) => {
-    if ( selectable ) {
-      return (
-        <View
-          className={classNames(
-            "flex items-center justify-center",
-            "rounded-full",
-            "absolute m-2.5 right-0",
-            {
-              "bg-white": selected,
-              "w-[24px] h-[24px]": selected,
-              "w-[24px] h-[24px] border-2 border-white": !selected,
-            },
-          )}
-          style={ICON_DROP_SHADOW}
-        >
-          {selected && (
-            <INatIcon name="checkmark" color={colors.darkGray} size={12} />
-          )}
-        </View>
-      );
-    }
-    return null;
-  }, [selectable, selected] );
-
   const renderGradient = useCallback( ( ) => {
     if ( hideGradientOverlay ) return null;
     if ( isSmall ) return null;
@@ -218,7 +193,25 @@ const ObsImagePreview = ( {
           }
         />
         {renderGradient( )}
-        {renderSelectable( )}
+        {selectable && (
+          <View
+            className={classNames(
+              "flex items-center justify-center",
+              "rounded-full",
+              "absolute m-2.5 right-0",
+              {
+                "bg-white": selected,
+                "w-[24px] h-[24px]": selected,
+                "w-[24px] h-[24px] border-2 border-white": !selected,
+              },
+            )}
+            style={ICON_DROP_SHADOW}
+          >
+            {selected && (
+              <INatIcon name="checkmark" color={colors.darkGray} size={12} />
+            )}
+          </View>
+        )}
         {renderPhotoCount( )}
         {renderSoundIcon( )}
         {children}

--- a/src/components/ObservationsFlashList/ObsImagePreview.tsx
+++ b/src/components/ObservationsFlashList/ObsImagePreview.tsx
@@ -16,6 +16,27 @@ const ICON_DROP_SHADOW = getShadow( {
   shadowRadius: 1,
 } );
 
+const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean} ) => {
+  if ( useShortGradient ) {
+    return (
+      <LinearGradient
+        colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.6) 100%)"]}
+        className="absolute w-full h-full"
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 0, y: 1 }}
+      />
+    );
+  }
+  return (
+    <LinearGradient
+      colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.5) 100%)"]}
+      className="absolute w-full h-full"
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0, y: 0.75 }}
+    />
+  );
+};
+
 interface Props extends PropsWithChildren {
   className?: string;
   hasSound?: boolean;
@@ -119,28 +140,7 @@ const ObsImagePreview = ( {
     obsPhotosCount,
   ] );
 
-  const renderGradient = useCallback( ( ) => {
-    if ( hideGradientOverlay ) return null;
-    if ( isSmall ) return null;
-    if ( useShortGradient ) {
-      return (
-        <LinearGradient
-          colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.6) 100%)"]}
-          className="absolute w-full h-full"
-          start={{ x: 0, y: 0.5 }}
-          end={{ x: 0, y: 1 }}
-        />
-      );
-    }
-    return (
-      <LinearGradient
-        colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.5) 100%)"]}
-        className="absolute w-full h-full"
-        start={{ x: 0, y: 0 }}
-        end={{ x: 0, y: 0.75 }}
-      />
-    );
-  }, [isSmall, useShortGradient, hideGradientOverlay] );
+  const shouldRenderGradient = !hideGradientOverlay && !isSmall;
 
   const renderSoundIcon = useCallback( ( ) => {
     if ( !hasSound ) return null;
@@ -192,7 +192,7 @@ const ObsImagePreview = ( {
               : 100
           }
         />
-        {renderGradient( )}
+        {shouldRenderGradient && <GradientOverlay useShortGradient={useShortGradient} />}
         {selectable && (
           <View
             className={classNames(

--- a/src/components/ObservationsFlashList/ObsImagePreview.tsx
+++ b/src/components/ObservationsFlashList/ObsImagePreview.tsx
@@ -16,7 +16,7 @@ const ICON_DROP_SHADOW = getShadow( {
   shadowRadius: 1,
 } );
 
-const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean} ) => {
+const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean } ) => {
   if ( useShortGradient ) {
     return (
       <LinearGradient
@@ -34,6 +34,30 @@ const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean} ) 
       start={{ x: 0, y: 0 }}
       end={{ x: 0, y: 0.75 }}
     />
+  );
+};
+
+const SoundIcon = ( { isSmall }: { isSmall?: boolean } ) => {
+  if ( isSmall ) {
+    return (
+      <View
+        className="absolute left-1 bottom-1"
+        style={ICON_DROP_SHADOW}
+      >
+        <INatIcon name="sound" color={colors.white} size={16} />
+      </View>
+    );
+  }
+
+  return (
+    <View
+      className={classNames( "absolute left-0 top-0 p-1", {
+        "p-2": !isSmall,
+      } )}
+      style={ICON_DROP_SHADOW}
+    >
+      <INatIcon name="sound" color={colors.white} size={18} />
+    </View>
   );
 };
 
@@ -142,32 +166,6 @@ const ObsImagePreview = ( {
 
   const shouldRenderGradient = !hideGradientOverlay && !isSmall;
 
-  const renderSoundIcon = useCallback( ( ) => {
-    if ( !hasSound ) return null;
-
-    if ( isSmall ) {
-      return (
-        <View
-          className="absolute left-1 bottom-1"
-          style={ICON_DROP_SHADOW}
-        >
-          <INatIcon name="sound" color={colors.white} size={16} />
-        </View>
-      );
-    }
-
-    return (
-      <View
-        className={classNames( "absolute left-0 top-0 p-1", {
-          "p-2": !isSmall,
-        } )}
-        style={ICON_DROP_SHADOW}
-      >
-        <INatIcon name="sound" color={colors.white} size={18} />
-      </View>
-    );
-  }, [hasSound, isSmall] );
-
   let content;
 
   if ( isSmall && ( obsPhotosCount === 0 && !source?.uri ) ) {
@@ -213,7 +211,7 @@ const ObsImagePreview = ( {
           </View>
         )}
         {renderPhotoCount( )}
-        {renderSoundIcon( )}
+        {hasSound && <SoundIcon isSmall={isSmall} />}
         {children}
       </>
     );

--- a/src/components/ObservationsFlashList/ObsImagePreview.tsx
+++ b/src/components/ObservationsFlashList/ObsImagePreview.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { INatIcon, PhotoCount } from "components/SharedComponents";
 import { LinearGradient, View } from "components/styledComponents";
 import type { PropsWithChildren } from "react";
-import React, { useCallback } from "react";
+import React from "react";
 import type { ViewStyle } from "react-native";
 import { getShadow } from "styles/global";
 import colors from "styles/tailwindColors";
@@ -15,6 +15,49 @@ const ICON_DROP_SHADOW = getShadow( {
   shadowOpacity: 1,
   shadowRadius: 1,
 } );
+
+ interface PhotoCountProps {
+  obsPhotosCount: number;
+  isSmall: boolean;
+  isMultiplePhotosTop: boolean;
+}
+const ObsImagePreviewPhotoCount = (
+  { obsPhotosCount, isMultiplePhotosTop, isSmall }: PhotoCountProps,
+) => {
+  if ( isSmall ) {
+    return (
+      <View
+        className={classNames(
+          "absolute",
+          "right-1",
+          isMultiplePhotosTop
+            ? "top-1"
+            : "bottom-1",
+        )}
+        style={ICON_DROP_SHADOW}
+      >
+        <INatIcon name="photos-outline" color={colors.white} size={16} />
+      </View>
+    );
+  }
+
+  return (
+    <View
+      className={classNames(
+        "absolute",
+        "right-0",
+        "p-2",
+        isMultiplePhotosTop
+          ? "top-0"
+          : "bottom-0",
+      )}
+      style={ICON_DROP_SHADOW}
+    >
+      { obsPhotosCount !== 0
+          && <PhotoCount count={obsPhotosCount} /> }
+    </View>
+  );
+};
 
 const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean } ) => {
   if ( useShortGradient ) {
@@ -121,48 +164,7 @@ const ObsImagePreview = ( {
     width,
   ];
 
-  const renderPhotoCount = useCallback( ( ) => {
-    if ( obsPhotosCount <= 1 || hidePhotoCount ) return null;
-
-    if ( isSmall ) {
-      return (
-        <View
-          className={classNames(
-            "absolute",
-            "right-1",
-            isMultiplePhotosTop
-              ? "top-1"
-              : "bottom-1",
-          )}
-          style={ICON_DROP_SHADOW}
-        >
-          <INatIcon name="photos-outline" color={colors.white} size={16} />
-        </View>
-      );
-    }
-
-    return (
-      <View
-        className={classNames(
-          "absolute",
-          "right-0",
-          "p-2",
-          isMultiplePhotosTop
-            ? "top-0"
-            : "bottom-0",
-        )}
-        style={ICON_DROP_SHADOW}
-      >
-        { obsPhotosCount !== 0
-          && <PhotoCount count={obsPhotosCount} /> }
-      </View>
-    );
-  }, [
-    hidePhotoCount,
-    isMultiplePhotosTop,
-    isSmall,
-    obsPhotosCount,
-  ] );
+  const shouldRenderPhotoCount = !hidePhotoCount && obsPhotosCount > 1;
 
   const shouldRenderGradient = !hideGradientOverlay && !isSmall;
 
@@ -210,7 +212,13 @@ const ObsImagePreview = ( {
             )}
           </View>
         )}
-        {renderPhotoCount( )}
+        {shouldRenderPhotoCount && (
+          <ObsImagePreviewPhotoCount
+            isMultiplePhotosTop={isMultiplePhotosTop}
+            isSmall={isSmall}
+            obsPhotosCount={obsPhotosCount}
+          />
+        )}
         {hasSound && <SoundIcon isSmall={isSmall} />}
         {children}
       </>

--- a/src/components/ObservationsFlashList/ObsImagePreview.tsx
+++ b/src/components/ObservationsFlashList/ObsImagePreview.tsx
@@ -16,10 +16,31 @@ const ICON_DROP_SHADOW = getShadow( {
   shadowRadius: 1,
 } );
 
- interface PhotoCountProps {
-  obsPhotosCount: number;
-  isSmall: boolean;
-  isMultiplePhotosTop: boolean;
+const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean } ) => {
+  if ( useShortGradient ) {
+    return (
+      <LinearGradient
+        colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.6) 100%)"]}
+        className="absolute w-full h-full"
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 0, y: 1 }}
+      />
+    );
+  }
+  return (
+    <LinearGradient
+      colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.5) 100%)"]}
+      className="absolute w-full h-full"
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0, y: 0.75 }}
+    />
+  );
+};
+
+interface PhotoCountProps {
+  obsPhotosCount: number; // file-local use enforces non-null
+  isSmall?: boolean;
+  isMultiplePhotosTop?: boolean;
 }
 const ObsImagePreviewPhotoCount = (
   { obsPhotosCount, isMultiplePhotosTop, isSmall }: PhotoCountProps,
@@ -56,27 +77,6 @@ const ObsImagePreviewPhotoCount = (
       { obsPhotosCount !== 0
           && <PhotoCount count={obsPhotosCount} /> }
     </View>
-  );
-};
-
-const GradientOverlay = ( { useShortGradient }: { useShortGradient?: boolean } ) => {
-  if ( useShortGradient ) {
-    return (
-      <LinearGradient
-        colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.6) 100%)"]}
-        className="absolute w-full h-full"
-        start={{ x: 0, y: 0.5 }}
-        end={{ x: 0, y: 1 }}
-      />
-    );
-  }
-  return (
-    <LinearGradient
-      colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.5) 100%)"]}
-      className="absolute w-full h-full"
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 0.75 }}
-    />
   );
 };
 


### PR DESCRIPTION
cherry-picked from work in [MOB-1458: Rework useLocalObservations to useLocalObservationUuids](https://linear.app/inaturalist/issue/MOB-1458/rework-uselocalobservations-to-uselocalobservationuuids) 

Doing my best to test downstream regressions for shifting the obs flashlist data flow. Performance testing shows that we were spending a _lot_ of time in ObsImagePreview and PhotoCount. It was unclear whether the callbacks themselves were causing issues. To make sure, I broke the render helpers into helper local components and inline conditions. 

It didn't end up having a material perf impact (turns out, our image count badge is expensive!), but I'm inclined to leave the refactor. We've discussed this a bit, but compared to render helpers, I think factoring Components like this is a bit more [semantic React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) and we can entirely avoid the "useMemo" / "useCallback" question.

commits broken down into one "concern" at a time