### PR TITLE
MOB-1341: Explore V2 locations permissions simplification

### DIFF
--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -1,90 +1,12 @@
 import ExploreStackNavigator
   from "navigation/StackNavigators/ExploreStackNavigator";
-import {
-  defaultExploreV2Location,
-  EXPLORE_V2_ACTION,
-  EXPLORE_V2_PLACE_MODE,
-  ExploreV2Provider,
-  useExploreV2,
-} from "providers/ExploreV2Context";
-import React, { useEffect, useEffectEvent } from "react";
-import useLocationPermission from "sharedHooks/useLocationPermission";
+import { ExploreV2Provider } from "providers/ExploreV2Context";
+import React from "react";
 
-interface ExploreV2WithProviderProps {
-  hasPermissions?: boolean;
-  hasBlockedPermissions: boolean;
-}
-
-const ExploreV2WithProvider = ( {
-  hasPermissions,
-  hasBlockedPermissions,
-}: ExploreV2WithProviderProps ) => {
-  const { state, dispatch } = useExploreV2( );
-  // useEffectEvent is a new pattern for us, which we are adding only to new code for the moment
-  // https://github.com/inaturalist/iNaturalistReactNative/pull/3585#discussion_r3220223241
-  const onPermissionsResolved = useEffectEvent( async ( ) => {
-    const { placeMode } = state.location;
-
-    if ( hasPermissions ) {
-      if (
-        placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED
-        && placeMode !== EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION
-      ) return;
-      // if we have location permissions
-      // and place mode isn't one of the viewable modes (worldwide, nearby, specfic place)
-      // then attempt to get and set the user's location
-      const next = await defaultExploreV2Location( );
-      if ( next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY ) {
-        dispatch( {
-          type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
-          lat: next.lat,
-          lng: next.lng,
-          radius: next.radius,
-        } );
-      } else {
-        dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
-      }
-    } else if ( hasBlockedPermissions ) {
-      if (
-        placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED
-        || placeMode === EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION
-      ) {
-        // user has explicitly denied location permissions, set place mode to worldwide
-        dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
-      }
-    } else if ( placeMode === EXPLORE_V2_PLACE_MODE.UNINITIALIZED ) {
-      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_NEEDS_PERMISSION } );
-    }
-  } );
-
-  useEffect( ( ) => {
-    if ( hasPermissions !== undefined ) {
-      onPermissionsResolved( );
-    }
-  }, [hasPermissions, hasBlockedPermissions] );
-
-  return (
+const ExploreV2Container = ( ) => (
+  <ExploreV2Provider>
     <ExploreStackNavigator />
-  );
-};
-
-const ExploreV2Container = ( ) => {
-  const {
-    hasPermissions,
-    hasBlockedPermissions,
-    renderPermissionsGate,
-    requestPermissions,
-  } = useLocationPermission( );
-
-  return (
-    <ExploreV2Provider requestLocationPermissions={requestPermissions}>
-      <ExploreV2WithProvider
-        hasPermissions={hasPermissions}
-        hasBlockedPermissions={hasBlockedPermissions}
-      />
-      {renderPermissionsGate( undefined )}
-    </ExploreV2Provider>
-  );
-};
+  </ExploreV2Provider>
+);
 
 export default ExploreV2Container;

--- a/src/components/Explore/ExploreV2/ExploreV2DebugSheet.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2DebugSheet.tsx
@@ -10,7 +10,6 @@ import {
   Pressable, ScrollView, Text, View,
 } from "components/styledComponents";
 import {
-  defaultExploreV2Location,
   EXPLORE_V2_ACTION,
   EXPLORE_V2_PLACE_MODE,
   useExploreV2,
@@ -133,20 +132,6 @@ const ExploreV2DebugSheet = ( ) => {
     ? state.location.place.id
     : null;
 
-  const handleNearby = async () => {
-    const next = await defaultExploreV2Location();
-    if ( next.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY ) {
-      dispatch( {
-        type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
-        lat: next.lat,
-        lng: next.lng,
-        radius: next.radius,
-      } );
-    } else {
-      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
-    }
-  };
-
   const onClose = () => setVisible( false );
 
   return (
@@ -236,9 +221,9 @@ const ExploreV2DebugSheet = ( ) => {
                   onPress={() => dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } )}
                 />
                 <DebugButton
-                  label="Nearby (re-fetch)"
+                  label="Nearby"
                   active={placeMode === EXPLORE_V2_PLACE_MODE.NEARBY}
-                  onPress={handleNearby}
+                  onPress={() => dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY } )}
                 />
                 {PLACES.map( place => (
                   <DebugButton
@@ -269,7 +254,7 @@ const ExploreV2DebugSheet = ( ) => {
 
               <Section title="Reset">
                 <DebugButton
-                  label="RESET (back to UNINITIALIZED)"
+                  label="RESET (back to NEARBY)"
                   onPress={() => dispatch( { type: EXPLORE_V2_ACTION.RESET } )}
                 />
               </Section>

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -42,7 +42,6 @@ function locationLabel( location: ExploreV2LocationState, t: TFunction ): string
     case EXPLORE_V2_PLACE_MODE.WORLDWIDE:
       return t( "Worldwide" );
     case EXPLORE_V2_PLACE_MODE.NEARBY:
-    case EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION:
       return t( "Nearby" );
     case EXPLORE_V2_PLACE_MODE.PLACE:
       return location.place.display_name || "";

--- a/src/components/Explore/ExploreV2/helpers/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/helpers/buildQueryParams.ts
@@ -21,8 +21,15 @@ export interface ExploreV2QueryParams {
   verifiable?: boolean;
 }
 
+export interface NearbyCoords {
+  lat: number;
+  lng: number;
+  radius: number;
+}
+
 const buildExploreV2QueryParams = (
   state: ExploreV2State,
+  nearbyCoords?: NearbyCoords,
 ): ExploreV2QueryParams => {
   const params: ExploreV2QueryParams = {
     per_page: PER_PAGE,
@@ -48,16 +55,16 @@ const buildExploreV2QueryParams = (
   const { location } = state;
   switch ( location.placeMode ) {
     case EXPLORE_V2_PLACE_MODE.NEARBY:
-      params.lat = location.lat;
-      params.lng = location.lng;
-      params.radius = location.radius;
+      if ( nearbyCoords ) {
+        params.lat = nearbyCoords.lat;
+        params.lng = nearbyCoords.lng;
+        params.radius = nearbyCoords.radius;
+      }
       break;
     case EXPLORE_V2_PLACE_MODE.PLACE:
       params.place_id = location.place.id;
       break;
     case EXPLORE_V2_PLACE_MODE.WORLDWIDE:
-    case EXPLORE_V2_PLACE_MODE.UNINITIALIZED:
-    case EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION:
       break;
     default: {
       // Exhaustiveness check: ts fails if a new placeMode is added without a case.

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -49,7 +49,12 @@ interface SortOption {
 
 const ExploreResults = ( ) => {
   const { dispatch, state } = useExploreV2( );
-  const { hasPermissions, renderPermissionsGate, requestPermissions } = useLocationPermission( );
+  const {
+    hasPermissions,
+    hasBlockedPermissions,
+    renderPermissionsGate,
+    requestPermissions,
+  } = useLocationPermission( );
   const { isConnected } = useNetInfo( );
   const { t } = useTranslation( );
   const [showSortSheet, setShowSortSheet] = useState( false );
@@ -69,28 +74,32 @@ const ExploreResults = ( ) => {
     {} as Record<OBSERVATIONS_SORT, SortOption>,
   );
 
-  // undefined = nearby coords not resolved yet; null = resolved but no fix
-  // (falls back to worldwide); object = resolved coords.
+  // undefined until nearby coords resolve; blocked / no-fix flip to worldwide.
   const isNearby = state.location.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY;
-  const [nearbyCoords, setNearbyCoords] = useState<NearbyCoords | null | undefined>( undefined );
+  const [nearbyCoords, setNearbyCoords] = useState<NearbyCoords | undefined>( undefined );
 
   useFocusEffect( useCallback( ( ) => {
     let cancelled = false;
-    if ( isNearby && hasPermissions === true ) {
+    if ( isNearby && hasBlockedPermissions ) {
+      // perms blocked: fall back to worldwide
+      dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
+    } else if ( isNearby && hasPermissions === true ) {
       setNearbyCoords( undefined );
       fetchCoarseUserLocation( ).then( location => {
-        if ( !cancelled ) {
-          setNearbyCoords( location?.latitude
-            ? { lat: location.latitude, lng: location.longitude, radius: 1 }
-            : null );
+        if ( cancelled ) return;
+        if ( location?.latitude ) {
+          setNearbyCoords( { lat: location.latitude, lng: location.longitude, radius: 1 } );
+        } else {
+          // Perms granted but no fix — fall back to worldwide.
+          dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
         }
       } );
     }
     return ( ) => { cancelled = true; };
-  }, [isNearby, hasPermissions] ) );
+  }, [isNearby, hasPermissions, hasBlockedPermissions, dispatch] ) );
 
-  const needsPermission = isNearby && hasPermissions === false;
-  const nearbyResolved = !isNearby || needsPermission || nearbyCoords !== undefined;
+  const needsPermission = isNearby && hasPermissions === false && !hasBlockedPermissions;
+  const nearbyResolved = !isNearby || nearbyCoords !== undefined;
   const canFetch = !needsPermission && nearbyResolved;
 
   const queryParams = useMemo(

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -85,7 +85,7 @@ const ExploreResults = ( ) => {
     } else if ( isNearby && hasPermissions === true && nearbyCoords === undefined ) {
       fetchCoarseUserLocation( ).then( location => {
         if ( cancelled ) return;
-        if ( location?.latitude ) {
+        if ( typeof location?.latitude === "number" ) {
           setNearbyCoords( { lat: location.latitude, lng: location.longitude, radius: 1 } );
         } else {
           // Perms granted but no fix — fall back to worldwide.
@@ -101,13 +101,8 @@ const ExploreResults = ( ) => {
   const canFetch = !needsPermission && nearbyResolved;
 
   const queryParams = useMemo(
-    ( ) => buildExploreV2QueryParams(
-      state,
-      isNearby && nearbyCoords
-        ? nearbyCoords
-        : undefined,
-    ),
-    [state, isNearby, nearbyCoords],
+    ( ) => buildExploreV2QueryParams( state, nearbyCoords ),
+    [state, nearbyCoords],
   );
 
   const {

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -1,4 +1,5 @@
 import { useNetInfo } from "@react-native-community/netinfo";
+import { useFocusEffect } from "@react-navigation/native";
 import { OBSERVATIONS_TAB } from "appConstants/tabs";
 import ExploreV2Header
   from "components/Explore/ExploreV2/components/ExploreV2Header";
@@ -6,6 +7,8 @@ import ExploreV2Tabs
   from "components/Explore/ExploreV2/components/ExploreV2Tabs";
 import ExploreV2DebugSheet
   from "components/Explore/ExploreV2/ExploreV2DebugSheet";
+import type { NearbyCoords }
+  from "components/Explore/ExploreV2/helpers/buildQueryParams";
 import buildExploreV2QueryParams
   from "components/Explore/ExploreV2/helpers/buildQueryParams";
 import ExploreV2SpeciesView
@@ -23,15 +26,20 @@ import {
 import SortButton from "components/SharedComponents/Buttons/SortButton";
 import { View } from "components/styledComponents";
 import { EXPLORE_V2_ACTION, EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 import {
   OBSERVATIONS_SORT_OPTIONS,
   useObservationsSortLabels,
 } from "sharedHelpers/observationsSort";
 import { useTranslation } from "sharedHooks";
+import useLocationPermission from "sharedHooks/useLocationPermission";
 import useSpeciesCount from "sharedHooks/useSpeciesCount";
 import useStoredLayout from "sharedHooks/useStoredLayout";
+
+// Please don't change this to an aliased path or the e2e mock will not get
+// used in our e2e tests on Github Actions
+import fetchCoarseUserLocation from "../../../../sharedHelpers/fetchCoarseUserLocation";
 
 interface SortOption {
   label: string;
@@ -40,7 +48,8 @@ interface SortOption {
 }
 
 const ExploreResults = ( ) => {
-  const { dispatch, state, requestLocationPermissions } = useExploreV2( );
+  const { dispatch, state } = useExploreV2( );
+  const { hasPermissions, renderPermissionsGate, requestPermissions } = useLocationPermission( );
   const { isConnected } = useNetInfo( );
   const { t } = useTranslation( );
   const [showSortSheet, setShowSortSheet] = useState( false );
@@ -60,13 +69,39 @@ const ExploreResults = ( ) => {
     {} as Record<OBSERVATIONS_SORT, SortOption>,
   );
 
-  const queryParams = useMemo(
-    ( ) => buildExploreV2QueryParams( state ),
-    [state],
-  );
+  // undefined = nearby coords not resolved yet; null = resolved but no fix
+  // (falls back to worldwide); object = resolved coords.
+  const isNearby = state.location.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY;
+  const [nearbyCoords, setNearbyCoords] = useState<NearbyCoords | null | undefined>( undefined );
 
-  const canFetch = state.location.placeMode !== EXPLORE_V2_PLACE_MODE.UNINITIALIZED
-    && state.location.placeMode !== EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION;
+  useFocusEffect( useCallback( ( ) => {
+    let cancelled = false;
+    if ( isNearby && hasPermissions === true ) {
+      setNearbyCoords( undefined );
+      fetchCoarseUserLocation( ).then( location => {
+        if ( !cancelled ) {
+          setNearbyCoords( location?.latitude
+            ? { lat: location.latitude, lng: location.longitude, radius: 1 }
+            : null );
+        }
+      } );
+    }
+    return ( ) => { cancelled = true; };
+  }, [isNearby, hasPermissions] ) );
+
+  const needsPermission = isNearby && hasPermissions === false;
+  const nearbyResolved = !isNearby || needsPermission || nearbyCoords !== undefined;
+  const canFetch = !needsPermission && nearbyResolved;
+
+  const queryParams = useMemo(
+    ( ) => buildExploreV2QueryParams(
+      state,
+      isNearby && nearbyCoords
+        ? nearbyCoords
+        : undefined,
+    ),
+    [state, isNearby, nearbyCoords],
+  );
 
   const {
     fetchNextPage,
@@ -99,7 +134,7 @@ const ExploreResults = ( ) => {
         text={t( "ALLOW-LOCATION-ACCESS" )}
         accessibilityHint={t( "Opens-location-permission-prompt" )}
         level="focus"
-        onPress={requestLocationPermissions}
+        onPress={requestPermissions}
       />
     </View>
   );
@@ -112,7 +147,7 @@ const ExploreResults = ( ) => {
           observationsCount={totalResults}
           speciesCount={speciesCount}
         />
-        {state.location.placeMode === EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION
+        {needsPermission
           ? renderPermissionPrompt( )
           : ( // more tabs to come in MOB-1347
             <>
@@ -135,7 +170,7 @@ const ExploreResults = ( ) => {
                       hideObsUploadStatus={layout !== "list"}
                       obsListKey="ExploreV2Observations"
                       onEndReached={fetchNextPage}
-                      showNoResults={!canFetch || totalResults === 0}
+                      showNoResults={canFetch && totalResults === 0}
                       testID="ExploreV2ObservationsList"
                     />
                     <ObservationsViewBar
@@ -177,6 +212,7 @@ const ExploreResults = ( ) => {
           onPressClose={() => setShowSortSheet( false )}
         />
       )}
+      {renderPermissionsGate( {} )}
     </ViewWrapper>
   );
 };

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -74,7 +74,6 @@ const ExploreResults = ( ) => {
     {} as Record<OBSERVATIONS_SORT, SortOption>,
   );
 
-  // undefined until nearby coords resolve; blocked / no-fix flip to worldwide.
   const isNearby = state.location.placeMode === EXPLORE_V2_PLACE_MODE.NEARBY;
   const [nearbyCoords, setNearbyCoords] = useState<NearbyCoords | undefined>( undefined );
 
@@ -83,8 +82,7 @@ const ExploreResults = ( ) => {
     if ( isNearby && hasBlockedPermissions ) {
       // perms blocked: fall back to worldwide
       dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );
-    } else if ( isNearby && hasPermissions === true ) {
-      setNearbyCoords( undefined );
+    } else if ( isNearby && hasPermissions === true && nearbyCoords === undefined ) {
       fetchCoarseUserLocation( ).then( location => {
         if ( cancelled ) return;
         if ( location?.latitude ) {
@@ -96,7 +94,7 @@ const ExploreResults = ( ) => {
       } );
     }
     return ( ) => { cancelled = true; };
-  }, [isNearby, hasPermissions, hasBlockedPermissions, dispatch] ) );
+  }, [isNearby, hasPermissions, hasBlockedPermissions, nearbyCoords, dispatch] ) );
 
   const needsPermission = isNearby && hasPermissions === false && !hasBlockedPermissions;
   const nearbyResolved = !isNearby || nearbyCoords !== undefined;

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -146,8 +146,12 @@ const ExploreResults = ( ) => {
       <View className="flex-1 overflow-hidden">
         <ExploreV2Header />
         <ExploreV2Tabs
-          observationsCount={totalResults}
-          speciesCount={speciesCount}
+          observationsCount={canFetch
+            ? totalResults
+            : undefined}
+          speciesCount={canFetch
+            ? speciesCount
+            : undefined}
         />
         {needsPermission
           ? renderPermissionPrompt( )

--- a/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
@@ -31,9 +31,7 @@ import {
 import type { ExploreStackScreenProps } from "navigation/types";
 import type { ExploreV2Subject, Place } from "providers/ExploreV2Context";
 import {
-  defaultExploreV2Location,
   EXPLORE_V2_ACTION,
-  EXPLORE_V2_PLACE_MODE,
   useExploreV2,
 } from "providers/ExploreV2Context";
 import React, { useCallback, useRef, useState } from "react";
@@ -62,8 +60,7 @@ type SearchResultItem = UniversalSearchResultItem | LocationSearchResultItem;
 
 type SelectedLocation =
   | { type: "place"; place: Place }
-  | { type: "nearby"; lat: number; lng: number; radius: number }
-  | { type: "nearby-needs-permission" }
+  | { type: "nearby" }
   | { type: "worldwide" };
 
 const resultKey = ( item: SearchResultItem ): string => {
@@ -158,21 +155,8 @@ const UniversalSearch = ( ) => {
     Keyboard.dismiss( );
   }, [commitLocation, t] );
 
-  const handleSelectNearby = useCallback( async ( ) => {
-    const next = await defaultExploreV2Location( );
-    switch ( next.placeMode ) {
-      case EXPLORE_V2_PLACE_MODE.NEARBY:
-        setSelectedLocation( {
-          type: "nearby", lat: next.lat, lng: next.lng, radius: next.radius,
-        } );
-        break;
-      case EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION:
-        setSelectedLocation( { type: "nearby-needs-permission" } );
-        break;
-      default:
-        // Permission granted but no fix available: fall back to worldwide.
-        setSelectedLocation( { type: "worldwide" } );
-    }
+  const handleSelectNearby = useCallback( ( ) => {
+    setSelectedLocation( { type: "nearby" } );
     commitLocation( t( "Nearby" ) );
     Keyboard.dismiss( );
   }, [commitLocation, t] );
@@ -202,15 +186,7 @@ const UniversalSearch = ( ) => {
         } );
         break;
       case "nearby":
-        dispatch( {
-          type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
-          lat: selectedLocation.lat,
-          lng: selectedLocation.lng,
-          radius: selectedLocation.radius,
-        } );
-        break;
-      case "nearby-needs-permission":
-        dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_NEEDS_PERMISSION } );
+        dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY } );
         break;
       default:
         dispatch( { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE } );

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -3,15 +3,9 @@ import { OBSERVATIONS_TAB } from "appConstants/tabs";
 import * as React from "react";
 import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 
-// Please don't change this to an aliased path or the e2e mock will not get
-// used in our e2e tests on Github Actions
-import fetchCoarseUserLocation from "../sharedHelpers/fetchCoarseUserLocation";
-import { checkLocationPermissions } from "../sharedHelpers/geolocationWrapper";
-
 export enum EXPLORE_V2_ACTION {
   SET_SUBJECT = "SET_SUBJECT",
   CLEAR_SUBJECT = "CLEAR_SUBJECT",
-  SET_LOCATION_NEEDS_PERMISSION = "SET_LOCATION_NEEDS_PERMISSION",
   SET_LOCATION_NEARBY = "SET_LOCATION_NEARBY",
   SET_LOCATION_WORLDWIDE = "SET_LOCATION_WORLDWIDE",
   SET_LOCATION_PLACE = "SET_LOCATION_PLACE",
@@ -22,8 +16,6 @@ export enum EXPLORE_V2_ACTION {
 }
 
 export enum EXPLORE_V2_PLACE_MODE {
-  UNINITIALIZED = "UNINITIALIZED",
-  NEEDS_PERMISSION = "NEEDS_PERMISSION",
   NEARBY = "NEARBY",
   WORLDWIDE = "WORLDWIDE",
   PLACE = "PLACE"
@@ -68,15 +60,8 @@ export interface ExploreV2Filters {
 }
 
 export type ExploreV2LocationState =
-  | { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED }
-  | { placeMode: EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION }
   | { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE }
-  | {
-    placeMode: EXPLORE_V2_PLACE_MODE.NEARBY;
-    lat: number;
-    lng: number;
-    radius: number;
-  }
+  | { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY }
   | { placeMode: EXPLORE_V2_PLACE_MODE.PLACE; place: Place };
 
 export interface ExploreV2State {
@@ -90,13 +75,7 @@ export interface ExploreV2State {
 export type ExploreV2Action =
   | { type: EXPLORE_V2_ACTION.SET_SUBJECT; subject: ExploreV2Subject }
   | { type: EXPLORE_V2_ACTION.CLEAR_SUBJECT }
-  | { type: EXPLORE_V2_ACTION.SET_LOCATION_NEEDS_PERMISSION }
-  | {
-    type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY;
-    lat: number;
-    lng: number;
-    radius: number;
-  }
+  | { type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY }
   | { type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE }
   | {
     type: EXPLORE_V2_ACTION.SET_LOCATION_PLACE;
@@ -109,7 +88,7 @@ export type ExploreV2Action =
 
 export const initialExploreV2State: ExploreV2State = {
   subject: null,
-  location: { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED },
+  location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
   sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
   filters: {},
   activeTab: OBSERVATIONS_TAB,
@@ -124,20 +103,10 @@ export function exploreV2Reducer(
       return { ...state, subject: action.subject };
     case EXPLORE_V2_ACTION.CLEAR_SUBJECT:
       return { ...state, subject: null };
-    case EXPLORE_V2_ACTION.SET_LOCATION_NEEDS_PERMISSION:
-      return {
-        ...state,
-        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION },
-      };
     case EXPLORE_V2_ACTION.SET_LOCATION_NEARBY:
       return {
         ...state,
-        location: {
-          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-          lat: action.lat,
-          lng: action.lng,
-          radius: action.radius,
-        },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
       };
     case EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE:
       return {
@@ -168,37 +137,9 @@ export function exploreV2Reducer(
   }
 }
 
-export type DefaultExploreV2Location =
-  | { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE }
-  | { placeMode: EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION }
-  | {
-    placeMode: EXPLORE_V2_PLACE_MODE.NEARBY;
-    lat: number;
-    lng: number;
-    radius: number;
-  };
-
-export async function defaultExploreV2Location( ): Promise<DefaultExploreV2Location> {
-  const location = await fetchCoarseUserLocation( );
-  if ( location && location.latitude ) {
-    return {
-      placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-      lat: location.latitude,
-      lng: location.longitude,
-      radius: 1,
-    };
-  }
-  // No coordinates, fallback to worldwide if we already have perms
-  const hasPermission = await checkLocationPermissions( );
-  return hasPermission
-    ? { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE }
-    : { placeMode: EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION };
-}
-
 interface ExploreV2ContextValue {
   state: ExploreV2State;
   dispatch: ( action: ExploreV2Action ) => void;
-  requestLocationPermissions: ( ) => void;
 }
 
 const ExploreV2Context = React.createContext<ExploreV2ContextValue | undefined>(
@@ -207,18 +148,14 @@ const ExploreV2Context = React.createContext<ExploreV2ContextValue | undefined>(
 
 interface ExploreV2ProviderProps {
   children: React.ReactNode;
-  requestLocationPermissions: ( ) => void;
 }
 
-export const ExploreV2Provider = ( {
-  children,
-  requestLocationPermissions,
-}: ExploreV2ProviderProps ) => {
+export const ExploreV2Provider = ( { children }: ExploreV2ProviderProps ) => {
   const [state, dispatch] = React.useReducer( exploreV2Reducer, initialExploreV2State );
 
   const value = React.useMemo(
-    () => ( { state, dispatch, requestLocationPermissions } ),
-    [state, requestLocationPermissions],
+    () => ( { state, dispatch } ),
+    [state],
   );
 
   return (

--- a/tests/unit/components/Explore/ExploreV2/buildQueryParams.test.js
+++ b/tests/unit/components/Explore/ExploreV2/buildQueryParams.test.js
@@ -40,20 +40,31 @@ describe( "buildExploreV2QueryParams", ( ) => {
   } );
 
   describe( "location", ( ) => {
-    it( "includes lat/lng/radius in NEARBY mode with coords", ( ) => {
+    it( "includes lat/lng/radius in NEARBY mode when coords are resolved", ( ) => {
       const state = {
         ...initialExploreV2State,
-        location: {
-          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-          lat: 37.5,
-          lng: -122.1,
-          radius: 1,
-        },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
       };
-      const params = buildExploreV2QueryParams( state );
+      const params = buildExploreV2QueryParams( state, {
+        lat: 37.5,
+        lng: -122.1,
+        radius: 1,
+      } );
       expect( params.lat ).toBe( 37.5 );
       expect( params.lng ).toBe( -122.1 );
       expect( params.radius ).toBe( 1 );
+      expect( params.place_id ).toBeUndefined( );
+    } );
+
+    it( "omits coords in NEARBY mode when coords are unresolved (worldwide fallback)", ( ) => {
+      const state = {
+        ...initialExploreV2State,
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
+      };
+      const params = buildExploreV2QueryParams( state );
+      expect( params.lat ).toBeUndefined( );
+      expect( params.lng ).toBeUndefined( );
+      expect( params.radius ).toBeUndefined( );
       expect( params.place_id ).toBeUndefined( );
     } );
 
@@ -64,17 +75,6 @@ describe( "buildExploreV2QueryParams", ( ) => {
       };
       const params = buildExploreV2QueryParams( state );
       expect( params.lat ).toBeUndefined( );
-      expect( params.place_id ).toBeUndefined( );
-    } );
-
-    it( "omits coords and place in NEEDS_PERMISSION mode", ( ) => {
-      const state = {
-        ...initialExploreV2State,
-        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION },
-      };
-      const params = buildExploreV2QueryParams( state );
-      expect( params.lat ).toBeUndefined( );
-      expect( params.lng ).toBeUndefined( );
       expect( params.place_id ).toBeUndefined( );
     } );
 
@@ -145,16 +145,15 @@ describe( "buildExploreV2QueryParams", ( ) => {
   it( "combines subject, location, and sort into a single query", ( ) => {
     const state = {
       subject: { type: "taxon", taxon: { id: 42 } },
-      location: {
-        placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-        lat: 37.5,
-        lng: -122.1,
-        radius: 1,
-      },
+      location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
       sortBy: OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST,
       filters: {},
     };
-    const params = buildExploreV2QueryParams( state );
+    const params = buildExploreV2QueryParams( state, {
+      lat: 37.5,
+      lng: -122.1,
+      radius: 1,
+    } );
     expect( params ).toEqual( {
       per_page: 20,
       verifiable: true,

--- a/tests/unit/components/Explore/ExploreV2/components/ExploreV2Header.test.js
+++ b/tests/unit/components/Explore/ExploreV2/components/ExploreV2Header.test.js
@@ -140,19 +140,7 @@ describe( "ExploreV2Header", () => {
   } );
 
   it( "renders the Nearby label when location is nearby", () => {
-    setState( null, {
-      placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-      lat: 1,
-      lng: 2,
-      radius: 1,
-    } );
-    renderComponent( <ExploreV2Header /> );
-
-    expect( screen.getByText( "Nearby" ) ).toBeTruthy();
-  } );
-
-  it( "renders the Nearby label when nearby is intended but permission is pending", () => {
-    setState( null, { placeMode: EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION } );
+    setState( null, { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } );
     renderComponent( <ExploreV2Header /> );
 
     expect( screen.getByText( "Nearby" ) ).toBeTruthy();

--- a/tests/unit/components/Explore/ExploreV2/components/ExploreV2SpeciesGridItem.test.js
+++ b/tests/unit/components/Explore/ExploreV2/components/ExploreV2SpeciesGridItem.test.js
@@ -50,7 +50,7 @@ const StateProbe = () => {
 const actor = userEvent.setup( );
 
 const renderGridItem = ( props = {} ) => renderComponent(
-  <ExploreV2Provider requestLocationPermissions={() => {}}>
+  <ExploreV2Provider>
     <ExploreV2SpeciesGridItem taxon={mockTaxon} {...props} />
     <StateProbe />
   </ExploreV2Provider>,

--- a/tests/unit/components/Explore/ExploreV2/components/ExploreV2Tabs.test.js
+++ b/tests/unit/components/Explore/ExploreV2/components/ExploreV2Tabs.test.js
@@ -7,7 +7,7 @@ import { renderComponent } from "tests/helpers/render";
 const actor = userEvent.setup( );
 
 const renderTabs = props => renderComponent(
-  <ExploreV2Provider requestLocationPermissions={() => {}}>
+  <ExploreV2Provider>
     <ExploreV2Tabs {...props} />
   </ExploreV2Provider>,
 );

--- a/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
@@ -1,0 +1,162 @@
+import { screen, waitFor } from "@testing-library/react-native";
+import ExploreResults from "components/Explore/ExploreV2/screens/ExploreResults";
+import initI18next from "i18n/initI18next";
+import {
+  EXPLORE_V2_ACTION,
+  EXPLORE_V2_PLACE_MODE,
+  initialExploreV2State,
+} from "providers/ExploreV2Context";
+import React from "react";
+import { renderComponent } from "tests/helpers/render";
+
+jest.mock( "@react-navigation/native", ( ) => {
+  const actualNav = jest.requireActual( "@react-navigation/native" );
+  return {
+    ...actualNav,
+    useFocusEffect: cb => jest.requireActual( "react" ).useEffect( cb, [] ),
+  };
+} );
+
+jest.mock( "providers/ExploreV2Context", ( ) => {
+  const actual = jest.requireActual( "providers/ExploreV2Context" );
+  return { ...actual, useExploreV2: jest.fn( ) };
+} );
+const { useExploreV2 } = require( "providers/ExploreV2Context" );
+
+let mockHasPermissions;
+let mockHasBlockedPermissions;
+const mockDispatch = jest.fn( );
+const mockRequestPermissions = jest.fn( );
+jest.mock( "sharedHooks/useLocationPermission", ( ) => ( {
+  __esModule: true,
+  default: ( ) => ( {
+    hasPermissions: mockHasPermissions,
+    hasBlockedPermissions: mockHasBlockedPermissions,
+    renderPermissionsGate: ( ) => null,
+    requestPermissions: mockRequestPermissions,
+  } ),
+} ) );
+
+jest.mock( "sharedHelpers/fetchCoarseUserLocation", ( ) => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+const fetchCoarseUserLocation = require( "sharedHelpers/fetchCoarseUserLocation" ).default;
+
+const mockUseInfiniteExploreScroll = jest.fn( );
+jest.mock( "components/Explore/hooks/useInfiniteExploreScroll", ( ) => ( {
+  __esModule: true,
+  default: args => mockUseInfiniteExploreScroll( args ),
+} ) );
+
+jest.mock( "sharedHooks/useSpeciesCount", ( ) => ( { __esModule: true, default: ( ) => 0 } ) );
+
+const mockState = location => ( {
+  ...initialExploreV2State,
+  location,
+} );
+
+const lastScrollArgs = ( ) => mockUseInfiniteExploreScroll.mock.calls.at( -1 )[0];
+
+beforeAll( async ( ) => {
+  await initI18next( );
+} );
+
+beforeEach( ( ) => {
+  mockHasPermissions = undefined;
+  mockHasBlockedPermissions = false;
+  mockDispatch.mockClear( );
+  mockRequestPermissions.mockClear( );
+  fetchCoarseUserLocation.mockReset( );
+  mockUseInfiniteExploreScroll.mockReset( );
+  mockUseInfiniteExploreScroll.mockReturnValue( {
+    fetchNextPage: jest.fn( ),
+    isFetchingNextPage: false,
+    handlePullToRefresh: jest.fn( ),
+    observations: [],
+    totalResults: 0,
+  } );
+} );
+
+describe( "ExploreResults nearby resolution", ( ) => {
+  it( "includes fetched coordinates in the query when nearby with permission", async ( ) => {
+    mockHasPermissions = true;
+    fetchCoarseUserLocation.mockResolvedValueOnce( { latitude: 37.5, longitude: -122.1 } );
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } ),
+      dispatch: mockDispatch,
+    } );
+
+    renderComponent( <ExploreResults /> );
+
+    await waitFor( ( ) => {
+      const { params, enabled } = lastScrollArgs( );
+      expect( params.lat ).toBe( 37.5 );
+      expect( params.lng ).toBe( -122.1 );
+      expect( params.radius ).toBe( 1 );
+      expect( enabled ).toBe( true );
+    } );
+  } );
+
+  it( "shows the permission prompt and does not fetch when nearby, no permission", async ( ) => {
+    mockHasPermissions = false;
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } ),
+      dispatch: mockDispatch,
+    } );
+
+    renderComponent( <ExploreResults /> );
+
+    expect(
+      await screen.findByText( /To view nearby organisms/ ),
+    ).toBeVisible( );
+    expect( fetchCoarseUserLocation ).not.toHaveBeenCalled( );
+    expect( lastScrollArgs( ).enabled ).toBe( false );
+  } );
+
+  it( "dispatches worldwide without prompting when permission is blocked", async ( ) => {
+    mockHasPermissions = false;
+    mockHasBlockedPermissions = true;
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } ),
+      dispatch: mockDispatch,
+    } );
+
+    renderComponent( <ExploreResults /> );
+
+    await waitFor( ( ) => expect( mockDispatch ).toHaveBeenCalledWith( {
+      type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE,
+    } ) );
+    expect( screen.queryByText( /To view nearby organisms/ ) ).toBeNull( );
+    expect( fetchCoarseUserLocation ).not.toHaveBeenCalled( );
+  } );
+
+  it( "dispatches worldwide when permission is granted but there is no fix", async ( ) => {
+    mockHasPermissions = true;
+    fetchCoarseUserLocation.mockResolvedValueOnce( null );
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } ),
+      dispatch: mockDispatch,
+    } );
+
+    renderComponent( <ExploreResults /> );
+
+    await waitFor( ( ) => expect( mockDispatch ).toHaveBeenCalledWith( {
+      type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE,
+    } ) );
+  } );
+
+  it( "fetches worldwide without coordinates when worldwide", async ( ) => {
+    mockHasPermissions = true;
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } ),
+      dispatch: mockDispatch,
+    } );
+
+    renderComponent( <ExploreResults /> );
+
+    await waitFor( ( ) => expect( lastScrollArgs( ).enabled ).toBe( true ) );
+    expect( lastScrollArgs( ).params.lat ).toBeUndefined( );
+    expect( fetchCoarseUserLocation ).not.toHaveBeenCalled( );
+  } );
+} );

--- a/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
@@ -114,6 +114,32 @@ describe( "ExploreResults nearby resolution", ( ) => {
     expect( lastScrollArgs( ).enabled ).toBe( false );
   } );
 
+  it( "does not show stale counts in the tabs when nearby, no permission", async ( ) => {
+    // Simulate the shared query cache still holding the previous (worldwide)
+    // result: the disabled query returns a non-zero totalResults.
+    mockUseInfiniteExploreScroll.mockReturnValue( {
+      fetchNextPage: jest.fn( ),
+      isFetchingNextPage: false,
+      handlePullToRefresh: jest.fn( ),
+      observations: [],
+      totalResults: 42,
+    } );
+    mockHasPermissions = false;
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } ),
+      dispatch: mockDispatch,
+    } );
+
+    renderComponent( <ExploreResults /> );
+
+    expect(
+      await screen.findByText( /To view nearby organisms/ ),
+    ).toBeVisible( );
+    // The stale worldwide count must not leak into the tabs.
+    expect( screen.queryByText( "42" ) ).toBeNull( );
+    expect( screen.getAllByText( "--" ).length ).toBeGreaterThanOrEqual( 1 );
+  } );
+
   it( "dispatches worldwide without prompting when permission is blocked", async ( ) => {
     mockHasPermissions = false;
     mockHasBlockedPermissions = true;

--- a/tests/unit/components/Explore/ExploreV2/screens/ExploreV2SpeciesView.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/ExploreV2SpeciesView.test.js
@@ -72,7 +72,7 @@ jest.mock( "@tanstack/react-query", () => {
 } );
 
 const renderView = ( props = {} ) => renderComponent(
-  <ExploreV2Provider requestLocationPermissions={() => {}}>
+  <ExploreV2Provider>
     <ExploreV2SpeciesView
       enabled
       isConnected

--- a/tests/unit/components/Explore/ExploreV2/screens/UniversalSearch.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/UniversalSearch.test.js
@@ -534,8 +534,7 @@ describe( "UniversalSearch screen", ( ) => {
       expect( mockDispatch ).toHaveBeenCalledWith( { type: "SET_LOCATION_WORLDWIDE" } );
     } );
 
-    it( "fills the field and stages nearby when Nearby is tapped", async ( ) => {
-      fetchCoarseUserLocation.mockResolvedValue( { latitude: 10, longitude: 20 } );
+    it( "fills the field and stages the nearby intent when Nearby is tapped", async ( ) => {
       renderComponent( <UniversalSearch /> );
 
       focusLocation( );
@@ -547,19 +546,12 @@ describe( "UniversalSearch screen", ( ) => {
       expect( mockDispatch ).not.toHaveBeenCalled( );
 
       await actor.press( screen.getByTestId( "UniversalSearch.searchButton" ) );
-      expect( mockDispatch ).toHaveBeenCalledWith( {
-        type: "SET_LOCATION_NEARBY",
-        lat: 10,
-        lng: 20,
-        radius: 1,
-      } );
+      expect( mockDispatch ).toHaveBeenCalledWith( { type: "SET_LOCATION_NEARBY" } );
     } );
 
     it(
-      "stages worldwide when permission is granted but no location fix is available",
+      "stages the nearby intent (no prompting, no fetch) regardless of permission",
       async ( ) => {
-        fetchCoarseUserLocation.mockResolvedValue( null );
-        checkLocationPermissions.mockResolvedValue( "granted" );
         renderComponent( <UniversalSearch /> );
 
         focusLocation( );
@@ -567,35 +559,12 @@ describe( "UniversalSearch screen", ( ) => {
         await waitFor( ( ) => {
           expect( screen.getByDisplayValue( i18next.t( "Nearby" ) ) ).toBeTruthy( );
         } );
-        expect( mockDispatch ).not.toHaveBeenCalled( );
 
-        await actor.press( screen.getByTestId( "UniversalSearch.searchButton" ) );
-        expect( mockDispatch ).toHaveBeenCalledWith( { type: "SET_LOCATION_WORLDWIDE" } );
-        expect( mockDispatch ).not.toHaveBeenCalledWith(
-          { type: "SET_LOCATION_NEEDS_PERMISSION" },
-        );
-      },
-    );
-
-    it(
-      "stages nearby-needs-permission (without prompting) when permission is missing",
-      async ( ) => {
-        fetchCoarseUserLocation.mockResolvedValue( null );
-        checkLocationPermissions.mockResolvedValue( null );
-        renderComponent( <UniversalSearch /> );
-
-        focusLocation( );
-        await actor.press( screen.getByRole( "button", { name: i18next.t( "Nearby" ) } ) );
-
-        await waitFor( ( ) => {
-          expect( screen.getByDisplayValue( i18next.t( "Nearby" ) ) ).toBeTruthy( );
-        } );
-
+        expect( fetchCoarseUserLocation ).not.toHaveBeenCalled( );
         expect( mockRequestLocationPermissions ).not.toHaveBeenCalled( );
-        expect( mockDispatch ).not.toHaveBeenCalled( );
 
         await actor.press( screen.getByTestId( "UniversalSearch.searchButton" ) );
-        expect( mockDispatch ).toHaveBeenCalledWith( { type: "SET_LOCATION_NEEDS_PERMISSION" } );
+        expect( mockDispatch ).toHaveBeenCalledWith( { type: "SET_LOCATION_NEARBY" } );
       },
     );
   } );

--- a/tests/unit/providers/ExploreV2Context.test.js
+++ b/tests/unit/providers/ExploreV2Context.test.js
@@ -1,22 +1,15 @@
 import {
-  defaultExploreV2Location,
   EXPLORE_V2_ACTION,
   EXPLORE_V2_PLACE_MODE,
   exploreV2Reducer,
   initialExploreV2State,
 } from "providers/ExploreV2Context";
-import fetchCoarseUserLocation from "sharedHelpers/fetchCoarseUserLocation";
 import { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
 
-jest.mock( "sharedHelpers/fetchCoarseUserLocation", ( ) => ( {
-  __esModule: true,
-  default: jest.fn( ),
-} ) );
-
 describe( "initialExploreV2State", ( ) => {
-  it( "starts with no subject, UNINITIALIZED placeMode, newest-upload sort, empty filters", ( ) => {
+  it( "starts with no subject, NEARBY placeMode, newest-upload sort, empty filters", ( ) => {
     expect( initialExploreV2State.subject ).toBeNull( );
-    expect( initialExploreV2State.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.UNINITIALIZED );
+    expect( initialExploreV2State.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.NEARBY );
     expect( initialExploreV2State.sortBy ).toBe( OBSERVATIONS_SORT.DATE_UPLOADED_NEWEST );
     expect( initialExploreV2State.filters ).toEqual( {} );
   } );
@@ -40,12 +33,7 @@ describe( "exploreV2Reducer", ( ) => {
     it( "preserves location, sortBy, and filters when changing subject", ( ) => {
       const state = {
         subject: null,
-        location: {
-          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-          lat: 1,
-          lng: 2,
-          radius: 3,
-        },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
         sortBy: OBSERVATIONS_SORT.MOST_FAVED,
         filters: { quality_grade: "research" },
       };
@@ -71,7 +59,7 @@ describe( "exploreV2Reducer", ( ) => {
   } );
 
   describe( "location actions", ( ) => {
-    it( "SET_LOCATION_NEARBY transitions from PLACE and drops place", ( ) => {
+    it( "SET_LOCATION_NEARBY transitions from PLACE and drops place (no coords stored)", ( ) => {
       const state = {
         ...initialExploreV2State,
         location: {
@@ -81,45 +69,28 @@ describe( "exploreV2Reducer", ( ) => {
       };
       const next = exploreV2Reducer( state, {
         type: EXPLORE_V2_ACTION.SET_LOCATION_NEARBY,
-        lat: 37.5,
-        lng: -122.1,
-        radius: 1,
       } );
       expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.NEARBY );
-      expect( next.location.lat ).toBe( 37.5 );
-      expect( next.location.lng ).toBe( -122.1 );
-      expect( next.location.radius ).toBe( 1 );
+      expect( next.location.lat ).toBeUndefined( );
       expect( next.location.place ).toBeUndefined( );
     } );
 
-    it( "SET_LOCATION_WORLDWIDE transitions from NEARBY and drops coords", ( ) => {
+    it( "SET_LOCATION_WORLDWIDE transitions from NEARBY", ( ) => {
       const state = {
         ...initialExploreV2State,
-        location: {
-          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-          lat: 1,
-          lng: 1,
-          radius: 1,
-        },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
       };
       const next = exploreV2Reducer( state, {
         type: EXPLORE_V2_ACTION.SET_LOCATION_WORLDWIDE,
       } );
       expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.WORLDWIDE );
       expect( next.location.lat ).toBeUndefined( );
-      expect( next.location.lng ).toBeUndefined( );
-      expect( next.location.radius ).toBeUndefined( );
     } );
 
-    it( "SET_LOCATION_PLACE transitions from NEARBY and drops coords", ( ) => {
+    it( "SET_LOCATION_PLACE transitions from NEARBY", ( ) => {
       const state = {
         ...initialExploreV2State,
-        location: {
-          placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-          lat: 1,
-          lng: 1,
-          radius: 1,
-        },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
       };
       const place = { id: 5, display_name: "Oakland" };
       const next = exploreV2Reducer( state, {
@@ -128,7 +99,6 @@ describe( "exploreV2Reducer", ( ) => {
       } );
       expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.PLACE );
       expect( next.location.place ).toEqual( place );
-      expect( next.location.lat ).toBeUndefined( );
     } );
 
     it( "SET_LOCATION_PLACE replaces an existing place", ( ) => {
@@ -148,32 +118,10 @@ describe( "exploreV2Reducer", ( ) => {
       expect( next.location.place ).toEqual( place );
     } );
 
-    it( "SET_LOCATION_NEEDS_PERMISSION transitions from UNINITIALIZED", ( ) => {
-      const next = exploreV2Reducer( initialExploreV2State, {
-        type: EXPLORE_V2_ACTION.SET_LOCATION_NEEDS_PERMISSION,
-      } );
-      expect( next.location.placeMode ).toBe( EXPLORE_V2_PLACE_MODE.NEEDS_PERMISSION );
-    } );
-
-    it( "SET_LOCATION_NEEDS_PERMISSION preserves subject, sortBy, and filters", ( ) => {
-      const state = {
-        subject: { type: "taxon", taxon: { id: 42 } },
-        location: { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED },
-        sortBy: OBSERVATIONS_SORT.MOST_FAVED,
-        filters: { quality_grade: "research" },
-      };
-      const next = exploreV2Reducer( state, {
-        type: EXPLORE_V2_ACTION.SET_LOCATION_NEEDS_PERMISSION,
-      } );
-      expect( next.subject ).toEqual( state.subject );
-      expect( next.sortBy ).toBe( state.sortBy );
-      expect( next.filters ).toEqual( state.filters );
-    } );
-
     it( "preserves subject, sortBy, and filters when changing location", ( ) => {
       const state = {
         subject: { type: "taxon", taxon: { id: 42 } },
-        location: { placeMode: EXPLORE_V2_PLACE_MODE.UNINITIALIZED },
+        location: { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY },
         sortBy: OBSERVATIONS_SORT.MOST_FAVED,
         filters: { quality_grade: "research" },
       };
@@ -221,28 +169,5 @@ describe( "exploreV2Reducer", ( ) => {
       const next = exploreV2Reducer( state, { type: EXPLORE_V2_ACTION.RESET } );
       expect( next ).toEqual( initialExploreV2State );
     } );
-  } );
-} );
-
-describe( "defaultExploreV2Location", ( ) => {
-  beforeEach( ( ) => {
-    fetchCoarseUserLocation.mockReset( );
-  } );
-
-  it( "returns NEARBY with radius 1 when a location is available", async ( ) => {
-    fetchCoarseUserLocation.mockResolvedValueOnce( { latitude: 37.5, longitude: -122.1 } );
-    const result = await defaultExploreV2Location( );
-    expect( result ).toEqual( {
-      placeMode: EXPLORE_V2_PLACE_MODE.NEARBY,
-      lat: 37.5,
-      lng: -122.1,
-      radius: 1,
-    } );
-  } );
-
-  it( "returns WORLDWIDE when fetchCoarseUserLocation returns null", async ( ) => {
-    fetchCoarseUserLocation.mockResolvedValueOnce( null );
-    const result = await defaultExploreV2Location( );
-    expect( result ).toEqual( { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } );
   } );
 } );


### PR DESCRIPTION
- Move all permissions handling to ExploreResults
- For nearby mode, keep the fetched location just in ExploreResults