### PR TITLE
MOB-1531 add nitro modules dep to test for impact

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -179,6 +179,35 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - NitroModules (0.35.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
@@ -3973,6 +4002,7 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - NitroModules (from `../node_modules/react-native-nitro-modules`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -4144,6 +4174,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-v0.14.1
+  NitroModules:
+    :path: "../node_modules/react-native-nitro-modules"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -4412,6 +4444,7 @@ SPEC CHECKSUMS:
   LicensePlist: 91465ee0724beab897ed5482775c5d3932a3f379
   Mute: 20135a96076f140cc82bfc8b810e2d6150d8ec7e
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  NitroModules: d2d7b8a417d5f498ef5affa78d82113ad8c35c59
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "react-native-mmkv": "^3.3.3",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-modal-datetime-picker": "^18.0.0",
+        "react-native-nitro-modules": "^0.35.9",
         "react-native-open-maps": "^0.4.3",
         "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
         "react-native-paper": "^5.12.3",
@@ -19993,6 +19994,16 @@
       "peerDependencies": {
         "@react-native-community/datetimepicker": ">=6.7.0",
         "react-native": ">=0.65.0"
+      }
+    },
+    "node_modules/react-native-nitro-modules": {
+      "version": "0.35.9",
+      "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.35.9.tgz",
+      "integrity": "sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-open-maps": {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "react-native-mmkv": "^3.3.3",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",
+    "react-native-nitro-modules": "^0.35.9",
     "react-native-open-maps": "^0.4.3",
     "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
     "react-native-paper": "^5.12.3",


### PR DESCRIPTION
This PR: adds the `react-native-nitro-modules` core dependency to support NitroModules-based native modules. no functional changes, just added to verify independent impact on build / app behavior.

Closes MOB-1531, subissue of MOB-1159

---

A number of our dependencies are moving to implementations dependent on [NitroModules](https://nitro.margelo.com/), an OSS alternative to the RN-official [TurboModules](https://reactnative.dev/docs/turbo-native-modules-introduction) approach for writing native modules (see also: [ExpoModules](https://docs.expo.dev/modules/overview)).

Those libraries include at least:

- react-native-vision-camera
- react-native-audio-recorder-player
- react-native-mmkv
- react-native-sensitive-info
- [prospective?] react-native-nitro-image (as a potential option for https://github.com/candlefinance/faster-image which is now unmaintained)

We expect that non-Nitro versions of those libraries may be left inactive (fine) and not be kept up to date to be compatible with new React Native versions (**less fine**).

In discussion with @jtklein, we've recognized the importance of caution in adopting NitroModules. It introduces a factor of vendor lock-in to a new, "non-official", shared dependency for multiple key packages, _especially_ rn-vision-camer, for which we have the critical [vision-camera-plugin-inatvision](https://github.com/inaturalist/vision-camera-plugin-inatvision) plugin.

As a first step for investigating / validating NitroModules for iNatRN, this PR pulls in the core NitroModules dependency for a build & soak test. We just want to confirm that it existing in the app doesn't break anything.