### PR TITLE
fix stale subscriptions in useObservationLocation & useWatchPosition

### DIFF
--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -289,14 +289,13 @@ const MatchContainer = ( ) => {
   const {
     isFetchingLocation,
     stopWatch,
-    subscriptionId,
     userLocation,
   } = useObservationLocation( { shouldFetchLocation } );
 
   const navToLocationPicker = useCallback( ( ) => {
-    stopWatch( subscriptionId );
+    stopWatch( );
     navigation.navigate( "LocationPicker" );
-  }, [stopWatch, subscriptionId, navigation] );
+  }, [stopWatch, navigation] );
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;
@@ -465,7 +464,7 @@ const MatchContainer = ( ) => {
       } );
       await saveObservation( getCurrentObservation( ), cameraRollUris, realm );
     }
-    stopWatch( subscriptionId );
+    stopWatch( );
     exitObservationFlow( );
   };
 

--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -288,14 +288,12 @@ const MatchContainer = ( ) => {
 
   const {
     isFetchingLocation,
-    stopWatch,
     userLocation,
   } = useObservationLocation( { shouldFetchLocation } );
 
   const navToLocationPicker = useCallback( ( ) => {
-    stopWatch( );
     navigation.navigate( "LocationPicker" );
-  }, [stopWatch, navigation] );
+  }, [navigation] );
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;
@@ -464,7 +462,6 @@ const MatchContainer = ( ) => {
       } );
       await saveObservation( getCurrentObservation( ), cameraRollUris, realm );
     }
-    stopWatch( );
     exitObservationFlow( );
   };
 

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -70,7 +70,6 @@ const ObsEdit = ( ): Node => {
 
   const {
     isFetchingLocation,
-    stopWatch,
     userLocation,
   } = useObservationLocation( { shouldFetchLocation } );
 
@@ -85,10 +84,9 @@ const ObsEdit = ( ): Node => {
   }, [resetUploadObservationsSlice] );
 
   const navToLocationPicker = useCallback( ( ) => {
-    stopWatch( );
     setNeedLocation( false );
     navigation.navigate( "LocationPicker" );
-  }, [stopWatch, navigation] );
+  }, [navigation] );
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -71,7 +71,6 @@ const ObsEdit = ( ): Node => {
   const {
     isFetchingLocation,
     stopWatch,
-    subscriptionId,
     userLocation,
   } = useObservationLocation( { shouldFetchLocation } );
 
@@ -86,10 +85,10 @@ const ObsEdit = ( ): Node => {
   }, [resetUploadObservationsSlice] );
 
   const navToLocationPicker = useCallback( ( ) => {
-    stopWatch( subscriptionId );
+    stopWatch( );
     setNeedLocation( false );
     navigation.navigate( "LocationPicker" );
-  }, [stopWatch, subscriptionId, navigation] );
+  }, [stopWatch, navigation] );
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -4,7 +4,7 @@ import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { SharedStackViewWrapper } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import type { Node } from "react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Animated } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import shouldFetchObservationLocation from "sharedHelpers/shouldFetchObservationLocation";
@@ -83,10 +83,10 @@ const ObsEdit = ( ): Node => {
     resetUploadObservationsSlice( );
   }, [resetUploadObservationsSlice] );
 
-  const navToLocationPicker = useCallback( ( ) => {
+  const navToLocationPicker = ( ) => {
     setNeedLocation( false );
     navigation.navigate( "LocationPicker" );
-  }, [navigation] );
+  };
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;

--- a/src/sharedHooks/useObservationLocation.ts
+++ b/src/sharedHooks/useObservationLocation.ts
@@ -17,7 +17,7 @@ const useObservationLocation = ( options: {
   const cancelledRef = useRef( false );
 
   useFocusEffect( useCallback( ( ) => {
-    if ( !shouldFetchLocation ) return ( ) => undefined;
+    if ( !shouldFetchLocation ) return ( ) => {};
     cancelledRef.current = false;
 
     ( async ( ) => {
@@ -49,7 +49,6 @@ const useObservationLocation = ( options: {
 
   const {
     isFetchingLocation: isFetchingFine,
-    stopWatch,
     userLocation: fineLocation,
   } = useWatchPosition( { shouldFetchLocation: shouldWatchFine } );
 
@@ -58,7 +57,6 @@ const useObservationLocation = ( options: {
       || isFetchingCoarse
       // cover first frame where shouldFetchLocation = true but both isFetching values are false
       || ( shouldFetchLocation && isCoarseOnly === null ),
-    stopWatch,
     userLocation: coarseLocation ?? fineLocation,
   };
 };

--- a/src/sharedHooks/useObservationLocation.ts
+++ b/src/sharedHooks/useObservationLocation.ts
@@ -1,6 +1,6 @@
-import { useNavigation } from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import { hasOnlyCoarseLocation } from "components/SharedComponents/PermissionGateContainer";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import fetchCoarseUserLocation from "../sharedHelpers/fetchCoarseUserLocation";
 import type { UserLocation } from "./useWatchPosition";
@@ -9,7 +9,6 @@ import useWatchPosition from "./useWatchPosition";
 const useObservationLocation = ( options: {
   shouldFetchLocation: boolean;
 } ) => {
-  const navigation = useNavigation( );
   const { shouldFetchLocation } = options;
 
   const [isCoarseOnly, setIsCoarseOnly] = useState<boolean | null>( null );
@@ -17,7 +16,7 @@ const useObservationLocation = ( options: {
   const [isFetchingCoarse, setIsFetchingCoarse] = useState( false );
   const cancelledRef = useRef( false );
 
-  useEffect( ( ) => {
+  useFocusEffect( useCallback( ( ) => {
     if ( !shouldFetchLocation ) return ( ) => undefined;
     cancelledRef.current = false;
 
@@ -38,18 +37,13 @@ const useObservationLocation = ( options: {
       }
     } )( );
 
-    return ( ) => { cancelledRef.current = true; };
-  }, [shouldFetchLocation] );
-
-  useEffect( ( ) => {
-    const unsubscribe = navigation.addListener( "blur", ( ) => {
+    return ( ) => {
       cancelledRef.current = true;
       setIsFetchingCoarse( false );
       setCoarseLocation( null );
       setIsCoarseOnly( null );
-    } );
-    return unsubscribe;
-  }, [navigation] );
+    };
+  }, [shouldFetchLocation] ) );
 
   const shouldWatchFine = shouldFetchLocation && isCoarseOnly === false;
 

--- a/src/sharedHooks/useObservationLocation.ts
+++ b/src/sharedHooks/useObservationLocation.ts
@@ -50,7 +50,6 @@ const useObservationLocation = ( options: {
   const {
     isFetchingLocation: isFetchingFine,
     stopWatch,
-    subscriptionId,
     userLocation: fineLocation,
   } = useWatchPosition( { shouldFetchLocation: shouldWatchFine } );
 
@@ -60,7 +59,6 @@ const useObservationLocation = ( options: {
       // cover first frame where shouldFetchLocation = true but both isFetching values are false
       || ( shouldFetchLocation && isCoarseOnly === null ),
     stopWatch,
-    subscriptionId,
     userLocation: coarseLocation ?? fineLocation,
   };
 };

--- a/src/sharedHooks/useWatchPosition.ts
+++ b/src/sharedHooks/useWatchPosition.ts
@@ -3,14 +3,13 @@ import type {
   GeolocationResponse,
 } from "@react-native-community/geolocation";
 import { useFocusEffect } from "@react-navigation/native";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 // Please don't change this to an aliased path or the e2e mock will not get
 // used in our e2e tests on Github Actions
 import { clearWatch, watchPosition } from "../sharedHelpers/geolocationWrapper";
 
 export const TARGET_POSITIONAL_ACCURACY = 10;
-const MAX_POSITION_AGE_MS = 60_000;
 
 export interface UserLocation {
   latitude: number;
@@ -32,37 +31,28 @@ const useWatchPosition = ( options: {
   const { shouldFetchLocation } = options;
   const [userLocation, setUserLocation] = useState<UserLocation | null>( null );
   const [isWatching, setIsWatching] = useState( false );
-  const watchIdRef = useRef<number | null>( null );
-  const stopRef = useRef<( ) => void>( ( ) => {} );
-
-  const stopWatch = useCallback( ( ) => stopRef.current( ), [] );
 
   useFocusEffect( useCallback( ( ) => {
-    const effectCleanupNoop = () => {};
-    if ( !shouldFetchLocation ) return effectCleanupNoop;
+    if ( !shouldFetchLocation ) return ( ) => {};
 
     let id: number | null = null;
 
     const stop = ( ) => {
-      if ( id === null ) return;
-      clearWatch( id );
-      id = null;
-      watchIdRef.current = null;
+      if ( id !== null ) {
+        clearWatch( id );
+        id = null;
+      }
       setIsWatching( false );
     };
-    stopRef.current = stop;
 
     const success = ( position: GeolocationResponse ) => {
-      const age = Date.now() - position.timestamp;
-      if ( age > MAX_POSITION_AGE_MS ) return;
-      const newLocation = {
+      setUserLocation( {
         latitude: position.coords.latitude,
         longitude: position.coords.longitude,
         positional_accuracy: position.coords.accuracy,
         altitude: position.coords.altitude,
         altitudinal_accuracy: position.coords.altitudeAccuracy,
-      };
-      setUserLocation( newLocation );
+      } );
       if ( position.coords.accuracy < TARGET_POSITIONAL_ACCURACY ) {
         stop( );
       }
@@ -73,27 +63,16 @@ const useWatchPosition = ( options: {
       stop( );
     };
 
-    const result = watchPosition( success, failure, geolocationOptions );
-    if ( typeof result !== "number" ) {
-      console.warn( "watchPosition failed to return a watchID" );
-      return effectCleanupNoop;
-    }
-    id = result;
-    watchIdRef.current = id;
+    id = watchPosition( success, failure, geolocationOptions );
     setIsWatching( true );
 
     return ( ) => {
       stop( );
       setUserLocation( null );
-      stopRef.current = ( ) => {};
     };
   }, [shouldFetchLocation] ) );
 
-  return {
-    isFetchingLocation: isWatching,
-    stopWatch,
-    userLocation,
-  };
+  return { isFetchingLocation: isWatching, userLocation };
 };
 
 export default useWatchPosition;

--- a/src/sharedHooks/useWatchPosition.ts
+++ b/src/sharedHooks/useWatchPosition.ts
@@ -10,6 +10,7 @@ import { useCallback, useState } from "react";
 import { clearWatch, watchPosition } from "../sharedHelpers/geolocationWrapper";
 
 export const TARGET_POSITIONAL_ACCURACY = 10;
+const MAX_POSITION_AGE_MS = 60_000;
 
 export interface UserLocation {
   latitude: number;
@@ -46,6 +47,13 @@ const useWatchPosition = ( options: {
     };
 
     const success = ( position: GeolocationResponse ) => {
+      const age = Date.now() - position.timestamp;
+      // 20260710 - FLGMwt: I don't know if this is necessary since
+      // we're passing maxAge: 0, but left it during a refactor for safety
+      // I didn't notice an impact testing on Android nor iOS with & w/o it.
+      if ( age > MAX_POSITION_AGE_MS ) {
+        return;
+      }
       setUserLocation( {
         latitude: position.coords.latitude,
         longitude: position.coords.longitude,

--- a/src/sharedHooks/useWatchPosition.ts
+++ b/src/sharedHooks/useWatchPosition.ts
@@ -2,8 +2,8 @@ import type {
   GeolocationError,
   GeolocationResponse,
 } from "@react-native-community/geolocation";
-import { useNavigation } from "@react-navigation/native";
-import { useCallback, useEffect, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { useCallback, useRef, useState } from "react";
 
 // Please don't change this to an aliased path or the e2e mock will not get
 // used in our e2e tests on Github Actions
@@ -29,103 +29,69 @@ const geolocationOptions = {
 const useWatchPosition = ( options: {
   shouldFetchLocation: boolean;
 } ) => {
-  const navigation = useNavigation( );
-  const [currentPosition, setCurrentPosition] = useState<GeolocationResponse | null>( null );
-  const [subscriptionId, setSubscriptionId] = useState<number | null>( null );
-  const [userLocation, setUserLocation] = useState<UserLocation | null>( null );
   const { shouldFetchLocation } = options;
-  const [hasFocus, setHasFocus] = useState( true );
+  const [userLocation, setUserLocation] = useState<UserLocation | null>( null );
+  const [isWatching, setIsWatching] = useState( false );
+  const watchIdRef = useRef<number | null>( null );
+  const stopRef = useRef<( ) => void>( ( ) => {} );
 
-  const shouldStartWatch = shouldFetchLocation
-    && subscriptionId === null
-    && hasFocus
-    && ( !userLocation || userLocation.positional_accuracy >= TARGET_POSITIONAL_ACCURACY );
+  const stopWatch = useCallback( ( ) => stopRef.current( ), [] );
 
-  const shouldStopWatch = subscriptionId !== null
-    && currentPosition?.coords?.accuracy < TARGET_POSITIONAL_ACCURACY;
+  useFocusEffect( useCallback( ( ) => {
+    const effectCleanupNoop = () => {};
+    if ( !shouldFetchLocation ) return effectCleanupNoop;
 
-  const stopWatch = useCallback( ( id: number ) => {
-    clearWatch( id );
-    setSubscriptionId( null );
-    setCurrentPosition( null );
-  }, [] );
+    let id: number | null = null;
 
-  const startWatch = useCallback( ( ) => {
+    const stop = ( ) => {
+      if ( id === null ) return;
+      clearWatch( id );
+      id = null;
+      watchIdRef.current = null;
+      setIsWatching( false );
+    };
+    stopRef.current = stop;
+
     const success = ( position: GeolocationResponse ) => {
       const age = Date.now() - position.timestamp;
       if ( age > MAX_POSITION_AGE_MS ) return;
-      setCurrentPosition( position );
+      const newLocation = {
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+        positional_accuracy: position.coords.accuracy,
+        altitude: position.coords.altitude,
+        altitudinal_accuracy: position.coords.altitudeAccuracy,
+      };
+      setUserLocation( newLocation );
+      if ( position.coords.accuracy < TARGET_POSITIONAL_ACCURACY ) {
+        stop( );
+      }
     };
 
     const failure = ( error: GeolocationError ) => {
-      console.warn( "useWatchPosition error: ", error );
-      if ( subscriptionId ) {
-        stopWatch( subscriptionId );
-      }
+      console.warn( "useWatchPosition error:", error );
+      stop( );
     };
 
-    try {
-      const watchID = watchPosition(
-        success,
-        failure,
-        geolocationOptions,
-      );
-      if ( typeof ( watchID ) !== "number" ) {
-        throw new Error( "watchPosition failed to return a watchID" );
-      }
-      setSubscriptionId( watchID );
-    } catch ( error ) {
-      failure( error as GeolocationError );
+    const result = watchPosition( success, failure, geolocationOptions );
+    if ( typeof result !== "number" ) {
+      console.warn( "watchPosition failed to return a watchID" );
+      return effectCleanupNoop;
     }
-  }, [stopWatch, subscriptionId] );
+    id = result;
+    watchIdRef.current = id;
+    setIsWatching( true );
 
-  useEffect( ( ) => {
-    if ( !currentPosition ) { return; }
-    const newLocation = {
-      latitude: currentPosition?.coords?.latitude,
-      longitude: currentPosition?.coords?.longitude,
-      positional_accuracy: currentPosition?.coords?.accuracy,
-      altitude: currentPosition?.coords?.altitude,
-      altitudinal_accuracy: currentPosition?.coords?.altitudeAccuracy,
-    };
-    setUserLocation( newLocation );
-    if ( shouldStopWatch ) {
-      stopWatch( subscriptionId );
-    }
-  }, [currentPosition, stopWatch, subscriptionId, shouldStopWatch] );
-
-  useEffect( ( ) => {
-    if ( shouldStartWatch ) {
-      startWatch( );
-    }
-  }, [shouldStartWatch, startWatch] );
-
-  useEffect( ( ) => {
-    // When we leave the screen this hook was used on...
-    const unsubscribe = navigation.addListener( "blur", ( ) => {
-      // ...stop watching for location updates if we were...
-      if ( subscriptionId !== null ) {
-        stopWatch( subscriptionId );
-      }
-      // ...and wipe the current location so we don't pick up a stale one later
+    return ( ) => {
+      stop( );
       setUserLocation( null );
-      setHasFocus( false );
-    } );
-    return unsubscribe;
-  }, [navigation, stopWatch, subscriptionId] );
-
-  // Listen for focus. We only want to fetch location when this screen has focus.
-  useEffect( ( ) => {
-    const unsubscribe = navigation.addListener( "focus", ( ) => {
-      setHasFocus( true );
-    } );
-    return unsubscribe;
-  }, [navigation] );
+      stopRef.current = ( ) => {};
+    };
+  }, [shouldFetchLocation] ) );
 
   return {
-    isFetchingLocation: subscriptionId !== null,
+    isFetchingLocation: isWatching,
     stopWatch,
-    subscriptionId,
     userLocation,
   };
 };

--- a/tests/unit/sharedHooks/useObservationLocation.test.js
+++ b/tests/unit/sharedHooks/useObservationLocation.test.js
@@ -42,7 +42,6 @@ const mockFineLocation = {
 
 const defaultWatchResult = {
   isFetchingLocation: false,
-  stopWatch: jest.fn( ),
   userLocation: null,
 };
 

--- a/tests/unit/sharedHooks/useObservationLocation.test.js
+++ b/tests/unit/sharedHooks/useObservationLocation.test.js
@@ -1,6 +1,12 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import useObservationLocation from "sharedHooks/useObservationLocation";
 
+jest.mock( "@react-navigation/native", () => ( {
+  ...jest.requireActual( "@react-navigation/native" ),
+  // Run the focus callback via useEffect so we don't need a NavigationContainer
+  useFocusEffect: cb => jest.requireActual( "react" ).useEffect( cb, [] ),
+} ) );
+
 const mockUseWatchPosition = jest.fn( );
 jest.mock( "sharedHooks/useWatchPosition", () => ( {
   __esModule: true,
@@ -37,7 +43,6 @@ const mockFineLocation = {
 const defaultWatchResult = {
   isFetchingLocation: false,
   stopWatch: jest.fn( ),
-  subscriptionId: null,
   userLocation: null,
 };
 

--- a/tests/unit/sharedHooks/useWatchPosition.test.js
+++ b/tests/unit/sharedHooks/useWatchPosition.test.js
@@ -2,6 +2,12 @@ import Geolocation from "@react-native-community/geolocation";
 import { renderHook, waitFor } from "@testing-library/react-native";
 import { useWatchPosition } from "sharedHooks";
 
+jest.mock( "@react-navigation/native", () => ( {
+  ...jest.requireActual( "@react-navigation/native" ),
+  // Run the focus callback via useEffect so we don't need a NavigationContainer
+  useFocusEffect: cb => jest.requireActual( "react" ).useEffect( cb, [] ),
+} ) );
+
 const mockPositions = [
   {
     coords: {
@@ -63,6 +69,7 @@ describe( "useWatchPosition with inaccurate location", ( ) => {
 
 describe( "useWatchPosition with accurate location", ( ) => {
   beforeEach( ( ) => {
+    Geolocation.clearWatch.mockClear( );
     Geolocation.watchPosition.mockImplementation( success => {
       setTimeout( ( ) => {
         mockWatchPositionSuccess( ( ) => success( mockPositions[0] ) );


### PR DESCRIPTION
We have some complicated state / effect logic that _seems_ to be smoothing over stale callback closures of state values, most importantly, our watchPosition subscriptionId.

By moving this to useFocusEffect for useObsLoc and useWatchPos, we can inline some of those values to obviate stale close issues. The bonus effect is simplifying the code and removing effect deps which likely exacerbated the buggy implementation.

[EDIT] We now rely on useWatchPosition for focus management. Previously, we were returning a `stopWatch` that was seemingly called before navigating away.

This should fix some hard-to-reproduce issues around "location never stops loading" around error'd location calls and focus. It _probably_ led to some leaked watch subscriptions too.