### PR TITLE
use ubuntu for androide2e slack notif, replace deprecated macos-latest label

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -289,7 +289,7 @@ jobs:
     name: Notify Slack
     needs: test
     if: ${{ success() || failure() }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: iRoachie/slack-github-actions@v2.3.0
         if: env.SLACK_WEBHOOK_URL != null


### PR DESCRIPTION
solving for this deprecation warning:

> [Notify Slack](https://github.com/inaturalist/iNaturalistReactNative/actions/runs/28896472564/job/85727695071)
The macos-latest label will migrate to macOS 26 beginning June 15, 2026. For more information see https://github.com/actions/runner-images/issues/14167

we needn't use macos for script-y jobs anyhow