### PR TITLE
Feature flag for traditional projects

### DIFF
--- a/src/sharedHooks/useRozenite.tsx
+++ b/src/sharedHooks/useRozenite.tsx
@@ -67,6 +67,10 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
     = useFeatureFlagForDebug( FeatureFlag.ExploreV2Enabled );
   const { resolvedValue: newsEnabled, setOverride: setNewsEnabled }
     = useFeatureFlagForDebug( FeatureFlag.NewsEnabled );
+  const {
+    resolvedValue: traditionalProjectsEnabled,
+    setOverride: setTraditionalProjectsEnabled,
+  } = useFeatureFlagForDebug( FeatureFlag.TraditionalProjectsEnabled );
 
   const sections = useMemo(
     () => [
@@ -109,10 +113,26 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
               setNewsEnabled( !newsEnabled );
             },
           },
+          {
+            id: "traditional-projects",
+            type: "toggle",
+            title: "TraditionalProjects",
+            value: traditionalProjectsEnabled,
+            onUpdate: () => {
+              setTraditionalProjectsEnabled( !traditionalProjectsEnabled );
+            },
+          },
         ],
       } ),
     ],
-    [exploreV2Enabled, setExploreV2Enabled, newsEnabled, setNewsEnabled],
+    [
+      exploreV2Enabled,
+      setExploreV2Enabled,
+      newsEnabled,
+      setNewsEnabled,
+      traditionalProjectsEnabled,
+      setTraditionalProjectsEnabled,
+    ],
   );
 
   useRozeniteControlsPlugin( { sections } );

--- a/src/stores/createFeatureFlagSlice.ts
+++ b/src/stores/createFeatureFlagSlice.ts
@@ -22,18 +22,21 @@ export enum FeatureFlag {
   // MyFeatureFlagEnabled = "myFeatureFlagEnabled",
   ExploreV2Enabled = "exploreV2Enabled",
   NewsEnabled = "newsEnabled",
+  TraditionalProjectsEnabled = "traditionalProjectsEnabled",
 }
 
 const initialFeatureFlagConfig: Record<FeatureFlag, boolean> = {
   // [FeatureFlag.MyFeatureFlagEnabled]: false,
   [FeatureFlag.ExploreV2Enabled]: false,
   [FeatureFlag.NewsEnabled]: false,
+  [FeatureFlag.TraditionalProjectsEnabled]: false,
 };
 
 const initialFeatureFlagDebugOverrides: Record<FeatureFlag, boolean | null> = {
   // [FeatureFlag.MyFeatureFlagEnabled]: null,
   [FeatureFlag.ExploreV2Enabled]: null,
   [FeatureFlag.NewsEnabled]: null,
+  [FeatureFlag.TraditionalProjectsEnabled]: null,
 };
 
 const DEFAULT_STATE = {


### PR DESCRIPTION
Closes MOB-1493

Add `TraditionalProjectsEnabled` feature flag.

Gates Traditional Projects behind a default-off flag with Developer and Rozenite debug overrides; other tickets will consume useFeatureFlag( FeatureFlag.TraditionalProjectsEnabled ).

No visible change until downstream tickets wire up the flag.