### PR TITLE
Mob 1596 deleting a photosound and pressing back on a savedunsynced

### DIFF
--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -187,7 +187,7 @@ const EvidenceList = ( {
       await ObservationSound.deleteLocalObservationSound(
         realm,
         uriToDelete,
-        currentObservation.uuid,
+        currentObservation?.uuid,
       );
       afterMediaDeleted( uriToDelete );
     }

--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -187,7 +187,7 @@ const EvidenceList = ( {
       await ObservationSound.deleteLocalObservationSound(
         realm,
         uriToDelete,
-        currentObservation?.uuid,
+        currentObservation.uuid,
       );
       afterMediaDeleted( uriToDelete );
     }

--- a/src/components/ObsEdit/EvidenceList.js
+++ b/src/components/ObsEdit/EvidenceList.js
@@ -175,10 +175,10 @@ const EvidenceList = ( {
   );
 
   const onDeletePhoto = useCallback( async uriToDelete => {
-    await ObservationPhoto.deletePhoto( uriToDelete, currentObservation );
+    await ObservationPhoto.deletePhoto( uriToDelete, currentObservation, realm );
     deletePhotoFromObservation( uriToDelete );
     afterMediaDeleted( uriToDelete );
-  }, [afterMediaDeleted, currentObservation, deletePhotoFromObservation] );
+  }, [afterMediaDeleted, currentObservation, deletePhotoFromObservation, realm] );
 
   const onDeleteSound = useCallback( async uriToDelete => {
     const obsSound = observationSounds.find( os => os.sound.file_url === uriToDelete );

--- a/src/realmModels/ObservationPhoto.ts
+++ b/src/realmModels/ObservationPhoto.ts
@@ -1,7 +1,8 @@
 import { Realm } from "@realm/react";
 import type { ApiObservationPhoto } from "api/types";
 import inatjs, { FileUpload } from "inaturalistjs";
-import type { RealmObservationPhoto, RealmPhoto } from "realmModels/types";
+import type { RealmObservation, RealmObservationPhoto, RealmPhoto } from "realmModels/types";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import * as uuid from "uuid";
 
 import Photo from "./Photo";
@@ -144,9 +145,18 @@ class ObservationPhoto extends Realm.Object {
     }
   }
 
-  static async deleteLocalPhoto( uri: string ) {
+  static async deleteLocalPhoto( uri: string, realm?: Realm, obsUUID?: string ) {
     // delete uri on disk
     Photo.deletePhotoFromDeviceStorage( uri );
+    if ( !realm || !obsUUID ) return;
+    const realmObs = realm.objectForPrimaryKey<RealmObservation>( "Observation", obsUUID );
+    const obsPhotoToDelete = realmObs?.observationPhotos
+      ?.find( p => Photo.getLocalPhotoUri( p.photo?.localFilePath ) === uri );
+    if ( obsPhotoToDelete ) {
+      safeRealmWrite( realm, ( ) => {
+        realm.delete( obsPhotoToDelete );
+      }, "deleting local observation photo in ObservationPhoto" );
+    }
   }
 
   // TODO: I don't know how what the type for currentObservation is outside of this context here,
@@ -155,12 +165,16 @@ class ObservationPhoto extends Realm.Object {
   // linear ticket so I'll skip typing it
   static async deletePhoto(
     uri: string,
-    currentObservation?: { observationPhotos?: { photo: { url?: string }; uuid: string }[] },
+    currentObservation?: {
+      observationPhotos?: { photo: { url?: string }; uuid: string }[];
+      uuid?: string;
+    },
+    realm?: Realm,
   ) {
     if ( uri.includes( "https://" ) ) {
       ObservationPhoto.deleteRemotePhoto( uri, currentObservation );
     } else {
-      ObservationPhoto.deleteLocalPhoto( uri );
+      ObservationPhoto.deleteLocalPhoto( uri, realm, currentObservation?.uuid );
     }
   }
 

--- a/src/realmModels/ObservationSound.ts
+++ b/src/realmModels/ObservationSound.ts
@@ -6,7 +6,7 @@ import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import * as uuid from "uuid";
 
 import Sound from "./Sound";
-import type { RealmObservationSound, RealmSound } from "./types";
+import type { RealmObservation, RealmObservationSound, RealmSound } from "./types";
 
 class ObservationSound extends Realm.Object {
   _created_at?: Date;
@@ -83,9 +83,9 @@ class ObservationSound extends Realm.Object {
   static async deleteLocalObservationSound( realm: Realm, uri: string, obsUUID: string ) {
     // delete uri on disk
     Sound.deleteSoundFromDeviceStorage( uri );
-    const realmObs = realm.objectForPrimaryKey( "Observation", obsUUID );
+    const realmObs = realm.objectForPrimaryKey<RealmObservation>( "Observation", obsUUID );
     const obsSoundToDelete = realmObs?.observationSounds
-      .find( p => p.file_url === uri );
+      .find( p => p.sound?.file_url === uri );
     if ( obsSoundToDelete ) {
       safeRealmWrite( realm, ( ) => {
         realm?.delete( obsSoundToDelete );


### PR DESCRIPTION
closes [MOB-1596](https://linear.app/inaturalist/issue/MOB-1596/deleting-a-photosound-and-pressing-back-on-a-savedunsynced-observation)

We were deleting files from disk, but the Realm observations still had references to them. Saving re-writes rewrites the embedded `observationPhotos/observationSounds` lists  so this issue is only caused by tapping back with unsaved changes. (There are some separate  but related ux issues around navving back vs saving, discarding changes, and what changes are even discardable that I'm gonna open a separate ticket for, but that will need product input).