### PR TITLE
Remove double padding in ProjectListItem

### DIFF
--- a/src/components/ProjectList/ProjectListItem.tsx
+++ b/src/components/ProjectList/ProjectListItem.tsx
@@ -32,7 +32,7 @@ interface Props {
 const ProjectListItem = ( { item, isHeader = false }: Props ) => {
   const { t, i18n } = useTranslation( );
 
-  const iconClassName = classnames( THUMBNAIL_CLASS, "bg-white mr-3" );
+  const iconClassName = classnames( THUMBNAIL_CLASS, "bg-white" );
 
   const displayBriefcase = ( ) => (
     <INatIcon


### PR DESCRIPTION
In ProjectListItem, we seem to have applied padding between the project icon and title sections twice.

The text container has `ml-3 `applied as well.