### PR TITLE
Mob 1388 allow comments with agreeing ids

### DIFF
--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -1,6 +1,9 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { createComment } from "api/comments";
 import { createIdentification } from "api/identifications";
+import type {
+  AgreeIdentification,
+} from "components/ObsDetailsSharedComponents/hooks/useObsDetailsSharedLogic";
 import AgreeWithIDSheet from "components/ObsDetailsSharedComponents/Sheets/AgreeWithIDSheet";
 import PotentialDisagreementSheet
   from "components/ObsDetailsSharedComponents/Sheets/PotentialDisagreementSheet";
@@ -141,14 +144,19 @@ export const identReducer = ( state: IdentState, action: IdentAction ): IdentSta
     case CLEAR_SUGGESTED_TAXON:
       return { ...state, identTaxon: null };
     case HIDE_SUGGESTED_ID_SHEET:
-      return { ...state, showSuggestIdSheet: false };
+      return {
+        ...state,
+        showSuggestIdSheet: false,
+        identTaxon: null,
+        newIdentification: null,
+      };
     default:
       return state;
   }
 };
 
 interface Props {
-  agreeIdentification: boolean;
+  agreeIdentification: AgreeIdentification | null;
   closeAgreeWithIdSheet: () => void;
   confirmRemoteObsWasDeleted?: () => void;
   handleCommentMutationSuccess: ( data: unknown ) => void;
@@ -212,9 +220,9 @@ const IdentificationSheets: React.FC<Props> = ( {
 
   const onChangeIdentBody = useCallback( ( body: string ) => dispatch( {
     type: SET_NEW_IDENTIFICATION,
-    taxon: newIdentification?.taxon,
+    taxon: newIdentification?.taxon || agreeIdentification?.taxon,
     body,
-  } ), [newIdentification?.taxon] );
+  } ), [newIdentification?.taxon, agreeIdentification?.taxon] );
 
   const onCloseIdentBodySheet = useCallback( ( ) => {
     dispatch( { type: HIDE_EDIT_IDENT_BODY_SHEET } );
@@ -416,7 +424,10 @@ const IdentificationSheets: React.FC<Props> = ( {
           hidden={showIdentBodySheet}
           loading={isCreateIdPending}
           onPressClose={closeAgreeWithIdSheet}
-          identification={agreeIdentification}
+          identification={{
+            taxon: agreeIdentification.taxon,
+            body: newIdentification?.body,
+          }}
         />
       )}
       {/* AddCommentSheet */}

--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -488,6 +488,7 @@ const IdentificationSheets: React.FC<Props> = ( {
           text={t( "Sorry-this-observation-was-deleted" )}
           buttonText={t( "OK" )}
           confirm={confirmRemoteObsWasDeleted}
+          loading={false}
         />
       ) }
     </>

--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -258,14 +258,14 @@ const IdentificationSheets: React.FC<Props> = ( {
   const hasPotentialDisagreement = useCallback( ( taxon: Taxon | null | undefined ) => {
     // based on disagreement code in iNat web
     // https://github.com/inaturalist/inaturalist/blob/30a27d0eb79dd17af38292785b0137e6024bbdb7/app/webpack/observations/show/ducks/observation.js#L827-L838
-    let observationTaxon = observation?.taxon;
+    let observationTaxon = observation.taxon;
 
     const doesNotPreferCommunityTaxon = observation.prefers_community_taxon === false
       || ( observation.user?.prefers_community_taxa === false
       && observation.prefers_community_taxon === null );
 
     if ( doesNotPreferCommunityTaxon ) {
-      observationTaxon = observation?.community_taxon || observation.taxon;
+      observationTaxon = observation.community_taxon || observation.taxon;
     }
     return observationTaxon
         && !!taxon?.id
@@ -323,14 +323,14 @@ const IdentificationSheets: React.FC<Props> = ( {
 
   const onAgree = useCallback( ( ident: Identification ) => {
     const agreeParams = {
-      observation_id: observation?.uuid,
+      observation_id: observation.uuid,
       taxon_id: ident.taxon?.id,
       body: ident.body,
     };
 
     loadActivityItem( );
     createIdentificationMutate( { identification: agreeParams } );
-  }, [createIdentificationMutate, observation?.uuid, loadActivityItem] );
+  }, [createIdentificationMutate, observation.uuid, loadActivityItem] );
 
   const potentialDisagreeSheetDiscardChanges = useCallback( ( ) => {
     dispatch( { type: HIDE_POTENTIAL_DISAGREEMENT_SHEET } );

--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -143,7 +143,6 @@ export const identReducer = ( state: IdentState, action: IdentAction ): IdentSta
       return {
         ...state,
         showSuggestIdSheet: false,
-        identTaxon: null,
         newIdentification: null,
       };
     default:

--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -219,7 +219,8 @@ const IdentificationSheets: React.FC<Props> = ( {
     dispatch( { type: HIDE_EDIT_IDENT_BODY_SHEET } );
   }, [] );
 
-  const showErrorAlert = useCallback( error => Alert.alert( "Error", error, [{ text: t( "OK" ) }], {
+  const showErrorAlert
+  = useCallback( ( error: string ) => Alert.alert( "Error", error, [{ text: t( "OK" ) }], {
     cancelable: true,
   } ), [t] );
 
@@ -267,6 +268,7 @@ const IdentificationSheets: React.FC<Props> = ( {
       observationTaxon = observation?.community_taxon || observation.taxon;
     }
     return observationTaxon
+        && !!taxon?.id
         && taxon?.id !== observationTaxon.id
         && observationTaxon.ancestor_ids.includes( taxon?.id );
   }, [observation] );

--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -323,14 +323,14 @@ const IdentificationSheets: React.FC<Props> = ( {
 
   const onAgree = useCallback( ( ident: Identification ) => {
     const agreeParams = {
-      observation_id: observation.uuid,
+      observation_id: observation?.uuid,
       taxon_id: ident.taxon?.id,
       body: ident.body,
     };
 
     loadActivityItem( );
     createIdentificationMutate( { identification: agreeParams } );
-  }, [createIdentificationMutate, observation.uuid, loadActivityItem] );
+  }, [createIdentificationMutate, observation?.uuid, loadActivityItem] );
 
   const potentialDisagreeSheetDiscardChanges = useCallback( ( ) => {
     dispatch( { type: HIDE_POTENTIAL_DISAGREEMENT_SHEET } );

--- a/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
+++ b/src/components/ObsDetailsDefaultMode/IdentificationSheets.tsx
@@ -56,8 +56,6 @@ interface Identification {
 }
 
 interface IdentState {
-  comment: string | null;
-  commentIsOptional: boolean;
   showIdentBodySheet: boolean;
   newIdentification: Identification | null;
   showPotentialDisagreementSheet: boolean;
@@ -77,8 +75,6 @@ type IdentAction =
   | { type: "HIDE_SUGGESTED_ID_SHEET" };
 
 const initialIdentState: IdentState = {
-  comment: null,
-  commentIsOptional: false,
   showIdentBodySheet: false,
   newIdentification: null,
   showPotentialDisagreementSheet: false,
@@ -193,8 +189,6 @@ const IdentificationSheets: React.FC<Props> = ( {
   const [state, dispatch] = useReducer( identReducer, initialIdentState );
 
   const {
-    comment,
-    commentIsOptional,
     showIdentBodySheet,
     identTaxon,
     newIdentification,
@@ -205,16 +199,13 @@ const IdentificationSheets: React.FC<Props> = ( {
   const realm = useRealm( );
   const { t } = useTranslation( );
 
-  const hasComment = ( comment || newIdentification?.body || "" ).length > 0;
+  const hasComment = ( newIdentification?.body || "" ).length > 0;
 
-  const showAddCommentHeader = useCallback( ( ) => {
-    if ( hasComment ) {
-      return t( "EDIT-COMMENT" );
-    } if ( commentIsOptional ) {
-      return t( "ADD-OPTIONAL-COMMENT" );
-    }
-    return t( "ADD-COMMENT" );
-  }, [commentIsOptional, hasComment, t] );
+  const showAddCommentHeader = useCallback( ( ) => (
+    hasComment
+      ? t( "EDIT-COMMENT" )
+      : t( "ADD-COMMENT" )
+  ), [hasComment, t] );
 
   const editIdentBody = useCallback( ( ) => dispatch( { type: SHOW_EDIT_IDENT_BODY_SHEET } ), [] );
 
@@ -404,10 +395,8 @@ const IdentificationSheets: React.FC<Props> = ( {
   }, [createCommentMutate, uuid, loadActivityItem] );
 
   const confirmCommentFromCommentSheet = useCallback( ( newComment: string ) => {
-    if ( !commentIsOptional ) {
-      onCommentAdded( newComment );
-    }
-  }, [commentIsOptional, onCommentAdded] );
+    onCommentAdded( newComment );
+  }, [onCommentAdded] );
 
   const hideSuggestedIdSheet = ( ) => {
     dispatch( { type: HIDE_SUGGESTED_ID_SHEET } );
@@ -438,7 +427,6 @@ const IdentificationSheets: React.FC<Props> = ( {
           onPressClose={hideAddCommentSheet}
           headerText={addCommentHeaderText}
           textInputStyle={textInputStyle}
-          initialInput={comment}
           confirm={confirmCommentFromCommentSheet}
         />
       )}

--- a/src/components/ObsDetailsSharedComponents/hooks/useObsDetailsSharedLogic.ts
+++ b/src/components/ObsDetailsSharedComponents/hooks/useObsDetailsSharedLogic.ts
@@ -42,7 +42,7 @@ const SET_INITIAL_OBSERVATION = "SET_INITIAL_OBSERVATION";
 const ADD_ACTIVITY_ITEM = "ADD_ACTIVITY_ITEM";
 const LOADING_ACTIVITY_ITEM = "LOADING_ACTIVITY_ITEM";
 
-interface AgreeIdentification {
+export interface AgreeIdentification {
   taxon: RealmTaxon;
 }
 

--- a/src/i18n/l10n/en.ftl
+++ b/src/i18n/l10n/en.ftl
@@ -63,7 +63,6 @@ Add-location-to-refresh-suggestions = Add location to refresh suggestions
 # Accessibility label for a button that starts the process of adding an
 # observation, e.g. the button in the tab bar
 Add-observations = Add observations
-ADD-OPTIONAL-COMMENT = ADD OPTIONAL COMMENT
 Add-optional-notes = Add optional notes
 Add-to-Projects = Add to Projects
 ADD-TO-PROJECTS = ADD TO PROJECTS

--- a/src/i18n/l10n/en.ftl.json
+++ b/src/i18n/l10n/en.ftl.json
@@ -25,7 +25,6 @@
   "ADD-LOCATION-FOR-BETTER-IDS": "ADD LOCATION FOR BETTER IDS",
   "Add-location-to-refresh-suggestions": "Add location to refresh suggestions",
   "Add-observations": "Add observations",
-  "ADD-OPTIONAL-COMMENT": "ADD OPTIONAL COMMENT",
   "Add-optional-notes": "Add optional notes",
   "Add-to-Projects": "Add to Projects",
   "ADD-TO-PROJECTS": "ADD TO PROJECTS",

--- a/src/i18n/strings.ftl
+++ b/src/i18n/strings.ftl
@@ -63,7 +63,6 @@ Add-location-to-refresh-suggestions = Add location to refresh suggestions
 # Accessibility label for a button that starts the process of adding an
 # observation, e.g. the button in the tab bar
 Add-observations = Add observations
-ADD-OPTIONAL-COMMENT = ADD OPTIONAL COMMENT
 Add-optional-notes = Add optional notes
 Add-to-Projects = Add to Projects
 ADD-TO-PROJECTS = ADD TO PROJECTS

--- a/tests/unit/components/ObsDetailsDefaultMode/IdentificationSheets.test.js
+++ b/tests/unit/components/ObsDetailsDefaultMode/IdentificationSheets.test.js
@@ -142,8 +142,6 @@ describe( "IdentificationSheets", () => {
 
   describe( "identReducer", () => {
     const initialState = {
-      comment: null,
-      commentIsOptional: false,
       showIdentBodySheet: false,
       newIdentification: null,
       showPotentialDisagreementSheet: false,


### PR DESCRIPTION
closes [MOB-1388](https://linear.app/inaturalist/issue/MOB-1388/allow-comments-with-agreeing-ids)

Fix is in the first commit, the rest is a bit of clean-up, and type error fixes for this file while avoiding anything that would balloon and touch too many other files.

I think I'd make the argument that agreeing Ids, whose state lives in `useObsDetailsSharedLogic.ts` and suggesting Ids, whose state is in `IdentificationSheets.tsx` could probably actually share a reducer, since they kind of do the same things. But that would be a tech-debt follow-up, and this just to fixes the current bug.