### PR TITLE
Traditional Projects: API types and wrappers

### DIFF
--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -13,21 +13,29 @@ const PROJECT_OBSERVATION_FIELDS_FIELDS = {
   required: true,
 };
 
-export const PROJECT_FIELDS = {
-  description: true,
-  header_image_url: true,
+export const PROJECT_SUMMARY_FIELDS = {
   icon: true,
   id: true,
-  membership_model: true,
-  place_id: true,
-  project_observation_fields: PROJECT_OBSERVATION_FIELDS_FIELDS,
   project_type: true,
   rule_preferences: {
     field: true,
     value: true,
   },
   title: true,
+};
+
+export const PROJECT_DETAIL_FIELDS = {
+  ...PROJECT_SUMMARY_FIELDS,
+  description: true,
+  header_image_url: true,
+  membership_model: true,
+  place_id: true,
   user_ids: true,
+};
+
+export const PROJECT_SUMMARY_POF_FIELDS = {
+  ...PROJECT_SUMMARY_FIELDS,
+  project_observation_fields: PROJECT_OBSERVATION_FIELDS_FIELDS,
 };
 
 export const PROJECT_FIELDS_ALL = "all";
@@ -41,7 +49,7 @@ export const OBSERVATION_FIELD_VALUE_FIELDS = {
 
 export const PROJECT_OBSERVATION_FIELDS = {
   id: true,
-  project: PROJECT_FIELDS,
+  project: PROJECT_SUMMARY_FIELDS,
   project_id: true,
   uuid: true,
 };

--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -31,3 +31,10 @@ export const PROJECT_FIELDS = {
 };
 
 export const PROJECT_FIELDS_ALL = "all";
+
+export const OBSERVATION_FIELD_VALUE_FIELDS = {
+  id: true,
+  observation_field: OBSERVATION_FIELD_FIELDS,
+  uuid: true,
+  value: true,
+};

--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -1,9 +1,9 @@
 const OBSERVATION_FIELD_FIELDS = {
+  allowed_values: true,
+  datatype: true,
+  description: true,
   id: true,
   name: true,
-  datatype: true,
-  allowed_values: true,
-  description: true,
 };
 
 const PROJECT_OBSERVATION_FIELDS = {

--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -6,7 +6,7 @@ const OBSERVATION_FIELD_FIELDS = {
   name: true,
 };
 
-const PROJECT_OBSERVATION_FIELDS = {
+const PROJECT_OBSERVATION_FIELDS_FIELDS = {
   id: true,
   observation_field: OBSERVATION_FIELD_FIELDS,
   position: true,
@@ -20,7 +20,7 @@ export const PROJECT_FIELDS = {
   id: true,
   membership_model: true,
   place_id: true,
-  project_observation_fields: PROJECT_OBSERVATION_FIELDS,
+  project_observation_fields: PROJECT_OBSERVATION_FIELDS_FIELDS,
   project_type: true,
   rule_preferences: {
     field: true,

--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -38,3 +38,10 @@ export const OBSERVATION_FIELD_VALUE_FIELDS = {
   uuid: true,
   value: true,
 };
+
+export const PROJECT_OBSERVATION_FIELDS = {
+  id: true,
+  project: PROJECT_FIELDS,
+  project_id: true,
+  uuid: true,
+};

--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -1,0 +1,17 @@
+export const PROJECT_FIELDS = {
+  description: true,
+  header_image_url: true,
+  icon: true,
+  id: true,
+  membership_model: true,
+  place_id: true,
+  project_type: true,
+  rule_preferences: {
+    field: true,
+    value: true,
+  },
+  title: true,
+  user_ids: true,
+};
+
+export const PROJECT_FIELDS_ALL = "all";

--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -1,3 +1,18 @@
+const OBSERVATION_FIELD_FIELDS = {
+  id: true,
+  name: true,
+  datatype: true,
+  allowed_values: true,
+  description: true,
+};
+
+const PROJECT_OBSERVATION_FIELDS = {
+  id: true,
+  observation_field: OBSERVATION_FIELD_FIELDS,
+  position: true,
+  required: true,
+};
+
 export const PROJECT_FIELDS = {
   description: true,
   header_image_url: true,
@@ -5,6 +20,7 @@ export const PROJECT_FIELDS = {
   id: true,
   membership_model: true,
   place_id: true,
+  project_observation_fields: PROJECT_OBSERVATION_FIELDS,
   project_type: true,
   rule_preferences: {
     field: true,

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -17,7 +17,7 @@ export interface ObservationFieldValueAttributes {
 }
 
 export interface ObservationFieldValueUpdateParams extends ObservationFieldValueAttributes {
-  id: number;
+  id: string; // uuid
 }
 
 const createObservationFieldValue = async (
@@ -57,7 +57,7 @@ const updateObservationFieldValue = async (
 };
 
 const deleteObservationFieldValue = async (
-  id: number,
+  id: string, // uuid
   opts: ApiOpts = {},
 ): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
   try {

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -1,0 +1,23 @@
+import type { ErrorWithResponse, INatApiError } from "api/error";
+import handleError from "api/error";
+import type { ApiOpts } from "api/types";
+import inatjs from "inaturalistjs";
+
+const deleteObservationFieldValue = async (
+  id: number,
+  opts: ApiOpts = {},
+): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+  try {
+    const { results } = await inatjs.observation_field_values.delete( { id }, opts );
+    return results;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "deleteObservationFieldValue", id, opts } },
+    );
+  }
+};
+
+export {
+  deleteObservationFieldValue,
+};

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -11,7 +11,7 @@ export interface ObservationFieldValueAttributes {
   observation_field_value: {
     observation_field_id: number;
     observation_id: number;
-    value: string;
+    value: string | number;
   };
 }
 

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -1,10 +1,11 @@
 import type { ErrorWithResponse, INatApiError } from "api/error";
 import handleError from "api/error";
+import { OBSERVATION_FIELD_VALUE_FIELDS } from "api/fields";
 import type { ApiOpts } from "api/types";
 import inatjs from "inaturalistjs";
 
 const PARAMS = {
-  fields: "all",
+  fields: OBSERVATION_FIELD_VALUE_FIELDS,
 };
 
 export interface ObservationFieldValueAttributes {

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -3,6 +3,36 @@ import handleError from "api/error";
 import type { ApiOpts } from "api/types";
 import inatjs from "inaturalistjs";
 
+const PARAMS = {
+  fields: "all",
+};
+
+export interface ObservationFieldValueAttributes {
+  observation_field_value: {
+    observation_field_id: number;
+    observation_id: number;
+    value: string;
+  };
+}
+
+const createObservationFieldValue = async (
+  params: ObservationFieldValueAttributes,
+  opts: ApiOpts = {},
+): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+  try {
+    const { results } = await inatjs.observation_field_values.create(
+      { ...PARAMS, ...params },
+      opts,
+    );
+    return results;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "createObservationFieldValue", opts } },
+    );
+  }
+};
+
 const deleteObservationFieldValue = async (
   id: number,
   opts: ApiOpts = {},
@@ -19,5 +49,6 @@ const deleteObservationFieldValue = async (
 };
 
 export {
+  createObservationFieldValue,
   deleteObservationFieldValue,
 };

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -15,6 +15,10 @@ export interface ObservationFieldValueAttributes {
   };
 }
 
+export interface ObservationFieldValueUpdateParams extends ObservationFieldValueAttributes {
+  id: number;
+}
+
 const createObservationFieldValue = async (
   params: ObservationFieldValueAttributes,
   opts: ApiOpts = {},
@@ -29,6 +33,24 @@ const createObservationFieldValue = async (
     return handleError(
       e as ErrorWithResponse,
       { context: { functionName: "createObservationFieldValue", opts } },
+    );
+  }
+};
+
+const updateObservationFieldValue = async (
+  params: ObservationFieldValueUpdateParams,
+  opts: ApiOpts = {},
+): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+  try {
+    const { results } = await inatjs.observation_field_values.update(
+      { ...PARAMS, ...params },
+      opts,
+    );
+    return results;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "updateObservationFieldValue", opts } },
     );
   }
 };
@@ -51,4 +73,5 @@ const deleteObservationFieldValue = async (
 export {
   createObservationFieldValue,
   deleteObservationFieldValue,
+  updateObservationFieldValue,
 };

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -11,7 +11,7 @@ const PARAMS = {
 export interface ObservationFieldValueAttributes {
   observation_field_value: {
     observation_field_id: number;
-    observation_id: number;
+    observation_id: string;
     value: string | number;
   };
 }

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -3,6 +3,28 @@ import handleError from "api/error";
 import type { ApiOpts } from "api/types";
 import inatjs from "inaturalistjs";
 
+export interface ProjectObservationWriteParams {
+  project_observation: {
+    observation_id: number;
+    project_id: number;
+  };
+}
+
+const createProjectObservation = async (
+  params: ProjectObservationWriteParams,
+  opts: ApiOpts = {},
+): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+  try {
+    const { results } = await inatjs.project_observations.create( params, opts );
+    return results;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "createProjectObservation", opts } },
+    );
+  }
+};
+
 const deleteProjectObservation = async (
   id: number,
   opts: ApiOpts = {},
@@ -19,5 +41,6 @@ const deleteProjectObservation = async (
 };
 
 export {
+  createProjectObservation,
   deleteProjectObservation,
 };

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -1,7 +1,12 @@
 import type { ErrorWithResponse, INatApiError } from "api/error";
 import handleError from "api/error";
+import { PROJECT_OBSERVATION_FIELDS } from "api/fields";
 import type { ApiOpts } from "api/types";
 import inatjs from "inaturalistjs";
+
+const PARAMS = {
+  fields: PROJECT_OBSERVATION_FIELDS,
+};
 
 export interface ProjectObservationWriteParams {
   project_observation: {
@@ -19,7 +24,7 @@ const createProjectObservation = async (
   opts: ApiOpts = {},
 ): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.project_observations.create( params, opts );
+    const { results } = await inatjs.project_observations.create( { ...PARAMS, ...params }, opts );
     return results;
   } catch ( e ) {
     return handleError(
@@ -34,7 +39,7 @@ const updateProjectObservation = async (
   opts: ApiOpts = {},
 ): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.project_observations.update( params, opts );
+    const { results } = await inatjs.project_observations.update( { ...PARAMS, ...params }, opts );
     return results;
   } catch ( e ) {
     return handleError(

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -15,8 +15,11 @@ export interface ProjectObservationWriteParams {
   };
 }
 
-export interface ProjectObservationUpdateParams extends ProjectObservationWriteParams {
+export interface ProjectObservationUpdateParams {
   id: string; // uuid
+  project_observation: {
+    prefers_curator_coordinate_access: boolean;
+  };
 }
 
 const createProjectObservation = async (

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -10,6 +10,10 @@ export interface ProjectObservationWriteParams {
   };
 }
 
+export interface ProjectObservationUpdateParams extends ProjectObservationWriteParams {
+  id: number;
+}
+
 const createProjectObservation = async (
   params: ProjectObservationWriteParams,
   opts: ApiOpts = {},
@@ -21,6 +25,21 @@ const createProjectObservation = async (
     return handleError(
       e as ErrorWithResponse,
       { context: { functionName: "createProjectObservation", opts } },
+    );
+  }
+};
+
+const updateProjectObservation = async (
+  params: ProjectObservationUpdateParams,
+  opts: ApiOpts = {},
+): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+  try {
+    const { results } = await inatjs.project_observations.update( params, opts );
+    return results;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "updateProjectObservation", opts } },
     );
   }
 };
@@ -43,4 +62,5 @@ const deleteProjectObservation = async (
 export {
   createProjectObservation,
   deleteProjectObservation,
+  updateProjectObservation,
 };

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -10,7 +10,7 @@ const PARAMS = {
 
 export interface ProjectObservationWriteParams {
   project_observation: {
-    observation_id: number;
+    observation_id: string;
     project_id: number;
   };
 }

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -16,7 +16,7 @@ export interface ProjectObservationWriteParams {
 }
 
 export interface ProjectObservationUpdateParams extends ProjectObservationWriteParams {
-  id: number;
+  id: string; // uuid
 }
 
 const createProjectObservation = async (
@@ -50,7 +50,7 @@ const updateProjectObservation = async (
 };
 
 const deleteProjectObservation = async (
-  id: number,
+  id: string, // uuid
   opts: ApiOpts = {},
 ): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
   try {

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -1,0 +1,23 @@
+import type { ErrorWithResponse, INatApiError } from "api/error";
+import handleError from "api/error";
+import type { ApiOpts } from "api/types";
+import inatjs from "inaturalistjs";
+
+const deleteProjectObservation = async (
+  id: number,
+  opts: ApiOpts = {},
+): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+  try {
+    const { results } = await inatjs.project_observations.delete( { id }, opts );
+    return results;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "deleteProjectObservation", id, opts } },
+    );
+  }
+};
+
+export {
+  deleteProjectObservation,
+};

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -201,6 +201,14 @@ export interface ApiProjectObservation {
   uuid: string;
 }
 
+// When using OBSERVATION_FIELD_VALUE_FIELDS
+export interface ApiObservationFieldValue {
+  id: number;
+  observation_field: ApiObservationField;
+  uuid: string;
+  value: string;
+}
+
 export interface ApiObservation extends ApiRecord {
   comments?: ApiComment[];
   identifications?: ApiIdentification[];

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -34,9 +34,9 @@ export interface ProjectRulePreference {
 }
 
 interface ApiObservationField {
-  allowed_values: string;
+  allowed_values: string | null;
   datatype: string;
-  description: string;
+  description: string | null;
   id: number;
   name: string;
 }
@@ -45,7 +45,7 @@ interface ApiProjectObservationField {
   id: number;
   observation_field: ApiObservationField;
   position: number;
-  required: boolean;
+  required: boolean | null;
 }
 
 // Result from using PROJECT_FIELDS

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -204,7 +204,7 @@ export interface ApiProjectObservation {
 export interface ApiObservation extends ApiRecord {
   comments?: ApiComment[];
   identifications?: ApiIdentification[];
-  non_traditional_projects?: ApiProjectObservation[];
+  non_traditional_projects?: { project: ApiProject }[];
   observation_photos?: ApiObservationPhoto[];
   observation_sounds?: ApiObservationSound[];
   project_observations?: ApiProjectObservation[];

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -195,7 +195,10 @@ export interface ApiNotification {
 }
 
 export interface ApiProjectObservation {
+  id: number;
   project: ApiProject;
+  project_id: number;
+  uuid: string;
 }
 
 export interface ApiObservation extends ApiRecord {

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -48,19 +48,27 @@ interface ApiProjectObservationField {
   required: boolean | null;
 }
 
-// Result from using PROJECT_FIELDS
-export interface ApiProject {
-  description: string;
-  header_image_url: string | null;
+// Result from using PROJECT_SUMMARY_FIELDS
+export interface ApiProjectSummary {
   icon: string;
   id: number;
-  membership_model: "inviteonly" | "open" | null;
-  place_id: number | null;
-  project_observation_fields: ApiProjectObservationField[];
   project_type: "collection" | "umbrella" | ""; // FYI "" means "traditional"
   rule_preferences: ProjectRulePreference[];
   title: string;
+}
+
+// Result from using PROJECT_DETAIL_FIELDS
+export interface ApiProject extends ApiProjectSummary {
+  description: string;
+  header_image_url: string | null;
+  membership_model: "inviteonly" | "open" | null;
+  place_id: number | null;
   user_ids: number[];
+}
+
+// Result from using PROJECT_SUMMARY_POF_FIELDS
+export interface ApiProjectSummaryWithPOF extends ApiProjectSummary {
+  project_observation_fields: ApiProjectObservationField[];
 }
 
 export interface ApiResponse {
@@ -196,7 +204,7 @@ export interface ApiNotification {
 
 export interface ApiProjectObservation {
   id: number;
-  project: ApiProject;
+  project: ApiProjectSummary;
   project_id: number;
   uuid: string;
 }
@@ -212,7 +220,7 @@ export interface ApiObservationFieldValue {
 export interface ApiObservation extends ApiRecord {
   comments?: ApiComment[];
   identifications?: ApiIdentification[];
-  non_traditional_projects?: { project: ApiProject }[];
+  non_traditional_projects?: { project: ApiProjectSummary }[];
   observation_photos?: ApiObservationPhoto[];
   observation_sounds?: ApiObservationSound[];
   project_observations?: ApiProjectObservation[];

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -33,6 +33,7 @@ export interface ProjectRulePreference {
   value: string | null;
 }
 
+// Result from using PROJECT_FIELDS
 export interface ApiProject {
   description: string;
   header_image_url: string | null;

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -33,6 +33,21 @@ export interface ProjectRulePreference {
   value: string | null;
 }
 
+interface ApiObservationField {
+  allowed_values: string;
+  datatype: string;
+  description: string;
+  id: number;
+  name: string;
+}
+
+interface ApiProjectObservationField {
+  id: number;
+  observation_field: ApiObservationField;
+  position: number;
+  required: boolean;
+}
+
 // Result from using PROJECT_FIELDS
 export interface ApiProject {
   description: string;
@@ -41,6 +56,7 @@ export interface ApiProject {
   id: number;
   membership_model: "inviteonly" | "open" | null;
   place_id: number | null;
+  project_observation_fields: ApiProjectObservationField[];
   project_type: "collection" | "umbrella" | ""; // FYI "" means "traditional"
   rule_preferences: ProjectRulePreference[];
   title: string;

--- a/src/components/ProjectDetails/ProjectDetailsContainer.tsx
+++ b/src/components/ProjectDetails/ProjectDetailsContainer.tsx
@@ -1,7 +1,7 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { useQueryClient } from "@tanstack/react-query";
 import {
-  PROJECT_FIELDS,
+  PROJECT_DETAIL_FIELDS,
 } from "api/fields";
 import { fetchSpeciesCounts, searchObservations } from "api/observations";
 import fetchPlace from "api/places";
@@ -36,7 +36,7 @@ const ProjectDetailsContainer = ( ) => {
   const { data: project } = useAuthenticatedQuery<ApiProject>(
     fetchProjectsQueryKey,
     optsWithAuth => fetchProjects( id, {
-      fields: PROJECT_FIELDS,
+      fields: PROJECT_DETAIL_FIELDS,
     }, optsWithAuth ),
   );
 

--- a/src/components/ProjectDetails/ProjectDetailsContainer.tsx
+++ b/src/components/ProjectDetails/ProjectDetailsContainer.tsx
@@ -1,5 +1,8 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { useQueryClient } from "@tanstack/react-query";
+import {
+  PROJECT_FIELDS,
+} from "api/fields";
 import { fetchSpeciesCounts, searchObservations } from "api/observations";
 import fetchPlace from "api/places";
 import {
@@ -33,21 +36,7 @@ const ProjectDetailsContainer = ( ) => {
   const { data: project } = useAuthenticatedQuery<ApiProject>(
     fetchProjectsQueryKey,
     optsWithAuth => fetchProjects( id, {
-      fields: {
-        description: true,
-        header_image_url: true,
-        icon: true,
-        id: true,
-        membership_model: true,
-        place_id: true,
-        project_type: true,
-        rule_preferences: {
-          field: true,
-          value: true,
-        },
-        title: true,
-        user_ids: true,
-      },
+      fields: PROJECT_FIELDS,
     }, optsWithAuth ),
   );
 

--- a/src/components/ProjectDetails/ProjectRequirements.tsx
+++ b/src/components/ProjectDetails/ProjectRequirements.tsx
@@ -1,4 +1,5 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
+import { PROJECT_FIELDS_ALL } from "api/fields";
 import {
   fetchProjects,
 } from "api/projects";
@@ -115,7 +116,7 @@ const ProjectRequirements = ( ) => {
     projectQueryKey,
     optsWithAuth => fetchProjects( id, {
       rule_details: true,
-      fields: "all",
+      fields: PROJECT_FIELDS_ALL,
       ttl: -1,
     }, optsWithAuth ),
   );

--- a/src/components/ProjectList/ProjectList.tsx
+++ b/src/components/ProjectList/ProjectList.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
-import type { ApiProject } from "api/types";
+import type { ApiProjectSummary } from "api/types";
 import {
   CustomFlashList,
 } from "components/SharedComponents";
@@ -14,11 +14,11 @@ import ProjectListItem from "./ProjectListItem";
 const ItemSeparator = () => <View className="border-b border-lightGray" />;
 
 interface Props {
-  projects: ApiProject[];
+  projects: ApiProjectSummary[];
   ListEmptyComponent?: React.ReactElement | null;
   ListFooterComponent?: React.ReactElement;
   onEndReached?: ( ) => void;
-  onPress?: ( project: ApiProject ) => void;
+  onPress?: ( project: ApiProjectSummary ) => void;
   accessibilityLabel?: string;
 }
 
@@ -33,7 +33,7 @@ const ProjectList = ( {
   const navigation = useNavigation( );
   const { t } = useTranslation( );
 
-  const renderProject = ( { item: project }: { item: ApiProject } ) => (
+  const renderProject = ( { item: project }: { item: ApiProjectSummary } ) => (
     <Pressable
       className="px-4 py-1.5"
       onPress={( ) => {
@@ -58,7 +58,7 @@ const ProjectList = ( {
       ListEmptyComponent={ListEmptyComponent}
       ListFooterComponent={ListFooterComponent}
       data={projects}
-      keyExtractor={( item: ApiProject ) => item.id}
+      keyExtractor={( item: ApiProjectSummary ) => item.id}
       onEndReached={onEndReached}
       renderItem={renderProject}
       testID="ProjectList"

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { PROJECT_FIELDS } from "api/fields";
-import type { ApiProject } from "api/types";
+import { PROJECT_SUMMARY_FIELDS } from "api/fields";
+import type { ApiProjectSummary } from "api/types";
 import { fetchUserProjects } from "api/users";
 import {
   ActivityIndicator,
@@ -40,13 +40,13 @@ const ProjectListContainer = ( ) => {
   const {
     data: userProjects,
     isLoading: userProjectsLoading,
-  } = useAuthenticatedQuery<ApiProject[]>(
+  } = useAuthenticatedQuery<ApiProjectSummary[]>(
     ["fetchUserProjects", userId],
     optsWithAuth => fetchUserProjects(
       {
         id: userId,
         per_page: 200,
-        fields: PROJECT_FIELDS,
+        fields: PROJECT_SUMMARY_FIELDS,
       },
       optsWithAuth,
     ),
@@ -70,7 +70,7 @@ const ProjectListContainer = ( ) => {
     };
   }, [observationUuid, remoteObservation, userLogin, userProjects, t] );
 
-  const projects: ApiProject[] = observationUuid
+  const projects: ApiProjectSummary[] = observationUuid
     ? observationProjects
     : ( userProjects ?? [] );
 

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,4 +1,5 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
+import { PROJECT_FIELDS } from "api/fields";
 import type { ApiProject } from "api/types";
 import { fetchUserProjects } from "api/users";
 import {
@@ -9,7 +10,6 @@ import { ScreenShell } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import type { TabStackScreenProps } from "navigation/types";
 import React, { useEffect, useMemo } from "react";
-import Observation from "realmModels/Observation";
 import {
   useAuthenticatedQuery,
   useRemoteObservation,
@@ -37,13 +37,16 @@ const ProjectListContainer = ( ) => {
   ) || [];
   const observationProjects = traditionalProjects.concat( nonTraditionalProjects );
 
-  const { data: userProjects, isLoading: userProjectsLoading } = useAuthenticatedQuery(
+  const {
+    data: userProjects,
+    isLoading: userProjectsLoading,
+  } = useAuthenticatedQuery<ApiProject[]>(
     ["fetchUserProjects", userId],
     optsWithAuth => fetchUserProjects(
       {
         id: userId,
         per_page: 200,
-        fields: Observation.PROJECT_FIELDS,
+        fields: PROJECT_FIELDS,
       },
       optsWithAuth,
     ),

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -1,4 +1,5 @@
 import { Realm } from "@realm/react";
+import { PROJECT_FIELDS } from "api/fields";
 import { Alert } from "react-native";
 import { getNowISO } from "sharedHelpers/dateAndTime";
 import { log } from "sharedHelpers/logger";
@@ -25,17 +26,6 @@ const logger = log.extend( "index.js" );
 // class is extended with Realm.Object per this issue:
 // https://github.com/realm/realm-js/issues/3600#issuecomment-785828614
 class Observation extends Realm.Object {
-  static PROJECT_FIELDS = {
-    id: true,
-    icon: true,
-    title: true,
-    project_type: true,
-    rule_preferences: {
-      field: true,
-      value: true,
-    },
-  };
-
   static FIELDS = {
     application: Application.APPLICATION_FIELDS,
     captive: true,
@@ -74,10 +64,10 @@ class Observation extends Realm.Object {
     private_place_guess: true,
     project_ids: true,
     project_observations: {
-      project: Observation.PROJECT_FIELDS,
+      project: PROJECT_FIELDS,
     },
     non_traditional_projects: {
-      project: Observation.PROJECT_FIELDS,
+      project: PROJECT_FIELDS,
     },
     positional_accuracy: true,
     preferences: {

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -1,5 +1,5 @@
 import { Realm } from "@realm/react";
-import { PROJECT_FIELDS } from "api/fields";
+import { PROJECT_FIELDS, PROJECT_OBSERVATION_FIELDS } from "api/fields";
 import { Alert } from "react-native";
 import { getNowISO } from "sharedHelpers/dateAndTime";
 import { log } from "sharedHelpers/logger";
@@ -63,12 +63,7 @@ class Observation extends Realm.Object {
     private_location: true,
     private_place_guess: true,
     project_ids: true,
-    project_observations: {
-      id: true,
-      project: PROJECT_FIELDS,
-      project_id: true,
-      uuid: true,
-    },
+    project_observations: PROJECT_OBSERVATION_FIELDS,
     non_traditional_projects: {
       project: PROJECT_FIELDS,
     },

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -64,7 +64,10 @@ class Observation extends Realm.Object {
     private_place_guess: true,
     project_ids: true,
     project_observations: {
+      id: true,
       project: PROJECT_FIELDS,
+      project_id: true,
+      uuid: true,
     },
     non_traditional_projects: {
       project: PROJECT_FIELDS,

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -1,5 +1,5 @@
 import { Realm } from "@realm/react";
-import { PROJECT_FIELDS, PROJECT_OBSERVATION_FIELDS } from "api/fields";
+import { PROJECT_OBSERVATION_FIELDS, PROJECT_SUMMARY_FIELDS } from "api/fields";
 import { Alert } from "react-native";
 import { getNowISO } from "sharedHelpers/dateAndTime";
 import { log } from "sharedHelpers/logger";
@@ -65,7 +65,7 @@ class Observation extends Realm.Object {
     project_ids: true,
     project_observations: PROJECT_OBSERVATION_FIELDS,
     non_traditional_projects: {
-      project: PROJECT_FIELDS,
+      project: PROJECT_SUMMARY_FIELDS,
     },
     positional_accuracy: true,
     preferences: {

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -81,6 +81,12 @@ inatjs.observations.search.mockResolvedValue( makeResponse( ) );
 inatjs.observations.speciesCounts.mockResolvedValue( makeResponse( ) );
 inatjs.observations.updates.mockResolvedValue( makeResponse( ) );
 inatjs.users.projects.mockResolvedValue( makeResponse( ) );
+inatjs.project_observations.create.mockResolvedValue( makeResponse( ) );
+inatjs.project_observations.update.mockResolvedValue( makeResponse( ) );
+inatjs.project_observations.delete.mockResolvedValue( undefined );
+inatjs.observation_field_values.create.mockResolvedValue( makeResponse( ) );
+inatjs.observation_field_values.update.mockResolvedValue( makeResponse( ) );
+inatjs.observation_field_values.delete.mockResolvedValue( undefined );
 inatjs.computervision.score_image.mockResolvedValue( makeResponse( ) );
 
 // Set up mocked fetch for testing (or disabling) fetch requests

--- a/tests/unit/api/observationFieldValues.test.js
+++ b/tests/unit/api/observationFieldValues.test.js
@@ -1,0 +1,63 @@
+import { OBSERVATION_FIELD_VALUE_FIELDS } from "api/fields";
+import {
+  createObservationFieldValue,
+  deleteObservationFieldValue,
+  updateObservationFieldValue,
+} from "api/observationFieldValues";
+import inatjs from "inaturalistjs";
+import { makeResponse } from "tests/factory";
+
+jest.mock( "inaturalistjs" );
+
+const mockCreate = jest.mocked( inatjs.observation_field_values.create );
+const mockUpdate = jest.mocked( inatjs.observation_field_values.update );
+const mockDelete = jest.mocked( inatjs.observation_field_values.delete );
+
+const PARAMS = {
+  fields: OBSERVATION_FIELD_VALUE_FIELDS,
+};
+
+describe( "observationFieldValues", () => {
+  const opts = { api_token: "test-token" };
+  const params = {
+    observation_field_value: {
+      observation_id: 42,
+      observation_field_id: 5,
+      value: "male",
+    },
+  };
+
+  beforeEach( () => {
+    jest.resetAllMocks();
+    mockCreate.mockResolvedValue( makeResponse( { id: 1 } ) );
+    mockUpdate.mockResolvedValue( makeResponse( { id: 1 } ) );
+    mockDelete.mockResolvedValue( makeResponse( ) );
+  } );
+
+  describe( "createObservationFieldValue", () => {
+    it( "passes nested params with fields to inatjs.observation_field_values.create", async () => {
+      await createObservationFieldValue( params, opts );
+
+      expect( mockCreate ).toHaveBeenCalledWith( { ...PARAMS, ...params }, opts );
+    } );
+  } );
+
+  describe( "updateObservationFieldValue", () => {
+    it( "passes id and params to inatjs.observation_field_values.update", async () => {
+      await updateObservationFieldValue( { id: 88, ...params }, opts );
+
+      expect( mockUpdate ).toHaveBeenCalledWith(
+        { ...PARAMS, id: 88, ...params },
+        opts,
+      );
+    } );
+  } );
+
+  describe( "deleteObservationFieldValue", () => {
+    it( "passes id to inatjs.observation_field_values.delete", async () => {
+      await deleteObservationFieldValue( 88, opts );
+
+      expect( mockDelete ).toHaveBeenCalledWith( { id: 88 }, opts );
+    } );
+  } );
+} );

--- a/tests/unit/api/observationFieldValues.test.js
+++ b/tests/unit/api/observationFieldValues.test.js
@@ -21,9 +21,9 @@ describe( "observationFieldValues", () => {
   const opts = { api_token: "test-token" };
   const params = {
     observation_field_value: {
-      observation_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      observation_field_id: 5,
-      value: "male",
+      observation_id: "609a4361-9c75-4841-9181-295b6ba55b8c",
+      observation_field_id: 2369,
+      value: 12,
     },
   };
 

--- a/tests/unit/api/observationFieldValues.test.js
+++ b/tests/unit/api/observationFieldValues.test.js
@@ -21,7 +21,7 @@ describe( "observationFieldValues", () => {
   const opts = { api_token: "test-token" };
   const params = {
     observation_field_value: {
-      observation_id: 42,
+      observation_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       observation_field_id: 5,
       value: "male",
     },

--- a/tests/unit/api/projectObservations.test.js
+++ b/tests/unit/api/projectObservations.test.js
@@ -1,0 +1,62 @@
+import { PROJECT_OBSERVATION_FIELDS } from "api/fields";
+import {
+  createProjectObservation,
+  deleteProjectObservation,
+  updateProjectObservation,
+} from "api/projectObservations";
+import inatjs from "inaturalistjs";
+import { makeResponse } from "tests/factory";
+
+jest.mock( "inaturalistjs" );
+
+const mockCreate = jest.mocked( inatjs.project_observations.create );
+const mockUpdate = jest.mocked( inatjs.project_observations.update );
+const mockDelete = jest.mocked( inatjs.project_observations.delete );
+
+const PARAMS = {
+  fields: PROJECT_OBSERVATION_FIELDS,
+};
+
+describe( "projectObservations", () => {
+  const opts = { api_token: "test-token" };
+  const params = {
+    project_observation: {
+      observation_id: 42,
+      project_id: 7,
+    },
+  };
+
+  beforeEach( () => {
+    jest.resetAllMocks();
+    mockCreate.mockResolvedValue( makeResponse( { id: 1 } ) );
+    mockUpdate.mockResolvedValue( makeResponse( { id: 1 } ) );
+    mockDelete.mockResolvedValue( makeResponse( ) );
+  } );
+
+  describe( "createProjectObservation", () => {
+    it( "passes nested params with fields to inatjs.project_observations.create", async () => {
+      await createProjectObservation( params, opts );
+
+      expect( mockCreate ).toHaveBeenCalledWith( { ...PARAMS, ...params }, opts );
+    } );
+  } );
+
+  describe( "updateProjectObservation", () => {
+    it( "passes id, nested params, and fields to inatjs.project_observations.update", async () => {
+      await updateProjectObservation( { id: 99, ...params }, opts );
+
+      expect( mockUpdate ).toHaveBeenCalledWith(
+        { ...PARAMS, id: 99, ...params },
+        opts,
+      );
+    } );
+  } );
+
+  describe( "deleteProjectObservation", () => {
+    it( "passes id to inatjs.project_observations.delete", async () => {
+      await deleteProjectObservation( 99, opts );
+
+      expect( mockDelete ).toHaveBeenCalledWith( { id: 99 }, opts );
+    } );
+  } );
+} );

--- a/tests/unit/api/projectObservations.test.js
+++ b/tests/unit/api/projectObservations.test.js
@@ -21,7 +21,7 @@ describe( "projectObservations", () => {
   const opts = { api_token: "test-token" };
   const params = {
     project_observation: {
-      observation_id: 42,
+      observation_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       project_id: 7,
     },
   };

--- a/tests/unit/api/projectObservations.test.js
+++ b/tests/unit/api/projectObservations.test.js
@@ -21,8 +21,8 @@ describe( "projectObservations", () => {
   const opts = { api_token: "test-token" };
   const params = {
     project_observation: {
-      observation_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      project_id: 7,
+      observation_id: "609a4361-9c75-4841-9181-295b6ba55b8c",
+      project_id: 508,
     },
   };
 


### PR DESCRIPTION
Closes MOB-1491

What is included:
* Consolidated all different versions of fields we queried for when getting projects into two new const in `fields.ts`. This is a marked divergence from prior code where the fields we query for are either at callsite directly or in the Realm model class that the queried data should be persisted as. I think having the declaration close to the call site is mostly fine but it leads to harder to type data I think. Having the fields definitions close to the realm models contributes to the confusion as to what data type API or realm are we actually passing down as prop in some places.
I'd like to use Projects which are currently solely retrieved from API but in this project have to be added to the realm persisted models as a new blueprint how to divide API and Realm classes.
So, for this PR please review if this new structure makes sense as well.

Other changes:
* Added fields and types that will be required for `project_observation_fields`. You can check the new fields with logging `project` in ProjectDetailsContainer and ProjectRequirements, and `userProjects` in ProjectListContainer.
* Added fields and types that will be required for `project_observations` and differentiated `non_traditional_projects` from it. You can see them by logging `remoteObservation` in ProjectListContainer.
* Endpoints wrapper for ObservationFieldValues (OFV) and ProjectObservations (PO) which will have to be wired up later. If you want to test them from within the app, I was asking an agent to add six debug buttons in the Developer menu to call them with example data, the IDs in the unit tests are real IDs from production that should work. Observation probably has to be one of yours (although I don't know if you it should be possible to add one of my observations to a project as a site admin)

Left some comments in some commit msg