### PR TITLE
Revert "Disable fastlane upload to Google Play"

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -471,13 +471,11 @@ lane :internal do
   end
   changelog = get_changelog
 
-  # TODO: disabled because we have just migrated this app to a new Google Play account and
-  # have not yet created credentials to talk to the upload API
-  # upload_to_play_store(
-  #   aab: aab_path,
-  #   track: "internal",
-  #   version_name: last_tag
-  # )
+  upload_to_play_store(
+    aab: aab_path,
+    track: "internal",
+    version_name: last_tag
+  )
 
   upload_to_testflight(
     ipa: get_ipa_path,
@@ -513,13 +511,11 @@ lane :beta do
   build_number = get_build_number( xcodeproj: XCODEPROJ )
 
   # UI.message "Play Store: promoting build #{build_number} to beta track"
-  # TODO: disabled because we have just migrated this app to a new Google Play account and
-  # have not yet created credentials to talk to the upload API
-  # upload_to_play_store(
-  #   version_code: build_number,
-  #   track: "internal",
-  #   track_promote_to: "beta"
-  # )
+  upload_to_play_store(
+    version_code: build_number,
+    track: "internal",
+    track_promote_to: "beta"
+  )
 
   UI.message "TestFlight: adding build #{build_number} to Open Beta group"
   add_build_to_testflight_beta_group(


### PR DESCRIPTION
This reverts commit e5eb0a6400bdd0f71884293f959e7a04b530a8ad.

MOB-1527 related.

Service account has been added to the new Play account and this step should work again. We'll know for sure during the next build.