### PR TITLE
expand tappable area with padding & negative margin

### DIFF
--- a/src/components/SharedComponents/SearchHeader.tsx
+++ b/src/components/SharedComponents/SearchHeader.tsx
@@ -37,12 +37,13 @@ const SearchHeader = ( {
       <Heading4 className="flex-1 wrap text-center">{headerText}</Heading4>
       <Pressable
         className={classnames(
-          "items-end py-5 px-5 -my-5 -mr-5",
+          "items-end",
           { "opacity-50": resetDisabled },
         )}
         onPress={onReset}
         disabled={resetDisabled}
         accessibilityRole="button"
+        hitSlop={20}
         accessibilityLabel={t( "Reset-verb" )}
         testID={`${testID}.reset`}
       >

--- a/src/components/SharedComponents/SearchHeader.tsx
+++ b/src/components/SharedComponents/SearchHeader.tsx
@@ -37,7 +37,7 @@ const SearchHeader = ( {
       <Heading4 className="flex-1 wrap text-center">{headerText}</Heading4>
       <Pressable
         className={classnames(
-          "w-[50px] items-end",
+          "items-end py-5 px-5 -my-5 -mr-5",
           { "opacity-50": resetDisabled },
         )}
         onPress={onReset}


### PR DESCRIPTION
closes [MOB-1538](https://linear.app/inaturalist/issue/MOB-1538/reset-button-tap-target-in-exploresearchheader-is-too-small)

<details>
<summary>Screenshots</summary>
Before:
<img width="1170" height="2532" alt="IMG_4640" src="https://github.com/user-attachments/assets/82dae8e4-c7fa-4d2c-b1eb-8a5d9888bd9b" />


After:
<img width="1170" height="2532" alt="IMG_4641" src="https://github.com/user-attachments/assets/898cfd05-e32b-4d3e-932c-009f6ae88e71" />

</details>