### PR TITLE
rn-maps patch: don't ignore region change cbs on large map jumps

### DIFF
--- a/patches/react-native-maps+1.27.1.patch
+++ b/patches/react-native-maps+1.27.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-maps/ios/AirMaps/RNMapsMapView.mm b/node_modules/react-native-maps/ios/AirMaps/RNMapsMapView.mm
+index 447520d..8043dcb 100644
+--- a/node_modules/react-native-maps/ios/AirMaps/RNMapsMapView.mm
++++ b/node_modules/react-native-maps/ios/AirMaps/RNMapsMapView.mm
+@@ -60,7 +60,7 @@ - (void)animateToRegion:(NSString *)regionJSON duration:(NSInteger)duration{
+     NSDictionary* regionDic = [RCTConvert dictonaryFromString:regionJSON];
+     MKCoordinateRegion region = [RCTConvert MKCoordinateRegion:regionDic];
+     Boolean animated = duration == 0 ? NO :YES;
+-    _view.ignoreRegionChanges = animated;
++    // _view.ignoreRegionChanges = animated;
+     [_view setRegion:region animated:animated];
+ }
+ - (void)setCamera:(NSString *)cameraJSON{


### PR DESCRIPTION
Fixes MOB-1529

the location picker lets you:
- pan
- search and select an iNat Place
- resolve "Current Location"

the latter two use `animateToRegion` and we display a loading indicator until rn-mapview's MapView's `handleRegionChangeComplete` callback triggers and we resolve the location.

On iOS `handleRegionChangeComplete` wasn't getting triggered for large map distances where the animation is and region change tracking are short-circuited. In my testing, it seems harmless to re-enable the change tracking so that we get our expected callbacks.

A new patch isn't ideal, but it's a lot cleaner than my other option of a timeout "cleanup" in case the callback never triggered (and would need separate changes for place & myLocation).