### PR TITLE
fix first obs UI hang, prime date-fns-tz / intl cache in deferred startup

### DIFF
--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -12,6 +12,7 @@
 import { cleanupLogFiles } from "components/Developer/logManagementHelpers";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import {
   clearComputerVisionPhotos,
   clearGalleryPhotos,
@@ -19,6 +20,7 @@ import {
   clearRotatedOriginalPhotosDirectory,
   clearSyncedMediaForUpload,
 } from "sharedHelpers/clearCaches";
+import { formatApiDatetime } from "sharedHelpers/dateAndTime";
 import { log } from "sharedHelpers/logger";
 import { logSentinelFiles } from "sharedHelpers/sentinelFiles";
 import getStorageMetrics from "sharedHelpers/storageMetrics";
@@ -77,6 +79,7 @@ const checkForPreviousCrash = async () => {
 
 const useDeferredStartup = ( ) => {
   const realm = useRealm( );
+  const { i18n } = useTranslation( );
 
   useEffect( ( ) => {
     // Diagnostic tasks that we need to finish even on a busy thread
@@ -97,6 +100,13 @@ const useDeferredStartup = ( ) => {
     const id8 = deferTask( "clearRollbackPhotos", clearRollbackPhotos );
 
     const id9 = deferTask( "cleanupLogFiles", cleanupLogFiles );
+    const id10 = deferTask( "warmIntlCache", () => {
+      // the first call per instance to formatApiDatetime takes >100ms which would typically
+      // be navigating from MyObs to ObsDetail and locking render during the animation.
+      // Until the Hermes / Intl situation improves, idleCallback is at least a bit better
+      formatApiDatetime( "1970", i18n, { timeZone: "Etc/UTC" } );
+      return Promise.resolve();
+    } );
 
     return ( ) => {
       cancelIdleCallback( id1 );
@@ -108,8 +118,9 @@ const useDeferredStartup = ( ) => {
       cancelIdleCallback( id7 );
       cancelIdleCallback( id8 );
       cancelIdleCallback( id9 );
+      cancelIdleCallback( id10 );
     };
-  }, [realm] );
+  }, [i18n, realm] );
 };
 
 export default useDeferredStartup;

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -12,7 +12,6 @@
 import { cleanupLogFiles } from "components/Developer/logManagementHelpers";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
 import {
   clearComputerVisionPhotos,
   clearGalleryPhotos,
@@ -24,6 +23,7 @@ import { formatApiDatetime } from "sharedHelpers/dateAndTime";
 import { log } from "sharedHelpers/logger";
 import { logSentinelFiles } from "sharedHelpers/sentinelFiles";
 import getStorageMetrics from "sharedHelpers/storageMetrics";
+import { useTranslation } from "sharedHooks";
 import { zustandStorage } from "stores/useStore";
 
 const { useRealm } = RealmContext;


### PR DESCRIPTION
The first launch of ObsDetails hangs for ~100ms because of DateDisplay's call to [formatApiDatetime](https://github.com/inaturalist/iNaturalistReactNative/blob/6d28c3d420902d2a280cafcac384c95da9ac9a88/src/components/SharedComponents/DateDisplay.tsx#L70) which turned out to be yet another downstream issue of Hermes & Intl compatibility: https://github.com/facebook/hermes/discussions/1211. Only the first call per app launch is affected.

This PR does not address the problem, it just adds a deferred task throwaway call to `formatApiDatetime` so that the expensive first call does not affect a user interaction.

React Profiler results on Simulator of DateDisplay initial render. On real device, I was seeing like 133ms for DateDisplay 😬:

|Before 85.6ms |After 2.4ms|
|---|---|
|<img width="626" height="579" alt="DateDisplay 85ms on first render" src="https://github.com/user-attachments/assets/93c06bd2-48fc-4e17-bdfd-139d0dfe5a91" />|<img width="680" height="411" alt="DateDisplay 2.4ms on first render" src="https://github.com/user-attachments/assets/0876f161-d401-491c-b9fc-8a5e7442db83" />| 

In both cases, subsequent renders are nominal (about 2ms for initial render, .5ms if Screen was recycled for a different obs).