### PR TITLE
Update detox emulator name

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -73,7 +73,7 @@ module.exports = {
       device: {
         // Make sure to follow the guide to setup an AOSP if you plan to test locally
         // https://wix.github.io/Detox/docs/guide/android-dev-env#android-aosp-emulators
-        avdName: "Pixel_5_API_31_AOSP",
+        avdName: "Pixel_5_API_34_AOSP",
       },
     },
   },


### PR DESCRIPTION
This is only a name change, of the emulator the detox command is trying to find and start.
On my local machine I have created a new AOSP with Android SK 34 instead of 31, and all e2e tests behaved as before. So, 1 fail 2 passes.