### PR TITLE
Make use translation shim android only

### DIFF
--- a/src/sharedHooks/useTranslation.android.ts
+++ b/src/sharedHooks/useTranslation.android.ts
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+
+console.log( "wrapped" );
+// Wrap react-i18next's useTranslation to catch a mysterious exception that
+// often gets thrown on initialization on Android only. https://github.com/inaturalist/iNaturalistReactNative/pull/515
+const useCustomTranslation = ( ) => {
+  const original = useTranslation( );
+  return {
+    ...original,
+    t: ( key: string, options = {} ) => {
+      try {
+        return original.t( key, options );
+      } catch ( translationError ) {
+        if ( translationError instanceof Error && !translationError.message.match( /NoClassDefFoundError/ ) ) {
+          throw translationError;
+        }
+      }
+      return "";
+    },
+  };
+};
+
+export default useCustomTranslation;

--- a/src/sharedHooks/useTranslation.android.ts
+++ b/src/sharedHooks/useTranslation.android.ts
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 
-console.log( "wrapped" );
 // Wrap react-i18next's useTranslation to catch a mysterious exception that
 // often gets thrown on initialization on Android only. https://github.com/inaturalist/iNaturalistReactNative/pull/515
 const useCustomTranslation = ( ) => {

--- a/src/sharedHooks/useTranslation.ts
+++ b/src/sharedHooks/useTranslation.ts
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
 
-console.log( "unwrapped" );
-// return unmodified `useTranslation` for all platforms except android
+// return unmodified `useTranslation` for all platforms except android which needs a shim
 export default useTranslation;

--- a/src/sharedHooks/useTranslation.ts
+++ b/src/sharedHooks/useTranslation.ts
@@ -1,22 +1,5 @@
 import { useTranslation } from "react-i18next";
 
-// Wrap react-i18next's useTranslation to catch a mysterious exception that
-// often gets thrown on initialization. https://github.com/inaturalist/iNaturalistReactNative/pull/515
-const useCustomTranslation = ( ) => {
-  const original = useTranslation( );
-  return {
-    ...original,
-    t: ( key: string, options = {} ) => {
-      try {
-        return original.t( key, options );
-      } catch ( translationError ) {
-        if ( translationError instanceof Error && !translationError.message.match( /NoClassDefFoundError/ ) ) {
-          throw translationError;
-        }
-      }
-      return "";
-    },
-  };
-};
-
-export default useCustomTranslation;
+console.log( "unwrapped" );
+// return unmodified `useTranslation` for all platforms except android
+export default useTranslation;


### PR DESCRIPTION
cherry-picked from work in [MOB-1458: Rework useLocalObservations to useLocalObservationUuids](https://linear.app/inaturalist/issue/MOB-1458/rework-uselocalobservations-to-uselocalobservationuuids)

we're shimming useTranslation for an Android-only Java exception. I haven't validated if we still need to handle the Android exception, but we can at least skip the shim on iOS since this is called so frequently. This doesn't have a demonstrable impact on the performance of ObsFlashList.