### PR TITLE
MOB-1469: pop back to Suggestions instead of pushing new screen

### DIFF
--- a/src/components/ObsEdit/ObsEditHeader.js
+++ b/src/components/ObsEdit/ObsEditHeader.js
@@ -100,7 +100,7 @@ const ObsEditHeader = ( {
 
   const handleBackButtonPress = useCallback( async ( ) => {
     if ( params?.lastScreen === "Suggestions" ) {
-      navigation.navigate( "Suggestions", { lastScreen: "ObsEdit" } );
+      navigation.dispatch( StackActions.popTo( "Suggestions", { lastScreen: "ObsEdit" } ) );
     } else if ( canRollbackToMatch ) {
       if ( unsavedChanges ) {
         setDiscardChangesSheetVisible( true );


### PR DESCRIPTION
Attached a video of the new behavior to the ticket: https://linear.app/inaturalist/issue/MOB-1469/back-button-behavior-flow-incorrect-on-both-cameras#comment-cf047523