### PR TITLE
MOB-1259: simplify login ref

### DIFF
--- a/src/components/LoginSignUp/Login.tsx
+++ b/src/components/LoginSignUp/Login.tsx
@@ -1,27 +1,25 @@
 import { t } from "i18next";
-import React, { useCallback } from "react";
+import React, { useRef } from "react";
+import type { ScrollView } from "react-native";
 
 import Header from "./Header";
 import LoginForm from "./LoginForm";
 import LoginSignUpWrapper from "./LoginSignUpWrapper";
 
 const Login = ( ) => {
-  const renderLoginForm = useCallback( ( { scrollViewRef } ) => (
-    <>
+  const scrollViewRef = useRef<ScrollView>( null );
+
+  return (
+    <LoginSignUpWrapper
+      backgroundSource={require( "images/background/toucan.jpg" )}
+      scrollViewRef={scrollViewRef}
+    >
       <Header
         headerText={t( "A-global-community-for-nature" )}
       />
       <LoginForm
         scrollViewRef={scrollViewRef}
       />
-    </>
-  ), [] );
-
-  return (
-    <LoginSignUpWrapper
-      backgroundSource={require( "images/background/toucan.jpg" )}
-    >
-      {renderLoginForm}
     </LoginSignUpWrapper>
   );
 };

--- a/src/components/LoginSignUp/LoginSignUpWrapper.tsx
+++ b/src/components/LoginSignUp/LoginSignUpWrapper.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useEffect, useRef } from "react";
 import type {
   ImageSourcePropType,
   ImageStyle,
+  ScrollView as RNScrollView,
   StyleProp,
 } from "react-native";
 import {
@@ -15,11 +16,10 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-type ScrollViewRef = { scrollTo: ( options: { y: number; animated: boolean } ) => void } | null;
-
 interface Props extends PropsWithChildren {
   backgroundSource: ImageSourcePropType;
   imageStyle?: StyleProp<ImageStyle>;
+  scrollViewRef?: React.RefObject<RNScrollView | null>;
 }
 
 const windowHeight = Dimensions.get( "window" ).height;
@@ -33,17 +33,21 @@ const LoginSignupWrapper = ( {
   backgroundSource,
   children,
   imageStyle,
+  scrollViewRef,
 }: Props ) => {
-  const scrollViewRef = useRef<ScrollViewRef>( null );
+  // Consumers that need to control the scroll (e.g. Login) pass their own ref in;
+  // otherwise we keep an internal ref so scroll-reset-on-focus still works.
+  const internalRef = useRef<RNScrollView>( null );
+  const ref = scrollViewRef ?? internalRef;
   const navigation = useNavigation( );
   const insets = useSafeAreaInsets();
 
   const resetScroll = useCallback( ( ) => {
-    const scrollNode = scrollViewRef.current;
+    const scrollNode = ref.current;
     if ( scrollNode && typeof scrollNode.scrollTo === "function" ) {
       scrollNode.scrollTo( { y: 0, animated: false } );
     }
-  }, [] );
+  }, [ref] );
 
   useEffect( ( ) => {
     const unsubscribe = navigation.addListener( "focus", ( ) => {
@@ -65,16 +69,14 @@ const LoginSignupWrapper = ( {
           barStyle="light-content"
         />
         <ScrollView
-          ref={scrollViewRef}
+          ref={ref}
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
           contentContainerStyle={SCROLL_VIEW_STYLE}
         >
           <View style={fitContentWithinScreenStyle}>
             <View className="flex-1 flex-column justify-between">
-              {typeof children === "function"
-                ? children( { scrollViewRef } )
-                : children}
+              {children}
             </View>
           </View>
         </ScrollView>


### PR DESCRIPTION
- Add scrollViewRef to Login and pass as a prop
- Remove children logic from LoginSignUpWrapper and add internalRef as a fallback for consumers that don't pass scrollViewRef