### PR TITLE
useQuery for iconic taxa

### DIFF
--- a/src/sharedHooks/useIconicTaxa.ts
+++ b/src/sharedHooks/useIconicTaxa.ts
@@ -7,7 +7,7 @@ import Taxon from "realmModels/Taxon";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { useAuthenticatedQuery } from "sharedHooks";
 
-const { useRealm } = RealmContext;
+const { useRealm, useQuery } = RealmContext;
 
 const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ) => {
   const { reload } = options;
@@ -37,7 +37,13 @@ const useIconicTaxa = ( options: { reload: boolean } = { reload: false } ) => {
     }
   }, [iconicTaxa, realm, isUpdatingRealm] );
 
-  return realm?.objects( "Taxon" ).filtered( "isIconic = true" );
+  return useQuery(
+    {
+      type: Taxon,
+      query: taxa => taxa.filtered( "isIconic = true" ),
+    },
+    [],
+  );
 };
 
 export default useIconicTaxa;

--- a/tests/integration/sharedHooks/useTaxon.test.js
+++ b/tests/integration/sharedHooks/useTaxon.test.js
@@ -21,6 +21,7 @@ jest.mock( "providers/contexts", ( ) => {
     RealmContext: {
       ...originalModule.RealmContext,
       useRealm: ( ) => global.mockRealms[mockRealmIdentifier],
+      useQuery: ( ) => [],
     },
   };
 } );


### PR DESCRIPTION
The main benefit here is returning a stable reference. I was seeing some unintended re-renders working on default search options for exploreV2

<details>
<summary>screenshot of iconic taxa in search</summary>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-07-06 at 10 46 58" src="https://github.com/user-attachments/assets/728de9ae-0ead-40da-8be8-eeeadffade41" />

</details>