### PR TITLE
jwt retry backoff

### DIFF
--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -66,12 +66,23 @@ const authCache: AuthCache = {
   cacheTimeout: 5000,
 };
 
+// module-level tracking of jwt failures. This works around a
+// fault where different parties were competing for retries
+// during downtime or cascading auth failure, sometimes requring
+// user-initiated app restart to heal.
+let jwtRefreshFailureCount = 0;
+let jwtRefreshFailedAt: number | null = null;
+const JWT_REFRESH_BACKOFF_BASE_MS = 5_000;
+const JWT_REFRESH_BACKOFF_MAX_MS = 60_000;
+
 /**
- * Clear cache for isLoggedIn.
+ * Clear cache for isLoggedIn, and any JWT refresh failure backoff.
  */
 const clearAuthCache = ( ): void => {
   authCache.isLoggedIn = null;
   authCache.lastChecked = null;
+  jwtRefreshFailureCount = 0;
+  jwtRefreshFailedAt = null;
 };
 
 async function getSensitiveItem(
@@ -316,6 +327,26 @@ const getAnonymousJWT = (): string => {
 // during downtime.
 let jwtRefreshPromise: Promise<string | null> | null = null;
 
+const jwtRefreshBackoffRemainingMs = ( ): number => {
+  if ( !jwtRefreshFailedAt || jwtRefreshFailureCount === 0 ) { return 0; }
+  const backoff = Math.min(
+    // 2^1, 2^2, 2^3........
+    JWT_REFRESH_BACKOFF_BASE_MS * 2 ** ( jwtRefreshFailureCount - 1 ),
+    JWT_REFRESH_BACKOFF_MAX_MS,
+  );
+  return Math.max( backoff - ( Date.now( ) - jwtRefreshFailedAt ), 0 );
+};
+
+const recordJwtRefreshFailure = ( ): void => {
+  jwtRefreshFailureCount += 1;
+  jwtRefreshFailedAt = Date.now( );
+};
+
+const recordJwtRefreshSuccess = ( ): void => {
+  jwtRefreshFailureCount = 0;
+  jwtRefreshFailedAt = null;
+};
+
 async function fetchFreshJWT( logContext: string | null ): Promise<string | null> {
   try {
     const accessToken = await getSensitiveItem( "accessToken" );
@@ -328,6 +359,7 @@ async function fetchFreshJWT( logContext: string | null ): Promise<string | null
       response = await api.get<{api_token: string}>( "/users/api_token.json" );
     } catch ( getUsersApiTokenError ) {
       logger.error( "Failed to fetch JWT: ", getUsersApiTokenError );
+      recordJwtRefreshFailure( );
       if ( !getUsersApiTokenError ) { return null; }
       throw getUsersApiTokenError;
     }
@@ -337,6 +369,7 @@ async function fetchFreshJWT( logContext: string | null ): Promise<string | null
         `JWT [${logContext}]: Token refresh failed - status: ${response.status}`,
         `- originalError: ${response.originalError} - problem: ${response.problem}`,
       );
+      recordJwtRefreshFailure( );
       // this deletes the user JWT and saved login details when a user is not
       // actually signed in anymore for example, if they installed, deleted,
       // and reinstalled the app without logging out
@@ -354,12 +387,15 @@ async function fetchFreshJWT( logContext: string | null ): Promise<string | null
     // Get newest JWT Token
     const newJwtToken = response.data?.api_token;
     if ( !newJwtToken ) {
+      recordJwtRefreshFailure( );
       throw new Error( "Fetched empty JWT" );
     }
     const newJwtGeneratedAt = Date.now();
 
     await setSensitiveItem( "jwtToken", newJwtToken );
     await setSensitiveItem( "jwtGeneratedAt", newJwtGeneratedAt.toString() );
+
+    recordJwtRefreshSuccess( );
 
     if ( logContext ) {
       logger.info( `JWT [${logContext}]: Token refreshed successfully` );
@@ -415,6 +451,10 @@ const getJWT = async (
     // If a refresh is already in-flight, return that shared promise instead
     // of starting a second concurrent request.
     if ( !jwtRefreshPromise ) {
+      // skip the fetch (and return null) if we're still waiting on backoff
+      if ( jwtRefreshBackoffRemainingMs() > 0 ) {
+        return null;
+      }
       jwtRefreshPromise = fetchFreshJWT( logContext );
     }
     return jwtRefreshPromise;

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -453,7 +453,7 @@ const getJWT = async (
     if ( !jwtRefreshPromise ) {
       // skip the fetch (and return null) if we're still waiting on backoff
       if ( jwtRefreshBackoffRemainingMs() > 0 ) {
-        return null;
+        return jwtToken ?? null;
       }
       jwtRefreshPromise = fetchFreshJWT( logContext );
     }

--- a/tests/unit/components/LoginSignUp/AuthenticationService.test.js
+++ b/tests/unit/components/LoginSignUp/AuthenticationService.test.js
@@ -192,4 +192,37 @@ describe( "getJWT 401 handling", ( ) => {
 
     expect( result ).toBeNull( );
   } );
+
+  it( "backs off and skips a second refresh attempt shortly after a failure", async ( ) => {
+    // Only one interceptor is registered (not .persist()), and net connect
+    // is disabled, so a second real request wouldn't silently succeed
+    // against the real network.
+    const errorSpy = jest.spyOn( console, "error" ).mockImplementation( ( ) => { } );
+    nock.disableNetConnect( );
+    try {
+      const scope = nock( API_HOST )
+        .get( "/users/api_token.json" )
+        .reply( 401 );
+
+      const countFailureLogs = ( ) => errorSpy.mock.calls.filter(
+        ( [msg] ) => typeof msg === "string" && msg.includes( "Token refresh failed" ),
+      ).length;
+
+      const firstResult = await getJWT( );
+      expect( firstResult ).toBeNull( );
+      expect( scope.isDone( ) ).toBe( true );
+      expect( countFailureLogs( ) ).toBe( 1 );
+
+      const secondResult = await getJWT( );
+
+      expect( secondResult ).toBeNull( );
+      // No new "Token refresh failed" log means getJWT skipped the network
+      // call entirely during the backoff window instead of trying (and
+      // failing) again.
+      expect( countFailureLogs( ) ).toBe( 1 );
+    } finally {
+      nock.enableNetConnect( );
+      errorSpy.mockRestore( );
+    }
+  } );
 } );


### PR DESCRIPTION
Closes MOB-1623 (retroactively created)

we have a key flaw in our authservice code where we hold a shared _jwt_ promise BUTTTTTT we don't care if it's failed or not. We'll wait until the shared promise is resolved but we're happy to retry it again if it immediately fails and fails and fails.

This sometimes results in a broken app state which is only resolved by quitting and restarting, pointing to the issue being instance-based.

This PR introduces module-level state for tracking JWT retries and implements exponential (0s, 2s, 4s, 8s ....) backoff for retries, replacing our sometimes 20-times-a-second failed JWT retries.