### PR TITLE
halted launch debug tool

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,8 @@ module.exports = {
   globals: {
     requestIdleCallback: "readonly",
     cancelIdleCallback: "readonly",
+    __DEV__: "readonly",
+    HermesInternal: "readonly",
   },
   parser: "@typescript-eslint/parser",
   parserOptions: {

--- a/index.js
+++ b/index.js
@@ -173,8 +173,8 @@ const AppWithProviders = ( ) => {
   );
 };
 
-if ( __DEV__ && shouldHaltLaunchForDebug() ) {
-  const HaltedWrappedApp = () => <HaltedLaunch><AppWithProviders /></HaltedLaunch>;
+if ( __DEV__ && shouldHaltLaunchForDebug( ) ) {
+  const HaltedWrappedApp = ( ) => <HaltedLaunch><AppWithProviders /></HaltedLaunch>;
   AppRegistry.registerComponent( appName, ( ) => HaltedWrappedApp );
 } else {
   AppRegistry.registerComponent( appName, ( ) => AppWithProviders );

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { getInstallID, store as installDataMMKVStorage } from "sharedHelpers/installData";
 import { reactQueryRetry } from "sharedHelpers/logging";
 import DeviceInfo from "react-native-device-info";
-import useRozenite from "sharedHooks/useRozenite";
+import useRozenite, { HaltedLaunch, shouldHaltLaunchForDebug } from "sharedHooks/useRozenite";
 import { createMMKVStorageAdapter } from "@rozenite/storage-plugin";
 import { name as appName } from "./app.json";
 import { log } from "./react-native-logs.config";
@@ -42,7 +42,6 @@ const logger = log.extend( "index.js" );
 // Log all unhandled promise rejections in release builds. Otherwise they will
 // die in silence. Debug builds have a more useful UI w/ desymbolicated stack
 // traces
-/* eslint-disable no-undef */
 if (
   !__DEV__
   && typeof (
@@ -174,4 +173,9 @@ const AppWithProviders = ( ) => {
   );
 };
 
-AppRegistry.registerComponent( appName, ( ) => AppWithProviders );
+if ( __DEV__ && shouldHaltLaunchForDebug() ) {
+  const HaltedWrappedApp = () => <HaltedLaunch><AppWithProviders /></HaltedLaunch>;
+  AppRegistry.registerComponent( appName, ( ) => HaltedWrappedApp );
+} else {
+  AppRegistry.registerComponent( appName, ( ) => AppWithProviders );
+}

--- a/react-native-logs.config.ts
+++ b/react-native-logs.config.ts
@@ -22,7 +22,6 @@ RNFS.exists( logFileDirectory ).then( exists => ( exists
 
 const sharedConfig = {
   dateFormat: "iso",
-  // eslint-disable-next-line no-undef
   severity: __DEV__
     ? "debug"
     : "info",

--- a/src/api/log/index.ts
+++ b/src/api/log/index.ts
@@ -75,7 +75,6 @@ type iNatLogstashTransportOptions = object;
 // Custom transport for posting to iNat API logging
 const iNatLogstashTransport: transportFunctionType<iNatLogstashTransportOptions> = async props => {
   // Don't bother to log from dev builds
-  // eslint-disable-next-line no-undef
   if ( __DEV__ ) return;
 
   // Note on `console.errors`: we use logging to report errors, so validating input

--- a/src/components/Developer/Developer.tsx
+++ b/src/components/Developer/Developer.tsx
@@ -176,56 +176,54 @@ const DebugTools = () => {
         text="LOG IN AGAIN"
         className="mb-5"
       />
-      { // eslint-disable-next-line no-undef
-        __DEV__ && (
-          <>
-            <Button
-              onPress={() => navigation.navigate( "UILibrary" )}
-              text="UI LIBRARY"
-              className="mb-5"
-            />
-            <Button
-              onPress={() => { throw new Error( "Test error" ); }}
-              text="TEST ERROR"
-              className="mb-5"
-            />
-            <Button
-              onPress={() => {
-                throw new INatApiError( {
-                  error: "Test error",
-                  status: 422,
-                  context: {
-                    routeName: "MyObservations",
-                    timestamp: new Date().toISOString(),
-                  },
-                } );
-              }}
-              text="TEST INATAPIERROR"
-              className="mb-5"
-            />
-            <Button
-              onPress={() => {
-                throw new INatApiTooManyRequestsError( {
-                  routeName: "TaxonDetails",
+      {__DEV__ && (
+        <>
+          <Button
+            onPress={() => navigation.navigate( "UILibrary" )}
+            text="UI LIBRARY"
+            className="mb-5"
+          />
+          <Button
+            onPress={() => { throw new Error( "Test error" ); }}
+            text="TEST ERROR"
+            className="mb-5"
+          />
+          <Button
+            onPress={() => {
+              throw new INatApiError( {
+                error: "Test error",
+                status: 422,
+                context: {
+                  routeName: "MyObservations",
                   timestamp: new Date().toISOString(),
-                } );
-              }}
-              text="TEST API TOO MANY REQUESTS ERROR"
-              className="mb-5"
-            />
-            <Button
-              onPress={async () => { throw new Error( "Test error in promise" ); }}
-              text="TEST UNHANDLED PROMISE REJECTION"
-              className="mb-5"
-            />
-            <Button
-              onPress={toggleRTLandLTR}
-              text="TOGGLE RTL<>LTR"
-              className="mb-5"
-            />
-          </>
-        )
-      }
+                },
+              } );
+            }}
+            text="TEST INATAPIERROR"
+            className="mb-5"
+          />
+          <Button
+            onPress={() => {
+              throw new INatApiTooManyRequestsError( {
+                routeName: "TaxonDetails",
+                timestamp: new Date().toISOString(),
+              } );
+            }}
+            text="TEST API TOO MANY REQUESTS ERROR"
+            className="mb-5"
+          />
+          <Button
+            onPress={async () => { throw new Error( "Test error in promise" ); }}
+            text="TEST UNHANDLED PROMISE REJECTION"
+            className="mb-5"
+          />
+          <Button
+            onPress={toggleRTLandLTR}
+            text="TOGGLE RTL<>LTR"
+            className="mb-5"
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/components/FullPageWebView/FullPageWebView.tsx
+++ b/src/components/FullPageWebView/FullPageWebView.tsx
@@ -37,7 +37,6 @@ export const ALLOWED_DOMAINS = [
 const ALLOWED_ORIGINS = ["https://*", "mailto:*"];
 const ALLOWED_AUTH_DOMAINS = ["inaturalist.org"];
 
-// eslint-disable-next-line no-undef
 if ( __DEV__ ) {
   ALLOWED_DOMAINS.push( "localhost:3000" );
   ALLOWED_ORIGINS.push( "http://localhost:3000*" );

--- a/src/sharedHooks/useRozenite.tsx
+++ b/src/sharedHooks/useRozenite.tsx
@@ -27,7 +27,7 @@ interface RozeniteOptions {
 
 const launchHaltStorageKey = "haltLaunch";
 // eslint-disable-next-line arrow-body-style
-export const shouldHaltLaunchForDebug = () => {
+export const shouldHaltLaunchForDebug = ( ) => {
   const result = installDataMMKVStorage.getBoolean( launchHaltStorageKey ) || false;
   // just unset this on read: make each halted launch intentional
   installDataMMKVStorage.delete( launchHaltStorageKey );
@@ -55,11 +55,11 @@ HaltedLaunch.displayName = "HaltedLaunch";
 // note: Rozenite plugins are automatically disabled / noops in Production builds
 const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
   useTanStackQueryDevTools( queryClient );
-  useNetworkActivityDevTools();
+  useNetworkActivityDevTools( );
   useRozeniteStoragePlugin( {
     storages: storageAdapters,
   } );
-  useRequireProfilerDevTools();
+  useRequireProfilerDevTools( );
   useFileSystemDevTools( {
     adapter: createRNFSAdapter( RNFS ),
   } );
@@ -78,7 +78,7 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
           type: "button",
           title: "Restart & Halt",
           description:
-            "Restarts the app and renders a placeholder root component."
+            "Restarts the app and renders a placeholder root component. "
             + "Useful for attaching a debugger or starting a profiling session.",
           onPress: () => {
             installDataMMKVStorage.set( launchHaltStorageKey, true );

--- a/src/sharedHooks/useRozenite.tsx
+++ b/src/sharedHooks/useRozenite.tsx
@@ -13,13 +13,40 @@ import type {
   QueryClient,
 } from "@tanstack/react-query";
 import { useFeatureFlagForDebug } from "components/Developer/FeatureFlags";
-import { useMemo } from "react";
+import type { PropsWithChildren } from "react";
+import React, { useMemo, useState } from "react";
+import { Button, View } from "react-native";
+import RNRestart from "react-native-restart";
+import { store as installDataMMKVStorage } from "sharedHelpers/installData";
 import { FeatureFlag } from "stores/createFeatureFlagSlice";
 
 interface RozeniteOptions {
-    queryClient: QueryClient;
-    storageAdapters: StorageAdapter[];
+  queryClient: QueryClient;
+  storageAdapters: StorageAdapter[];
 }
+
+const launchHaltStorageKey = "haltLaunch";
+// eslint-disable-next-line arrow-body-style
+export const shouldHaltLaunchForDebug = () => {
+  const result = installDataMMKVStorage.getBoolean( launchHaltStorageKey ) || false;
+  // just unset this on read: make each halted launch intentional
+  installDataMMKVStorage.delete( launchHaltStorageKey );
+  return result;
+};
+
+export const HaltedLaunch = ( { children }: PropsWithChildren ) => {
+  const [unhalted, setUnhalted] = useState( false );
+  if ( unhalted ) {
+    return children;
+  }
+  return (
+    // eslint-disable-next-line react-native/no-inline-styles
+    <View style={{ justifyContent: "center", alignItems: "center", flex: 1 }}>
+      <Button title="Continue App Launch" onPress={() => setUnhalted( true )} />
+    </View>
+  );
+};
+HaltedLaunch.displayName = "HaltedLaunch";
 
 // TODO: the react-navigation rozenite plugin is called elsewhere and should be moved here
 // src/navigation/OfflineNavigationGuard.tsx. We need to lift the navRef state
@@ -28,11 +55,11 @@ interface RozeniteOptions {
 // note: Rozenite plugins are automatically disabled / noops in Production builds
 const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
   useTanStackQueryDevTools( queryClient );
-  useNetworkActivityDevTools( );
+  useNetworkActivityDevTools();
   useRozeniteStoragePlugin( {
     storages: storageAdapters,
   } );
-  useRequireProfilerDevTools( );
+  useRequireProfilerDevTools();
   useFileSystemDevTools( {
     adapter: createRNFSAdapter( RNFS ),
   } );
@@ -43,6 +70,23 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
 
   const sections = useMemo(
     () => [
+      createSection( {
+        id: "operations",
+        title: "Operations",
+        items: [{
+          id: "halt-launch",
+          type: "button",
+          title: "Restart & Halt",
+          description:
+            "Restarts the app and renders a placeholder root component."
+            + "Useful for attaching a debugger or starting a profiling session.",
+          onPress: () => {
+            installDataMMKVStorage.set( launchHaltStorageKey, true );
+            RNRestart.restart();
+          },
+        },
+        ],
+      } ),
       createSection( {
         id: "feature-flags",
         title: "Feature Flags",

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -15,3 +15,5 @@ declare function requestIdleCallback(
 ): number;
 
 declare function cancelIdleCallback( handle: number ): void;
+
+declare const __DEV__: boolean;


### PR DESCRIPTION
Thanks for the inspiration @jtklein! https://github.com/inaturalist/iNaturalistReactNative/pull/3686#pullrequestreview-4405216245 

The app has to be launched for us to be able to attach a debugger or create a profiling session. That's annoying when we're interested in the actual launch itself!

This adds a Button control in Rozenite Controls to set a flag and restart the app:
<img width="747" height="498" alt="image" src="https://github.com/user-attachments/assets/a7c0c03e-f425-473a-a450-b59747012a92" />

On restart in `__DEV__`, we now conditionally set up the app root with wrapper that waits for dev to press a button before rendering the actual app root:
<img width="430" height="922" alt="image" src="https://github.com/user-attachments/assets/1a938fe6-f9b2-44e2-b655-c6ff1db8894b" />

[Sample React Performance trace](https://github.com/user-attachments/files/28485737/initial-launch.json):

<img width="1219" height="546" alt="image" src="https://github.com/user-attachments/assets/eaf98a9f-0c20-41c0-9d88-187391f1d2d9" />


Bonus: adds `__DEV__` global type / eslint key

Creates & closes MOB-1485: Add capability to debug / profile app startup