### PR TITLE
disable flashlist maintainVisibleContentPosition for render issues

### DIFF
--- a/src/components/SharedComponents/FlashList/CustomFlashList.tsx
+++ b/src/components/SharedComponents/FlashList/CustomFlashList.tsx
@@ -163,7 +163,6 @@ const CustomFlashList = <T, >( props: FlashListProps<T> & { ref?: React.Ref<Flas
   return (
     <FlashList
       ref={internalRef}
-      initialNumToRender={5}
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.2}
       onViewableItemsChanged={handleViewableItemsChanged}
@@ -172,6 +171,9 @@ const CustomFlashList = <T, >( props: FlashListProps<T> & { ref?: React.Ref<Flas
       onScrollEndDrag={handleScrollEndDrag}
       onMomentumScrollEnd={handleMomentumScrollEnd}
       viewabilityConfig={viewabilityConfig}
+      // Fixes MOB-1464 where successful upload creates reordering issues and sometimes gaps
+      // https://shopify.github.io/flash-list/docs/known-issues#3-data-re-ordering-can-cause-items-to-move
+      maintainVisibleContentPosition={{ disabled: true }}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...otherProps}
     />


### PR DESCRIPTION
opens and closes MOB-1464

also uncovered in "gotchas" docs looking at flashlist stuff: https://shopify.github.io/flash-list/docs/known-issues#3-data-re-ordering-can-cause-items-to-move This has annoyed me for a while but never found what I thought was a spacing issue.

My impression from the docs is that this configuration doesn't apply to our use of flashlist at the moment.

Before:

https://github.com/user-attachments/assets/f647dc37-09b9-4c13-8bb1-c76d8933a45f


https://github.com/user-attachments/assets/266daf6a-a5ae-49ad-ac83-79beb98e3f5f


After:

https://github.com/user-attachments/assets/4a650da0-b3e1-4ce2-b402-9cdc40ec2aa0

(lost the grid fixed vid, lemme know if I should shoot another one)