### PR TITLE
add user id to list fields

### DIFF
--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -111,6 +111,9 @@ class Observation extends Realm.Object {
       rank_level: true,
     },
     time_observed_at: true,
+    user: {
+      id: true,
+    },
     uuid: true,
   };
 


### PR DESCRIPTION
closes [MOB-1559](https://linear.app/inaturalist/issue/MOB-1559/tapping-into-my-own-observations-sometimes-shows-the-kebab-menu)

We just didn't have the user id available in the local stub version of an obs, and the first time we visit, we default to this local version while we get the remote one. So this check returns false:

```
const belongsToCurrentUser = (
  observation?.user?.id === currentUser?.id
  || ( !observation?.user && !observation?.id )
);
```
until the next time we visit (and `useRemoteObservation` has had a chance to upsert missing data to realm).
