### PR TITLE
MOB-1602 prevent pivot card from crashing first launch

### DIFF
--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -519,11 +519,13 @@ const MyObservationsSimple = ( {
             imageComponentOptions={{
               onImageComponentPress: handlePivotCardGridItemPress,
               accessibilityHint: t( "Navigates-to-observation-details" ),
-              imageComponent: (
-                <PivotCardObsGridItem
-                  uuid={observationIds[0].uuid}
-                />
-              ),
+              imageComponent: observationIds.length
+                ? (
+                  <PivotCardObsGridItem
+                    uuid={observationIds[0].uuid}
+                  />
+                )
+                : null,
             }}
           />
           <FiveObservationCard triggerCondition={numTotalObservations === 5} />


### PR DESCRIPTION
This fixes the local source of a reliable crash on _initial_ login in default mode when a user has at least one remote obs. 

<img width="1008" height="2244" alt="image" src="https://github.com/user-attachments/assets/5567fb92-8b62-414e-95de-09bf7929db82" />

FYI @abbeycampbell I think I tracked it down to this change: https://github.com/inaturalist/iNaturalistReactNative/commit/a38414a0e569b84105c6e2479bc0c4d51cc54211#diff-07ff17bf25fd2c24f5bfad7f70d54783e036fb7df3268eb9e167d8d8dcfee224L446. I think with that change, we have now have a render pass of MyObsSimple where obsIds doesn't yet have the upserted API results. 

This eventually settles and with a small check to guard the property access, everything seems fine. Just wanted to bring to your attention for if you think we need to look further into this (and keep the loading state while obsIds.length hasn't reflected API results)