### PR TITLE
one-off simplified obs grid item for onboarding modal

### DIFF
--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -2,7 +2,6 @@ import { useNavigation, useRoute } from "@react-navigation/native";
 import type { FlashListRef } from "@shopify/flash-list";
 import ObservationsViewBar from "components/Explore/ObservationsViewBar";
 import ObservationsFlashList from "components/ObservationsFlashList/ObservationsFlashList";
-import ObsGridItem from "components/ObservationsFlashList/ObsGridItem";
 import {
   AccountCreationCard,
   FiftyObservationCard,
@@ -41,6 +40,7 @@ import type { SpeciesCount } from "types/sorting";
 import LoginSheet from "./LoginSheet";
 import { ACTIVE_SHEET } from "./MyObservationsContainer";
 import MyObservationsSimpleHeader from "./MyObservationsSimpleHeader";
+import PivotCardObsGridItem from "./PivotCardObsGridItem";
 import SimpleHeader from "./SimpleHeader";
 import SimpleTaxonGridItem from "./SimpleTaxonGridItem";
 import StatTab from "./StatTab";
@@ -456,12 +456,8 @@ const MyObservationsSimple = ( {
               onImageComponentPress: handlePivotCardGridItemPress,
               accessibilityHint: t( "Navigates-to-observation-details" ),
               imageComponent: (
-                <ObsGridItem
-                  observation={observations[0]}
-                  currentUser={currentUser}
-                  explore={false}
-                  queued={false}
-                  testID="PivotCardGridItem"
+                <PivotCardObsGridItem
+                  uuid={observations[0].uuid}
                 />
               ),
             }}

--- a/src/components/MyObservations/PivotCardObsGridItem.tsx
+++ b/src/components/MyObservations/PivotCardObsGridItem.tsx
@@ -1,0 +1,52 @@
+import ObsImagePreview from "components/ObservationsFlashList/ObsImagePreview";
+import { photoFromObservation } from "components/ObservationsFlashList/util";
+import { Body2, DisplayTaxonName } from "components/SharedComponents";
+import { View } from "components/styledComponents";
+import { RealmContext } from "providers/contexts";
+import React from "react";
+import Observation from "realmModels/Observation";
+import Photo from "realmModels/Photo";
+import { useCurrentUser } from "sharedHooks";
+
+const { useObject } = RealmContext;
+
+// one-off simplified version of ObsGridItem for the Onboarding PivotCard
+const PivotCardObsGridItem = ( { uuid }: { uuid: string } ) => {
+  const obs = useObject<{ uuid: string }>( "Observation", uuid );
+  const currentUser = useCurrentUser( );
+  if ( !obs ) return null;
+  const photo = photoFromObservation( obs );
+  const photoUri = Photo.displayLocalOrRemoteMediumPhoto( photo );
+  const taxon = obs.taxon
+    ? Observation.mapTaxonForMyObs( obs.taxon )
+    : undefined;
+  return (
+    <ObsImagePreview
+      height="h-[200px]"
+      width="w-[200px]"
+      iconicTaxonName={taxon?.iconic_taxon_name}
+      isMultiplePhotosTop
+      source={photoUri
+        ? { uri: photoUri }
+        : undefined}
+      testID="PivotCardGridItem"
+      useShortGradient
+      white
+    >
+      <View className="absolute bottom-0 items-start p-2">
+        <DisplayTaxonName
+          bottomTextComponent={Body2}
+          color="text-white"
+          ellipsizeCommonName
+          layout="vertical"
+          prefersCommonNames={currentUser?.prefers_common_names}
+          scientificNameFirst={currentUser?.prefers_scientific_name_first}
+          showOneNameOnly
+          taxon={taxon}
+        />
+      </View>
+    </ObsImagePreview>
+  );
+};
+
+export default PivotCardObsGridItem;

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -312,6 +312,17 @@ class Observation extends Realm.Object {
     };
   }
 
+  static mapTaxonForMyObs( taxon ) {
+    return {
+      id: taxon.id,
+      name: taxon.name,
+      preferred_common_name: taxon.preferred_common_name,
+      rank: taxon.rank,
+      rank_level: taxon.rank_level,
+      iconic_taxon_name: taxon.iconic_taxon_name,
+    };
+  }
+
   static mapObservationForMyObsDefaultMode( obs ) {
     return {
       uuid: obs.uuid,
@@ -326,14 +337,7 @@ class Observation extends Realm.Object {
         : [],
       quality_grade: obs.quality_grade,
       taxon: obs.taxon
-        ? {
-          id: obs?.taxon?.id,
-          name: obs?.taxon?.name,
-          preferred_common_name: obs?.taxon?.preferred_common_name,
-          rank: obs?.taxon?.rank,
-          rank_level: obs?.taxon?.rank_level,
-          iconic_taxon_name: obs?.taxon?.iconic_taxon_name,
-        }
+        ? Observation.mapTaxonForMyObs( obs.taxon )
         : null,
       comments_viewed: obs.comments_viewed,
       identifications_viewed: obs.identifications_viewed,


### PR DESCRIPTION
The scope of https://github.com/inaturalist/iNaturalistReactNative/pull/3690 ballooned too much, splitting for better reviewability & testing. Part of [MOB-1458](https://linear.app/inaturalist/issue/MOB-1458)

This introduces a simplified clone of ObsGridItem (rendered by ObsFlashList) for displaying a similar obs preview in the "congrats on your first observation!" onboarding modal / PivotCard. This is to reduce logic / data dependency above the ObsFlashList level.