### PR TITLE
Update vision-plugin to 6rc3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3931,7 +3931,7 @@ PODS:
   - VisionCamera/React (4.7.3):
     - React-Core
     - VisionCamera/FrameProcessors
-  - VisionCameraPluginInatVision (6.0.0-rc.2):
+  - VisionCameraPluginInatVision (6.0.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -4531,7 +4531,7 @@ SPEC CHECKSUMS:
   SensitiveInfo: 09107b865dc23b4e9c0a61ec01385387bf3391a8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
-  VisionCameraPluginInatVision: d29c27577b88822f59906fd8d3550054cffdbe55
+  VisionCameraPluginInatVision: 561ffc82eb61315312414a9f4424c5d6411c83ab
   Yoga: e9fea23bf9b2766818ce9a8df72f584bf5ad36cd
 
 PODFILE CHECKSUM: 73e24a8590e365c9fec451abf69476ae07116d98

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "realm": "^20.2.0",
         "sanitize-html": "^2.17.4",
         "uuid": "^11.1.1",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#5cb51942939f704acbb5d451a444f7aa36268c66",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#e8c4782cee82e781e8dc7016fffedbbd95070931",
         "zustand": "^4.5.7"
       },
       "devDependencies": {
@@ -23072,15 +23072,18 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "6.0.0-rc.2",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#5cb51942939f704acbb5d451a444f7aa36268c66",
-      "integrity": "sha512-/e4lWjTIWZMw8xYMsTJkIW8KiFAerHlfitQplL2f+59vE9pySKQrTKdXDDVF0/8wSBpZjTOrntZ8kA1abP4ytA==",
+      "version": "6.0.0-rc.3",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#e8c4782cee82e781e8dc7016fffedbbd95070931",
+      "integrity": "sha512-aarLhPkpgxtFSjrbcbNtzL2VZNM8So+hBzVQROFIEQrj5e/dPp8zWGQ4gONRW9rkUH7t1pmWD4125Eq1/w45+g==",
       "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
       "dependencies": {
         "h3-js": "^4.4.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "realm": "^20.2.0",
     "sanitize-html": "^2.17.4",
     "uuid": "^11.1.1",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#5cb51942939f704acbb5d451a444f7aa36268c66",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#e8c4782cee82e781e8dc7016fffedbbd95070931",
     "zustand": "^4.5.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Over creative day I had a bit of time to fix some smaller bugs with our vision-plugin while working in the code.

This is the entire diff for this update: https://github.com/inaturalist/vision-camera-plugin-inatvision/compare/5cb5194...main

This includes a big chunk of repo scaffolding updates from earlier this year, but the "client-side" relevant changes are the introduction of a model provider class on iOS and a few minor bugfixes in src/index.tsx and src/lookUpLocation.ts (e.g. few places on the earth used a wrong elevation as input).

The biggest wanted fix is the model provider on iOS:
Before if one session of the app used the AI camera as well as offline cv predictions from a photo we put the cv model into memory twice.
<img width="194" height="63" alt="Screenshot 2026-06-18 at 11 44 17" src="https://github.com/user-attachments/assets/d6cc7126-312b-4ff5-b1e9-05540b0746cb" />


After: Only once per session.
<img width="204" height="73" alt="Screenshot 2026-06-18 at 11 11 31" src="https://github.com/user-attachments/assets/7c6e1bb7-99df-44d6-8c95-f720dc0c4a05" />
