### PR TITLE
E2e android needs secrets check and skip

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -13,6 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  checksecret:
+    name: check for secrets presence
+    runs-on: ubuntu-latest
+    outputs:
+      is_SECRETS_PRESENT_set: ${{ steps.checksecret_job.outputs.is_SECRETS_PRESENT_set }}
+    steps:
+      - name: Check whether secrets are present in the action runner
+        id: checksecret_job
+        env:
+            SECRETS_PRESENT: ${{ secrets.OAUTH_CLIENT_SECRET }}
+        run: |
+            echo "is_SECRETS_PRESENT_set: ${{ env.SECRETS_PRESENT != '' }}"
+            echo "::set-output name=is_SECRETS_PRESENT_set::${{ env.SECRETS_PRESENT != '' }}"
   build:
     # 4-core Ubunutu GitHub Larger Runner
     # https://docs.github.com/en/enterprise-cloud@latest/billing/reference/actions-runner-pricing#x64-powered-larger-runners

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -27,6 +27,8 @@ jobs:
             echo "is_SECRETS_PRESENT_set: ${{ env.SECRETS_PRESENT != '' }}"
             echo "::set-output name=is_SECRETS_PRESENT_set::${{ env.SECRETS_PRESENT != '' }}"
   build:
+    needs: checksecret
+    if: needs.checksecret.outputs.is_SECRETS_PRESENT_set == 'true' 
     # 4-core Ubunutu GitHub Larger Runner
     # https://docs.github.com/en/enterprise-cloud@latest/billing/reference/actions-runner-pricing#x64-powered-larger-runners
     runs-on: ubuntu-24.04-m

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -15,12 +15,12 @@ concurrency:
   
 jobs:
   checksecret:
-    name: check for oauth client
+    name: check for secrets presence
     runs-on: macos-26
     outputs:
       is_SECRETS_PRESENT_set: ${{ steps.checksecret_job.outputs.is_SECRETS_PRESENT_set }}
     steps:
-      - name: Check whether unity activation requests should be done
+      - name: Check whether secrets are present in the action runner
         id: checksecret_job
         env:
             SECRETS_PRESENT: ${{ secrets.OAUTH_CLIENT_SECRET }}


### PR DESCRIPTION
iOS e2e tests are being skipped when there are no secrets present in the GitHub Actions runner, like when an OSS contributor or dependabot open a PR.
Android did not have the same check.
So, e.g. this PR tries to run Android and shows an error state instead of skipping the CI actions.
https://github.com/inaturalist/iNaturalistReactNative/actions/runs/29463336343?pr=3840
https://github.com/inaturalist/iNaturalistReactNative/actions/runs/29463336350?pr=3840
So, the overall PR show an error: https://github.com/inaturalist/iNaturalistReactNative/pull/3840

This is just cosmetics so that ios and Android CI pipelines behave the same.
