### PR TITLE
Mob 1479 wire up observation sort in myobs UI only

### DIFF
--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -20,6 +20,7 @@ import { Alert } from "react-native";
 import Observation from "realmModels/Observation";
 import Taxon from "realmModels/Taxon";
 import type { RealmObservation } from "realmModels/types";
+import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 import type { SPECIES_SORT } from "sharedHelpers/speciesSort";
 import {
   sortSpeciesCounts,
@@ -131,6 +132,13 @@ const MyObservationsResults = ( ) => {
     myObsDispatch( {
       type: MY_OBSERVATIONS_ACTION.SET_SPECIES_SORT,
       speciesSort: value,
+    } );
+  };
+
+  const setObservationsSortOptionId = ( value: OBSERVATIONS_SORT ) => {
+    myObsDispatch( {
+      type: MY_OBSERVATIONS_ACTION.SET_OBSERVATIONS_SORT,
+      observationsSort: value,
     } );
   };
 
@@ -446,12 +454,14 @@ const MyObservationsResults = ( ) => {
         numUnuploadedObservations={numUnuploadedObservations}
         numObsMissingBasics={numObsMissingBasics}
         observationIds={observationIds}
+        observationsSortOptionId={myObsState.observationsSort}
         onEndReached={fetchNextPage}
         onListLayout={restoreScrollOffset}
         onScroll={onScroll}
         openSheet={openSheet}
         refetchTaxa={refetchTaxa}
         setActiveTab={setActiveTab}
+        setObservationsSortOptionId={setObservationsSortOptionId}
         setOpenSheet={setOpenSheet}
         setSpeciesSortOptionId={setSpeciesSortOptionId}
         showNoResults={showNoResults}

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -137,6 +137,9 @@ const MyObservationsSimple = ( {
   const searchMyObservationsEnabled = useFeatureFlag(
     FeatureFlag.SearchMyObservationsEnabled,
   );
+  const sortMyObservationsEnabled = useFeatureFlag(
+    FeatureFlag.SortMyObservationsEnabled,
+  );
   const speciesSortLabels = useSpeciesSortLabels( );
   const navigation = useNavigation( );
   const route = useRoute( );
@@ -396,10 +399,12 @@ const MyObservationsSimple = ( {
               layout={layout}
               updateObservationsView={toggleLayout}
             />
-            {/* <SortButton
-              onPress={() => setOpenSheet( ACTIVE_SHEET.SORT )}
-              accessibilityLabel={t( "Change-observations-sort-order" )}
-            /> */}
+            {sortMyObservationsEnabled && (
+              <SortButton
+                onPress={() => setOpenSheet( ACTIVE_SHEET.SORT )}
+                accessibilityLabel={t( "Change-observations-sort-order" )}
+              />
+            )}
           </>
         ) }
         { ( activeTab === TAXA_TAB && taxa.length > 0 ) && (

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -28,6 +28,11 @@ import type {
   RealmObservation,
   RealmUser,
 } from "realmModels/types";
+import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
+import {
+  OBSERVATIONS_SORT_OPTIONS,
+  useObservationsSortLabels,
+} from "sharedHelpers/observationsSort";
 import type { SPECIES_SORT } from "sharedHelpers/speciesSort";
 import {
   MY_OBSERVATIONS_SPECIES_SORT_OPTIONS,
@@ -65,11 +70,13 @@ interface Props {
   numUnuploadedObservations: number;
   numObsMissingBasics: number;
   observationIds: { uuid: string }[];
+  observationsSortOptionId: OBSERVATIONS_SORT;
   onEndReached: ( ) => void;
   onListLayout?: ( ) => void;
   onScroll?: ( ) => void;
   openSheet: ACTIVE_SHEET;
   setActiveTab: ( newTab: string ) => void;
+  setObservationsSortOptionId: ( value: OBSERVATIONS_SORT ) => void;
   setOpenSheet: ( value: ACTIVE_SHEET ) => void;
   setSpeciesSortOptionId: ( value: SPECIES_SORT ) => void;
   showNoResults: boolean;
@@ -95,6 +102,12 @@ interface TaxaSortOption {
   value: SPECIES_SORT;
 }
 
+interface ObservationsSortOption {
+  label: string;
+  text?: string;
+  value: OBSERVATIONS_SORT;
+}
+
 export const OBSERVATIONS_TAB = "observations";
 export const TAXA_TAB = "taxa";
 
@@ -115,11 +128,13 @@ const MyObservationsSimple = ( {
   numUnuploadedObservations,
   numObsMissingBasics: numUnuploadedObsMissingBasics,
   observationIds,
+  observationsSortOptionId,
   onEndReached,
   onListLayout,
   onScroll,
   openSheet,
   setActiveTab,
+  setObservationsSortOptionId,
   setOpenSheet,
   setSpeciesSortOptionId,
   showNoResults,
@@ -141,6 +156,7 @@ const MyObservationsSimple = ( {
     FeatureFlag.SortMyObservationsEnabled,
   );
   const speciesSortLabels = useSpeciesSortLabels( );
+  const observationsSortLabels = useObservationsSortLabels( );
   const navigation = useNavigation( );
   const route = useRoute( );
   const {
@@ -164,6 +180,19 @@ const MyObservationsSimple = ( {
       return acc;
     },
     {} as Record<SPECIES_SORT, TaxaSortOption>,
+  );
+
+  const observationsSortOptions = OBSERVATIONS_SORT_OPTIONS.reduce(
+    ( acc, sortBy ) => {
+      const { label, text } = observationsSortLabels[sortBy];
+      acc[sortBy] = {
+        label,
+        text,
+        value: sortBy,
+      };
+      return acc;
+    },
+    {} as Record<OBSERVATIONS_SORT, ObservationsSortOption>,
   );
 
   const renderTaxaItem = useCallback( ( { item: speciesCount }: TaxaFlashListRenderItemProps ) => {
@@ -306,7 +335,7 @@ const MyObservationsSimple = ( {
     Alert.alert( t( "You-are-offline" ), t( "Please-try-again-when-you-are-online" ) );
   }
 
-  const handleSortConfirm = ( optionId: SPECIES_SORT ) => {
+  const handleSpeciesSortConfirm = ( optionId: SPECIES_SORT ) => {
     if ( currentUser && !isConnected ) {
       showOfflineAlert( );
       return;
@@ -320,6 +349,16 @@ const MyObservationsSimple = ( {
         taxaListRef.current.scrollToOffset( { offset: 0, animated: true } );
       }
     }, 0 );
+
+    setOpenSheet( ACTIVE_SHEET.NONE );
+  };
+
+  const handleObservationsSortConfirm = ( optionId: OBSERVATIONS_SORT ) => {
+    if ( currentUser && !isConnected ) {
+      showOfflineAlert( );
+      return;
+    }
+    setObservationsSortOptionId( optionId );
 
     setOpenSheet( ACTIVE_SHEET.NONE );
   };
@@ -439,12 +478,21 @@ const MyObservationsSimple = ( {
         )}
         { ( activeTab === TAXA_TAB && taxa.length === 0 ) && renderOfflineNotice( )}
       </ViewWrapper>
-      {openSheet === ACTIVE_SHEET.SORT && (
+      {openSheet === ACTIVE_SHEET.SORT && activeTab === OBSERVATIONS_TAB && (
+        <RadioButtonSheet
+          headerText={t( "SORT-OBSERVATIONS" )}
+          radioValues={observationsSortOptions}
+          selectedValue={observationsSortOptionId}
+          confirm={optionId => handleObservationsSortConfirm( optionId as OBSERVATIONS_SORT )}
+          onPressClose={() => setOpenSheet( ACTIVE_SHEET.NONE )}
+        />
+      )}
+      {openSheet === ACTIVE_SHEET.SORT && activeTab === TAXA_TAB && (
         <RadioButtonSheet
           headerText={t( "SORT-SPECIES" )}
           radioValues={taxaSortOptions}
           selectedValue={speciesSortOptionId}
-          confirm={optionId => handleSortConfirm( optionId as SPECIES_SORT )}
+          confirm={optionId => handleSpeciesSortConfirm( optionId as SPECIES_SORT )}
           onPressClose={() => setOpenSheet( ACTIVE_SHEET.NONE )}
         />
       )}

--- a/src/sharedHooks/useRozenite.tsx
+++ b/src/sharedHooks/useRozenite.tsx
@@ -75,6 +75,10 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
     resolvedValue: searchMyObservationsEnabled,
     setOverride: setSearchMyObservationsEnabled,
   } = useFeatureFlagForDebug( FeatureFlag.SearchMyObservationsEnabled );
+  const {
+    resolvedValue: sortMyObservationsEnabled,
+    setOverride: setSortMyObservationsEnabled,
+  } = useFeatureFlagForDebug( FeatureFlag.SortMyObservationsEnabled );
 
   const sections = useMemo(
     () => [
@@ -135,6 +139,15 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
               setSearchMyObservationsEnabled( !searchMyObservationsEnabled );
             },
           },
+          {
+            id: "sort-my-observations",
+            type: "toggle",
+            title: "Sort My Observations",
+            value: sortMyObservationsEnabled,
+            onUpdate: () => {
+              setSortMyObservationsEnabled( !sortMyObservationsEnabled );
+            },
+          },
         ],
       } ),
     ],
@@ -147,6 +160,8 @@ const useRozenite = ( { queryClient, storageAdapters }: RozeniteOptions ) => {
       setTraditionalProjectsEnabled,
       searchMyObservationsEnabled,
       setSearchMyObservationsEnabled,
+      sortMyObservationsEnabled,
+      setSortMyObservationsEnabled,
     ],
   );
 

--- a/src/stores/createFeatureFlagSlice.ts
+++ b/src/stores/createFeatureFlagSlice.ts
@@ -24,6 +24,7 @@ export enum FeatureFlag {
   NewsEnabled = "newsEnabled",
   TraditionalProjectsEnabled = "traditionalProjectsEnabled",
   SearchMyObservationsEnabled = "searchMyObservationsEnabled",
+  SortMyObservationsEnabled = "sortMyObservationsEnabled",
 }
 
 const initialFeatureFlagConfig: Record<FeatureFlag, boolean> = {
@@ -32,6 +33,7 @@ const initialFeatureFlagConfig: Record<FeatureFlag, boolean> = {
   [FeatureFlag.NewsEnabled]: false,
   [FeatureFlag.TraditionalProjectsEnabled]: false,
   [FeatureFlag.SearchMyObservationsEnabled]: false,
+  [FeatureFlag.SortMyObservationsEnabled]: false,
 };
 
 const initialFeatureFlagDebugOverrides: Record<FeatureFlag, boolean | null> = {
@@ -40,6 +42,7 @@ const initialFeatureFlagDebugOverrides: Record<FeatureFlag, boolean | null> = {
   [FeatureFlag.NewsEnabled]: null,
   [FeatureFlag.TraditionalProjectsEnabled]: null,
   [FeatureFlag.SearchMyObservationsEnabled]: null,
+  [FeatureFlag.SortMyObservationsEnabled]: null,
 };
 
 const DEFAULT_STATE = {


### PR DESCRIPTION
Partial [MOB-1479](https://linear.app/inaturalist/issue/MOB-1479/wire-up-observation-sort-in-myobs)

I decided to put this behind a separate feature flag from search, since there's a strong possibility that sort is ready first and I don't want to keep touching/changing the feature flag names to keep them properly descriptive. I think it will be nice to have the option to test and ship them independently. 