### PR TITLE
move LAST_CRASH_DATA from zustandmmkv to installdata

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ import "react-native-url-polyfill/auto";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { Alert, AppRegistry } from "react-native";
 import { getCurrentRoute } from "navigation/navigationUtils";
-import { zustandStorage } from "stores/useStore";
 import zustandMMKVBackingStorage from "stores/zustandMMKVBackingStorage";
 import {
   QueryClient,
@@ -104,7 +103,7 @@ setNativeExceptionHandler(
       };
 
       // Store crash data for retrieval on next app launch
-      zustandStorage.setItem( "LAST_CRASH_DATA", JSON.stringify( crashData ) );
+      installDataMMKVStorage.setItem( "LAST_CRASH_DATA", JSON.stringify( crashData ) );
 
       logger.error( `Native Error: ${exceptionString}`, JSON.stringify( crashData ) );
     } catch ( e ) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,11 @@ import Config from "react-native-config";
 import { setJSExceptionHandler, setNativeExceptionHandler } from "react-native-exception-handler";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { getInstallID, store as installDataMMKVStorage } from "sharedHelpers/installData";
+import {
+  getInstallID,
+  store as installDataMMKVStorage,
+  LAST_CRASH_DATA,
+} from "sharedHelpers/installData";
 import { reactQueryRetry } from "sharedHelpers/logging";
 import DeviceInfo from "react-native-device-info";
 import useRozenite, { HaltedLaunch, shouldHaltLaunchForDebug } from "sharedHooks/useRozenite";
@@ -103,7 +107,7 @@ setNativeExceptionHandler(
       };
 
       // Store crash data for retrieval on next app launch
-      installDataMMKVStorage.setItem( "LAST_CRASH_DATA", JSON.stringify( crashData ) );
+      installDataMMKVStorage.setItem( LAST_CRASH_DATA, JSON.stringify( crashData ) );
 
       logger.error( `Native Error: ${exceptionString}`, JSON.stringify( crashData ) );
     } catch ( e ) {

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -20,7 +20,7 @@ import {
   clearSyncedMediaForUpload,
 } from "sharedHelpers/clearCaches";
 import { formatApiDatetime } from "sharedHelpers/dateAndTime";
-import { store as installDataMMKVStorage } from "sharedHelpers/installData";
+import { LAST_CRASH_DATA, store as installDataMMKVStorage } from "sharedHelpers/installData";
 import { log } from "sharedHelpers/logger";
 import { logSentinelFiles } from "sharedHelpers/sentinelFiles";
 import getStorageMetrics from "sharedHelpers/storageMetrics";
@@ -66,11 +66,11 @@ const deferTask = (
 
 const checkForPreviousCrash = async () => {
   try {
-    const crashData = installDataMMKVStorage.getString( "LAST_CRASH_DATA" );
+    const crashData = installDataMMKVStorage.getString( LAST_CRASH_DATA );
     if ( crashData ) {
       const parsedData = JSON.parse( crashData.toString() );
       logger.error( "Last Crash Data:", JSON.stringify( parsedData ) );
-      installDataMMKVStorage.delete( "LAST_CRASH_DATA" );
+      installDataMMKVStorage.delete( LAST_CRASH_DATA );
     }
   } catch ( e ) {
     logger.error( "Failed to process previous crash data", e );

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -20,11 +20,11 @@ import {
   clearSyncedMediaForUpload,
 } from "sharedHelpers/clearCaches";
 import { formatApiDatetime } from "sharedHelpers/dateAndTime";
+import { store as installDataMMKVStorage } from "sharedHelpers/installData";
 import { log } from "sharedHelpers/logger";
 import { logSentinelFiles } from "sharedHelpers/sentinelFiles";
 import getStorageMetrics from "sharedHelpers/storageMetrics";
 import { useTranslation } from "sharedHooks";
-import { zustandStorage } from "stores/useStore";
 
 const { useRealm } = RealmContext;
 const logger = log.extend( "useDeferredStartup" );
@@ -66,11 +66,11 @@ const deferTask = (
 
 const checkForPreviousCrash = async () => {
   try {
-    const crashData = zustandStorage.getItem( "LAST_CRASH_DATA" );
+    const crashData = installDataMMKVStorage.getString( "LAST_CRASH_DATA" );
     if ( crashData ) {
       const parsedData = JSON.parse( crashData.toString() );
       logger.error( "Last Crash Data:", JSON.stringify( parsedData ) );
-      zustandStorage.removeItem( "LAST_CRASH_DATA" );
+      installDataMMKVStorage.delete( "LAST_CRASH_DATA" );
     }
   } catch ( e ) {
     logger.error( "Failed to process previous crash data", e );

--- a/src/sharedHelpers/installData.ts
+++ b/src/sharedHelpers/installData.ts
@@ -10,6 +10,7 @@ const MMKV_ID = "install-data";
 const INSTALL_ID = "installID";
 const ONBOARDING_SHOWN = "onboardingShown";
 export const IS_FRESH_INSTALL = "isFreshInstall";
+export const LAST_CRASH_DATA = "LAST_CRASH_DATA";
 
 // This store is separate from the zustand store b/c it needs to survive sign
 // out, i.e these values should remain untill the app is uninstalled


### PR DESCRIPTION
closes MOB-1375, subtask of MOB-1372

full detail for class of issue this addresses in #3556 

tl;dr: we want to eliminate any _non_ zustand access to the mmkv kvs backing zustand. zustand can't be reactive to those updates and non-zustand consumers can't be reactive to their own `.get`s.