### PR TITLE
MOB-1327: MVP explorev2 header

### DIFF
--- a/src/components/Explore/ExploreV2/ExploreV2DebugSheet.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2DebugSheet.tsx
@@ -127,7 +127,7 @@ const ExploreV2DebugSheet = ( ) => {
       <INatIconButton
         icon="triangle-exclamation"
         className={classnames(
-          "absolute top-5 right-5",
+          "absolute top-64 right-5",
           "rounded-full",
         )}
         color="white"

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -75,15 +75,15 @@ const ExploreV2Header = ( ) => {
           : null}
       </View>
       <INatIconButton
-        icon="magnifying-glass"
-        size={20}
-        color={colors.white}
-        className="bg-inatGreen rounded-md"
         onPress={() => navigation.navigate( "UniversalSearch" )}
         accessibilityLabel={t( "Search" )}
         accessibilityHint={t( "Opens-search-interface" )}
         testID="ExploreV2Header.searchButton"
-      />
+      >
+        <View className="w-10 h-10 bg-inatGreen rounded-md items-center justify-center">
+          <INatIcon name="magnifying-glass" size={20} color={colors.white} />
+        </View>
+      </INatIconButton>
     </View>
   );
 };

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -53,8 +53,8 @@ const ExploreV2Header = ( ) => {
   const place = locationLabel( state.location, t );
 
   return (
-    <View className="bg-white px-6 py-4 flex-row justify-between items-center">
-      <View className="flex-1 mr-3">
+    <View className="bg-white p-4 flex-row justify-between items-center">
+      <View className="flex-1 mr-5">
         <Heading4 numberOfLines={1} ellipsizeMode="tail">
           {subject}
         </Heading4>
@@ -76,6 +76,7 @@ const ExploreV2Header = ( ) => {
       </View>
       <INatIconButton
         icon="magnifying-glass"
+        size={20}
         color={colors.white}
         className="bg-inatGreen rounded-md"
         onPress={() => navigation.navigate( "UniversalSearch" )}

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -1,0 +1,90 @@
+import {
+  Body3,
+  Heading4,
+  INatIcon,
+  INatIconButton,
+} from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import type { TFunction } from "i18next";
+import type { ExploreV2LocationState, ExploreV2Subject } from "providers/ExploreV2Context";
+import {
+  EXPLORE_V2_PLACE_MODE,
+  useExploreV2,
+} from "providers/ExploreV2Context";
+import React from "react";
+import { useTranslation } from "sharedHooks";
+import colors from "styles/tailwindColors";
+
+interface Props {
+  onPressSearch: () => void;
+}
+
+function subjectLabel( subject: ExploreV2Subject | null, t: TFunction ): string {
+  if ( !subject ) { return t( "All-organisms" ); }
+  switch ( subject.type ) {
+    case "taxon":
+      return subject.taxon.name;
+    case "user":
+      return subject.user.login;
+    case "project":
+      return subject.project.title;
+    default:
+      return t( "All-organisms" );
+  }
+}
+
+function locationLabel( location: ExploreV2LocationState, t: TFunction ): string {
+  switch ( location.placeMode ) {
+    case EXPLORE_V2_PLACE_MODE.WORLDWIDE:
+      return t( "Worldwide" );
+    case EXPLORE_V2_PLACE_MODE.NEARBY:
+      return t( "Nearby" );
+    case EXPLORE_V2_PLACE_MODE.PLACE:
+      return location.place.display_name || "";
+    default:
+      return "";
+  }
+}
+
+const ExploreV2Header = ( { onPressSearch }: Props ) => {
+  const { t } = useTranslation( );
+  const { state } = useExploreV2( );
+
+  const subject = subjectLabel( state.subject, t );
+  const place = locationLabel( state.location, t );
+
+  return (
+    <View className="bg-white px-6 py-4 flex-row justify-between items-center">
+      <View className="flex-1 mr-3">
+        <Heading4 numberOfLines={1} ellipsizeMode="tail">
+          {subject}
+        </Heading4>
+        {place
+          ? (
+            <View className="flex-row items-center pt-2">
+              <INatIcon name="location" size={15} />
+              <Body3
+                maxFontSizeMultiplier={1.5}
+                className="ml-3"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {place}
+              </Body3>
+            </View>
+          )
+          : null}
+      </View>
+      <INatIconButton
+        icon="magnifying-glass"
+        color={colors.white}
+        className="bg-inatGreen rounded-md"
+        onPress={onPressSearch}
+        accessibilityLabel={t( "Search" )}
+        testID="ExploreV2Header.searchButton"
+      />
+    </View>
+  );
+};
+
+export default ExploreV2Header;

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from "@react-navigation/native";
 import {
   Body3,
   Heading4,
@@ -6,6 +7,7 @@ import {
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { TFunction } from "i18next";
+import type { ExploreStackScreenProps } from "navigation/types";
 import type { ExploreV2LocationState, ExploreV2Subject } from "providers/ExploreV2Context";
 import {
   EXPLORE_V2_PLACE_MODE,
@@ -14,10 +16,6 @@ import {
 import React from "react";
 import { useTranslation } from "sharedHooks";
 import colors from "styles/tailwindColors";
-
-interface Props {
-  onPressSearch: () => void;
-}
 
 function subjectLabel( subject: ExploreV2Subject | null, t: TFunction ): string {
   if ( !subject ) { return t( "All-organisms" ); }
@@ -46,9 +44,10 @@ function locationLabel( location: ExploreV2LocationState, t: TFunction ): string
   }
 }
 
-const ExploreV2Header = ( { onPressSearch }: Props ) => {
+const ExploreV2Header = ( ) => {
   const { t } = useTranslation( );
   const { state } = useExploreV2( );
+  const navigation = useNavigation<ExploreStackScreenProps<"ExploreResults">["navigation"]>( );
 
   const subject = subjectLabel( state.subject, t );
   const place = locationLabel( state.location, t );
@@ -79,8 +78,9 @@ const ExploreV2Header = ( { onPressSearch }: Props ) => {
         icon="magnifying-glass"
         color={colors.white}
         className="bg-inatGreen rounded-md"
-        onPress={onPressSearch}
+        onPress={() => navigation.navigate( "UniversalSearch" )}
         accessibilityLabel={t( "Search" )}
+        accessibilityHint={t( "Opens-search-interface" )}
         testID="ExploreV2Header.searchButton"
       />
     </View>

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -1,6 +1,9 @@
 import { useNetInfo } from "@react-native-community/netinfo";
+import { useNavigation } from "@react-navigation/native";
 import buildExploreV2QueryParams
   from "components/Explore/ExploreV2/buildQueryParams";
+import ExploreV2Header
+  from "components/Explore/ExploreV2/components/ExploreV2Header";
 import ExploreV2DebugSheet
   from "components/Explore/ExploreV2/ExploreV2DebugSheet";
 import useInfiniteExploreScroll
@@ -13,6 +16,7 @@ import {
 } from "components/SharedComponents";
 import SortButton from "components/SharedComponents/Buttons/SortButton";
 import { View } from "components/styledComponents";
+import type { ExploreStackScreenProps } from "navigation/types";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React from "react";
 import { useTranslation } from "sharedHooks";
@@ -21,6 +25,9 @@ const ExploreResults = ( ) => {
   const { state, requestLocationPermissions } = useExploreV2( );
   const { isConnected } = useNetInfo( );
   const { t } = useTranslation( );
+  const navigation = useNavigation<
+    ExploreStackScreenProps<"ExploreResults">["navigation"]
+  >( );
 
   const queryParams = buildExploreV2QueryParams( state );
 
@@ -53,8 +60,9 @@ const ExploreResults = ( ) => {
   return (
     <ViewWrapper testID="ExploreResults" wrapperClassName="overflow-hidden">
       <View className="flex-1 overflow-hidden">
-        {/* eslint-disable-next-line i18next/no-literal-string */}
-        <Body2>TODO: Header — MOB-1327</Body2>
+        <ExploreV2Header
+          onPressSearch={() => navigation.navigate( "UniversalSearch" )}
+        />
         {state.location.placeMode === EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION
           ? renderPermissionPrompt( )
           : (

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -1,5 +1,4 @@
 import { useNetInfo } from "@react-native-community/netinfo";
-import { useNavigation } from "@react-navigation/native";
 import buildExploreV2QueryParams
   from "components/Explore/ExploreV2/buildQueryParams";
 import ExploreV2Header
@@ -16,7 +15,6 @@ import {
 } from "components/SharedComponents";
 import SortButton from "components/SharedComponents/Buttons/SortButton";
 import { View } from "components/styledComponents";
-import type { ExploreStackScreenProps } from "navigation/types";
 import { EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React from "react";
 import { useTranslation } from "sharedHooks";
@@ -25,10 +23,6 @@ const ExploreResults = ( ) => {
   const { state, requestLocationPermissions } = useExploreV2( );
   const { isConnected } = useNetInfo( );
   const { t } = useTranslation( );
-  const navigation = useNavigation<
-    ExploreStackScreenProps<"ExploreResults">["navigation"]
-  >( );
-
   const queryParams = buildExploreV2QueryParams( state );
 
   const canFetch = state.location.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED
@@ -60,9 +54,7 @@ const ExploreResults = ( ) => {
   return (
     <ViewWrapper testID="ExploreResults" wrapperClassName="overflow-hidden">
       <View className="flex-1 overflow-hidden">
-        <ExploreV2Header
-          onPressSearch={() => navigation.navigate( "UniversalSearch" )}
-        />
+        <ExploreV2Header />
         {state.location.placeMode === EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION
           ? renderPermissionPrompt( )
           : (

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -901,6 +901,8 @@ Opens-AI-camera = Opens AI camera.
 # Accessibility hint for a button that opens a form for editing a comment
 Opens-edit-comment-form = Opens edit comment form.
 Opens-location-permission-prompt = Opens location permission prompt
+# Accessibility hint for search button in Explore header that navigates to the search interface
+Opens-search-interface = Opens search interface.
 OR-SIGN-IN-WITH = OR SIGN IN WITH
 Or-you-can-try-to-get-a-clearer-photo-by-zooming-in-getting-closer = Or, you can try to get a clearer photo by zooming in, getting closer, or trying a different angle.
 # Picker prompt on observation edit

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -525,6 +525,7 @@
   "Opens-AI-camera": "Opens AI camera.",
   "Opens-edit-comment-form": "Opens edit comment form.",
   "Opens-location-permission-prompt": "Opens location permission prompt",
+  "Opens-search-interface": "Opens search interface.",
   "OR-SIGN-IN-WITH": "OR SIGN IN WITH",
   "Or-you-can-try-to-get-a-clearer-photo-by-zooming-in-getting-closer": "Or, you can try to get a clearer photo by zooming in, getting closer, or trying a different angle.",
   "Organism-is-captive": "Organism is captive",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -901,6 +901,8 @@ Opens-AI-camera = Opens AI camera.
 # Accessibility hint for a button that opens a form for editing a comment
 Opens-edit-comment-form = Opens edit comment form.
 Opens-location-permission-prompt = Opens location permission prompt
+# Accessibility hint for search button in Explore header that navigates to the search interface
+Opens-search-interface = Opens search interface.
 OR-SIGN-IN-WITH = OR SIGN IN WITH
 Or-you-can-try-to-get-a-clearer-photo-by-zooming-in-getting-closer = Or, you can try to get a clearer photo by zooming in, getting closer, or trying a different angle.
 # Picker prompt on observation edit


### PR DESCRIPTION
We need some sort of header component so we can get to and work on UniversalSearch. This minimal component just shows ExploreV2Subject, ExploreV2LocationState, and the magnifying glass icon.

I also moved the debug icon out of the way

<details>
<summary>screenshot</summary>
<img width="603" height="1311" alt="Simulator Screenshot - iPhone 17 - 2026-06-04 at 11 43 16" src="https://github.com/user-attachments/assets/0406a3c8-c400-4fd0-bb53-17a435d01f07" />

</details>