### PR TITLE
Traditional projects: joined projects sync triggers on app startup and chooser screen

### DIFF
--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -1,4 +1,8 @@
 // Generic types, please keep alphabetized
+export interface ApiDefaultResult {
+  id: number;
+}
+
 export interface ApiOpts {
   api_token?: string;
 }

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -41,18 +41,6 @@ const fetchUserMe = async ( params: Object = {}, opts: Object = {} ): Promise<?O
   }
 };
 
-const fetchUserProjects = async ( params: Object = {}, opts: Object = {} ): Promise<?Object> => {
-  try {
-    const response = await inatjs.users.projects(
-      params,
-      opts,
-    );
-    return response;
-  } catch ( e ) {
-    return handleError( e, { context: { functionName: "fetchUserProjects", opts } } );
-  }
-};
-
 const fetchRemoteUser = async (
   id: number | string,
   params: Object = {},
@@ -172,7 +160,6 @@ export {
   fetchRemoteUser,
   fetchUserEmailAvailable,
   fetchUserMe,
-  fetchUserProjects,
   fetchUsers,
   muteUser,
   unblockUser,

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -47,7 +47,7 @@ const fetchUserProjects = async ( params: Object = {}, opts: Object = {} ): Prom
       params,
       opts,
     );
-    return response?.results;
+    return response;
   } catch ( e ) {
     return handleError( e, { context: { functionName: "fetchUserProjects", opts } } );
   }

--- a/src/api/usersTyped.ts
+++ b/src/api/usersTyped.ts
@@ -2,13 +2,15 @@ import inatjs from "inaturalistjs";
 
 import type { ErrorWithResponse, INatApiError } from "./error";
 import handleError from "./error";
-import type { ApiOpts, ApiParams, ApiResponse } from "./types";
+import type {
+  ApiDefaultResult, ApiOpts, ApiParams, ApiResponse,
+} from "./types";
 
 interface UsersProjectsParams extends ApiParams {
   id: number;
 }
 
-const fetchUserProjects = async <T>(
+const fetchUserProjects = async <T = ApiDefaultResult>(
   params: UsersProjectsParams = {},
   opts: ApiOpts = {},
 ): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {

--- a/src/api/usersTyped.ts
+++ b/src/api/usersTyped.ts
@@ -2,8 +2,16 @@ import inatjs from "inaturalistjs";
 
 import type { ErrorWithResponse } from "./error";
 import handleError from "./error";
+import type { ApiParams } from "./types";
 
-const fetchUserProjects = async ( params = {}, opts = {} ): Promise<object> => {
+interface UsersProjectsParams extends ApiParams {
+  id: number;
+}
+
+const fetchUserProjects = async (
+  params: UsersProjectsParams = {},
+  opts = {},
+): Promise<object> => {
   try {
     const response = await inatjs.users.projects(
       params,

--- a/src/api/usersTyped.ts
+++ b/src/api/usersTyped.ts
@@ -2,7 +2,7 @@ import inatjs from "inaturalistjs";
 
 import type { ErrorWithResponse } from "./error";
 import handleError from "./error";
-import type { ApiParams } from "./types";
+import type { ApiOpts, ApiParams } from "./types";
 
 interface UsersProjectsParams extends ApiParams {
   id: number;
@@ -10,7 +10,7 @@ interface UsersProjectsParams extends ApiParams {
 
 const fetchUserProjects = async (
   params: UsersProjectsParams = {},
-  opts = {},
+  opts: ApiOpts = {},
 ): Promise<object> => {
   try {
     const response = await inatjs.users.projects(

--- a/src/api/usersTyped.ts
+++ b/src/api/usersTyped.ts
@@ -1,0 +1,21 @@
+import inatjs from "inaturalistjs";
+
+import type { ErrorWithResponse } from "./error";
+import handleError from "./error";
+
+const fetchUserProjects = async ( params = {}, opts = {} ): Promise<object> => {
+  try {
+    const response = await inatjs.users.projects(
+      params,
+      opts,
+    );
+    return response;
+  } catch ( e ) {
+    return handleError(
+      e as ErrorWithResponse,
+      { context: { functionName: "fetchUserProjects", opts } },
+    );
+  }
+};
+
+export default fetchUserProjects;

--- a/src/api/usersTyped.ts
+++ b/src/api/usersTyped.ts
@@ -11,7 +11,7 @@ interface UsersProjectsParams extends ApiParams {
 }
 
 const fetchUserProjects = async <T = ApiDefaultResult>(
-  params: UsersProjectsParams = {},
+  params: UsersProjectsParams,
   opts: ApiOpts = {},
 ): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {

--- a/src/api/usersTyped.ts
+++ b/src/api/usersTyped.ts
@@ -1,22 +1,20 @@
 import inatjs from "inaturalistjs";
 
-import type { ErrorWithResponse } from "./error";
+import type { ErrorWithResponse, INatApiError } from "./error";
 import handleError from "./error";
-import type { ApiOpts, ApiParams } from "./types";
+import type { ApiOpts, ApiParams, ApiResponse } from "./types";
 
 interface UsersProjectsParams extends ApiParams {
   id: number;
 }
 
-const fetchUserProjects = async (
+const fetchUserProjects = async <T>(
   params: UsersProjectsParams = {},
   opts: ApiOpts = {},
-): Promise<object> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const response = await inatjs.users.projects(
-      params,
-      opts,
-    );
+    const response = await inatjs.users.projects( params, opts );
+    if ( !response ) { return null; }
     return response;
   } catch ( e ) {
     return handleError(

--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -21,6 +21,7 @@ import useStore from "stores/useStore";
 import { getShadow } from "styles/global";
 import colors from "styles/tailwindColors";
 
+import useSyncJoinedProjects from "./hooks/useSyncJoinedProjects";
 import ObservationFieldInput from "./ObservationFieldInput";
 
 const { useQuery } = RealmContext;
@@ -35,6 +36,7 @@ const ItemSeparator = ( ) => <View className="border-b border-lightGray" />;
 const AddToProjects = ( ) => {
   const { t } = useTranslation( );
   const navigation = useNavigation( );
+  useSyncJoinedProjects( );
   const joinedProjectsCollection = useQuery(
     {
       type: Project,

--- a/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
+++ b/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
@@ -11,6 +11,9 @@ const useSyncJoinedProjects = ( ) => {
   const currentUser = useCurrentUser( );
 
   useEffect( ( ) => {
+    if ( !currentUser?.id ) {
+      return;
+    }
     syncJoinedProjects( realm, currentUser?.id );
   }, [currentUser?.id, realm] );
 };

--- a/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
+++ b/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
@@ -1,0 +1,18 @@
+import { RealmContext } from "providers/contexts";
+import { useEffect } from "react";
+import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
+import { useCurrentUser } from "sharedHooks";
+
+const { useRealm } = RealmContext;
+
+const useSyncJoinedProjects = ( ) => {
+  const realm = useRealm( );
+
+  const currentUser = useCurrentUser( );
+
+  useEffect( ( ) => {
+    syncJoinedProjects( realm, currentUser?.id );
+  }, [currentUser?.id, realm] );
+};
+
+export default useSyncJoinedProjects;

--- a/src/components/ProjectDetails/ProjectDetailsContainer.tsx
+++ b/src/components/ProjectDetails/ProjectDetailsContainer.tsx
@@ -108,10 +108,9 @@ const ProjectDetailsContainer = ( ) => {
     ( _, optsWithAuth ) => joinProject( { id }, optsWithAuth ),
     {
       onSuccess: ( ) => {
-        // Persist traditional projects on join
-        if ( project?.project_type === "" ) {
-          Project.upsertRemoteProjects( [project], realm );
-        }
+        // project is not undefined here because we call the mutation in the child
+        // which has a !project check before rendering the buttons that call here
+        Project.upsertRemoteProjects( [project as ApiProject], realm );
         queryClient.invalidateQueries( membershipQueryKey );
       },
       onError: error => {

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
-import type { ApiProjectSummary, ApiProjectSummaryWithPOF } from "api/types";
+import type { ApiProjectSummary, ApiProjectSummaryWithPOF, ApiResponse } from "api/types";
 import { fetchUserProjects } from "api/users";
 import {
   ActivityIndicator,
@@ -49,9 +49,9 @@ const ProjectListContainer = ( ) => {
     ? PROJECT_SUMMARY_POF_FIELDS
     : PROJECT_SUMMARY_FIELDS;
   const {
-    data: userProjects,
+    data,
     isLoading: userProjectsLoading,
-  } = useAuthenticatedQuery<ApiProjectSummary[] | ApiProjectSummaryWithPOF[]>(
+  } = useAuthenticatedQuery<ApiResponse<ApiProjectSummary | ApiProjectSummaryWithPOF>>(
     ["fetchUserProjects", userId, fields],
     optsWithAuth => fetchUserProjects(
       {
@@ -63,6 +63,8 @@ const ProjectListContainer = ( ) => {
     ),
     { enabled: !!userId },
   );
+
+  const { results: userProjects } = data || {};
 
   // Update local copy of the current user's joined projects
   useEffect( () => {

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -52,7 +52,7 @@ const ProjectListContainer = ( ) => {
     ["fetchUserProjects", userId, fields],
     optsWithAuth => fetchUserProjects<ApiProjectSummary | ApiProjectSummaryWithPOF>(
       {
-        id: userId,
+        id: userId as number,
         per_page: 200,
         fields,
       },

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -9,9 +9,7 @@ import {
 import { ScreenShell } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import type { TabStackScreenProps } from "navigation/types";
-import { RealmContext } from "providers/contexts";
 import React, { useEffect, useMemo } from "react";
-import Project from "realmModels/Project";
 import {
   useAuthenticatedQuery,
   useCurrentUser,
@@ -21,10 +19,7 @@ import {
 
 import ProjectList from "./ProjectList";
 
-const { useRealm } = RealmContext;
-
 const ProjectListContainer = ( ) => {
-  const realm = useRealm( );
   const navigation = useNavigation<TabStackScreenProps<"ProjectList">["navigation"]>( );
   const { params } = useRoute<TabStackScreenProps<"ProjectList">["route"]>( );
   const { observationUuid, userId, userLogin } = params;
@@ -62,13 +57,6 @@ const ProjectListContainer = ( ) => {
   );
 
   const { results: userProjects } = data || {};
-
-  // Update local copy of the current user's joined projects
-  useEffect( () => {
-    if ( isCurrentUser ) {
-      Project.upsertRemoteProjects( userProjects as ApiProjectSummaryWithPOF[], realm );
-    }
-  }, [isCurrentUser, userProjects, realm] );
 
   const headerOptions = useMemo( ( ) => {
     if ( observationUuid ) {

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,7 +1,7 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
-import type { ApiProjectSummary, ApiProjectSummaryWithPOF, ApiResponse } from "api/types";
-import { fetchUserProjects } from "api/users";
+import type { ApiProjectSummary, ApiProjectSummaryWithPOF } from "api/types";
+import fetchUserProjects from "api/usersTyped";
 import {
   ActivityIndicator,
   Body1,
@@ -48,12 +48,9 @@ const ProjectListContainer = ( ) => {
   const fields = isCurrentUser
     ? PROJECT_SUMMARY_POF_FIELDS
     : PROJECT_SUMMARY_FIELDS;
-  const {
-    data,
-    isLoading: userProjectsLoading,
-  } = useAuthenticatedQuery<ApiResponse<ApiProjectSummary | ApiProjectSummaryWithPOF>>(
+  const { data, isLoading: userProjectsLoading } = useAuthenticatedQuery(
     ["fetchUserProjects", userId, fields],
-    optsWithAuth => fetchUserProjects(
+    optsWithAuth => fetchUserProjects<ApiProjectSummary | ApiProjectSummaryWithPOF>(
       {
         id: userId,
         per_page: 200,

--- a/src/components/ProjectList/ProjectListContainer.tsx
+++ b/src/components/ProjectList/ProjectListContainer.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { PROJECT_SUMMARY_FIELDS, PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
+import { PROJECT_SUMMARY_FIELDS } from "api/fields";
 import type { ApiProjectSummary, ApiProjectSummaryWithPOF } from "api/types";
 import fetchUserProjects from "api/usersTyped";
 import {
@@ -12,7 +12,6 @@ import type { TabStackScreenProps } from "navigation/types";
 import React, { useEffect, useMemo } from "react";
 import {
   useAuthenticatedQuery,
-  useCurrentUser,
   useRemoteObservation,
   useTranslation,
 } from "sharedHooks";
@@ -24,7 +23,6 @@ const ProjectListContainer = ( ) => {
   const { params } = useRoute<TabStackScreenProps<"ProjectList">["route"]>( );
   const { observationUuid, userId, userLogin } = params;
   const { t } = useTranslation( );
-  const currentUser = useCurrentUser( );
 
   const { remoteObservation } = useRemoteObservation(
     observationUuid,
@@ -39,17 +37,13 @@ const ProjectListContainer = ( ) => {
   ) || [];
   const observationProjects = traditionalProjects.concat( nonTraditionalProjects );
 
-  const isCurrentUser = userId === currentUser?.id;
-  const fields = isCurrentUser
-    ? PROJECT_SUMMARY_POF_FIELDS
-    : PROJECT_SUMMARY_FIELDS;
   const { data, isLoading: userProjectsLoading } = useAuthenticatedQuery(
-    ["fetchUserProjects", userId, fields],
+    ["fetchUserProjects", userId],
     optsWithAuth => fetchUserProjects<ApiProjectSummary | ApiProjectSummaryWithPOF>(
       {
         id: userId as number,
         per_page: 200,
-        fields,
+        fields: PROJECT_SUMMARY_FIELDS,
       },
       optsWithAuth,
     ),

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -110,7 +110,7 @@ const useDeferredStartup = ( ) => {
       return Promise.resolve();
     } );
     const id11 = deferTask( "syncJoinedProjects", async () => {
-      const currentUserId = User.currentUser( realm ).id;
+      const currentUserId = User.currentUser( realm )?.id;
       await syncJoinedProjects( realm, currentUserId );
     }, 30000 );
 

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -111,6 +111,9 @@ const useDeferredStartup = ( ) => {
     } );
     const id11 = deferTask( "syncJoinedProjects", async () => {
       const currentUserId = User.currentUser( realm )?.id;
+      if ( !currentUserId ) {
+        return;
+      }
       await syncJoinedProjects( realm, currentUserId );
     }, 30000 );
 

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -12,6 +12,7 @@
 import { cleanupLogFiles } from "components/Developer/logManagementHelpers";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
+import User from "realmModels/User";
 import {
   clearComputerVisionPhotos,
   clearGalleryPhotos,
@@ -23,6 +24,7 @@ import { formatApiDatetime } from "sharedHelpers/dateAndTime";
 import { log } from "sharedHelpers/logger";
 import { logSentinelFiles } from "sharedHelpers/sentinelFiles";
 import getStorageMetrics from "sharedHelpers/storageMetrics";
+import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
 import { useTranslation } from "sharedHooks";
 import { zustandStorage } from "stores/useStore";
 
@@ -107,6 +109,10 @@ const useDeferredStartup = ( ) => {
       formatApiDatetime( "1970", i18n, { timeZone: "Etc/UTC" } );
       return Promise.resolve();
     } );
+    const id11 = deferTask( "syncJoinedProjects", async () => {
+      const currentUserId = User.currentUser( realm ).id;
+      await syncJoinedProjects( realm, currentUserId );
+    }, 30000 );
 
     return ( ) => {
       cancelIdleCallback( id1 );
@@ -119,6 +125,7 @@ const useDeferredStartup = ( ) => {
       cancelIdleCallback( id8 );
       cancelIdleCallback( id9 );
       cancelIdleCallback( id10 );
+      cancelIdleCallback( id11 );
     };
   }, [i18n, realm] );
 };

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -5,6 +5,21 @@ import { getJWT } from "components/LoginSignUp/AuthenticationService";
 import type Realm from "realm";
 import Project from "realmModels/Project";
 
+import safeRealmWrite from "./safeRealmWrite";
+
+const deleteRemotelyDeletedObservations = ( deletedObservations, realm ) => {
+  if ( !deletedObservations ) { return; }
+  if ( deletedObservations?.length > 0 ) {
+    safeRealmWrite( realm, ( ) => {
+      const localObservationsToDelete = realm.objects( "Observation" )
+        .filtered( `id IN { ${deletedObservations} }` );
+      localObservationsToDelete.forEach( observation => {
+        realm.delete( observation );
+      } );
+    }, "removing remotely deleted observations from realm" );
+  }
+};
+
 async function syncJoinedProjects(
   realm: Realm,
   currentUserId: number | undefined,
@@ -32,6 +47,9 @@ async function syncJoinedProjects(
 
   // Update local copy of the current user's joined projects
   Project.upsertRemoteProjects( response.results, realm );
+
+  // Remove projects that are present locally but no longer in server response
+  console.log( "deleteRemotelyDeletedObservations", deleteRemotelyDeletedObservations );
 }
 
 export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -12,7 +12,7 @@ const deleteNotRemoteProjects = ( remoteProjects: { id: number }[], realm: Realm
   if ( remoteProjects?.length > 0 ) {
     safeRealmWrite( realm, ( ) => {
       const localObservationsToDelete = realm.objects( "Observation" )
-        .filtered( `id IN { ${remoteProjects} }` );
+        .filtered( `NOT (id IN { ${remoteProjects} })` );
       localObservationsToDelete.forEach( observation => {
         realm.delete( observation );
       } );

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -1,0 +1,14 @@
+import type Realm from "realm";
+
+async function syncJoinedProjects(
+  realm: Realm,
+  currentUserId: number | undefined,
+): Promise<void> {
+  if ( !currentUserId ) {
+    return;
+  }
+
+  console.log( "realm", realm );
+}
+
+export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -1,3 +1,7 @@
+import { PROJECT_SUMMARY_POF_FIELDS } from "api/fields";
+import type { ApiProjectSummaryWithPOF } from "api/types";
+import fetchUserProjects from "api/usersTyped";
+import { getJWT } from "components/LoginSignUp/AuthenticationService";
 import type Realm from "realm";
 
 async function syncJoinedProjects(
@@ -8,6 +12,20 @@ async function syncJoinedProjects(
     return;
   }
 
+  const params = {
+    id: currentUserId,
+    per_page: 200,
+    fields: PROJECT_SUMMARY_POF_FIELDS,
+    ttl: -1,
+  };
+
+  const apiToken = await getJWT( );
+  const response = await fetchUserProjects<ApiProjectSummaryWithPOF>(
+    params,
+    { api_token: apiToken },
+  );
+
+  console.log( "response", response );
   console.log( "realm", realm );
 }
 

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -27,6 +27,11 @@ async function syncJoinedProjects(
 
   console.log( "response", response );
   console.log( "realm", realm );
+
+  // Update local copy of the current user's joined projects
+  //   if ( isCurrentUser ) {
+  //     Project.upsertRemoteProjects( userProjects as ApiProjectSummaryWithPOF[], realm );
+  //   }
 }
 
 export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -7,12 +7,12 @@ import Project from "realmModels/Project";
 
 import safeRealmWrite from "./safeRealmWrite";
 
-const deleteRemotelyDeletedObservations = ( deletedObservations, realm ) => {
-  if ( !deletedObservations ) { return; }
-  if ( deletedObservations?.length > 0 ) {
+const deleteNotRemoteProjects = ( remoteProjects: { id: number }[], realm: Realm ) => {
+  if ( !remoteProjects ) { return; }
+  if ( remoteProjects?.length > 0 ) {
     safeRealmWrite( realm, ( ) => {
       const localObservationsToDelete = realm.objects( "Observation" )
-        .filtered( `id IN { ${deletedObservations} }` );
+        .filtered( `id IN { ${remoteProjects} }` );
       localObservationsToDelete.forEach( observation => {
         realm.delete( observation );
       } );
@@ -49,7 +49,7 @@ async function syncJoinedProjects(
   Project.upsertRemoteProjects( response.results, realm );
 
   // Remove projects that are present locally but no longer in server response
-  console.log( "deleteRemotelyDeletedObservations", deleteRemotelyDeletedObservations );
+  console.log( "deleteNotRemoteProjects", deleteNotRemoteProjects );
 }
 
 export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -7,7 +7,7 @@ import Project from "realmModels/Project";
 
 import safeRealmWrite from "./safeRealmWrite";
 
-const deleteNotRemoteProjects = ( remoteProjects: { id: number }[], realm: Realm ) => {
+const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }
   if ( remoteProjects?.length > 0 ) {
     safeRealmWrite( realm, ( ) => {
@@ -49,7 +49,8 @@ async function syncJoinedProjects(
   Project.upsertRemoteProjects( response.results, realm );
 
   // Remove projects that are present locally but no longer in server response
-  console.log( "deleteNotRemoteProjects", deleteNotRemoteProjects );
+  const remoteProjectsId = response.results.map( p => p.id );
+  deleteNotRemoteProjects( remoteProjectsId, realm );
 }
 
 export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -9,15 +9,15 @@ import safeRealmWrite from "./safeRealmWrite";
 
 const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }
-  if ( remoteProjects?.length > 0 ) {
-    safeRealmWrite( realm, ( ) => {
-      const localProjectsToDelete = realm.objects( "Project" )
+  safeRealmWrite( realm, ( ) => {
+    const localProjectsToDelete = remoteProjects.length === 0
+      ? realm.objects( "Project" )
+      : realm.objects( "Project" )
         .filtered( `NOT (id IN { ${remoteProjects} })` );
-      localProjectsToDelete.forEach( project => {
-        realm.delete( project );
-      } );
-    }, "removing projects from realm that are not remote" );
-  }
+    localProjectsToDelete.forEach( project => {
+      realm.delete( project );
+    } );
+  }, "removing projects from realm that are not remote" );
 };
 
 async function syncJoinedProjects(

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -11,12 +11,12 @@ const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }
   if ( remoteProjects?.length > 0 ) {
     safeRealmWrite( realm, ( ) => {
-      const localObservationsToDelete = realm.objects( "Observation" )
+      const localProjectsToDelete = realm.objects( "Project" )
         .filtered( `NOT (id IN { ${remoteProjects} })` );
-      localObservationsToDelete.forEach( observation => {
-        realm.delete( observation );
+      localProjectsToDelete.forEach( project => {
+        realm.delete( project );
       } );
-    }, "removing remotely deleted observations from realm" );
+    }, "removing projects from realm that are not remote" );
   }
 };
 

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -22,12 +22,8 @@ const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
 
 async function syncJoinedProjects(
   realm: Realm,
-  currentUserId: number | undefined,
+  currentUserId: number,
 ): Promise<void> {
-  if ( !currentUserId ) {
-    return;
-  }
-
   const params = {
     id: currentUserId,
     per_page: 200,

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -3,6 +3,7 @@ import type { ApiProjectSummaryWithPOF } from "api/types";
 import fetchUserProjects from "api/usersTyped";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
 import type Realm from "realm";
+import Project from "realmModels/Project";
 
 async function syncJoinedProjects(
   realm: Realm,
@@ -25,13 +26,12 @@ async function syncJoinedProjects(
     { api_token: apiToken },
   );
 
-  console.log( "response", response );
-  console.log( "realm", realm );
+  if ( response === null || !response.results ) {
+    return;
+  }
 
   // Update local copy of the current user's joined projects
-  //   if ( isCurrentUser ) {
-  //     Project.upsertRemoteProjects( userProjects as ApiProjectSummaryWithPOF[], realm );
-  //   }
+  Project.upsertRemoteProjects( response.results, realm );
 }
 
 export default syncJoinedProjects;

--- a/tests/unit/components/SharedComponents/ProjectList/ProjectListContainer.test.js
+++ b/tests/unit/components/SharedComponents/ProjectList/ProjectListContainer.test.js
@@ -76,7 +76,14 @@ describe( "ProjectListContainer", () => {
           userId: mockUserId,
         },
       } ) );
-      mockUseAuthenticatedQuery.mockReturnValue( { data: mockProjects } );
+      mockUseAuthenticatedQuery.mockReturnValue( {
+        data: {
+          results: mockProjects,
+          total_results: mockProjects.length,
+          page: 1,
+          per_page: 200,
+        },
+      } );
     } );
 
     it( "should display a list with all project titles from user projects", async () => {

--- a/tests/unit/components/SharedComponents/ProjectList/ProjectListContainer.test.js
+++ b/tests/unit/components/SharedComponents/ProjectList/ProjectListContainer.test.js
@@ -1,6 +1,5 @@
 import { useRoute } from "@react-navigation/native";
 import { render, screen } from "@testing-library/react-native";
-import { PROJECT_SUMMARY_FIELDS } from "api/fields";
 import ProjectListContainer from "components/ProjectList/ProjectListContainer";
 import React from "react";
 import factory from "tests/factory";
@@ -97,7 +96,7 @@ describe( "ProjectListContainer", () => {
     it( "should call useAuthenticatedQuery with the correct query key", ( ) => {
       render( <ProjectListContainer /> );
       expect( mockUseAuthenticatedQuery ).toHaveBeenCalledWith(
-        ["fetchUserProjects", mockUserId, PROJECT_SUMMARY_FIELDS],
+        ["fetchUserProjects", mockUserId],
         expect.any( Function ),
         expect.objectContaining( { enabled: true } ),
       );

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -1,4 +1,5 @@
 import fetchUserProjects from "api/usersTyped";
+import Project from "realmModels/Project";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
 import factory from "tests/factory";
@@ -39,6 +40,26 @@ describe( "syncJoinedProjects", ( ) => {
 
     expect( fetchUserProjects ).toHaveBeenCalled();
     expect( global.realm.objects( "Project" ) ).toHaveLength( 2 );
+  } );
+
+  it( "prunes stale joined projects after a successful sync", async () => {
+    // Local
+    const staleProject = factory( "RemoteProject", { id: 9999 } );
+    Project.upsertRemoteProjects( [staleProject], global.realm );
+    // API
+    const freshProject = factory( "RemoteProject", { id: 1 } );
+    fetchUserProjects.mockResolvedValue(
+      makeUserProjectsResponse( [freshProject] ),
+    );
+
+    await syncJoinedProjects( global.realm, currentUserId );
+
+    expect(
+      global.realm.objectForPrimaryKey( "Project", staleProject.id ),
+    ).toBeNull();
+    expect(
+      global.realm.objectForPrimaryKey( "Project", freshProject.id ),
+    ).not.toBeNull();
   } );
 
   it( "no-ops when currentUserId is missing", async () => {

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -1,0 +1,15 @@
+import fetchUserProjects from "api/usersTyped";
+import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
+
+jest.mock( "api/usersTyped", () => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+
+describe( "syncJoinedProjects", ( ) => {
+  it( "no-ops when currentUserId is missing", async () => {
+    await syncJoinedProjects( global.realm, undefined );
+
+    expect( fetchUserProjects ).not.toHaveBeenCalled( );
+  } );
+} );

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -87,10 +87,4 @@ describe( "syncJoinedProjects", ( ) => {
       global.realm.objectForPrimaryKey( "Project", staleProject.id ),
     ).not.toBeNull();
   } );
-
-  it( "no-ops when currentUserId is missing", async () => {
-    await syncJoinedProjects( global.realm, undefined );
-
-    expect( fetchUserProjects ).not.toHaveBeenCalled( );
-  } );
 } );

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -16,6 +16,10 @@ const makeUserProjectsResponse = results => ( {
   total_results: results.length,
 } );
 
+beforeEach( ( ) => {
+  jest.clearAllMocks( );
+} );
+
 describe( "syncJoinedProjects", ( ) => {
   it( "fetches joined projects", async () => {
     const remoteProjects = [

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -1,12 +1,37 @@
 import fetchUserProjects from "api/usersTyped";
 import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
+import factory from "tests/factory";
 
 jest.mock( "api/usersTyped", () => ( {
   __esModule: true,
   default: jest.fn( ),
 } ) );
 
+const currentUserId = 42;
+
+const makeUserProjectsResponse = results => ( {
+  results,
+  page: 1,
+  per_page: 200,
+  total_results: results.length,
+} );
+
 describe( "syncJoinedProjects", ( ) => {
+  it( "fetches joined projects", async () => {
+    const remoteProjects = [
+      factory( "RemoteProject", { id: 1 } ),
+      factory( "RemoteProject", { id: 2 } ),
+    ];
+
+    fetchUserProjects.mockResolvedValue(
+      makeUserProjectsResponse( remoteProjects ),
+    );
+
+    await syncJoinedProjects( global.realm, currentUserId );
+
+    expect( fetchUserProjects ).toHaveBeenCalled();
+  } );
+
   it( "no-ops when currentUserId is missing", async () => {
     await syncJoinedProjects( global.realm, undefined );
 

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -62,6 +62,20 @@ describe( "syncJoinedProjects", ( ) => {
     ).not.toBeNull();
   } );
 
+  it( "does not prune when the fetch returns null", async () => {
+    // Local
+    const staleProject = factory( "RemoteProject", { id: 9999 } );
+    Project.upsertRemoteProjects( [staleProject], global.realm );
+    // API
+    fetchUserProjects.mockResolvedValue( null );
+
+    await syncJoinedProjects( global.realm, currentUserId );
+
+    expect(
+      global.realm.objectForPrimaryKey( "Project", staleProject.id ),
+    ).not.toBeNull();
+  } );
+
   it( "no-ops when currentUserId is missing", async () => {
     await syncJoinedProjects( global.realm, undefined );
 

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -1,4 +1,5 @@
 import fetchUserProjects from "api/usersTyped";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
 import factory from "tests/factory";
 
@@ -18,10 +19,13 @@ const makeUserProjectsResponse = results => ( {
 
 beforeEach( ( ) => {
   jest.clearAllMocks( );
+  safeRealmWrite( global.realm, ( ) => {
+    global.realm.delete( global.realm.objects( "Project" ) );
+  }, "resetting projects in syncJoinedProjects test" );
 } );
 
 describe( "syncJoinedProjects", ( ) => {
-  it( "fetches joined projects", async () => {
+  it( "fetches joined projects and upserts them into Realm", async () => {
     const remoteProjects = [
       factory( "RemoteProject", { id: 1 } ),
       factory( "RemoteProject", { id: 2 } ),
@@ -34,6 +38,7 @@ describe( "syncJoinedProjects", ( ) => {
     await syncJoinedProjects( global.realm, currentUserId );
 
     expect( fetchUserProjects ).toHaveBeenCalled();
+    expect( global.realm.objects( "Project" ) ).toHaveLength( 2 );
   } );
 
   it( "no-ops when currentUserId is missing", async () => {

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -62,6 +62,18 @@ describe( "syncJoinedProjects", ( ) => {
     ).not.toBeNull();
   } );
 
+  it( "prunes all local joined projects when the server returns an empty list", async () => {
+    // Local
+    const staleProject = factory( "RemoteProject", { id: 9999 } );
+    Project.upsertRemoteProjects( [staleProject], global.realm );
+    // API
+    fetchUserProjects.mockResolvedValue( makeUserProjectsResponse( [] ) );
+
+    await syncJoinedProjects( global.realm, currentUserId );
+
+    expect( global.realm.objects( "Project" ) ).toHaveLength( 0 );
+  } );
+
   it( "does not prune when the fetch returns null", async () => {
     // Local
     const staleProject = factory( "RemoteProject", { id: 9999 } );


### PR DESCRIPTION
Closes MOB-1535

Caches joined projects in Realm on app start (deferred task) and when opening the AddToProject screen. Adds syncJoinedProjects helper (fetch, upsert, prune stale + empty list).

Originally the ticket also laid out to paginate through all possible multiple pages of a users joined projects. But I pushed the remaining pagination/online-guard work to a new ticket MOB-1568. Because I wanted to get a review on the following already:

Took the one API call I am using here out into a new file to type: `fetchUserProjects`. In `usersTyped` there is now one API with a typed full api response (not only returning results). I have added the possibility to specify with a generic type what the results array entails. For me this would be my blueprint forward for such a wrapper. So, I'd be happy to get some eyes on it.
Some open questions:
How can I make it clearer that as soon as you add a fields param to opts the returned results shape will differ? I did add a default api result type which I want to be using as the result when there is no fields param set.
I had to add the two possible error return because `handleError` does return these two types in some code paths. Two codepaths are only optional and I am not using the option here. One code path depends on the error thrown by the API, so potentially possible. I could "typecast" the return of handleError as `never` to get rid of the error types. Or I could add handling around if these types are the return in the caller of this wrapper. Neither seems quite as ideal to me. Any other ideas?
