### PR TITLE
Mob 1565 pagination for server ordered observations

### DIFF
--- a/src/components/MyObservations/MyObsServerOrderedDebugSheet.tsx
+++ b/src/components/MyObservations/MyObsServerOrderedDebugSheet.tsx
@@ -101,8 +101,10 @@ const DebugSheetContent = ( { onClose }: DebugSheetContentProps ) => {
     observationIds,
     isServerAuthoritative,
     isLoading,
+    isFetchingNextPage,
     error,
     refetch,
+    fetchNextPage,
   } = useMyObservationsQuery( );
 
   return (
@@ -147,6 +149,14 @@ const DebugSheetContent = ( { onClose }: DebugSheetContentProps ) => {
         {observationIds.map( ( { uuid }, index ) => (
           <ObservationRow key={uuid} uuid={uuid} index={index} />
         ) )}
+        {isServerAuthoritative && (
+          <DebugButton
+            label={isFetchingNextPage
+              ? "Loading more…"
+              : "Load more"}
+            onPress={( ) => !isFetchingNextPage && fetchNextPage( )}
+          />
+        )}
       </ScrollView>
     </View>
   );

--- a/src/components/MyObservations/hooks/useMyObservationsQuery.ts
+++ b/src/components/MyObservations/hooks/useMyObservationsQuery.ts
@@ -9,13 +9,16 @@ import useServerOrderedObservations from "./useServerOrderedObservations";
 const { useQuery } = RealmContext;
 
 const NOOP_REFETCH = ( ) => undefined;
+const NOOP_FETCH_NEXT_PAGE = ( ) => undefined;
 
 interface UseMyObservationsQueryResult {
   observationIds: { uuid: string }[];
   isServerAuthoritative: boolean;
   isLoading: boolean;
+  isFetchingNextPage: boolean;
   error: Error | null;
   refetch: ( ) => void;
+  fetchNextPage: ( ) => void;
 }
 
 // We want to preserve offline behavior for the default sort (created at, desc) so a user can see
@@ -32,7 +35,9 @@ const useMyObservationsQuery = ( ): UseMyObservationsQueryResult => {
   const {
     observationIds: serverObservationIds,
     isLoading,
+    isFetchingNextPage,
     error,
+    fetchNextPage,
     refetch,
   } = useServerOrderedObservations( {
     sortBy: state.observationsSort,
@@ -75,14 +80,20 @@ const useMyObservationsQuery = ( ): UseMyObservationsQueryResult => {
     isLoading: isDefaultSort
       ? false
       : isLoading,
+    isFetchingNextPage: isDefaultSort
+      ? false
+      : isFetchingNextPage,
     error: isDefaultSort
       ? null
       : error,
-    // since we never fetched for default sort, we don't need to refetch.
+    // since we never fetched for default sort, we don't need to refetch or paginate.
     // pagination is still handled by useInfiniteObservationsScroll
     refetch: isDefaultSort
       ? NOOP_REFETCH
       : refetch,
+    fetchNextPage: isDefaultSort
+      ? NOOP_FETCH_NEXT_PAGE
+      : fetchNextPage,
   };
 };
 

--- a/src/components/MyObservations/hooks/useServerOrderedObservations.ts
+++ b/src/components/MyObservations/hooks/useServerOrderedObservations.ts
@@ -4,7 +4,7 @@ import Observation from "realmModels/Observation";
 import { log } from "sharedHelpers/logger";
 import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 import { observationSortToApiParams } from "sharedHelpers/observationsSort";
-import { useAuthenticatedQuery, useCurrentUser } from "sharedHooks";
+import { useAuthenticatedInfiniteQuery, useCurrentUser } from "sharedHooks";
 
 const { useRealm } = RealmContext;
 
@@ -18,79 +18,94 @@ interface SearchObservationsResult {
 }
 
 interface SearchObservationsResponse {
+  page: number;
   results: SearchObservationsResult[];
   total_results: number;
 }
 
-interface ServerOrderedObservationsData {
-  observationIds: { uuid: string }[];
-  totalResults: number;
-}
-
 interface UseServerOrderedObservationsParams {
   sortBy: OBSERVATIONS_SORT;
-  page?: number;
   enabled?: boolean;
 }
 
 interface UseServerOrderedObservationsResult {
   observationIds: { uuid: string }[];
   isLoading: boolean;
+  isFetchingNextPage: boolean;
   error: Error | null;
   totalResults?: number;
+  fetchNextPage: ( ) => void;
   refetch: ( ) => void;
 }
 
 const useServerOrderedObservations = ( {
   sortBy,
-  page = 1,
   enabled = true,
 }: UseServerOrderedObservationsParams ): UseServerOrderedObservationsResult => {
   const realm = useRealm( );
   const currentUser = useCurrentUser( );
 
-  const params = {
+  const baseParams = {
     user_id: currentUser?.id,
     ...observationSortToApiParams( sortBy ),
-    page,
     per_page: PER_PAGE,
     fields: Observation.ADVANCED_MODE_LIST_FIELDS,
     // Bypass API response caching so newly created/updated observations show up
     ttl: -1,
   };
 
-  const queryKey = ["useServerOrderedObservations", params];
+  const queryKey = ["useServerOrderedObservations", baseParams];
 
   const {
     data,
     isLoading,
+    isFetchingNextPage,
     error,
+    fetchNextPage,
     refetch,
-  } = useAuthenticatedQuery<ServerOrderedObservationsData>(
+  } = useAuthenticatedInfiniteQuery(
     queryKey,
-    async ( optsWithAuth ): Promise<ServerOrderedObservationsData> => {
+    async ( { pageParam = 1 }, optsWithAuth ): Promise<SearchObservationsResponse> => {
+      const params = {
+        ...baseParams,
+        page: pageParam,
+      };
       const rawResponse = await searchObservations( params, optsWithAuth );
       const response = rawResponse as SearchObservationsResponse;
       const results = response.results || [];
+      // upsert results to Realm
       try {
         Observation.upsertRemoteObservations( results, realm );
       } catch ( upsertError ) {
         // A local Realm-write failure shouldn't be reported as a failed search
         logger.error( "Failed to upsert server-ordered observations", upsertError );
       }
-      return {
-        observationIds: results.map( ( { uuid } ) => ( { uuid } ) ),
-        totalResults: response.total_results,
-      };
+      return response;
     },
-    { enabled: enabled && !!currentUser },
+    {
+      getNextPageParam: ( lastPage: SearchObservationsResponse ) => {
+        if ( !lastPage ) return null;
+        const totalFetchedCount = lastPage.page * PER_PAGE;
+        return totalFetchedCount < lastPage.total_results
+          ? lastPage.page + 1
+          : null;
+      },
+      enabled: enabled && !!currentUser,
+    },
   );
 
+  const pages: SearchObservationsResponse[] = data?.pages || [];
+  const observationIds = pages
+    .flatMap( page => page.results || [] )
+    .map( ( { uuid } ) => ( { uuid } ) );
+
   return {
-    observationIds: data?.observationIds || [],
+    observationIds,
     isLoading,
+    isFetchingNextPage,
     error,
-    totalResults: data?.totalResults,
+    totalResults: pages[0]?.total_results,
+    fetchNextPage,
     refetch,
   };
 };

--- a/tests/unit/components/MyObservations/hooks/useMyObservationsQuery.test.js
+++ b/tests/unit/components/MyObservations/hooks/useMyObservationsQuery.test.js
@@ -56,7 +56,9 @@ const createObservation = observation => {
 const defaultServerResult = {
   observationIds: [],
   isLoading: false,
+  isFetchingNextPage: false,
   error: null,
+  fetchNextPage: jest.fn( ),
   refetch: jest.fn( ),
 };
 
@@ -80,11 +82,14 @@ describe( "useMyObservationsQuery", ( ) => {
       state: { observationsSort: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST },
     } );
     const serverRefetch = jest.fn( );
+    const serverFetchNextPage = jest.fn( );
     useServerOrderedObservations.mockReturnValue( {
       observationIds: [{ uuid: "should-be-ignored-in-default-sort" }],
       isLoading: true,
+      isFetchingNextPage: true,
       error: new Error( "should be suppressed for default sort" ),
       refetch: serverRefetch,
+      fetchNextPage: serverFetchNextPage,
     } );
     const localObs = factory( "LocalObservation", { needs_sync: false } );
     createObservation( localObs );
@@ -94,8 +99,10 @@ describe( "useMyObservationsQuery", ( ) => {
     expect( result.current.observationIds ).toEqual( [{ uuid: localObs.uuid }] );
     expect( result.current.isServerAuthoritative ).toEqual( false );
     expect( result.current.isLoading ).toEqual( false );
+    expect( result.current.isFetchingNextPage ).toEqual( false );
     expect( result.current.error ).toBeNull( );
     expect( result.current.refetch ).not.toBe( serverRefetch );
+    expect( result.current.fetchNextPage ).not.toBe( serverFetchNextPage );
     expect( useServerOrderedObservations ).toHaveBeenCalledWith(
       expect.objectContaining( { enabled: false } ),
     );
@@ -106,9 +113,12 @@ describe( "useMyObservationsQuery", ( ) => {
       state: { observationsSort: OBSERVATIONS_SORT.DATE_OBSERVED_OLDEST },
     } );
     const serverObs = { uuid: factory( "LocalObservation" ).uuid };
+    const serverFetchNextPage = jest.fn( );
     useServerOrderedObservations.mockReturnValue( {
       ...defaultServerResult,
       observationIds: [serverObs],
+      isFetchingNextPage: true,
+      fetchNextPage: serverFetchNextPage,
     } );
     const unsyncedObs = factory( "LocalObservation", { needs_sync: true } );
     createObservation( unsyncedObs );
@@ -120,6 +130,8 @@ describe( "useMyObservationsQuery", ( ) => {
       serverObs,
     ] );
     expect( result.current.isServerAuthoritative ).toEqual( true );
+    expect( result.current.isFetchingNextPage ).toEqual( true );
+    expect( result.current.fetchNextPage ).toBe( serverFetchNextPage );
     expect( useServerOrderedObservations ).toHaveBeenCalledWith(
       expect.objectContaining( { enabled: true } ),
     );

--- a/tests/unit/components/MyObservations/hooks/useServerOrderedObservations.test.js
+++ b/tests/unit/components/MyObservations/hooks/useServerOrderedObservations.test.js
@@ -3,7 +3,7 @@ import useServerOrderedObservations
   from "components/MyObservations/hooks/useServerOrderedObservations";
 import inatjs from "inaturalistjs";
 import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
-import useAuthenticatedQuery from "sharedHooks/useAuthenticatedQuery";
+import useAuthenticatedInfiniteQuery from "sharedHooks/useAuthenticatedInfiniteQuery";
 import useCurrentUser from "sharedHooks/useCurrentUser";
 import factory, { makeResponse } from "tests/factory";
 import setupUniqueRealm from "tests/helpers/uniqueRealm";
@@ -15,7 +15,7 @@ jest.mock( "sharedHooks/useCurrentUser", ( ) => ( {
   default: jest.fn( ),
 } ) );
 
-jest.mock( "sharedHooks/useAuthenticatedQuery", ( ) => ( {
+jest.mock( "sharedHooks/useAuthenticatedInfiniteQuery", ( ) => ( {
   __esModule: true,
   default: jest.fn( ),
 } ) );
@@ -47,13 +47,15 @@ const getLocalObservation = uuid => getRealm( ).objectForPrimaryKey( "Observatio
 const defaultQueryResult = {
   data: undefined,
   isLoading: false,
+  isFetchingNextPage: false,
   error: null,
+  fetchNextPage: jest.fn( ),
   refetch: jest.fn( ),
 };
 
 beforeEach( ( ) => {
   useCurrentUser.mockReturnValue( mockUser );
-  useAuthenticatedQuery.mockReturnValue( defaultQueryResult );
+  useAuthenticatedInfiniteQuery.mockReturnValue( defaultQueryResult );
 } );
 
 afterEach( ( ) => {
@@ -66,7 +68,7 @@ describe( "useServerOrderedObservations", ( ) => {
       sortBy: OBSERVATIONS_SORT.DATE_OBSERVED_OLDEST,
     } ) );
 
-    const [queryKey] = useAuthenticatedQuery.mock.calls[0];
+    const [queryKey] = useAuthenticatedInfiniteQuery.mock.calls[0];
     const [, params] = queryKey;
     expect( params ).toEqual( expect.objectContaining( {
       user_id: mockUser.id,
@@ -79,19 +81,27 @@ describe( "useServerOrderedObservations", ( ) => {
       props => useServerOrderedObservations( props ),
       { initialProps: { sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST, enabled: false } },
     );
-    expect( useAuthenticatedQuery.mock.calls[0][2].enabled ).toEqual( false );
+    expect( useAuthenticatedInfiniteQuery.mock.calls[0][2].enabled ).toEqual( false );
 
     useCurrentUser.mockReturnValue( null );
     rerender( { sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST, enabled: true } );
-    expect( useAuthenticatedQuery.mock.calls[1][2].enabled ).toEqual( false );
+    expect( useAuthenticatedInfiniteQuery.mock.calls[1][2].enabled ).toEqual( false );
   } );
 
-  it( "passes through the query's uuid-only data and metadata as-is", ( ) => {
+  it( "flattens uuid-only data across pages and passes through pagination metadata", ( ) => {
     const mockRefetch = jest.fn( );
-    useAuthenticatedQuery.mockReturnValue( {
-      data: { observationIds: [{ uuid: "a" }, { uuid: "b" }], totalResults: 2 },
+    const mockFetchNextPage = jest.fn( );
+    useAuthenticatedInfiniteQuery.mockReturnValue( {
+      data: {
+        pages: [
+          { results: [{ uuid: "a" }, { uuid: "b" }], total_results: 3, page: 1 },
+          { results: [{ uuid: "c" }], total_results: 3, page: 2 },
+        ],
+      },
       isLoading: false,
+      isFetchingNextPage: true,
       error: null,
+      fetchNextPage: mockFetchNextPage,
       refetch: mockRefetch,
     } );
 
@@ -99,12 +109,16 @@ describe( "useServerOrderedObservations", ( ) => {
       sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
     } ) );
 
-    expect( result.current.observationIds ).toEqual( [{ uuid: "a" }, { uuid: "b" }] );
-    expect( result.current.totalResults ).toEqual( 2 );
+    expect( result.current.observationIds ).toEqual( [
+      { uuid: "a" }, { uuid: "b" }, { uuid: "c" },
+    ] );
+    expect( result.current.totalResults ).toEqual( 3 );
+    expect( result.current.isFetchingNextPage ).toEqual( true );
+    expect( result.current.fetchNextPage ).toEqual( mockFetchNextPage );
     expect( result.current.refetch ).toEqual( mockRefetch );
   } );
 
-  it( "queryFn upserts fetched results into Realm and returns a uuid-only list", async ( ) => {
+  it( "requests the next page via pageParam and upserts fetched results into Realm", async ( ) => {
     const remoteObservation = factory( "RemoteObservation" );
     inatjs.observations.search.mockResolvedValueOnce( makeResponse( [remoteObservation] ) );
 
@@ -112,15 +126,28 @@ describe( "useServerOrderedObservations", ( ) => {
       sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
     } ) );
 
-    const [, queryFunction] = useAuthenticatedQuery.mock.calls[0];
-    const data = await queryFunction( { api_token: "fake-token" } );
+    const [, queryFunction] = useAuthenticatedInfiniteQuery.mock.calls[0];
+    const data = await queryFunction( { pageParam: 2 }, { api_token: "fake-token" } );
 
-    expect( data ).toEqual( {
-      observationIds: [{ uuid: remoteObservation.uuid }],
-      totalResults: 1,
-    } );
+    expect( inatjs.observations.search ).toHaveBeenCalledWith(
+      expect.objectContaining( { page: 2 } ),
+      expect.anything( ),
+    );
+    expect( data.results ).toEqual( [remoteObservation] );
     const localObs = getLocalObservation( remoteObservation.uuid );
     expect( localObs ).toBeTruthy( );
     expect( localObs.id ).toEqual( remoteObservation.id );
+  } );
+
+  describe( "getNextPageParam", ( ) => {
+    it( "requests the next page until all results have been fetched", ( ) => {
+      renderHook( ( ) => useServerOrderedObservations( {
+        sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
+      } ) );
+
+      const { getNextPageParam } = useAuthenticatedInfiniteQuery.mock.calls[0][2];
+      expect( getNextPageParam( { page: 1, total_results: 45 } ) ).toEqual( 2 );
+      expect( getNextPageParam( { page: 3, total_results: 45 } ) ).toBeNull( );
+    } );
   } );
 } );


### PR DESCRIPTION
closes [MOB-1565](https://linear.app/inaturalist/issue/MOB-1565/pagination-for-server-ordered-observations)

Adds server-ordered pagination so we can finish wiring this to the sort UI.