### PR TITLE
trust wix / applesimutils brew cask for detox CI

### DIFF
--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -219,6 +219,7 @@ jobs:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: |
         brew tap wix/brew
+        brew trust --formula wix/brew/applesimutils
         brew install applesimutils
 
     - name: Ensure servers are running


### PR DESCRIPTION
CI has started failing with the following:

```
Error: Refusing to load formula wix/brew/applesimutils from untrusted tap wix/brew.
Run `brew trust --formula wix/brew/applesimutils` or `brew trust wix/brew` to trust it.
Error: Process completed with exit code 1.
```

This PR makes homebrew explicitly trust the applesimutils formula which Detox depends on