### PR TITLE
Traditional projects: joined projects sync to realm

### DIFF
--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
-import type { ApiProjectSummary } from "api/types";
+import type { ApiProjectSummary, ApiProjectSummaryWithPOF } from "api/types";
 import { fetchUserProjects } from "api/users";
 import {
   ActivityIndicator,
@@ -9,7 +9,9 @@ import {
 import { ScreenShell } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import type { TabStackScreenProps } from "navigation/types";
+import { RealmContext } from "providers/contexts";
 import React, { useEffect, useMemo } from "react";
+import Project from "realmModels/Project";
 import {
   useAuthenticatedQuery,
   useCurrentUser,
@@ -19,7 +21,10 @@ import {
 
 import ProjectList from "./ProjectList";
 
+const { useRealm } = RealmContext;
+
 const ProjectListContainer = ( ) => {
+  const realm = useRealm( );
   const navigation = useNavigation<TabStackScreenProps<"ProjectList">["navigation"]>( );
   const { params } = useRoute<TabStackScreenProps<"ProjectList">["route"]>( );
   const { observationUuid, userId, userLogin } = params;
@@ -46,7 +51,7 @@ const ProjectListContainer = ( ) => {
   const {
     data: userProjects,
     isLoading: userProjectsLoading,
-  } = useAuthenticatedQuery<ApiProjectSummary[]>(
+  } = useAuthenticatedQuery<ApiProjectSummary[] | ApiProjectSummaryWithPOF[]>(
     ["fetchUserProjects", userId, fields],
     optsWithAuth => fetchUserProjects(
       {
@@ -58,6 +63,13 @@ const ProjectListContainer = ( ) => {
     ),
     { enabled: !!userId },
   );
+
+  // Update local copy of the current user's joined projects
+  useEffect( () => {
+    if ( isCurrentUser ) {
+      Project.upsertRemoteProjects( userProjects as ApiProjectSummaryWithPOF[], realm );
+    }
+  }, [isCurrentUser, userProjects, realm] );
 
   const headerOptions = useMemo( ( ) => {
     if ( observationUuid ) {

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { PROJECT_SUMMARY_FIELDS } from "api/fields";
+import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
 import type { ApiProjectSummary } from "api/types";
 import { fetchUserProjects } from "api/users";
 import {
@@ -12,6 +12,7 @@ import type { TabStackScreenProps } from "navigation/types";
 import React, { useEffect, useMemo } from "react";
 import {
   useAuthenticatedQuery,
+  useCurrentUser,
   useRemoteObservation,
   useTranslation,
 } from "sharedHooks";
@@ -23,6 +24,7 @@ const ProjectListContainer = ( ) => {
   const { params } = useRoute<TabStackScreenProps<"ProjectList">["route"]>( );
   const { observationUuid, userId, userLogin } = params;
   const { t } = useTranslation( );
+  const currentUser = useCurrentUser( );
 
   const { remoteObservation } = useRemoteObservation(
     observationUuid,
@@ -37,16 +39,20 @@ const ProjectListContainer = ( ) => {
   ) || [];
   const observationProjects = traditionalProjects.concat( nonTraditionalProjects );
 
+  const isCurrentUser = userId === currentUser?.id;
+  const fields = isCurrentUser
+    ? PROJECT_SUMMARY_POF_FIELDS
+    : PROJECT_SUMMARY_FIELDS;
   const {
     data: userProjects,
     isLoading: userProjectsLoading,
   } = useAuthenticatedQuery<ApiProjectSummary[]>(
-    ["fetchUserProjects", userId],
+    ["fetchUserProjects", userId, fields],
     optsWithAuth => fetchUserProjects(
       {
         id: userId,
         per_page: 200,
-        fields: PROJECT_SUMMARY_FIELDS,
+        fields,
       },
       optsWithAuth,
     ),

--- a/src/components/Projects/ProjectsContainer.tsx
+++ b/src/components/Projects/ProjectsContainer.tsx
@@ -1,6 +1,8 @@
 import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
 import isEmpty from "lodash/isEmpty";
-import React, { useCallback, useState } from "react";
+import { RealmContext } from "providers/contexts";
+import React, { useCallback, useEffect, useState } from "react";
+import Project from "realmModels/Project";
 import {
   useCurrentUser,
   useLocationPermission,
@@ -20,7 +22,10 @@ export enum TAB_ID {
   NEARBY = "NEARBY"
 }
 
+const { useRealm } = RealmContext;
+
 const ProjectsContainer = ( ) => {
+  const realm = useRealm( );
   const [searchInput, setSearchInput] = useState( "" );
   const currentUser = useCurrentUser( );
   const memberId = currentUser?.id;
@@ -65,6 +70,13 @@ const ProjectsContainer = ( ) => {
     params: apiParams,
     enabled: !isEmpty( apiParams ),
   } );
+
+  // Update local copy of a user's joined projects
+  useEffect( () => {
+    if ( currentTabId === TAB_ID.JOINED ) {
+      Project.upsertRemoteProjects( projects, realm );
+    }
+  }, [currentTabId, projects, realm] );
 
   const tabs = [
     {

--- a/src/components/Projects/ProjectsContainer.tsx
+++ b/src/components/Projects/ProjectsContainer.tsx
@@ -1,4 +1,4 @@
-import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
+import { PROJECT_SUMMARY_FIELDS } from "api/fields";
 import isEmpty from "lodash/isEmpty";
 import React, { useCallback, useState } from "react";
 import {
@@ -39,7 +39,6 @@ const ProjectsContainer = ( ) => {
     apiParams.q = searchInput;
   } else if ( currentTabId === TAB_ID.JOINED ) {
     apiParams.member_id = memberId;
-    apiParams.fields = PROJECT_SUMMARY_POF_FIELDS;
   } else if ( currentTabId === TAB_ID.FEATURED ) {
     apiParams.featured = true;
   } else if ( currentTabId === TAB_ID.NEARBY && userLocation ) {

--- a/src/components/Projects/ProjectsContainer.tsx
+++ b/src/components/Projects/ProjectsContainer.tsx
@@ -1,8 +1,6 @@
 import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
 import isEmpty from "lodash/isEmpty";
-import { RealmContext } from "providers/contexts";
-import React, { useCallback, useEffect, useState } from "react";
-import Project from "realmModels/Project";
+import React, { useCallback, useState } from "react";
 import {
   useCurrentUser,
   useLocationPermission,
@@ -22,10 +20,7 @@ export enum TAB_ID {
   NEARBY = "NEARBY"
 }
 
-const { useRealm } = RealmContext;
-
 const ProjectsContainer = ( ) => {
-  const realm = useRealm( );
   const [searchInput, setSearchInput] = useState( "" );
   const currentUser = useCurrentUser( );
   const memberId = currentUser?.id;
@@ -70,13 +65,6 @@ const ProjectsContainer = ( ) => {
     params: apiParams,
     enabled: !isEmpty( apiParams ),
   } );
-
-  // Update local copy of a user's joined projects
-  useEffect( () => {
-    if ( currentTabId === TAB_ID.JOINED ) {
-      Project.upsertRemoteProjects( projects, realm );
-    }
-  }, [currentTabId, projects, realm] );
 
   const tabs = [
     {

--- a/src/components/Projects/ProjectsContainer.tsx
+++ b/src/components/Projects/ProjectsContainer.tsx
@@ -1,4 +1,4 @@
-import { PROJECT_SUMMARY_FIELDS } from "api/fields";
+import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
 import isEmpty from "lodash/isEmpty";
 import React, { useCallback, useState } from "react";
 import {
@@ -39,6 +39,7 @@ const ProjectsContainer = ( ) => {
     apiParams.q = searchInput;
   } else if ( currentTabId === TAB_ID.JOINED ) {
     apiParams.member_id = memberId;
+    apiParams.fields = PROJECT_SUMMARY_POF_FIELDS;
   } else if ( currentTabId === TAB_ID.FEATURED ) {
     apiParams.featured = true;
   } else if ( currentTabId === TAB_ID.NEARBY && userLocation ) {

--- a/src/components/Projects/ProjectsContainer.tsx
+++ b/src/components/Projects/ProjectsContainer.tsx
@@ -30,7 +30,18 @@ const ProjectsContainer = ( ) => {
   const { hasPermissions, renderPermissionsGate, requestPermissions } = useLocationPermission( );
   const [userLocation, setUserLocation] = useState( null );
 
-  const apiParams = { };
+  const apiParams = {
+    fields: {
+      id: true,
+      project_type: true,
+      title: true,
+      icon: true,
+      rule_preferences: {
+        field: true,
+        value: true,
+      },
+    },
+  };
 
   if ( searchInput.length > 0 ) {
     apiParams.q = searchInput;

--- a/src/components/Projects/ProjectsContainer.tsx
+++ b/src/components/Projects/ProjectsContainer.tsx
@@ -1,3 +1,4 @@
+import { PROJECT_SUMMARY_FIELDS } from "api/fields";
 import isEmpty from "lodash/isEmpty";
 import React, { useCallback, useState } from "react";
 import {
@@ -31,16 +32,7 @@ const ProjectsContainer = ( ) => {
   const [userLocation, setUserLocation] = useState( null );
 
   const apiParams = {
-    fields: {
-      id: true,
-      project_type: true,
-      title: true,
-      icon: true,
-      rule_preferences: {
-        field: true,
-        value: true,
-      },
-    },
+    fields: PROJECT_SUMMARY_FIELDS,
   };
 
   if ( searchInput.length > 0 ) {

--- a/src/components/Projects/hooks/useInfiniteProjectsScroll.ts
+++ b/src/components/Projects/hooks/useInfiniteProjectsScroll.ts
@@ -12,16 +12,6 @@ const useInfiniteProjectsScroll = ( { params: newInputParams, enabled }: object 
     per_page: ITEMS_PER_PAGE,
     ttl: -1,
     rule_details: true,
-    fields: {
-      id: true,
-      project_type: true,
-      title: true,
-      icon: true,
-      rule_preferences: {
-        field: true,
-        value: true,
-      },
-    },
   };
 
   const { ...queryKeyParams } = baseParams;

--- a/src/realmModels/ObservationField.ts
+++ b/src/realmModels/ObservationField.ts
@@ -1,6 +1,24 @@
 import { Realm } from "@realm/react";
+import type { ApiObservationField } from "api/types";
+
+const splitAllowedValues = ( allowedValues: string | null ): string[] => {
+  if ( !allowedValues ) return [];
+  return allowedValues.split( "|" );
+};
 
 class ObservationField extends Realm.Object {
+  static mapApiToRealm( apiOf: ApiObservationField ) {
+    if ( !apiOf ) return apiOf;
+
+    const localOf = {
+      ...apiOf,
+      // Allowed values is a string of a pipe-separated list
+      allowedValues: splitAllowedValues( apiOf.allowed_values ),
+    };
+
+    return localOf;
+  }
+
   static schema = {
     name: "ObservationField",
     embedded: true,

--- a/src/realmModels/Project.ts
+++ b/src/realmModels/Project.ts
@@ -1,6 +1,8 @@
 import { Realm } from "@realm/react";
 import type { ApiProjectSummaryWithPOF } from "api/types";
+import { UpdateMode } from "realm";
 import ProjectObservationField from "realmModels/ProjectObservationField";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 
 class Project extends Realm.Object {
   static mapApiToRealm( apiProject: ApiProjectSummaryWithPOF ) {
@@ -19,6 +21,21 @@ class Project extends Realm.Object {
     };
 
     return localProject;
+  }
+
+  static upsertRemoteProjects( apiProjects: ApiProjectSummaryWithPOF[], realm: Realm ) {
+    if ( !apiProjects || apiProjects.length === 0 ) return;
+
+    safeRealmWrite( realm, ( ) => {
+      apiProjects.forEach( apiProject => {
+        const projectMappedForRealm = Project.mapApiToRealm( apiProject );
+        realm.create(
+          "Project",
+          projectMappedForRealm,
+          UpdateMode.Modified,
+        );
+      } );
+    }, "upserting projects in Project" );
   }
 
   static schema = {

--- a/src/realmModels/Project.ts
+++ b/src/realmModels/Project.ts
@@ -1,6 +1,26 @@
 import { Realm } from "@realm/react";
+import type { ApiProjectSummaryWithPOF } from "api/types";
+import ProjectObservationField from "realmModels/ProjectObservationField";
 
 class Project extends Realm.Object {
+  static mapApiToRealm( apiProject: ApiProjectSummaryWithPOF ) {
+    if ( !apiProject ) return apiProject;
+
+    const pofs = ( apiProject.project_observation_fields || [] ).map(
+      pof => ProjectObservationField.mapApiToRealm( pof ),
+    );
+
+    const localProject = {
+      ...apiProject,
+      projectObservationFields: pofs,
+      // Leaving this here explicitly as a reminder to potentially need to refactor project_type
+      // into projectType across the entire codebase for consistency with other data models
+      project_type: apiProject.project_type,
+    };
+
+    return localProject;
+  }
+
   static schema = {
     name: "Project",
     primaryKey: "id",

--- a/src/realmModels/ProjectObservationField.ts
+++ b/src/realmModels/ProjectObservationField.ts
@@ -1,6 +1,19 @@
 import { Realm } from "@realm/react";
+import type { ApiProjectObservationField } from "api/types";
+import ObservationField from "realmModels/ObservationField";
 
 class ProjectObservationField extends Realm.Object {
+  static mapApiToRealm( apiPof: ApiProjectObservationField ) {
+    if ( !apiPof ) return apiPof;
+
+    const localPof = {
+      ...apiPof,
+      obsField: ObservationField.mapApiToRealm( apiPof.observation_field ),
+    };
+
+    return localPof;
+  }
+
   static schema = {
     name: "ProjectObservationField",
     embedded: true,

--- a/tests/factories/RemoteProject.js
+++ b/tests/factories/RemoteProject.js
@@ -1,9 +1,13 @@
 import { define } from "factoria";
 
+import pofFactory from "./RemoteProjectObservationField";
+
 export default define( "RemoteProject", faker => ( {
   description: faker.lorem.paragraph( ),
   icon: faker.image.url( ),
   id: faker.number.int( ),
+  project_observation_fields: [pofFactory( "RemoteProjectObservationField" )],
+  project_type: "",
   rule_preferences: [],
   title: faker.lorem.sentence( ),
   user_ids: [faker.number.int( )],

--- a/tests/factories/RemoteProjectObservationField.js
+++ b/tests/factories/RemoteProjectObservationField.js
@@ -1,0 +1,14 @@
+import { define } from "factoria";
+
+// TODO: use this instead once MOB-1497 has landed
+// import ofFactory from "./RemoteObservationField";
+
+export default define( "RemoteProjectObservationField", faker => ( {
+  id: faker.number.int(),
+  // observation_field: ofFactory( "RemoteObservationField" ),
+  observation_field: {
+    id: 1,
+  },
+  position: faker.number.int(),
+  required: faker.datatype.boolean( 0.5 ),
+} ) );

--- a/tests/unit/components/SharedComponents/ProjectList/ProjectListContainer.test.js
+++ b/tests/unit/components/SharedComponents/ProjectList/ProjectListContainer.test.js
@@ -1,5 +1,6 @@
 import { useRoute } from "@react-navigation/native";
 import { render, screen } from "@testing-library/react-native";
+import { PROJECT_SUMMARY_FIELDS } from "api/fields";
 import ProjectListContainer from "components/ProjectList/ProjectListContainer";
 import React from "react";
 import factory from "tests/factory";
@@ -89,7 +90,7 @@ describe( "ProjectListContainer", () => {
     it( "should call useAuthenticatedQuery with the correct query key", ( ) => {
       render( <ProjectListContainer /> );
       expect( mockUseAuthenticatedQuery ).toHaveBeenCalledWith(
-        ["fetchUserProjects", mockUserId],
+        ["fetchUserProjects", mockUserId, PROJECT_SUMMARY_FIELDS],
         expect.any( Function ),
         expect.objectContaining( { enabled: true } ),
       );

--- a/tests/unit/models/ObservationField.test.js
+++ b/tests/unit/models/ObservationField.test.js
@@ -1,0 +1,28 @@
+import ObservationField from "realmModels/ObservationField";
+// import factory from "tests/factory";
+
+const mockRemoteOf = {
+  allowed_values: "yes|no",
+  datatype: "text",
+  description: "A field",
+  id: 5,
+  name: "Alive?",
+};
+
+describe( "ObservationField", ( ) => {
+  describe( "mapApiToRealm", ( ) => {
+    it( "maps fields, splitting allowed_values", ( ) => {
+      // TODO: use this instead once MOB-1497 has landed
+      // const mockRemoteOf = factory( "RemoteObservationField", {
+      //   allowed_values: "yes|no",
+      // } );
+      const mappedOf = ObservationField.mapApiToRealm( mockRemoteOf );
+
+      expect( mappedOf.id ).toBe( mockRemoteOf.id );
+      expect( mappedOf.datatype ).toBe( mockRemoteOf.datatype );
+      expect( mappedOf.description ).toBe( mockRemoteOf.description );
+      expect( mappedOf.name ).toBe( mockRemoteOf.name );
+      expect( mappedOf.allowedValues ).toEqual( ["yes", "no"] );
+    } );
+  } );
+} );

--- a/tests/unit/models/Project.test.js
+++ b/tests/unit/models/Project.test.js
@@ -15,4 +15,22 @@ describe( "Project", ( ) => {
       expect( mappedProject.project_type ).toBe( mockRemoteProject.project_type );
     } );
   } );
+
+  describe( "upsertRemoteProjects", ( ) => {
+    it( "upserts projects and embedded POF and OF", ( ) => {
+      const mockRemoteProject = factory( "RemoteProject" );
+      Project.upsertRemoteProjects( [mockRemoteProject], global.realm );
+
+      const upsertedProject = global.realm.objectForPrimaryKey( "Project", mockRemoteProject.id );
+      expect( upsertedProject.title ).toBe( mockRemoteProject.title );
+      const { projectObservationFields } = upsertedProject;
+      const pof1 = projectObservationFields[0];
+      expect( pof1.id ).toBe(
+        mockRemoteProject.project_observation_fields[0].id,
+      );
+      expect( pof1.obsField.id ).toBe(
+        mockRemoteProject.project_observation_fields[0].observation_field.id,
+      );
+    } );
+  } );
 } );

--- a/tests/unit/models/Project.test.js
+++ b/tests/unit/models/Project.test.js
@@ -1,0 +1,18 @@
+import Project from "realmModels/Project";
+import factory from "tests/factory";
+
+describe( "Project", ( ) => {
+  describe( "mapApiToRealm", ( ) => {
+    it( "maps summary fields and POFs", ( ) => {
+      const mockRemoteProject = factory( "RemoteProject" );
+      const mappedProject = Project.mapApiToRealm( mockRemoteProject );
+
+      expect( mappedProject.description ).toBe( mockRemoteProject.description );
+      expect( mappedProject.icon ).toBe( mockRemoteProject.icon );
+      expect( mappedProject.id ).toBe( mockRemoteProject.id );
+      expect( mappedProject.title ).toBe( mockRemoteProject.title );
+      expect( mappedProject.projectObservationFields ).toHaveLength( 1 );
+      expect( mappedProject.project_type ).toBe( mockRemoteProject.project_type );
+    } );
+  } );
+} );

--- a/tests/unit/models/ProjectObservationField.test.js
+++ b/tests/unit/models/ProjectObservationField.test.js
@@ -1,0 +1,18 @@
+import ProjectObservationField from "realmModels/ProjectObservationField";
+import factory from "tests/factory";
+
+describe( "ProjectObservationField", ( ) => {
+  describe( "mapApiToRealm", ( ) => {
+    it( "maps fields, splitting allowed_values", ( ) => {
+      const mockRemotePof = factory( "RemoteProjectObservationField" );
+      const mappedPof = ProjectObservationField.mapApiToRealm( mockRemotePof );
+
+      expect( mappedPof.id ).toBe( mockRemotePof.id );
+      expect( mappedPof.obsField.id ).toBe(
+        mockRemotePof.observation_field.id,
+      );
+      expect( mappedPof.position ).toBe( mockRemotePof.position );
+      expect( mappedPof.required ).toBe( mockRemotePof.required );
+    } );
+  } );
+} );


### PR DESCRIPTION
Closes MOB-1496

New persistence code and mapApiToRealm code added by closely following the same code for Observation realm model. With one major deviance, we do not store a _created_at or _synced_at date for Projects, POF, and OF because we currently have no plans of adding project admin functions (CRUD) to the app. The only purpose of this persisted info is to allow to add obs to projects while offline.

As a proof-of-concept, I wired up the ProjectList and Projects screens to persist all projects the current user has joined. This is not final because we probably should decouple fetching all joined projects from a certain UI state and place it on app start instead.

After: Navigating to projects list persists project summary data into realm:
<img width="1896" height="973" alt="Screenshot 2026-06-25 at 14 40 41" src="https://github.com/user-attachments/assets/4d13aa38-20b9-4598-ba70-d048cc806c34" />
<img width="1907" height="995" alt="Screenshot 2026-06-25 at 14 43 07" src="https://github.com/user-attachments/assets/e9c837c6-e4b0-431b-9c18-4a6f58367914" />

