### PR TITLE
Mob 1461 create hook for server ordered observations in myobs

### DIFF
--- a/src/components/MyObservations/MyObsServerOrderedDebugSheet.tsx
+++ b/src/components/MyObservations/MyObsServerOrderedDebugSheet.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable i18next/no-literal-string */
 import classnames from "classnames";
-import useServerOrderedObservations
-  from "components/MyObservations/hooks/useServerOrderedObservations";
+import useMyObservationsQuery from "components/MyObservations/hooks/useMyObservationsQuery";
 import { INatIconButton } from "components/SharedComponents";
 import Modal from "components/SharedComponents/Modal";
 import Body3 from "components/SharedComponents/Typography/Body3";
@@ -10,6 +9,10 @@ import {
   Image, Pressable, ScrollView, Text, View,
 } from "components/styledComponents";
 import { RealmContext } from "providers/contexts";
+import {
+  MY_OBSERVATIONS_ACTION,
+  useMyObservations,
+} from "providers/MyObservationsContext";
 import React, { useState } from "react";
 import type { RealmObservation } from "realmModels/types";
 import { OBSERVATIONS_SORT, OBSERVATIONS_SORT_OPTIONS } from "sharedHelpers/observationsSort";
@@ -86,23 +89,72 @@ const ObservationRow = ( { uuid, index }: ObservationRowProps ) => {
   );
 };
 
+interface DebugSheetContentProps {
+  onClose: ( ) => void;
+}
+
+// Split out from the sheet shell so useObservationsQuery (and the network
+// fetch it can trigger) only runs while the sheet is actually open
+const DebugSheetContent = ( { onClose }: DebugSheetContentProps ) => {
+  const { state, dispatch } = useMyObservations( );
+  const {
+    observationIds,
+    isServerAuthoritative,
+    isLoading,
+    error,
+    refetch,
+  } = useMyObservationsQuery( );
+
+  return (
+    <View className="bg-white rounded-t-2xl h-[85%]">
+      <View
+        className={classnames(
+          "px-4 pt-4 pb-2 flex-row items-center justify-between",
+          "border-b border-lightGray",
+        )}
+      >
+        <Heading4>MyObs Query Debug</Heading4>
+        <Pressable accessibilityRole="button" onPress={onClose}>
+          <Text className="text-base text-inatGreen">Close</Text>
+        </Pressable>
+      </View>
+      <ScrollView
+        className="flex-1 px-4 py-3"
+        contentContainerStyle={SCROLL_CONTENT}
+      >
+        <View className="flex-row flex-wrap mb-3">
+          {OBSERVATIONS_SORT_OPTIONS.map( sort => (
+            <DebugButton
+              key={sort}
+              label={SORT_LABELS[sort]}
+              active={state.observationsSort === sort}
+              onPress={( ) => dispatch( {
+                type: MY_OBSERVATIONS_ACTION.SET_OBSERVATIONS_SORT,
+                observationsSort: sort,
+              } )}
+            />
+          ) )}
+          <DebugButton label="Refresh" onPress={( ) => refetch( )} />
+        </View>
+        <Body3 className="mb-3">
+          {`Server authoritative: ${isServerAuthoritative
+            ? "yes"
+            : "no"}`}
+        </Body3>
+        {isLoading && <Body3 className="mb-2">Loading…</Body3>}
+        {!!error && <Body3 className="mb-2">{`Error: ${error.message}`}</Body3>}
+        <Body3 className="mb-3">{`Showing ${observationIds.length} observations`}</Body3>
+        {observationIds.map( ( { uuid }, index ) => (
+          <ObservationRow key={uuid} uuid={uuid} index={index} />
+        ) )}
+      </ScrollView>
+    </View>
+  );
+};
+
 const MyObsServerOrderedDebugSheet = ( ) => {
   const { isDebug } = useDebugMode( );
   const [visible, setVisible] = useState( false );
-  const [selectedSort, setSelectedSort] = useState<OBSERVATIONS_SORT>(
-    OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
-  );
-
-  const {
-    observationIds,
-    isLoading,
-    error,
-    totalResults,
-    refetch,
-  } = useServerOrderedObservations( {
-    sortBy: selectedSort,
-    enabled: visible,
-  } );
 
   if ( !isDebug ) return null;
 
@@ -122,43 +174,9 @@ const MyObsServerOrderedDebugSheet = ( ) => {
         showModal={visible}
         closeModal={onClose}
         disableSwipeDirection
-        modal={(
-          <View className="bg-white rounded-t-2xl h-[85%]">
-            <View
-              className={classnames(
-                "px-4 pt-4 pb-2 flex-row items-center justify-between",
-                "border-b border-lightGray",
-              )}
-            >
-              <Heading4>MyObs Server Order Debug</Heading4>
-              <Pressable accessibilityRole="button" onPress={onClose}>
-                <Text className="text-base text-inatGreen">Close</Text>
-              </Pressable>
-            </View>
-            <ScrollView
-              className="flex-1 px-4 py-3"
-              contentContainerStyle={SCROLL_CONTENT}
-            >
-              <View className="flex-row flex-wrap mb-3">
-                {OBSERVATIONS_SORT_OPTIONS.map( sort => (
-                  <DebugButton
-                    key={sort}
-                    label={SORT_LABELS[sort]}
-                    active={selectedSort === sort}
-                    onPress={( ) => setSelectedSort( sort )}
-                  />
-                ) )}
-                <DebugButton label="Refresh" onPress={( ) => refetch( )} />
-              </View>
-              {isLoading && <Body3 className="mb-2">Loading…</Body3>}
-              {!!error && <Body3 className="mb-2">{`Error: ${error.message}`}</Body3>}
-              <Body3 className="mb-3">{`Total results: ${totalResults ?? "n/a"}`}</Body3>
-              {observationIds.map( ( { uuid }, index ) => (
-                <ObservationRow key={uuid} uuid={uuid} index={index} />
-              ) )}
-            </ScrollView>
-          </View>
-        )}
+        modal={visible
+          ? <DebugSheetContent onClose={onClose} />
+          : null}
       />
     </>
   );

--- a/src/components/MyObservations/MyObsServerOrderedDebugSheet.tsx
+++ b/src/components/MyObservations/MyObsServerOrderedDebugSheet.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable i18next/no-literal-string */
+import classnames from "classnames";
+import useServerOrderedObservations
+  from "components/MyObservations/hooks/useServerOrderedObservations";
+import { INatIconButton } from "components/SharedComponents";
+import Modal from "components/SharedComponents/Modal";
+import Body3 from "components/SharedComponents/Typography/Body3";
+import Heading4 from "components/SharedComponents/Typography/Heading4";
+import {
+  Image, Pressable, ScrollView, Text, View,
+} from "components/styledComponents";
+import { RealmContext } from "providers/contexts";
+import React, { useState } from "react";
+import type { RealmObservation } from "realmModels/types";
+import { OBSERVATIONS_SORT, OBSERVATIONS_SORT_OPTIONS } from "sharedHelpers/observationsSort";
+import useDebugMode from "sharedHooks/useDebugMode";
+
+const { useObject } = RealmContext;
+
+const SORT_LABELS: Record<OBSERVATIONS_SORT, string> = {
+  [OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST]: "Uploaded ↓",
+  [OBSERVATIONS_SORT.DATE_UPLOADED_OLDEST]: "Uploaded ↑",
+  [OBSERVATIONS_SORT.DATE_OBSERVED_NEWEST]: "Observed ↓",
+  [OBSERVATIONS_SORT.DATE_OBSERVED_OLDEST]: "Observed ↑",
+};
+
+const SCROLL_CONTENT = { paddingBottom: 32 };
+
+interface DebugButtonProps {
+  label: string;
+  onPress: ( ) => void;
+  active?: boolean;
+}
+
+const DebugButton = ( { label, onPress, active }: DebugButtonProps ) => (
+  <Pressable
+    accessibilityRole="button"
+    onPress={onPress}
+    className={`px-3 py-2 mr-2 mb-2 rounded ${
+      active
+        ? "bg-inatGreen"
+        : "bg-darkGray"
+    }`}
+  >
+    <Text className="text-white text-xs">{label}</Text>
+  </Pressable>
+);
+
+interface DebugRealmObservation extends RealmObservation {
+  id?: number;
+}
+
+interface ObservationRowProps {
+  uuid: string;
+  index: number;
+}
+
+const ObservationRow = ( { uuid, index }: ObservationRowProps ) => {
+  const observation = useObject<DebugRealmObservation>( "Observation", uuid );
+  const thumbnailUrl = observation?.observationPhotos?.[0]?.photo?.url;
+  const name = observation?.taxon?.preferredCommonName
+    || observation?.taxon?.name
+    || "(no taxon)";
+  const uploadedAt = observation?._created_at
+    ? observation._created_at.toLocaleDateString( )
+    : "—";
+  const observedOn = observation?.observed_on
+    ? new Date( observation.observed_on ).toLocaleDateString( )
+    : "—";
+
+  return (
+    <View className="flex-row items-center mb-3 pb-3 border-b border-lightGray">
+      <Text className="w-6 text-xs">{index + 1}</Text>
+      {thumbnailUrl
+        ? <Image source={{ uri: thumbnailUrl }} className="w-12 h-12 rounded mr-2" />
+        : <View className="w-12 h-12 rounded mr-2 bg-lightGray" />}
+      <View className="flex-1">
+        <Text numberOfLines={1} className="font-bold">{name}</Text>
+        <Text className="text-xs text-darkGray">
+          {`id: ${observation?.id ?? "—"} · uuid: ${uuid}`}
+        </Text>
+        <Text className="text-xs text-darkGray">{`uploaded: ${uploadedAt}`}</Text>
+        <Text className="text-xs text-darkGray">{`observed: ${observedOn}`}</Text>
+      </View>
+    </View>
+  );
+};
+
+const MyObsServerOrderedDebugSheet = ( ) => {
+  const { isDebug } = useDebugMode( );
+  const [visible, setVisible] = useState( false );
+  const [selectedSort, setSelectedSort] = useState<OBSERVATIONS_SORT>(
+    OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
+  );
+
+  const {
+    observationIds,
+    isLoading,
+    error,
+    totalResults,
+    refetch,
+  } = useServerOrderedObservations( {
+    sortBy: selectedSort,
+    enabled: visible,
+  } );
+
+  if ( !isDebug ) return null;
+
+  const onClose = ( ) => setVisible( false );
+
+  return (
+    <>
+      <INatIconButton
+        icon="triangle-exclamation"
+        className="absolute top-64 right-5 rounded-full bg-deepPink"
+        color="white"
+        size={27}
+        accessibilityLabel="MyObs server order diagnostics"
+        onPress={( ) => setVisible( true )}
+      />
+      <Modal
+        showModal={visible}
+        closeModal={onClose}
+        disableSwipeDirection
+        modal={(
+          <View className="bg-white rounded-t-2xl h-[85%]">
+            <View
+              className={classnames(
+                "px-4 pt-4 pb-2 flex-row items-center justify-between",
+                "border-b border-lightGray",
+              )}
+            >
+              <Heading4>MyObs Server Order Debug</Heading4>
+              <Pressable accessibilityRole="button" onPress={onClose}>
+                <Text className="text-base text-inatGreen">Close</Text>
+              </Pressable>
+            </View>
+            <ScrollView
+              className="flex-1 px-4 py-3"
+              contentContainerStyle={SCROLL_CONTENT}
+            >
+              <View className="flex-row flex-wrap mb-3">
+                {OBSERVATIONS_SORT_OPTIONS.map( sort => (
+                  <DebugButton
+                    key={sort}
+                    label={SORT_LABELS[sort]}
+                    active={selectedSort === sort}
+                    onPress={( ) => setSelectedSort( sort )}
+                  />
+                ) )}
+                <DebugButton label="Refresh" onPress={( ) => refetch( )} />
+              </View>
+              {isLoading && <Body3 className="mb-2">Loading…</Body3>}
+              {!!error && <Body3 className="mb-2">{`Error: ${error.message}`}</Body3>}
+              <Body3 className="mb-3">{`Total results: ${totalResults ?? "n/a"}`}</Body3>
+              {observationIds.map( ( { uuid }, index ) => (
+                <ObservationRow key={uuid} uuid={uuid} index={index} />
+              ) )}
+            </ScrollView>
+          </View>
+        )}
+      />
+    </>
+  );
+};
+
+export default MyObsServerOrderedDebugSheet;

--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -52,6 +52,7 @@ import MyObservationsSimple, {
   OBSERVATIONS_TAB,
   TAXA_TAB,
 } from "./MyObservationsSimple";
+import MyObsServerOrderedDebugSheet from "./MyObsServerOrderedDebugSheet";
 
 const { useRealm } = RealmContext;
 
@@ -422,40 +423,43 @@ const MyObservationsResults = ( ) => {
   }
 
   return (
-    <MyObservationsSimple
-      activeTab={activeTab}
-      currentUser={currentUser}
-      fetchMoreTaxa={fetchMoreTaxa}
-      fetchFromLastObservation={fetchFromLastObservation}
-      handleIndividualUploadPress={handleIndividualUploadPress}
-      handlePullToRefresh={handlePullToRefresh}
-      handleSyncButtonPress={handleSyncButtonPress}
-      isConnected={isConnected}
-      isFetchingNextPage={isFetchingNextPage}
-      isFetchingTaxa={isFetchingTaxa}
-      justFinishedSignup={justFinishedSignup}
-      layout={layout}
-      listRef={listRef}
-      loggedInWhileInDefaultMode={loggedInWhileInDefaultMode}
-      taxaListRef={taxaListRef}
-      numTotalObservations={numOfUserObservations}
-      numTotalTaxa={numOfUserSpecies}
-      numUnuploadedObservations={numUnuploadedObservations}
-      numObsMissingBasics={numObsMissingBasics}
-      observationIds={observationIds}
-      onEndReached={fetchNextPage}
-      onListLayout={restoreScrollOffset}
-      onScroll={onScroll}
-      openSheet={openSheet}
-      refetchTaxa={refetchTaxa}
-      setActiveTab={setActiveTab}
-      setOpenSheet={setOpenSheet}
-      setSpeciesSortOptionId={setSpeciesSortOptionId}
-      showNoResults={showNoResults}
-      speciesSortOptionId={myObsState.speciesSort}
-      taxa={taxa}
-      toggleLayout={toggleLayout}
-    />
+    <>
+      <MyObservationsSimple
+        activeTab={activeTab}
+        currentUser={currentUser}
+        fetchMoreTaxa={fetchMoreTaxa}
+        fetchFromLastObservation={fetchFromLastObservation}
+        handleIndividualUploadPress={handleIndividualUploadPress}
+        handlePullToRefresh={handlePullToRefresh}
+        handleSyncButtonPress={handleSyncButtonPress}
+        isConnected={isConnected}
+        isFetchingNextPage={isFetchingNextPage}
+        isFetchingTaxa={isFetchingTaxa}
+        justFinishedSignup={justFinishedSignup}
+        layout={layout}
+        listRef={listRef}
+        loggedInWhileInDefaultMode={loggedInWhileInDefaultMode}
+        taxaListRef={taxaListRef}
+        numTotalObservations={numOfUserObservations}
+        numTotalTaxa={numOfUserSpecies}
+        numUnuploadedObservations={numUnuploadedObservations}
+        numObsMissingBasics={numObsMissingBasics}
+        observationIds={observationIds}
+        onEndReached={fetchNextPage}
+        onListLayout={restoreScrollOffset}
+        onScroll={onScroll}
+        openSheet={openSheet}
+        refetchTaxa={refetchTaxa}
+        setActiveTab={setActiveTab}
+        setOpenSheet={setOpenSheet}
+        setSpeciesSortOptionId={setSpeciesSortOptionId}
+        showNoResults={showNoResults}
+        speciesSortOptionId={myObsState.speciesSort}
+        taxa={taxa}
+        toggleLayout={toggleLayout}
+      />
+      <MyObsServerOrderedDebugSheet />
+    </>
   );
 };
 

--- a/src/components/MyObservations/hooks/useMyObservationsQuery.ts
+++ b/src/components/MyObservations/hooks/useMyObservationsQuery.ts
@@ -1,0 +1,89 @@
+import { RealmContext } from "providers/contexts";
+import { useMyObservations } from "providers/MyObservationsContext";
+import { useMemo } from "react";
+import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
+import useLocalObservationIds from "sharedHooks/useLocalObservationIds";
+
+import useServerOrderedObservations from "./useServerOrderedObservations";
+
+const { useQuery } = RealmContext;
+
+const NOOP_REFETCH = ( ) => undefined;
+
+interface UseMyObservationsQueryResult {
+  observationIds: { uuid: string }[];
+  isServerAuthoritative: boolean;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: ( ) => void;
+}
+
+// We want to preserve offline behavior for the default sort (created at, desc) so a user can see
+// and interact with their obs offline. This hook uses selected sort to determine whether Realm or
+// the server should be the authoritative source of a user's observations (unsynced obs
+// are always merged in at the top regardless of source).
+
+const useMyObservationsQuery = ( ): UseMyObservationsQueryResult => {
+  const { state } = useMyObservations( );
+  const isDefaultSort = state.observationsSort === OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST;
+
+  const localObservationIds = useLocalObservationIds( );
+
+  const {
+    observationIds: serverObservationIds,
+    isLoading,
+    error,
+    refetch,
+  } = useServerOrderedObservations( {
+    sortBy: state.observationsSort,
+    enabled: !isDefaultSort,
+  } );
+
+  // if we want obs from the server, we'll want to prepend local, unsynced obs to the top
+  const unsyncedObs = useQuery<{ uuid: string }>(
+    {
+      type: "Observation",
+      query: observations => observations
+        .filtered(
+          "needs_sync == true AND "
+          + "(_deleted_at == nil OR _pending_deletion == false OR _pending_deletion == nil)",
+        )
+        .sorted( "_created_at", true ),
+      keyPaths: ["uuid"],
+    },
+    [],
+  );
+
+  const unsyncedObservationIds = useMemo(
+    ( ) => unsyncedObs.map( ( { uuid } ) => ( { uuid } ) ),
+    [unsyncedObs],
+  );
+
+  // dedupe in case any locally unsynced obs also exist in the server results
+  const observationIds = useMemo( ( ) => {
+    if ( isDefaultSort ) return localObservationIds;
+    const unsyncedUuids = new Set( unsyncedObservationIds.map( o => o.uuid ) );
+    return [
+      ...unsyncedObservationIds,
+      ...serverObservationIds.filter( o => !unsyncedUuids.has( o.uuid ) ),
+    ];
+  }, [isDefaultSort, localObservationIds, unsyncedObservationIds, serverObservationIds] );
+
+  return {
+    observationIds,
+    isServerAuthoritative: !isDefaultSort,
+    isLoading: isDefaultSort
+      ? false
+      : isLoading,
+    error: isDefaultSort
+      ? null
+      : error,
+    // since we never fetched for default sort, we don't need to refetch.
+    // pagination is still handled by useInfiniteObservationsScroll
+    refetch: isDefaultSort
+      ? NOOP_REFETCH
+      : refetch,
+  };
+};
+
+export default useMyObservationsQuery;

--- a/src/components/MyObservations/hooks/useServerOrderedObservations.ts
+++ b/src/components/MyObservations/hooks/useServerOrderedObservations.ts
@@ -1,9 +1,12 @@
 import { searchObservations } from "api/observations";
-import { useMemo } from "react";
+import { RealmContext } from "providers/contexts";
+import { useEffect, useMemo } from "react";
 import Observation from "realmModels/Observation";
 import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 import { observationSortToApiParams } from "sharedHelpers/observationsSort";
 import { useAuthenticatedQuery, useCurrentUser } from "sharedHooks";
+
+const { useRealm } = RealmContext;
 
 const PER_PAGE = 20;
 
@@ -36,6 +39,7 @@ const useServerOrderedObservations = ( {
   page = 1,
   enabled = true,
 }: UseServerOrderedObservationsParams ): UseServerOrderedObservationsResult => {
+  const realm = useRealm( );
   const currentUser = useCurrentUser( );
 
   const params = {
@@ -60,6 +64,12 @@ const useServerOrderedObservations = ( {
     optsWithAuth => searchObservations( params, optsWithAuth ),
     { enabled: enabled && !!currentUser },
   );
+
+  useEffect( ( ) => {
+    if ( data?.results ) {
+      Observation.upsertRemoteObservations( data.results, realm );
+    }
+  }, [data?.results, realm] );
 
   const observationIds = useMemo(
     ( ) => ( data?.results || [] ).map( ( { uuid } ) => ( { uuid } ) ),

--- a/src/components/MyObservations/hooks/useServerOrderedObservations.ts
+++ b/src/components/MyObservations/hooks/useServerOrderedObservations.ts
@@ -1,12 +1,14 @@
 import { searchObservations } from "api/observations";
 import { RealmContext } from "providers/contexts";
-import { useEffect, useMemo } from "react";
 import Observation from "realmModels/Observation";
+import { log } from "sharedHelpers/logger";
 import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 import { observationSortToApiParams } from "sharedHelpers/observationsSort";
 import { useAuthenticatedQuery, useCurrentUser } from "sharedHooks";
 
 const { useRealm } = RealmContext;
+
+const logger = log.extend( "useServerOrderedObservations" );
 
 const PER_PAGE = 20;
 
@@ -18,6 +20,11 @@ interface SearchObservationsResult {
 interface SearchObservationsResponse {
   results: SearchObservationsResult[];
   total_results: number;
+}
+
+interface ServerOrderedObservationsData {
+  observationIds: { uuid: string }[];
+  totalResults: number;
 }
 
 interface UseServerOrderedObservationsParams {
@@ -59,28 +66,31 @@ const useServerOrderedObservations = ( {
     isLoading,
     error,
     refetch,
-  } = useAuthenticatedQuery<SearchObservationsResponse>(
+  } = useAuthenticatedQuery<ServerOrderedObservationsData>(
     queryKey,
-    optsWithAuth => searchObservations( params, optsWithAuth ),
+    async ( optsWithAuth ): Promise<ServerOrderedObservationsData> => {
+      const rawResponse = await searchObservations( params, optsWithAuth );
+      const response = rawResponse as SearchObservationsResponse;
+      const results = response.results || [];
+      try {
+        Observation.upsertRemoteObservations( results, realm );
+      } catch ( upsertError ) {
+        // A local Realm-write failure shouldn't be reported as a failed search
+        logger.error( "Failed to upsert server-ordered observations", upsertError );
+      }
+      return {
+        observationIds: results.map( ( { uuid } ) => ( { uuid } ) ),
+        totalResults: response.total_results,
+      };
+    },
     { enabled: enabled && !!currentUser },
   );
 
-  useEffect( ( ) => {
-    if ( data?.results ) {
-      Observation.upsertRemoteObservations( data.results, realm );
-    }
-  }, [data?.results, realm] );
-
-  const observationIds = useMemo(
-    ( ) => ( data?.results || [] ).map( ( { uuid } ) => ( { uuid } ) ),
-    [data?.results],
-  );
-
   return {
-    observationIds,
+    observationIds: data?.observationIds || [],
     isLoading,
     error,
-    totalResults: data?.total_results,
+    totalResults: data?.totalResults,
     refetch,
   };
 };

--- a/src/components/MyObservations/hooks/useServerOrderedObservations.ts
+++ b/src/components/MyObservations/hooks/useServerOrderedObservations.ts
@@ -1,0 +1,78 @@
+import { searchObservations } from "api/observations";
+import { useMemo } from "react";
+import Observation from "realmModels/Observation";
+import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
+import { observationSortToApiParams } from "sharedHelpers/observationsSort";
+import { useAuthenticatedQuery, useCurrentUser } from "sharedHooks";
+
+const PER_PAGE = 20;
+
+interface SearchObservationsResult {
+  uuid: string;
+  [key: string]: unknown;
+}
+
+interface SearchObservationsResponse {
+  results: SearchObservationsResult[];
+  total_results: number;
+}
+
+interface UseServerOrderedObservationsParams {
+  sortBy: OBSERVATIONS_SORT;
+  page?: number;
+  enabled?: boolean;
+}
+
+interface UseServerOrderedObservationsResult {
+  observationIds: { uuid: string }[];
+  isLoading: boolean;
+  error: Error | null;
+  totalResults?: number;
+  refetch: ( ) => void;
+}
+
+const useServerOrderedObservations = ( {
+  sortBy,
+  page = 1,
+  enabled = true,
+}: UseServerOrderedObservationsParams ): UseServerOrderedObservationsResult => {
+  const currentUser = useCurrentUser( );
+
+  const params = {
+    user_id: currentUser?.id,
+    ...observationSortToApiParams( sortBy ),
+    page,
+    per_page: PER_PAGE,
+    fields: Observation.ADVANCED_MODE_LIST_FIELDS,
+    // Bypass API response caching so newly created/updated observations show up
+    ttl: -1,
+  };
+
+  const queryKey = ["useServerOrderedObservations", params];
+
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+  } = useAuthenticatedQuery<SearchObservationsResponse>(
+    queryKey,
+    optsWithAuth => searchObservations( params, optsWithAuth ),
+    { enabled: enabled && !!currentUser },
+  );
+
+  const observationIds = useMemo(
+    ( ) => ( data?.results || [] ).map( ( { uuid } ) => ( { uuid } ) ),
+    [data?.results],
+  );
+
+  return {
+    observationIds,
+    isLoading,
+    error,
+    totalResults: data?.total_results,
+    refetch,
+  };
+};
+
+export default useServerOrderedObservations;

--- a/tests/unit/components/MyObservations/hooks/useMyObservationsQuery.test.js
+++ b/tests/unit/components/MyObservations/hooks/useMyObservationsQuery.test.js
@@ -1,0 +1,147 @@
+import { renderHook } from "@testing-library/react-native";
+import useMyObservationsQuery from "components/MyObservations/hooks/useMyObservationsQuery";
+import useServerOrderedObservations
+  from "components/MyObservations/hooks/useServerOrderedObservations";
+import { useMyObservations } from "providers/MyObservationsContext";
+import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
+import factory from "tests/factory";
+import setupUniqueRealm from "tests/helpers/uniqueRealm";
+
+jest.mock( "components/MyObservations/hooks/useServerOrderedObservations", ( ) => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+
+jest.mock( "providers/MyObservationsContext", ( ) => ( {
+  __esModule: true,
+  useMyObservations: jest.fn( ),
+} ) );
+
+// UNIQUE REALM SETUP
+const mockRealmIdentifier = __filename;
+const { mockRealmModelsIndex, uniqueRealmBeforeAll, uniqueRealmAfterAll } = setupUniqueRealm(
+  mockRealmIdentifier,
+);
+jest.mock( "realmModels/index", ( ) => mockRealmModelsIndex );
+jest.mock( "providers/contexts", ( ) => {
+  const originalModule = jest.requireActual( "providers/contexts" );
+  return {
+    __esModule: true,
+    ...originalModule,
+    RealmContext: {
+      ...originalModule.RealmContext,
+      useRealm: ( ) => global.mockRealms[mockRealmIdentifier],
+      useQuery: ( { type, query } ) => {
+        const realm = global.mockRealms[mockRealmIdentifier];
+        const results = realm.objects( type );
+        return query
+          ? query( results )
+          : results;
+      },
+    },
+  };
+} );
+beforeAll( uniqueRealmBeforeAll );
+afterAll( uniqueRealmAfterAll );
+// /UNIQUE REALM SETUP
+
+const createObservation = observation => {
+  const realm = global.mockRealms[mockRealmIdentifier];
+  safeRealmWrite( realm, ( ) => {
+    realm.create( "Observation", observation, "modified" );
+  }, "create test observation for useMyObservationsQuery" );
+};
+
+const defaultServerResult = {
+  observationIds: [],
+  isLoading: false,
+  error: null,
+  refetch: jest.fn( ),
+};
+
+beforeEach( ( ) => {
+  // clear leftover state from previous test
+  const realm = global.mockRealms[mockRealmIdentifier];
+  safeRealmWrite( realm, ( ) => {
+    realm.deleteAll( );
+  }, "clear realm before each useMyObservationsQuery test" );
+  useServerOrderedObservations.mockReturnValue( defaultServerResult );
+} );
+
+afterEach( ( ) => {
+  jest.clearAllMocks( );
+} );
+
+describe( "useMyObservationsQuery", ( ) => {
+  it( "uses the local Realm manifest for the default sort, ignoring server results "
+    + "and suppressing server loading/error/refetch since that query is disabled", ( ) => {
+    useMyObservations.mockReturnValue( {
+      state: { observationsSort: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST },
+    } );
+    const serverRefetch = jest.fn( );
+    useServerOrderedObservations.mockReturnValue( {
+      observationIds: [{ uuid: "should-be-ignored-in-default-sort" }],
+      isLoading: true,
+      error: new Error( "should be suppressed for default sort" ),
+      refetch: serverRefetch,
+    } );
+    const localObs = factory( "LocalObservation", { needs_sync: false } );
+    createObservation( localObs );
+
+    const { result } = renderHook( ( ) => useMyObservationsQuery( ) );
+
+    expect( result.current.observationIds ).toEqual( [{ uuid: localObs.uuid }] );
+    expect( result.current.isServerAuthoritative ).toEqual( false );
+    expect( result.current.isLoading ).toEqual( false );
+    expect( result.current.error ).toBeNull( );
+    expect( result.current.refetch ).not.toBe( serverRefetch );
+    expect( useServerOrderedObservations ).toHaveBeenCalledWith(
+      expect.objectContaining( { enabled: false } ),
+    );
+  } );
+
+  it( "prepends unsynced local observations ahead of server results for non-default sort", ( ) => {
+    useMyObservations.mockReturnValue( {
+      state: { observationsSort: OBSERVATIONS_SORT.DATE_OBSERVED_OLDEST },
+    } );
+    const serverObs = { uuid: factory( "LocalObservation" ).uuid };
+    useServerOrderedObservations.mockReturnValue( {
+      ...defaultServerResult,
+      observationIds: [serverObs],
+    } );
+    const unsyncedObs = factory( "LocalObservation", { needs_sync: true } );
+    createObservation( unsyncedObs );
+
+    const { result } = renderHook( ( ) => useMyObservationsQuery( ) );
+
+    expect( result.current.observationIds ).toEqual( [
+      { uuid: unsyncedObs.uuid },
+      serverObs,
+    ] );
+    expect( result.current.isServerAuthoritative ).toEqual( true );
+    expect( useServerOrderedObservations ).toHaveBeenCalledWith(
+      expect.objectContaining( { enabled: true } ),
+    );
+  } );
+
+  it( "dedupes an observation that is both unsynced locally and present in server results", ( ) => {
+    useMyObservations.mockReturnValue( {
+      state: { observationsSort: OBSERVATIONS_SORT.DATE_OBSERVED_OLDEST },
+    } );
+    const unsyncedObs = factory( "LocalObservation", { needs_sync: true } );
+    const otherServerObs = { uuid: factory( "LocalObservation" ).uuid };
+    useServerOrderedObservations.mockReturnValue( {
+      ...defaultServerResult,
+      observationIds: [{ uuid: unsyncedObs.uuid }, otherServerObs],
+    } );
+    createObservation( unsyncedObs );
+
+    const { result } = renderHook( ( ) => useMyObservationsQuery( ) );
+
+    expect( result.current.observationIds ).toEqual( [
+      { uuid: unsyncedObs.uuid },
+      otherServerObs,
+    ] );
+  } );
+} );

--- a/tests/unit/components/MyObservations/hooks/useServerOrderedObservations.test.js
+++ b/tests/unit/components/MyObservations/hooks/useServerOrderedObservations.test.js
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+import useServerOrderedObservations
+  from "components/MyObservations/hooks/useServerOrderedObservations";
+import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
+import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useCurrentUser from "sharedHooks/useCurrentUser";
+import factory from "tests/factory";
+import setupUniqueRealm from "tests/helpers/uniqueRealm";
+
+const mockUser = factory( "LocalUser" );
+
+jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+
+jest.mock( "sharedHooks/useAuthenticatedQuery", ( ) => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+
+// UNIQUE REALM SETUP
+const mockRealmIdentifier = __filename;
+const { mockRealmModelsIndex, uniqueRealmBeforeAll, uniqueRealmAfterAll } = setupUniqueRealm(
+  mockRealmIdentifier,
+);
+jest.mock( "realmModels/index", ( ) => mockRealmModelsIndex );
+jest.mock( "providers/contexts", ( ) => {
+  const originalModule = jest.requireActual( "providers/contexts" );
+  return {
+    __esModule: true,
+    ...originalModule,
+    RealmContext: {
+      ...originalModule.RealmContext,
+      useRealm: ( ) => global.mockRealms[mockRealmIdentifier],
+    },
+  };
+} );
+beforeAll( uniqueRealmBeforeAll );
+afterAll( uniqueRealmAfterAll );
+// /UNIQUE REALM SETUP
+
+const getRealm = ( ) => global.mockRealms[mockRealmIdentifier];
+const getLocalObservation = uuid => getRealm( ).objectForPrimaryKey( "Observation", uuid );
+
+const defaultQueryResult = {
+  data: undefined,
+  isLoading: false,
+  error: null,
+  refetch: jest.fn( ),
+};
+
+beforeEach( ( ) => {
+  useCurrentUser.mockReturnValue( mockUser );
+  useAuthenticatedQuery.mockReturnValue( defaultQueryResult );
+} );
+
+afterEach( ( ) => {
+  jest.clearAllMocks( );
+} );
+
+describe( "useServerOrderedObservations", ( ) => {
+  it( "scopes API params to the current user and bypasses response caching", ( ) => {
+    renderHook( ( ) => useServerOrderedObservations( {
+      sortBy: OBSERVATIONS_SORT.DATE_OBSERVED_OLDEST,
+    } ) );
+
+    const [queryKey] = useAuthenticatedQuery.mock.calls[0];
+    const [, params] = queryKey;
+    expect( params ).toEqual( expect.objectContaining( {
+      user_id: mockUser.id,
+      ttl: -1,
+    } ) );
+  } );
+
+  it( "disables the query when enabled is false or there is no current user", ( ) => {
+    const { rerender } = renderHook(
+      props => useServerOrderedObservations( props ),
+      { initialProps: { sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST, enabled: false } },
+    );
+    expect( useAuthenticatedQuery.mock.calls[0][2].enabled ).toEqual( false );
+
+    useCurrentUser.mockReturnValue( null );
+    rerender( { sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST, enabled: true } );
+    expect( useAuthenticatedQuery.mock.calls[1][2].enabled ).toEqual( false );
+  } );
+
+  it( "maps fetched results to a uuid-only list and passes through query metadata", ( ) => {
+    const mockRefetch = jest.fn( );
+    const remoteObservations = [
+      factory( "RemoteObservation" ),
+      factory( "RemoteObservation" ),
+    ];
+    useAuthenticatedQuery.mockReturnValue( {
+      data: { results: remoteObservations, total_results: 2 },
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } );
+
+    const { result } = renderHook( ( ) => useServerOrderedObservations( {
+      sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
+    } ) );
+
+    expect( result.current.observationIds ).toEqual( [
+      { uuid: remoteObservations[0].uuid },
+      { uuid: remoteObservations[1].uuid },
+    ] );
+    expect( result.current.totalResults ).toEqual( 2 );
+    expect( result.current.refetch ).toEqual( mockRefetch );
+  } );
+
+  it( "upserts newly fetched results into Realm", async ( ) => {
+    const remoteObservation = factory( "RemoteObservation" );
+    useAuthenticatedQuery.mockReturnValue( {
+      data: { results: [remoteObservation], total_results: 1 },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn( ),
+    } );
+
+    renderHook( ( ) => useServerOrderedObservations( {
+      sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
+    } ) );
+
+    await waitFor( ( ) => {
+      const localObs = getLocalObservation( remoteObservation.uuid );
+      expect( localObs ).toBeTruthy( );
+      expect( localObs.id ).toEqual( remoteObservation.id );
+    } );
+  } );
+} );

--- a/tests/unit/components/MyObservations/hooks/useServerOrderedObservations.test.js
+++ b/tests/unit/components/MyObservations/hooks/useServerOrderedObservations.test.js
@@ -1,10 +1,11 @@
-import { renderHook, waitFor } from "@testing-library/react-native";
+import { renderHook } from "@testing-library/react-native";
 import useServerOrderedObservations
   from "components/MyObservations/hooks/useServerOrderedObservations";
+import inatjs from "inaturalistjs";
 import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
 import useCurrentUser from "sharedHooks/useCurrentUser";
-import factory from "tests/factory";
+import factory, { makeResponse } from "tests/factory";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
 
 const mockUser = factory( "LocalUser" );
@@ -85,14 +86,10 @@ describe( "useServerOrderedObservations", ( ) => {
     expect( useAuthenticatedQuery.mock.calls[1][2].enabled ).toEqual( false );
   } );
 
-  it( "maps fetched results to a uuid-only list and passes through query metadata", ( ) => {
+  it( "passes through the query's uuid-only data and metadata as-is", ( ) => {
     const mockRefetch = jest.fn( );
-    const remoteObservations = [
-      factory( "RemoteObservation" ),
-      factory( "RemoteObservation" ),
-    ];
     useAuthenticatedQuery.mockReturnValue( {
-      data: { results: remoteObservations, total_results: 2 },
+      data: { observationIds: [{ uuid: "a" }, { uuid: "b" }], totalResults: 2 },
       isLoading: false,
       error: null,
       refetch: mockRefetch,
@@ -102,31 +99,28 @@ describe( "useServerOrderedObservations", ( ) => {
       sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
     } ) );
 
-    expect( result.current.observationIds ).toEqual( [
-      { uuid: remoteObservations[0].uuid },
-      { uuid: remoteObservations[1].uuid },
-    ] );
+    expect( result.current.observationIds ).toEqual( [{ uuid: "a" }, { uuid: "b" }] );
     expect( result.current.totalResults ).toEqual( 2 );
     expect( result.current.refetch ).toEqual( mockRefetch );
   } );
 
-  it( "upserts newly fetched results into Realm", async ( ) => {
+  it( "queryFn upserts fetched results into Realm and returns a uuid-only list", async ( ) => {
     const remoteObservation = factory( "RemoteObservation" );
-    useAuthenticatedQuery.mockReturnValue( {
-      data: { results: [remoteObservation], total_results: 1 },
-      isLoading: false,
-      error: null,
-      refetch: jest.fn( ),
-    } );
+    inatjs.observations.search.mockResolvedValueOnce( makeResponse( [remoteObservation] ) );
 
     renderHook( ( ) => useServerOrderedObservations( {
       sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
     } ) );
 
-    await waitFor( ( ) => {
-      const localObs = getLocalObservation( remoteObservation.uuid );
-      expect( localObs ).toBeTruthy( );
-      expect( localObs.id ).toEqual( remoteObservation.id );
+    const [, queryFunction] = useAuthenticatedQuery.mock.calls[0];
+    const data = await queryFunction( { api_token: "fake-token" } );
+
+    expect( data ).toEqual( {
+      observationIds: [{ uuid: remoteObservation.uuid }],
+      totalResults: 1,
     } );
+    const localObs = getLocalObservation( remoteObservation.uuid );
+    expect( localObs ).toBeTruthy( );
+    expect( localObs.id ).toEqual( remoteObservation.id );
   } );
 } );


### PR DESCRIPTION
closes [MOB-1461](https://linear.app/inaturalist/issue/MOB-1461/create-hook-for-server-ordered-observations-in-myobs)

Adds the groundwork for sorting MyObs by something other than the current default (and eventually for search & grouped by iconic taxa) in the form of two hooks:

`useServerOrderedObservations` — hook that fetches a page of server-ordered observation uuids for a given sort and upserts the results into Realm. Pagination to be handled in a follow-up.
`useMyObservationsQuery` — wrapper hook that reads the current sort selectionfrom `MyObservationsContext` and picks a data source: the default sort stays fully local so offline experience is preserved, and any other sort uses the aforementioned hook with the locally-unsynced observations merged in and pinned to the top.

Also adds a debug sheet in the flavor or the one we have in ExploreV2, for testing. This new logic isn't wired to anything but that right now; that will happen in [MOB-1479](https://linear.app/inaturalist/issue/MOB-1479/wire-up-observation-sort-in-myobs).