### PR TITLE
Correctly track owners_identification_from_vision through match screen

### DIFF
--- a/src/components/Match/MatchContainer.tsx
+++ b/src/components/Match/MatchContainer.tsx
@@ -371,7 +371,6 @@ const MatchContainer = ( ) => {
   const onSuggestionChosen = useCallback( ( selection: ApiSuggestion ) => {
     setSelectedSuggestionId( selection.taxon.id );
     scrollToTop( );
-    // TODO: should this set owners_identification_from_vision: false?
   }, [scrollToTop] );
 
   const createUploadParams = useCallback( async ( uri: string, showLocation: boolean ) => {
@@ -461,7 +460,7 @@ const MatchContainer = ( ) => {
     if ( action === "save" ) {
       updateObservationKeys( {
         taxon: taxon || iconicTaxon,
-        owners_identification_from_vision: true,
+        owners_identification_from_vision: !!taxon,
       } );
       await saveObservation( getCurrentObservation( ), cameraRollUris, realm );
     }


### PR DESCRIPTION
Closes MOB-1167

Do not set indicator for CV used to true for iconicTaxon which is a user choice not based on CV.


Before
<img width="246" height="104" alt="Screenshot 2026-07-03 at 12 14 20" src="https://github.com/user-attachments/assets/2c3f5673-7976-4889-a80a-48884b32aafd" />

After
<img width="256" height="96" alt="Screenshot 2026-07-03 at 12 14 34" src="https://github.com/user-attachments/assets/f12d56bf-5216-4cf0-9e39-1a73e4b434e8" />
