### PR TITLE
MOB-1369: refactor useperformance to use an imperative stop

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,22 +3,18 @@
 import { useNavigation } from "@react-navigation/native";
 import RootStackNavigator from "navigation/RootStackNavigator";
 import type { Node } from "react";
-import React, { useCallback, useEffect } from "react";
-import { log } from "sharedHelpers/logger";
+import React, { useCallback } from "react";
 import {
   useCurrentUser,
   usePerformance,
   useShare,
 } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
 
 import AppStateListener from "./AppStateListener";
 import useDeferredStartup from "./hooks/useDeferredStartup";
 import useLinking from "./hooks/useLinking";
 import NetworkService from "./NetworkService";
 import StartupService from "./StartupService";
-
-const logger = log.extend( "App" );
 
 type SharedItem = {
   mimeType: string,
@@ -55,15 +51,10 @@ type Props = {
 // normally we would never do this in code
 const App = ( { children }: Props ): Node => {
   const navigation = useNavigation( );
-  const { loadTime } = usePerformance( {
+  usePerformance( {
     screenName: "App",
+    stopOnMount: true,
   } );
-  const { isDebug } = useDebugMode();
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   // attempting to make sure that navigation is only called once
   // for performance reasons

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -53,7 +53,7 @@ const App = ( { children }: Props ): Node => {
   const navigation = useNavigation( );
   usePerformance( {
     screenName: "App",
-    stopOnMount: true,
+    isLoading: false,
   } );
 
   // attempting to make sure that navigation is only called once

--- a/src/components/AppStateListener.ts
+++ b/src/components/AppStateListener.ts
@@ -2,25 +2,15 @@ import { focusManager } from "@tanstack/react-query";
 import useDeviceStorageFull from "components/Camera/hooks/useDeviceStorageFull";
 import { useEffect, useState } from "react";
 import { AppState } from "react-native";
-import { log } from "sharedHelpers/logger";
 import {
   usePerformance,
 } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
-
-const logger = log.extend( "AppStateListener" );
 
 const AppStateListener = ( ) => {
-  const { loadTime } = usePerformance( {
+  usePerformance( {
     screenName: "AppStateListener",
-    isLoading: false,
+    stopOnMount: true,
   } );
-  const { isDebug } = useDebugMode();
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
   const { deviceStorageFull, showStorageFullAlert } = useDeviceStorageFull( );
   const [deviceStorageFullShown, setDeviceStorageFullShown] = useState( false );
 

--- a/src/components/AppStateListener.ts
+++ b/src/components/AppStateListener.ts
@@ -9,7 +9,7 @@ import {
 const AppStateListener = ( ) => {
   usePerformance( {
     screenName: "AppStateListener",
-    stopOnMount: true,
+    isLoading: false,
   } );
   const { deviceStorageFull, showStorageFullAlert } = useDeviceStorageFull( );
   const [deviceStorageFullShown, setDeviceStorageFullShown] = useState( false );

--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -14,7 +14,6 @@ import LinearGradient from "react-native-linear-gradient";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { VolumeManager } from "react-native-volume-manager";
 import convertScoreToConfidence from "sharedHelpers/convertScores";
-import { log } from "sharedHelpers/logger";
 import { deleteSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
 import { logFirebaseEvent } from "sharedHelpers/tracking";
 import {
@@ -39,8 +38,6 @@ import usePredictions from "./hooks/usePredictions";
 import LocationStatus from "./LocationStatus";
 
 const isTablet = DeviceInfo.isTablet();
-
-const logger = log.extend( "AICamera" );
 
 // const exampleTaxonResult = {
 //   id: 12704,
@@ -142,14 +139,9 @@ const AICamera = ( {
 
   const { t } = useTranslation();
 
-  const { loadTime } = usePerformance( {
-    isLoading: camera?.current !== null,
+  const stop = usePerformance( {
+    screenName: "AICamera",
   } );
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   const resetCameraOnFocus = useCallback( ( ) => {
     setResult( null );
@@ -241,6 +233,7 @@ const AICamera = ( {
         <View className="w-full h-full absolute z-0">
           <FrameProcessorCamera
             cameraRef={camera}
+            onCameraReady={stop}
             confidenceThreshold={confidenceThreshold}
             debugFormat={debugFormat}
             device={device}

--- a/src/components/Camera/AICamera/FrameProcessorCamera.js
+++ b/src/components/Camera/AICamera/FrameProcessorCamera.js
@@ -35,6 +35,7 @@ type Props = {
   numStoredResults?: number,
   cropRatio?: number,
   onCameraError: Function,
+  onCameraReady?: Function,
   onCaptureError: Function,
   onClassifierError: Function,
   onDeviceNotSupported: Function,
@@ -64,6 +65,7 @@ const FrameProcessorCamera = ( {
   fps = DEFAULT_FPS,
   numStoredResults = DEFAULT_NUM_STORED_RESULTS,
   onCameraError,
+  onCameraReady,
   onCaptureError,
   onClassifierError,
   onDeviceNotSupported,
@@ -219,6 +221,7 @@ const FrameProcessorCamera = ( {
         onCameraError( error );
         await logStage( sentinelFileName, "fallback_camera_error" );
       }}
+      onCameraReady={onCameraReady}
       onCaptureError={async error => {
         onCaptureError( error );
         await logStage( sentinelFileName, "camera_capture_error" );

--- a/src/components/Camera/CameraView.tsx
+++ b/src/components/Camera/CameraView.tsx
@@ -36,6 +36,7 @@ interface Props {
   device: CameraDevice;
   frameProcessor?: () => void;
   onCameraError: ( error: CameraRuntimeError ) => void;
+  onCameraReady?: ( ) => void;
   onCaptureError: ( error: CameraRuntimeError ) => void;
   onClassifierError: ( error: CameraRuntimeError ) => void;
   onDeviceNotSupported: ( error: CameraRuntimeError ) => void;
@@ -55,6 +56,7 @@ const CameraView = ( {
   device,
   frameProcessor,
   onCameraError,
+  onCameraReady,
   onCaptureError,
   onClassifierError,
   onDeviceNotSupported,
@@ -176,6 +178,7 @@ const CameraView = ( {
           frameProcessor={frameProcessor}
           isActive={isActive}
           onError={onError}
+          onInitialized={onCameraReady}
           outputOrientation="device"
           photo
           photoQualityBalance="quality"

--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -20,9 +20,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { VolumeManager } from "react-native-volume-manager";
 import ObservationPhoto from "realmModels/ObservationPhoto";
 import { BREAKPOINTS } from "sharedHelpers/breakpoint";
-import { log } from "sharedHelpers/logger";
 import { useDeviceOrientation, usePerformance } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
 import useStore from "stores/useStore";
 
 import {
@@ -36,8 +34,6 @@ import CameraOptionsButtons from "./CameraOptionsButtons";
 import DiscardChangesSheet from "./DiscardChangesSheet";
 import useBackPress from "./hooks/useBackPress";
 import PhotoPreview from "./PhotoPreview";
-
-const logger = log.extend( "StandardCamera" );
 
 const isTablet = DeviceInfo.isTablet( );
 
@@ -91,15 +87,9 @@ const StandardCamera = ( {
   const navigation = useNavigation( );
   const insets = useSafeAreaInsets();
 
-  const { loadTime } = usePerformance( {
-    isLoading: camera?.current !== null,
+  const stop = usePerformance( {
+    screenName: "StandardCamera",
   } );
-  const { isDebug } = useDebugMode();
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   const cameraUris = useStore( state => state.cameraUris );
   const prepareCamera = useStore( state => state.prepareCamera );
@@ -234,6 +224,7 @@ const StandardCamera = ( {
               cameraScreen="standard"
               device={device}
               onCameraError={handleCameraError}
+              onCameraReady={stop}
               onCaptureError={handleCaptureError}
               onClassifierError={handleClassifierError}
               onDeviceNotSupported={handleDeviceNotSupported}

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -25,16 +25,12 @@ import Realm, { UpdateMode } from "realm";
 import realmConfig from "realmModels/index";
 import changeLanguage from "sharedHelpers/changeLanguage";
 import { getInstallID } from "sharedHelpers/installData";
+import isDebugMode from "sharedHelpers/isDebugMode";
 import { log, logFileDirectory, logWithoutRemote } from "sharedHelpers/logger";
 import removeAllFilesFromDirectory from "sharedHelpers/removeAllFilesFromDirectory";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { setFirebaseDataCollectionEnabled } from "sharedHelpers/tracking";
-import useStore from "stores/useStore";
 import zustandMMKVBackingStorage from "stores/zustandMMKVBackingStorage";
-
-function isDebugModeSync( ): boolean {
-  return useStore.getState().layout.debugModeEnabled === true;
-}
 
 const logger = log.extend( "AuthenticationService" );
 // The remote transport in the default logger uses many of the methods in this
@@ -101,7 +97,7 @@ async function getSensitiveItem(
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const getItemError = e as SensitiveInfoError;
-      if ( isDebugModeSync() ) {
+      if ( isDebugMode( ) ) {
         switch ( getItemError.code ) {
           case ErrorCode.NOT_FOUND:
             // Value doesn't exist
@@ -132,7 +128,7 @@ async function setSensitiveItem( key: string, value: string, options = {} ) {
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const setItemError = e as SensitiveInfoError;
-      if ( isDebugModeSync( ) ) {
+      if ( isDebugMode( ) ) {
         localLogger.info(
           `RNSInfo.setItem error for ${key}, ${setItemError.code} ${setItemError.message}`,
         );
@@ -155,7 +151,7 @@ async function deleteSensitiveItem(
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const deleteItemError = e as SensitiveInfoError;
-      if ( isDebugModeSync() ) {
+      if ( isDebugMode( ) ) {
         localLogger.info(
           `RNSInfo.deleteItem error for ${key}, ${deleteItemError.code} ${deleteItemError.message}`,
         );

--- a/src/components/NetworkService.ts
+++ b/src/components/NetworkService.ts
@@ -9,7 +9,7 @@ import useWorkQueue from "./hooks/useWorkQueue";
 const NetworkService = ( ) => {
   usePerformance( {
     screenName: "NetworkService",
-    stopOnMount: true,
+    isLoading: false,
   } );
 
   useObservationUpdatesWhenFocused( );

--- a/src/components/NetworkService.ts
+++ b/src/components/NetworkService.ts
@@ -1,27 +1,16 @@
-import { useEffect } from "react";
-import { log } from "sharedHelpers/logger";
 import {
   useIconicTaxa,
   useObservationUpdatesWhenFocused, usePerformance,
 } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
 
 import useTaxonCommonNames from "./hooks/useTaxonCommonNames";
 import useWorkQueue from "./hooks/useWorkQueue";
 
-const logger = log.extend( "NetworkService" );
-
 const NetworkService = ( ) => {
-  const { loadTime } = usePerformance( {
+  usePerformance( {
     screenName: "NetworkService",
-    isLoading: false,
+    stopOnMount: true,
   } );
-  const { isDebug } = useDebugMode();
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   useObservationUpdatesWhenFocused( );
 

--- a/src/components/Notifications/NotificationsContainer.tsx
+++ b/src/components/Notifications/NotificationsContainer.tsx
@@ -4,16 +4,12 @@ import {
 import { useFocusEffect } from "@react-navigation/native";
 import type { ApiObservationsUpdatesParams } from "api/types";
 import NotificationsList from "components/Notifications/NotificationsList";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import type { RealmUser } from "realmModels/types";
-import { log } from "sharedHelpers/logger";
 import {
   useInfiniteNotificationsScroll,
   usePerformance,
 } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
-
-const logger = log.extend( "NotificationsContainer" );
 
 interface Props {
   currentUser: RealmUser | null;
@@ -39,15 +35,10 @@ const NotificationsContainer = ( {
     refetch,
   } = useInfiniteNotificationsScroll( notificationParams );
 
-  const { loadTime } = usePerformance( {
+  usePerformance( {
+    screenName: "Notifications",
     isLoading: isInitialLoading,
   } );
-  const { isDebug } = useDebugMode( );
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   useFocusEffect(
     useCallback( ( ) => {

--- a/src/components/StartupService.tsx
+++ b/src/components/StartupService.tsx
@@ -39,7 +39,7 @@ const StartupService = ( ) => {
   const currentUser = realm.objects( "User" ).filtered( "signedIn == true" )[0]?.isValid( );
   usePerformance( {
     screenName: "StartupService",
-    stopOnMount: true,
+    isLoading: false,
   } );
 
   useEffect( ( ) => {

--- a/src/components/StartupService.tsx
+++ b/src/components/StartupService.tsx
@@ -12,7 +12,6 @@ import { IS_FRESH_INSTALL, store } from "sharedHelpers/installData";
 import { log } from "sharedHelpers/logger";
 import { addARCameraFiles } from "sharedHelpers/mlModel";
 import { usePerformance } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
 
 Realm.setLogLevel( "warn" );
 
@@ -38,16 +37,10 @@ const geolocationConfig = {
 const StartupService = ( ) => {
   const realm = useRealm( );
   const currentUser = realm.objects( "User" ).filtered( "signedIn == true" )[0]?.isValid( );
-  const { loadTime } = usePerformance( {
+  usePerformance( {
     screenName: "StartupService",
-    isLoading: false,
+    stopOnMount: true,
   } );
-  const { isDebug } = useDebugMode();
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   useEffect( ( ) => {
     const initializeApp = async ( ) => {

--- a/src/components/Suggestions/SuggestionsContainer.tsx
+++ b/src/components/Suggestions/SuggestionsContainer.tsx
@@ -11,14 +11,12 @@ import React, {
   useReducer,
 } from "react";
 import ObservationPhoto from "realmModels/ObservationPhoto";
-import { log } from "sharedHelpers/logger";
 import {
   useLastScreen,
   useLocationPermission,
   usePerformance,
   useSuggestions,
 } from "sharedHooks";
-import useDebugMode from "sharedHooks/useDebugMode";
 import {
   internalUseSuggestionsInitialSuggestions,
 } from "sharedHooks/useSuggestions/filterSuggestions";
@@ -30,8 +28,6 @@ import flattenUploadParams from "./helpers/flattenUploadParams";
 import useNavigateWithTaxonSelected from "./hooks/useNavigateWithTaxonSelected";
 import Suggestions from "./Suggestions";
 import TaxonSearchButton from "./TaxonSearchButton";
-
-const logger = log.extend( "SuggestionsContainer" );
 
 export enum FETCH_STATUSES {
   FETCH_STATUS_LOADING = "loading",
@@ -286,15 +282,10 @@ const SuggestionsContainer = ( ) => {
   const isLoading = onlineFetchStatus === FETCH_STATUSES.FETCH_STATUS_LOADING
     || offlineFetchStatus === FETCH_STATUSES.FETCH_STATUS_LOADING;
 
-  const { loadTime } = usePerformance( {
+  usePerformance( {
+    screenName: "Suggestions",
     isLoading,
   } );
-  const { isDebug } = useDebugMode();
-  useEffect( () => {
-    if ( isDebug && loadTime ) {
-      logger.info( loadTime );
-    }
-  }, [isDebug, loadTime] );
 
   const toggleLocation = useCallback( async ( { showLocation }: { showLocation: boolean } ) => {
     const newImageParams = await createUploadParams( selectedPhotoUri, showLocation );

--- a/src/sharedHelpers/isDebugMode.ts
+++ b/src/sharedHelpers/isDebugMode.ts
@@ -1,0 +1,6 @@
+import useStore from "stores/useStore";
+
+// Imperative read of debug mode
+const isDebugMode = ( ): boolean => useStore.getState( ).layout.debugModeEnabled === true;
+
+export default isDebugMode;

--- a/src/sharedHooks/usePerformance.ts
+++ b/src/sharedHooks/usePerformance.ts
@@ -1,39 +1,45 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import performance from "react-native-performance";
+import isDebugMode from "sharedHelpers/isDebugMode";
+import { log } from "sharedHelpers/logger";
 
-interface PerformanceType {
-  screenName?: string; // name of the screen to profile; helpful if not using logger
-  isLoading: boolean | undefined; // indicate whether data finished loading
+const logger = log.extend( "usePerformance" );
+
+interface PerformanceOptions {
+  screenName?: string;
+  stopOnMount?: boolean;
+  isLoading?: boolean;
 }
 
 const usePerformance = ( {
   screenName,
+  stopOnMount = false,
   isLoading,
-}: PerformanceType ) => {
-  const [startTime, setStartTime] = useState( 0 );
-  const [loadTime, setLoadTime] = useState( "" );
+}: PerformanceOptions = {} ) => {
+  const startTime = useRef( 0 );
 
   useEffect( ( ) => {
-    const getPerformanceReport = ( ) => {
-      const endTime = global.performance.now( );
-      const timeToRender = endTime - startTime;
-      const loadTimeMessage = `Load Time: ${timeToRender.toFixed( 0 )} milliseconds`;
-      const logMessage = screenName
-        ? `${screenName} ${loadTimeMessage}`
-        : loadTimeMessage;
+    startTime.current = performance.now( );
+  }, [] );
 
-      setLoadTime( logMessage );
-    };
-    if ( startTime === 0 ) {
-      setStartTime( global.performance.now() );
-    }
-    if ( !isLoading ) {
-      getPerformanceReport();
-    }
-  }, [isLoading, startTime, screenName] );
+  const stop = useCallback( ( ) => {
+    if ( !isDebugMode( ) ) { return; }
+    const endTime = performance.now( );
+    const elapsed = endTime - startTime.current;
+    const loadTimeMessage = `Load Time: ${elapsed.toFixed( 0 )} milliseconds`;
+    const logMessage = screenName
+      ? `${screenName} ${loadTimeMessage}`
+      : loadTimeMessage;
+    logger.info( logMessage );
+  }, [screenName] );
 
-  return {
-    loadTime,
-  };
+  useEffect( ( ) => {
+    if ( stopOnMount || isLoading === false ) {
+      stop( );
+    }
+  }, [stopOnMount, isLoading, stop] );
+
+  return stop;
 };
 
 export default usePerformance;

--- a/src/sharedHooks/usePerformance.ts
+++ b/src/sharedHooks/usePerformance.ts
@@ -7,13 +7,11 @@ const logger = log.extend( "usePerformance" );
 
 interface PerformanceOptions {
   screenName?: string;
-  stopOnMount?: boolean;
   isLoading?: boolean;
 }
 
 const usePerformance = ( {
   screenName,
-  stopOnMount = false,
   isLoading,
 }: PerformanceOptions = {} ) => {
   const startTime = useRef( 0 );
@@ -34,10 +32,10 @@ const usePerformance = ( {
   }, [screenName] );
 
   useEffect( ( ) => {
-    if ( stopOnMount || isLoading === false ) {
+    if ( isLoading === false ) {
       stop( );
     }
-  }, [stopOnMount, isLoading, stop] );
+  }, [isLoading, stop] );
 
   return stop;
 };

--- a/tests/unit/sharedHooks/usePerformance.test.ts
+++ b/tests/unit/sharedHooks/usePerformance.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from "@testing-library/react-native";
+import usePerformance from "sharedHooks/usePerformance";
+
+const mockLoggerInfo = jest.fn( );
+jest.mock( "sharedHelpers/logger", ( ) => ( {
+  log: { extend: ( ) => ( { info: ( ...args: unknown[] ) => mockLoggerInfo( ...args ) } ) },
+} ) );
+
+const mockDebugModeEnabled = jest.fn( ( ): boolean => false );
+jest.mock( "stores/useStore", ( ) => ( {
+  __esModule: true,
+  default: {
+    getState: ( ) => ( { layout: { debugModeEnabled: mockDebugModeEnabled( ) } } ),
+  },
+} ) );
+
+const mockNow = jest.fn( ( ): number => 0 );
+jest.mock( "react-native-performance", ( ) => ( {
+  __esModule: true,
+  default: {
+    now: ( ) => mockNow( ),
+  },
+} ) );
+
+describe( "usePerformance", ( ) => {
+  beforeEach( ( ) => {
+    mockNow.mockReturnValue( 0 );
+    mockDebugModeEnabled.mockReturnValue( true );
+    mockLoggerInfo.mockClear( );
+  } );
+
+  it( "measures elapsed time from mount to stop and prefixes the screen name", ( ) => {
+    mockNow.mockReturnValue( 1000 ); // mount
+    const { result } = renderHook( ( ) => usePerformance( { screenName: "Test" } ) );
+
+    mockNow.mockReturnValue( 1500 ); // stop
+    result.current( );
+
+    expect( mockLoggerInfo ).toHaveBeenCalledWith( "Test Load Time: 500 milliseconds" );
+  } );
+
+  it( "stops automatically on mount when isLoading is false", ( ) => {
+    mockNow.mockReturnValue( 300 );
+
+    renderHook( ( ) => usePerformance( {
+      screenName: "Test",
+      isLoading: false,
+    } ) );
+
+    expect( mockLoggerInfo ).toHaveBeenCalledWith( "Test Load Time: 0 milliseconds" );
+  } );
+
+  it( "stops automatically when isLoading flips to false", ( ) => {
+    mockNow.mockReturnValue( 1000 ); // mount
+    const { rerender } = renderHook(
+      ( { isLoading }: { isLoading: boolean } ) => usePerformance( {
+        screenName: "Test",
+        isLoading,
+      } ),
+      { initialProps: { isLoading: true } },
+    );
+
+    expect( mockLoggerInfo ).not.toHaveBeenCalled( );
+
+    mockNow.mockReturnValue( 1400 );
+    rerender( { isLoading: false } );
+
+    expect( mockLoggerInfo ).toHaveBeenCalledWith( "Test Load Time: 400 milliseconds" );
+  } );
+
+  it( "does not log when debug mode is disabled", ( ) => {
+    mockDebugModeEnabled.mockReturnValue( false );
+
+    const { result } = renderHook( ( ) => usePerformance( { screenName: "Test" } ) );
+    result.current( );
+
+    expect( mockLoggerInfo ).not.toHaveBeenCalled( );
+  } );
+
+  it( "returns a stable stop reference across renders", ( ) => {
+    const { result, rerender } = renderHook( ( ) => usePerformance( { screenName: "Test" } ) );
+    const firstStop = result.current;
+    rerender( { } );
+
+    expect( result.current ).toBe( firstStop );
+  } );
+} );


### PR DESCRIPTION
Apologies for some scope creep here. I tried to keep things limited but wanted the after state to be something I was comfortable with.

Of note:
- Add imperative stop
- Move logging effect into hook
- import `performance` from react-native-performance