### PR TITLE
fix observation owner display for "Others" notifications.

### DIFF
--- a/src/sharedHooks/useInfiniteNotificationsScroll.ts
+++ b/src/sharedHooks/useInfiniteNotificationsScroll.ts
@@ -73,11 +73,11 @@ async function fetchObsByUUIDs(
     uuids,
     {
       fields: {
+        ...Observation.ADVANCED_MODE_LIST_FIELDS,
         user: {
-          id: true,
+          ...Observation.ADVANCED_MODE_LIST_FIELDS.user,
           login: true,
         },
-        ...Observation.ADVANCED_MODE_LIST_FIELDS,
       },
     },
     authOptions,


### PR DESCRIPTION

|Before Notification shows "Unknown" for all obs in "Others" notifications|After shows owning user login when available|
|---|---|
|<img width="243" height="402" alt="image" src="https://github.com/user-attachments/assets/d2aa05db-c94f-4a46-acba-ff558e2d5888" />|<img width="358" height="395" alt="image" src="https://github.com/user-attachments/assets/d47f6678-2ae1-41aa-9a5f-ada8de739393" />|

https://github.com/inaturalist/iNaturalistReactNative/pull/3835 added a `user` fields to the obs API request where we weren't asking for it before. This would have been fine except that when the Notifications tab grabs obs, it overrides the full `user` fields object to request id & `login` (the username). Since were spreading the default fields _after_ this full object, it got clobbered.

Fix: Now that the default obs fields have a `user` fields object, spread over the defaults instead of fully clobbering them