### PR TITLE
Location picker types

### DIFF
--- a/src/components/LocationPicker/LocationPicker.tsx
+++ b/src/components/LocationPicker/LocationPicker.tsx
@@ -8,7 +8,8 @@ import {
 import { SharedStackViewWrapper } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import React from "react";
-import type { LatLng } from "react-native-maps";
+import type { LayoutChangeEvent } from "react-native";
+import type { LatLng, Region } from "react-native-maps";
 import { useTranslation } from "sharedHooks";
 
 import CrosshairCircle from "./CrosshairCircle";
@@ -16,22 +17,23 @@ import DisplayLatLng from "./DisplayLatLng";
 import Footer from "./Footer";
 import LoadingIndicator from "./LoadingIndicator";
 import LocationSearch from "./LocationSearch";
+import type { LocationPickerPlace } from "./types";
 
 interface Props {
   accuracy: number;
-  handleSave: () => void;
+  handleSave: ( ) => void;
   hidePlaceResults: boolean;
   loading: boolean;
   locationName: string;
   initialRegion: LatLng;
-  onCurrentLocationPress: () => void;
-  onMapReady: () => void;
-  onRegionChangeComplete: () => void;
+  onCurrentLocationPress: ( ) => void;
+  onMapReady: ( ) => void;
+  onRegionChangeComplete: ( newRegion: Region ) => void;
   region: LatLng;
   regionToAnimate: object;
-  selectPlaceResult: () => void;
-  updateLocationName: () => void;
-  onMapLayout: () => void;
+  selectPlaceResult: ( place: LocationPickerPlace ) => void;
+  updateLocationName: ( name: string ) => void;
+  onMapLayout: ( event: LayoutChangeEvent ) => void;
 }
 
 const LocationPicker = ( {

--- a/src/components/LocationPicker/LocationPicker.tsx
+++ b/src/components/LocationPicker/LocationPicker.tsx
@@ -1,5 +1,3 @@
-// @flow
-
 import classnames from "classnames";
 import {
   CloseButton,
@@ -9,8 +7,8 @@ import {
 } from "components/SharedComponents";
 import { SharedStackViewWrapper } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
-import type { Node } from "react";
 import React from "react";
+import type { LatLng } from "react-native-maps";
 import { useTranslation } from "sharedHooks";
 
 import CrosshairCircle from "./CrosshairCircle";
@@ -19,22 +17,22 @@ import Footer from "./Footer";
 import LoadingIndicator from "./LoadingIndicator";
 import LocationSearch from "./LocationSearch";
 
-type Props = {
-  accuracy: number,
-  handleSave: Function,
-  hidePlaceResults: boolean,
-  loading: boolean,
-  locationName: string,
-  initialRegion: Object,
-  onCurrentLocationPress: Function,
-  onMapReady: Function,
-  onRegionChangeComplete: Function,
-  region: Object,
-  regionToAnimate: Object,
-  selectPlaceResult: Function,
-  updateLocationName: Function,
-  onMapLayout: Function,
-};
+interface Props {
+  accuracy: number;
+  handleSave: () => void;
+  hidePlaceResults: boolean;
+  loading: boolean;
+  locationName: string;
+  initialRegion: LatLng;
+  onCurrentLocationPress: () => void;
+  onMapReady: () => void;
+  onRegionChangeComplete: () => void;
+  region: LatLng;
+  regionToAnimate: object;
+  selectPlaceResult: () => void;
+  updateLocationName: () => void;
+  onMapLayout: () => void;
+}
 
 const LocationPicker = ( {
   accuracy,
@@ -51,7 +49,7 @@ const LocationPicker = ( {
   selectPlaceResult,
   updateLocationName,
   onMapLayout,
-}: Props ): Node => {
+}: Props ) => {
   const { t } = useTranslation( );
 
   let regionToDisplay;

--- a/src/components/LocationPicker/LocationPicker.tsx
+++ b/src/components/LocationPicker/LocationPicker.tsx
@@ -9,7 +9,7 @@ import { SharedStackViewWrapper } from "components/SharedComponents/ViewWrapper"
 import { View } from "components/styledComponents";
 import React from "react";
 import type { LayoutChangeEvent } from "react-native";
-import type { LatLng, Region } from "react-native-maps";
+import type { Region } from "react-native-maps";
 import { useTranslation } from "sharedHooks";
 
 import CrosshairCircle from "./CrosshairCircle";
@@ -25,12 +25,12 @@ interface Props {
   hidePlaceResults: boolean;
   loading: boolean;
   locationName: string;
-  initialRegion: LatLng;
+  initialRegion: Region | null;
   onCurrentLocationPress: ( ) => void;
   onMapReady: ( ) => void;
   onRegionChangeComplete: ( newRegion: Region ) => void;
-  region: LatLng;
-  regionToAnimate: object;
+  region: Region;
+  regionToAnimate: Region;
   selectPlaceResult: ( place: LocationPickerPlace ) => void;
   updateLocationName: ( name: string ) => void;
   onMapLayout: ( event: LayoutChangeEvent ) => void;
@@ -110,6 +110,9 @@ const LocationPicker = ( {
           </View>
           <Map
             className="h-full"
+            // TODO: reconcile null vs undef: does a changing initialRegion actually have an effect?
+            // it requires the map ref to settle to inform region's delta properties, but
+            // per docs, prop changes to `initialRegion` are ignored.
             initialRegion={initialRegion}
             onCurrentLocationPress={onCurrentLocationPress}
             onMapReady={onMapReady}

--- a/src/components/LocationPicker/LocationPickerContainer.tsx
+++ b/src/components/LocationPicker/LocationPickerContainer.tsx
@@ -24,7 +24,7 @@ const getInitialRegion = (
   currentObservation: LocationPickerObservation,
   radiusToMapHeight: number | null,
   mapDimensionsRatio: number | null,
-) => {
+): Region | null => {
   if ( !radiusToMapHeight || !mapDimensionsRatio ) {
     return null;
   }

--- a/src/components/LocationPicker/LocationPickerContainer.tsx
+++ b/src/components/LocationPicker/LocationPickerContainer.tsx
@@ -1,26 +1,30 @@
-// @flow
-
 import { useNavigation } from "@react-navigation/native";
 import {
   getMapRegion,
   latitudeDeltaToMeters,
   metersToLatitudeDelta,
 } from "components/SharedComponents/Map/helpers/mapHelpers";
-import type { Node } from "react";
 import React, {
   useCallback,
   useEffect,
   useReducer,
   useState,
 } from "react";
+import type { LayoutChangeEvent } from "react-native";
+import type { Region } from "react-native-maps";
 import fetchPlaceName from "sharedHelpers/fetchPlaceName";
 import useStore from "stores/useStore";
 
 import LocationPicker from "./LocationPicker";
+import type { LocationPickerObservation, LocationPickerPlace } from "./types";
 
 const CROSSHAIRRADIUS = 254 / 2;
 
-const setInitialRegion = ( currentObservation, radiusToMapHeight, mapDimensionsRatio ) => {
+const getInitialRegion = (
+  currentObservation: LocationPickerObservation,
+  radiusToMapHeight: number | null,
+  mapDimensionsRatio: number | null,
+) => {
   if ( !radiusToMapHeight || !mapDimensionsRatio ) {
     return null;
   }
@@ -59,7 +63,7 @@ const initializeMap = ( state, action ) => {
     accuracy: action.currentObservation?.positional_accuracy,
     locationName: action.currentObservation?.place_guess,
   };
-  const initialRegion = setInitialRegion(
+  const initialRegion = getInitialRegion(
     action.currentObservation,
     action.radiusToMapHeight,
     action.mapDimensionsRatio,
@@ -131,14 +135,14 @@ const reducer = ( state, action ) => {
   }
 };
 
-const LocationPickerContainer = ( ): Node => {
+const LocationPickerContainer = ( ) => {
   const currentObservation = useStore( state => state.currentObservation );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );
   const navigation = useNavigation( );
 
   const [state, dispatch] = useReducer( reducer, initialState );
-  const [radiusToMapHeight, setRadiusToMapHeight] = useState( undefined );
-  const [mapDimensionsRatio, setMapDimensionsRatio] = useState( undefined );
+  const [radiusToMapHeight, setRadiusToMapHeight] = useState<number | null>( null );
+  const [mapDimensionsRatio, setMapDimensionsRatio] = useState<number | null>( null );
 
   const {
     accuracy,
@@ -150,20 +154,20 @@ const LocationPickerContainer = ( ): Node => {
     regionToAnimate,
   } = state;
 
-  const initialRegion = setInitialRegion(
+  const initialRegion = getInitialRegion(
     currentObservation,
     radiusToMapHeight,
     mapDimensionsRatio,
   );
 
-  const onRegionChangeComplete = useCallback( async newRegion => {
+  const onRegionChangeComplete = useCallback( async ( newRegion: Region ) => {
     // prevent initial map render from resetting the coordinates and locationName
     if ( isFirstMapRender ) {
       dispatch( { type: "HANDLE_FIRST_MAP_RENDER" } );
       return;
     }
     // We need this ratio to calculate accuracy
-    if ( radiusToMapHeight === undefined ) {
+    if ( radiusToMapHeight === null ) {
       return;
     }
     // We calculate accuracy in meters as the distance represented by the radius of the crosshair
@@ -182,7 +186,7 @@ const LocationPickerContainer = ( ): Node => {
     } );
   }, [isFirstMapRender, radiusToMapHeight] );
 
-  const updateLocationName = useCallback( name => {
+  const updateLocationName = useCallback( ( name: string ) => {
     dispatch( { type: "UPDATE_LOCATION_NAME", locationName: name } );
   }, [] );
 
@@ -200,7 +204,7 @@ const LocationPickerContainer = ( ): Node => {
     [navigation, currentObservation, radiusToMapHeight, mapDimensionsRatio],
   );
 
-  const selectPlaceResult = place => {
+  const selectPlaceResult = ( place: LocationPickerPlace ) => {
     const { coordinates } = place.point_geojson;
     let newRegion = {
       ...region,
@@ -248,7 +252,7 @@ const LocationPickerContainer = ( ): Node => {
     navigation.goBack( );
   };
 
-  const onMapLayout = event => {
+  const onMapLayout = ( event: LayoutChangeEvent ) => {
     const { height, width } = event.nativeEvent.layout;
     setRadiusToMapHeight( CROSSHAIRRADIUS / height );
     setMapDimensionsRatio( width / height );

--- a/src/components/LocationPicker/LocationSearch.tsx
+++ b/src/components/LocationPicker/LocationSearch.tsx
@@ -12,22 +12,14 @@ import { Keyboard } from "react-native";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 import { getShadow } from "styles/global";
 
+import type { LocationPickerPlace } from "./types";
+
 const DROP_SHADOW = getShadow( );
 
-interface Place {
-  id: string;
-  display_name: string;
-  point_geojson: {
-    coordinates: [number, number];
-  };
-  bounding_box_geojson?: {
-    coordinates: [number, number][][];
-  };
-}
 interface Props {
   locationName: string;
-  updateLocationName: ( _text: string ) => void;
-  selectPlaceResult: ( _place: Place ) => void;
+  updateLocationName: ( name: string ) => void;
+  selectPlaceResult: ( place: LocationPickerPlace ) => void;
   hidePlaceResults: boolean;
 }
 
@@ -72,7 +64,7 @@ const LocationSearch = ( {
         className="absolute top-[65px] right-[26px] left-[26px] bg-white rounded-lg z-100"
         style={DROP_SHADOW}
       >
-        {!hidePlaceResults && placeResults?.map( ( place: Place ) => (
+        {!hidePlaceResults && placeResults?.map( ( place: LocationPickerPlace ) => (
           <Pressable
             accessibilityRole="button"
             key={place.id}

--- a/src/components/LocationPicker/types.ts
+++ b/src/components/LocationPicker/types.ts
@@ -6,7 +6,6 @@ export interface LocationPickerObservation {
   privateLongitude?: number;
 
   positional_accuracy?: number;
-  positionalAccuracy?: number;
 }
 
 export interface LocationPickerPlace {

--- a/src/components/LocationPicker/types.ts
+++ b/src/components/LocationPicker/types.ts
@@ -1,0 +1,33 @@
+export interface LocationPickerObservation {
+  latitude?: number;
+  longitude?: number;
+
+  privateLatitude?: number;
+  privateLongitude?: number;
+
+  positional_accuracy?: number;
+  positionalAccuracy?: number;
+}
+
+export interface LocationPickerPlace {
+  id: string;
+  display_name: string;
+  point_geojson: {
+    coordinates: number[];
+  };
+  bounding_box_geojson: {
+    // bbox is a 5-point clockwise rectangle starting from SW (5th === 1st),
+    // so the 1st and 3rd points give us the SW and NE corners.
+    coordinates: [
+      [
+        // SW
+        [number, number],
+        // (discard)
+        [number, number],
+        // NE
+        [number, number],
+        // ... don't need the rest
+      ]
+    ];
+  };
+}

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -13,6 +13,7 @@ import type { DimensionValue, LayoutChangeEvent, ViewStyle } from "react-native"
 import { Platform } from "react-native";
 import type {
   BoundingBox, LatLng, Region,
+  UserLocationChangeEvent,
 } from "react-native-maps";
 import MapView, { UrlTile } from "react-native-maps";
 import type Observation from "realmModels/Observation";
@@ -313,7 +314,7 @@ const Map = ( {
     minCenterCoordinateDistance: MIN_CENTER_COORDINATE_DISTANCE,
   };
 
-  const handleUserLocationChange = async locationChangeEvent => {
+  const handleUserLocationChange = async ( locationChangeEvent: UserLocationChangeEvent ) => {
     const coordinate = locationChangeEvent?.nativeEvent?.coordinate;
     setUserLocation( coordinate );
   };
@@ -335,12 +336,15 @@ const Map = ( {
 
   const [previousTileUrl, setPreviousTileUrl] = useState( tileUrlTemplate );
 
-  const handleRegionChangeComplete = useCallback( async ( newRegion, gesture ) => {
+  const handleRegionChangeComplete = useCallback( async (
+    newRegion: Region,
+    { isGesture }: { isGesture?: boolean },
+  ) => {
     // We are only interested in region changes due to user interaction.
     // In Android, onRegionChangeComplete also fires for other map region
     // changes and gesture.isGesture is available to test for user interaction.
     let shouldSkipRegionUpdate = false;
-    if ( Platform.OS === "android" && !gesture.isGesture ) {
+    if ( Platform.OS === "android" && !isGesture ) {
       if ( previousTileUrl !== tileUrlTemplate ) {
         setPreviousTileUrl( tileUrlTemplate );
       }
@@ -409,19 +413,19 @@ const Map = ( {
   // In Android, when we render a single frame of <MapView> without <UrlTile>
   // we use a tiny region increase of 0.001% to get onRegionChangeComplete to
   // fire and update the obs tile url. This change is too small to be visible.
-  const fuzzRegion = curRegion => (
+  const fuzzRegion = ( curRegion: Region ) => (
     {
       ...curRegion,
       latitudeDelta: 1.00001 * curRegion.latitudeDelta,
       longitudeDelta: 1.00001 * curRegion.longitudeDelta,
     } );
-  const shouldFuzzRegion = curRegion => (
+  const unfuzzedMapRegion = setRegion( );
+  const shouldFuzzRegion = (
     Platform.OS === "android"
-    && curRegion
+    && unfuzzedMapRegion
     && previousTileUrl !== tileUrlTemplate
   );
-  const unfuzzedMapRegion = setRegion( );
-  const mapRegion = shouldFuzzRegion( unfuzzedMapRegion )
+  const mapRegion = shouldFuzzRegion
     ? fuzzRegion( unfuzzedMapRegion )
     : unfuzzedMapRegion;
 
@@ -534,6 +538,7 @@ const Map = ( {
         onUserLocationChange={handleUserLocationChange}
         pitchEnabled={false}
         ref={setRefs}
+        // TODO: reconcile possible `null` state
         region={mapRegion}
         rotateEnabled={false}
         scrollEnabled={scrollEnabled}
@@ -563,7 +568,7 @@ const Map = ( {
             <LocationIndicator
               latitude={latitude}
               longitude={longitude}
-              positionalAccuracy={observation.positionalAccuracy}
+              positionalAccuracy={observation.positional_accuracy}
             />
           )
           : (

--- a/src/components/SharedComponents/Map/Map.tsx
+++ b/src/components/SharedComponents/Map/Map.tsx
@@ -9,7 +9,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import type { DimensionValue, ViewStyle } from "react-native";
+import type { DimensionValue, LayoutChangeEvent, ViewStyle } from "react-native";
 import { Platform } from "react-native";
 import type {
   BoundingBox, LatLng, Region,
@@ -43,7 +43,7 @@ const CURRENT_LOCATION_ZOOM_LEVEL = 20; // target zoom level when user hits curr
 const MIN_ZOOM_LEVEL = 0; // default in react-native-maps, for Google Maps only
 const MIN_CENTER_COORDINATE_DISTANCE = 5;
 
-const getDefaultRegion = ( initialLatitude, initialLongitude ) => ( {
+const getDefaultRegion = ( initialLatitude?: number, initialLongitude?: number ) => ( {
   latitude: initialLatitude || 25, // Default to something US centric
   longitude: initialLongitude || -85, // Default to something US centric
   latitudeDelta: initialLatitude
@@ -83,7 +83,7 @@ interface Props {
   withPressableObsTiles?: boolean;
   zoomEnabled?: boolean;
   zoomTapEnabled?: boolean;
-  onMapLayout?: ( event: { nativeEvent: { layout: { width: number; height: number } } } ) => void;
+  onMapLayout?: ( event: LayoutChangeEvent ) => void;
 }
 
 // TODO: fallback to another map library


### PR DESCRIPTION
doing some types while looking into MOB-1529.

I'm taking advantage of the fact that `LocationPicker` is its own island to do some type isolation. Two key ones there:

`LocationPickerPlace`: types a `Place` _as used by this feature_. The fields are non-null because we rely on the API to return them. We still need to figure out how we want to handle `api/types` as API descriptions vs app / feature descriptions and how to bridge useQuery => app typings, but this at least draws a line there.

`LocationPickerObservation`: minimal subset of obs props _as used by this feature_. We have a _big_ thing to figure out w/ "how to type obs" throughout the app / API / Realm. This type draws the line at LocationPicker and `const currentObservation = useStore( state => state.currentObservation );` <- however that is defined. Importantly, it highlights that we (probably incorrectly?) use `positional_accuracy` & `positionalAccuracy`. 

Once we have a more holistic obs typing approach and enforcement, it would probably make sense to remove `LocationPickerObservation`. For now, I'm thinking it's helpful as documentation towards that.