### PR TITLE
Traditional projects: joined projects pagination

### DIFF
--- a/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
+++ b/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
@@ -1,6 +1,6 @@
 import { useNetInfo } from "@react-native-community/netinfo";
 import { RealmContext } from "providers/contexts";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
 import { useCurrentUser } from "sharedHooks";
 
@@ -13,11 +13,16 @@ const useSyncJoinedProjects = ( ) => {
 
   const { isConnected } = useNetInfo( );
 
+  // Sync at most once per mount so connectivity flapping while the screen
+  // is open can't refire it
+  const hasSynced = useRef( false );
+
   useEffect( ( ) => {
     // only sync once we know we're online (matches iOS Legacy chooser behavior)
-    if ( !currentUser?.id || isConnected !== true ) {
+    if ( hasSynced.current || !currentUser?.id || isConnected !== true ) {
       return;
     }
+    hasSynced.current = true;
     syncJoinedProjects( realm, currentUser.id );
   }, [currentUser?.id, realm, isConnected] );
 };

--- a/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
+++ b/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
@@ -18,7 +18,7 @@ const useSyncJoinedProjects = ( ) => {
     if ( !currentUser?.id || isConnected !== true ) {
       return;
     }
-    syncJoinedProjects( realm, currentUser?.id );
+    syncJoinedProjects( realm, currentUser.id );
   }, [currentUser?.id, realm, isConnected] );
 };
 

--- a/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
+++ b/src/components/AddToProjects/hooks/useSyncJoinedProjects.ts
@@ -1,3 +1,4 @@
+import { useNetInfo } from "@react-native-community/netinfo";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
 import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
@@ -10,12 +11,15 @@ const useSyncJoinedProjects = ( ) => {
 
   const currentUser = useCurrentUser( );
 
+  const { isConnected } = useNetInfo( );
+
   useEffect( ( ) => {
-    if ( !currentUser?.id ) {
+    // only sync once we know we're online (matches iOS Legacy chooser behavior)
+    if ( !currentUser?.id || isConnected !== true ) {
       return;
     }
     syncJoinedProjects( realm, currentUser?.id );
-  }, [currentUser?.id, realm] );
+  }, [currentUser?.id, realm, isConnected] );
 };
 
 export default useSyncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -10,6 +10,8 @@ import safeRealmWrite from "./safeRealmWrite";
 
 const logger = log.extend( "syncJoinedProjects.ts" );
 
+const PER_PAGE = 100;
+
 const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }
   safeRealmWrite( realm, ( ) => {
@@ -30,27 +32,38 @@ async function syncJoinedProjects(
   try {
     const apiToken = await getJWT( );
     const remoteProjectIds: number[] = [];
+    let page = 1;
+    const totalPages = 1;
 
-    const params = {
-      id: currentUserId,
-      per_page: 100,
-      fields: PROJECT_SUMMARY_POF_FIELDS,
-      ttl: -1,
-    };
-    const response = await fetchUserProjects<ApiProjectSummaryWithPOF>(
-      params,
-      { api_token: apiToken },
-    );
+    while ( page <= totalPages ) {
+      const params = {
+        id: currentUserId,
+        per_page: PER_PAGE,
+        page,
+        fields: PROJECT_SUMMARY_POF_FIELDS,
+        ttl: -1,
+      };
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetchUserProjects<ApiProjectSummaryWithPOF>(
+        params,
+        { api_token: apiToken },
+      );
 
-    // Unusable page: abort without pruning so we never delete local
-    // projects based on an incomplete picture of the remote state
-    if ( response === null || !response.results ) {
-      return;
+      // Unusable page: abort without pruning so we never delete local
+      // projects based on an incomplete picture of the remote state
+      if ( response === null || !response.results ) {
+        return;
+      }
+
+      // Update local copy of the current user's joined projects
+      Project.upsertRemoteProjects( response.results, realm );
+      remoteProjectIds.push( ...response.results.map( p => p.id ) );
+
+      totalPages = Math.ceil( ( response.total_results ?? 0 ) / PER_PAGE );
+      // Guard against a misreported total_results keeping the loop alive
+      if ( response.results.length === 0 ) { break; }
+      page += 1;
     }
-
-    // Update local copy of the current user's joined projects
-    Project.upsertRemoteProjects( response.results, realm );
-    remoteProjectIds.push( ...response.results.map( p => p.id ) );
 
     // Remove projects that are present locally but no longer in server response
     deleteNotRemoteProjects( remoteProjectIds, realm );

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -28,7 +28,7 @@ async function syncJoinedProjects(
 
   const params = {
     id: currentUserId,
-    per_page: 200,
+    per_page: 100,
     fields: PROJECT_SUMMARY_POF_FIELDS,
     ttl: -1,
   };

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -37,6 +37,8 @@ async function syncJoinedProjects(
     { api_token: apiToken },
   );
 
+  // Unusable page: abort without pruning so we never delete local
+  // projects based on an incomplete picture of the remote state
   if ( response === null || !response.results ) {
     return;
   }

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -33,7 +33,7 @@ async function syncJoinedProjects(
     const apiToken = await getJWT( );
     const remoteProjectIds: number[] = [];
     let page = 1;
-    const totalPages = 1;
+    let totalPages = 1;
 
     while ( page <= totalPages ) {
       const params = {

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -24,14 +24,14 @@ async function syncJoinedProjects(
   realm: Realm,
   currentUserId: number,
 ): Promise<void> {
+  const apiToken = await getJWT( );
+
   const params = {
     id: currentUserId,
     per_page: 200,
     fields: PROJECT_SUMMARY_POF_FIELDS,
     ttl: -1,
   };
-
-  const apiToken = await getJWT( );
   const response = await fetchUserProjects<ApiProjectSummaryWithPOF>(
     params,
     { api_token: apiToken },

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -65,7 +65,8 @@ async function syncJoinedProjects(
       page += 1;
     }
 
-    // Remove projects that are present locally but no longer in server response
+    // Remove projects that are present locally but no longer in server
+    // response, only after every page was fetched successfully
     deleteNotRemoteProjects( remoteProjectIds, realm );
   } catch ( error ) {
     // Both triggers (deferred startup and chooser mount) are fire-and-forget

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -4,8 +4,11 @@ import fetchUserProjects from "api/usersTyped";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
 import type Realm from "realm";
 import Project from "realmModels/Project";
+import { log } from "sharedHelpers/logger";
 
 import safeRealmWrite from "./safeRealmWrite";
+
+const logger = log.extend( "syncJoinedProjects.ts" );
 
 const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }
@@ -24,32 +27,38 @@ async function syncJoinedProjects(
   realm: Realm,
   currentUserId: number,
 ): Promise<void> {
-  const apiToken = await getJWT( );
-  const remoteProjectIds: number[] = [];
+  try {
+    const apiToken = await getJWT( );
+    const remoteProjectIds: number[] = [];
 
-  const params = {
-    id: currentUserId,
-    per_page: 100,
-    fields: PROJECT_SUMMARY_POF_FIELDS,
-    ttl: -1,
-  };
-  const response = await fetchUserProjects<ApiProjectSummaryWithPOF>(
-    params,
-    { api_token: apiToken },
-  );
+    const params = {
+      id: currentUserId,
+      per_page: 100,
+      fields: PROJECT_SUMMARY_POF_FIELDS,
+      ttl: -1,
+    };
+    const response = await fetchUserProjects<ApiProjectSummaryWithPOF>(
+      params,
+      { api_token: apiToken },
+    );
 
-  // Unusable page: abort without pruning so we never delete local
-  // projects based on an incomplete picture of the remote state
-  if ( response === null || !response.results ) {
-    return;
+    // Unusable page: abort without pruning so we never delete local
+    // projects based on an incomplete picture of the remote state
+    if ( response === null || !response.results ) {
+      return;
+    }
+
+    // Update local copy of the current user's joined projects
+    Project.upsertRemoteProjects( response.results, realm );
+    remoteProjectIds.push( ...response.results.map( p => p.id ) );
+
+    // Remove projects that are present locally but no longer in server response
+    deleteNotRemoteProjects( remoteProjectIds, realm );
+  } catch ( error ) {
+    // Both triggers (deferred startup and chooser mount) are fire-and-forget
+    // background syncs, so failures must not surface to the user
+    logger.error( "Failed to sync joined projects", error );
   }
-
-  // Update local copy of the current user's joined projects
-  Project.upsertRemoteProjects( response.results, realm );
-  remoteProjectIds.push( ...response.results.map( p => p.id ) );
-
-  // Remove projects that are present locally but no longer in server response
-  deleteNotRemoteProjects( remoteProjectIds, realm );
 }
 
 export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -25,6 +25,7 @@ async function syncJoinedProjects(
   currentUserId: number,
 ): Promise<void> {
   const apiToken = await getJWT( );
+  const remoteProjectIds: number[] = [];
 
   const params = {
     id: currentUserId,
@@ -45,10 +46,10 @@ async function syncJoinedProjects(
 
   // Update local copy of the current user's joined projects
   Project.upsertRemoteProjects( response.results, realm );
+  remoteProjectIds.push( ...response.results.map( p => p.id ) );
 
   // Remove projects that are present locally but no longer in server response
-  const remoteProjectsId = response.results.map( p => p.id );
-  deleteNotRemoteProjects( remoteProjectsId, realm );
+  deleteNotRemoteProjects( remoteProjectIds, realm );
 }
 
 export default syncJoinedProjects;

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -11,6 +11,8 @@ import safeRealmWrite from "./safeRealmWrite";
 const logger = log.extend( "syncJoinedProjects.ts" );
 
 const PER_PAGE = 100;
+// Runaway guard, generously above any realistic number of joined projects
+export const MAX_PAGES = 100;
 
 const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }
@@ -36,6 +38,12 @@ async function syncJoinedProjects(
     let totalPages = 1;
 
     while ( page <= totalPages ) {
+      // Incomplete sync: abort without pruning, same as the unusable-page
+      // case below, so we never delete local projects we did not re-fetch
+      if ( page > MAX_PAGES ) {
+        logger.error( `Aborted joined-projects sync after ${MAX_PAGES} pages` );
+        return;
+      }
       const params = {
         id: currentUserId,
         per_page: PER_PAGE,

--- a/src/sharedHelpers/syncJoinedProjects.ts
+++ b/src/sharedHelpers/syncJoinedProjects.ts
@@ -12,7 +12,7 @@ const logger = log.extend( "syncJoinedProjects.ts" );
 
 const PER_PAGE = 100;
 // Runaway guard, generously above any realistic number of joined projects
-export const MAX_PAGES = 100;
+const MAX_PAGES = 100;
 
 const deleteNotRemoteProjects = ( remoteProjects: number[], realm: Realm ) => {
   if ( !remoteProjects ) { return; }

--- a/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
+++ b/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
@@ -35,6 +35,15 @@ describe( "useSyncJoinedProjects", () => {
 
     expect( syncJoinedProjects ).toHaveBeenCalledWith( mockRealm, currentUserId );
   } );
+
+  it( "does not sync when offline", () => {
+    useNetInfo.mockReturnValue( { isConnected: false } );
+
+    renderHook( () => useSyncJoinedProjects() );
+
+    expect( syncJoinedProjects ).not.toHaveBeenCalled();
+  } );
+
   it( "does not sync when there is no current user", () => {
     useCurrentUser.mockReturnValue( null );
 

--- a/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
+++ b/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
@@ -1,3 +1,4 @@
+import { useNetInfo } from "@react-native-community/netinfo";
 import { renderHook } from "@testing-library/react-native";
 import useSyncJoinedProjects from "components/AddToProjects/hooks/useSyncJoinedProjects";
 import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
@@ -26,6 +27,13 @@ describe( "useSyncJoinedProjects", () => {
   beforeEach( () => {
     jest.clearAllMocks();
     useCurrentUser.mockReturnValue( { id: currentUserId } );
+    useNetInfo.mockReturnValue( { isConnected: true } );
+  } );
+
+  it( "syncs joined projects when connected and signed in", () => {
+    renderHook( () => useSyncJoinedProjects() );
+
+    expect( syncJoinedProjects ).toHaveBeenCalledWith( mockRealm, currentUserId );
   } );
   it( "does not sync when there is no current user", () => {
     useCurrentUser.mockReturnValue( null );

--- a/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
+++ b/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
@@ -72,4 +72,17 @@ describe( "useSyncJoinedProjects", () => {
     expect( syncJoinedProjects ).toHaveBeenCalledTimes( 1 );
     expect( syncJoinedProjects ).toHaveBeenCalledWith( mockRealm, currentUserId );
   } );
+
+  it( "does not sync again when connectivity is lost and regained", () => {
+    const { rerender } = renderHook( () => useSyncJoinedProjects() );
+    expect( syncJoinedProjects ).toHaveBeenCalledTimes( 1 );
+
+    useNetInfo.mockReturnValue( { isConnected: false } );
+    rerender();
+
+    useNetInfo.mockReturnValue( { isConnected: true } );
+    rerender();
+
+    expect( syncJoinedProjects ).toHaveBeenCalledTimes( 1 );
+  } );
 } );

--- a/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
+++ b/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react-native";
+import useSyncJoinedProjects from "components/AddToProjects/hooks/useSyncJoinedProjects";
+import syncJoinedProjects from "sharedHelpers/syncJoinedProjects";
+import { useCurrentUser } from "sharedHooks";
+
+const mockRealm = {};
+jest.mock( "providers/contexts", () => ( {
+  RealmContext: {
+    useRealm: () => mockRealm,
+  },
+} ) );
+
+jest.mock( "sharedHelpers/syncJoinedProjects", () => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+
+jest.mock( "sharedHooks", () => ( {
+  __esModule: true,
+  useCurrentUser: jest.fn( ),
+} ) );
+
+const currentUserId = 42;
+
+describe( "useSyncJoinedProjects", () => {
+  beforeEach( () => {
+    jest.clearAllMocks();
+    useCurrentUser.mockReturnValue( { id: currentUserId } );
+  } );
+  it( "does not sync when there is no current user", () => {
+    useCurrentUser.mockReturnValue( null );
+
+    renderHook( () => useSyncJoinedProjects() );
+
+    expect( syncJoinedProjects ).not.toHaveBeenCalled();
+  } );
+} );

--- a/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
+++ b/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
@@ -44,6 +44,14 @@ describe( "useSyncJoinedProjects", () => {
     expect( syncJoinedProjects ).not.toHaveBeenCalled();
   } );
 
+  it( "does not sync while connectivity is still undetermined", () => {
+    useNetInfo.mockReturnValue( { isConnected: null } );
+
+    renderHook( () => useSyncJoinedProjects() );
+
+    expect( syncJoinedProjects ).not.toHaveBeenCalled();
+  } );
+
   it( "does not sync when there is no current user", () => {
     useCurrentUser.mockReturnValue( null );
 

--- a/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
+++ b/tests/unit/components/AddToProjects/hooks/useSyncJoinedProjects.test.js
@@ -59,4 +59,17 @@ describe( "useSyncJoinedProjects", () => {
 
     expect( syncJoinedProjects ).not.toHaveBeenCalled();
   } );
+
+  it( "syncs once connectivity is restored", () => {
+    useNetInfo.mockReturnValue( { isConnected: false } );
+
+    const { rerender } = renderHook( () => useSyncJoinedProjects() );
+    expect( syncJoinedProjects ).not.toHaveBeenCalled();
+
+    useNetInfo.mockReturnValue( { isConnected: true } );
+    rerender();
+
+    expect( syncJoinedProjects ).toHaveBeenCalledTimes( 1 );
+    expect( syncJoinedProjects ).toHaveBeenCalledWith( mockRealm, currentUserId );
+  } );
 } );

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -90,4 +90,41 @@ describe( "syncJoinedProjects", ( ) => {
       global.realm.objectForPrimaryKey( "Project", staleProject.id ),
     ).not.toBeNull();
   } );
+
+  it( "fetches all pages and prunes after the last page", async () => {
+    // Local
+    const staleProject = factory( "RemoteProject", { id: 9999 } );
+    Project.upsertRemoteProjects( [staleProject], global.realm );
+    // API: 150 total results across two pages
+    const pageOneProjects = [
+      factory( "RemoteProject", { id: 1 } ),
+      factory( "RemoteProject", { id: 2 } ),
+    ];
+    const pageTwoProjects = [factory( "RemoteProject", { id: 3 } )];
+    fetchUserProjects
+      .mockResolvedValueOnce(
+        makeUserProjectsResponse( pageOneProjects, { totalResults: 150 } ),
+      )
+      .mockResolvedValueOnce(
+        makeUserProjectsResponse( pageTwoProjects, { page: 2, totalResults: 150 } ),
+      );
+
+    await syncJoinedProjects( global.realm, currentUserId );
+
+    expect( fetchUserProjects ).toHaveBeenCalledTimes( 2 );
+    expect( fetchUserProjects ).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining( { page: 1, per_page: 100 } ),
+      expect.anything( ),
+    );
+    expect( fetchUserProjects ).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining( { page: 2, per_page: 100 } ),
+      expect.anything( ),
+    );
+    expect( global.realm.objects( "Project" ) ).toHaveLength( 3 );
+    expect(
+      global.realm.objectForPrimaryKey( "Project", staleProject.id ),
+    ).toBeNull();
+  } );
 } );

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -153,4 +153,19 @@ describe( "syncJoinedProjects", ( ) => {
       global.realm.objectForPrimaryKey( "Project", staleProject.id ),
     ).not.toBeNull();
   } );
+  it( "does not prune or throw when the first fetch fails", async () => {
+    // Local
+    const staleProject = factory( "RemoteProject", { id: 9999 } );
+    Project.upsertRemoteProjects( [staleProject], global.realm );
+    // API
+    fetchUserProjects.mockRejectedValue( new Error( "network request failed" ) );
+
+    await expect(
+      syncJoinedProjects( global.realm, currentUserId ),
+    ).resolves.toBeUndefined( );
+
+    expect(
+      global.realm.objectForPrimaryKey( "Project", staleProject.id ),
+    ).not.toBeNull();
+  } );
 } );

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -11,11 +11,14 @@ jest.mock( "api/usersTyped", () => ( {
 
 const currentUserId = 42;
 
-const makeUserProjectsResponse = results => ( {
+const makeUserProjectsResponse = (
   results,
-  page: 1,
-  per_page: 200,
-  total_results: results.length,
+  { page = 1, totalResults = results.length } = {},
+) => ( {
+  results,
+  page,
+  per_page: 100,
+  total_results: totalResults,
 } );
 
 beforeEach( ( ) => {

--- a/tests/unit/sharedHelpers/syncJoinedProjects.test.js
+++ b/tests/unit/sharedHelpers/syncJoinedProjects.test.js
@@ -127,4 +127,30 @@ describe( "syncJoinedProjects", ( ) => {
       global.realm.objectForPrimaryKey( "Project", staleProject.id ),
     ).toBeNull();
   } );
+
+  it( "does not prune or throw when a later page fails", async () => {
+    // Local
+    const staleProject = factory( "RemoteProject", { id: 9999 } );
+    Project.upsertRemoteProjects( [staleProject], global.realm );
+    // API: page 1 succeeds, page 2 fails
+    const pageOneProject = factory( "RemoteProject", { id: 1 } );
+    fetchUserProjects
+      .mockResolvedValueOnce(
+        makeUserProjectsResponse( [pageOneProject], { totalResults: 150 } ),
+      )
+      .mockRejectedValueOnce( new Error( "network request failed" ) );
+
+    await expect(
+      syncJoinedProjects( global.realm, currentUserId ),
+    ).resolves.toBeUndefined( );
+
+    expect( fetchUserProjects ).toHaveBeenCalledTimes( 2 );
+    // Page 1 was upserted, but the stale local project was not pruned
+    expect(
+      global.realm.objectForPrimaryKey( "Project", pageOneProject.id ),
+    ).not.toBeNull();
+    expect(
+      global.realm.objectForPrimaryKey( "Project", staleProject.id ),
+    ).not.toBeNull();
+  } );
 } );


### PR DESCRIPTION
Closes MOB-1568

This PR adds pagination to the existent call to persist all projects a user has joined.

For testing: I have joined hundreds of projects with the user called `inaturalist-test` on staging, available until staging resets.
