### PR TITLE
Enable mobile CV model 2.30

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3960,7 +3960,7 @@ PODS:
   - VisionCamera/React (4.7.3):
     - React-Core
     - VisionCamera/FrameProcessors
-  - VisionCameraPluginInatVision (6.0.0-rc.3):
+  - VisionCameraPluginInatVision (6.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4564,7 +4564,7 @@ SPEC CHECKSUMS:
   SensitiveInfo: 09107b865dc23b4e9c0a61ec01385387bf3391a8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
-  VisionCameraPluginInatVision: 561ffc82eb61315312414a9f4424c5d6411c83ab
+  VisionCameraPluginInatVision: 3b006a7a434ddfc23d789729b6d98e451f90c4e4
   Yoga: e9fea23bf9b2766818ce9a8df72f584bf5ad36cd
 
 PODFILE CHECKSUM: 73e24a8590e365c9fec451abf69476ae07116d98

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "realm": "^20.2.0",
         "sanitize-html": "^2.17.4",
         "uuid": "^11.1.1",
-        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#e8c4782cee82e781e8dc7016fffedbbd95070931",
+        "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#0354705c124e3a9fabcca3e5881e64cd93d2f0df",
         "zustand": "^4.5.7"
       },
       "devDependencies": {
@@ -23084,9 +23084,9 @@
       }
     },
     "node_modules/vision-camera-plugin-inatvision": {
-      "version": "6.0.0-rc.3",
-      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#e8c4782cee82e781e8dc7016fffedbbd95070931",
-      "integrity": "sha512-aarLhPkpgxtFSjrbcbNtzL2VZNM8So+hBzVQROFIEQrj5e/dPp8zWGQ4gONRW9rkUH7t1pmWD4125Eq1/w45+g==",
+      "version": "6.0.0",
+      "resolved": "git+ssh://git@github.com/inaturalist/vision-camera-plugin-inatvision.git#0354705c124e3a9fabcca3e5881e64cd93d2f0df",
+      "integrity": "sha512-HYfaSSb5WnjOLLWLioF7ZgXlk8He8YmoPNV789mhDUBFBgXPaE452O+qW7mIcYVV6cz/WDt+qW3C1ImLEDAWQw==",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "realm": "^20.2.0",
     "sanitize-html": "^2.17.4",
     "uuid": "^11.1.1",
-    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#e8c4782cee82e781e8dc7016fffedbbd95070931",
+    "vision-camera-plugin-inatvision": "github:inaturalist/vision-camera-plugin-inatvision#0354705c124e3a9fabcca3e5881e64cd93d2f0df",
     "zustand": "^4.5.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes MOB-1555
To enable the CV model 2.30 in the app we need to explicitly allow it in the vision plugin (for reasons).

Diff in the package is only these two commits:
https://github.com/inaturalist/vision-camera-plugin-inatvision/commit/214eb07b94ccf9d65a933a9b330f3c806f2c6f8d https://github.com/inaturalist/vision-camera-plugin-inatvision/commit/0354705c124e3a9fabcca3e5881e64cd93d2f0df

Have tested in Debug and Release mode on Android and iOS with cv model 2.30 included. AI camera works in all cases with and without location (= with or without geomodel). In airplane mode predictions from file also worked. A newly added species according to the blog post also works.