### PR TITLE
Traditional projects: post join project sync for offline chooser

### DIFF
--- a/src/api/fields.ts
+++ b/src/api/fields.ts
@@ -30,6 +30,7 @@ export const PROJECT_DETAIL_FIELDS = {
   header_image_url: true,
   membership_model: true,
   place_id: true,
+  project_observation_fields: PROJECT_OBSERVATION_FIELDS_FIELDS,
   user_ids: true,
 };
 

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -63,6 +63,7 @@ export interface ApiProject extends ApiProjectSummary {
   header_image_url: string | null;
   membership_model: "inviteonly" | "open" | null;
   place_id: number | null;
+  project_observation_fields: ApiProjectObservationField[];
   user_ids: number[];
 }
 

--- a/src/components/ProjectDetails/ProjectDetailsContainer.tsx
+++ b/src/components/ProjectDetails/ProjectDetailsContainer.tsx
@@ -16,18 +16,22 @@ import type {
   ApiObservationsSearchResponse, ApiPlace, ApiProject, ApiResponse,
 } from "api/types";
 import type { TabStackScreenProps } from "navigation/types";
+import { RealmContext } from "providers/contexts";
 import React, { useMemo, useState } from "react";
+import Project from "realmModels/Project";
 import { log } from "sharedHelpers/logger";
 import { useAuthenticatedMutation, useAuthenticatedQuery, useCurrentUser } from "sharedHooks";
 
 import ProjectDetails from "./ProjectDetails";
 
 const logger = log.extend( "ProjectDetailsContainer" );
+const { useRealm } = RealmContext;
 
 const ProjectDetailsContainer = ( ) => {
   const navigation = useNavigation<TabStackScreenProps<"ProjectDetails">["navigation"]>( );
   const { params } = useRoute<TabStackScreenProps<"ProjectDetails">["route"]>( );
   const { id } = params;
+  const realm = useRealm( );
   const currentUser = useCurrentUser( );
   const [loading, setLoading] = useState( false );
 
@@ -104,6 +108,10 @@ const ProjectDetailsContainer = ( ) => {
     ( _, optsWithAuth ) => joinProject( { id }, optsWithAuth ),
     {
       onSuccess: ( ) => {
+        // Persist traditional projects on join
+        if ( project?.project_type === "" ) {
+          Project.upsertRemoteProjects( [project], realm );
+        }
         queryClient.invalidateQueries( membershipQueryKey );
       },
       onError: error => {


### PR DESCRIPTION
Closes MOB-1524

On join success for a traditional project it is persisted to realm.

To test:
New app install
Login
Join a traditional project
Go to the Add to Projects screen and see the newly joined project in the list