### PR TITLE
MOB-1466 extract journal post image preview

### DIFF
--- a/src/components/Journal/PostListItem.tsx
+++ b/src/components/Journal/PostListItem.tsx
@@ -34,15 +34,16 @@ const PostListItem = ( {
       : item.parent.icon_url ?? null;
   }, [item.body, item.parent.icon_url] );
 
-  if ( !item ) {
-    return null;
-  }
-
   return (
     <View className="flex-row items-center mx-3 my-2">
       {imgSrc && (
         <Image
           source={{ uri: imgSrc }}
+          // Passing a key here is not ideal for FlashList, but we do actually want to avoid
+          // recycling on images. When Image gets a new `source` prop, it continues displaying
+          // the previously-loaded image until the new source is loaded, which leads to "stale"
+          // images being associated with a post. Passing a key forced an unmount/remount.
+          key={imgSrc}
           className={THUMBNAIL_CLASS}
           accessibilityRole="image"
           accessibilityIgnoresInvertColors

--- a/src/components/Journal/PostListItem.tsx
+++ b/src/components/Journal/PostListItem.tsx
@@ -8,9 +8,15 @@ import {
   Image,
   View,
 } from "components/styledComponents";
-import React from "react";
+import React, { useMemo } from "react";
 import { formatLongDate } from "sharedHelpers/dateAndTime";
 import { useTranslation } from "sharedHooks";
+
+// we use the first image from the announcement html body
+// as the list post preview. The following regex pattern matches
+// <img ..... src="CAPTURE_GROUP_1"
+// for testing / reference: https://regexr.com/8no7d
+const imgSrcPattern = /<img[^>]*\s+src="([^>\s]+)"/;
 
 interface Props {
   item: ApiPostForUser;
@@ -21,15 +27,22 @@ const PostListItem = ( {
 }: Props ) => {
   const { i18n } = useTranslation( );
 
+  const imgSrc = useMemo( () => {
+    const match = item.body.match( imgSrcPattern );
+    return match
+      ? match[1]
+      : item.parent.icon_url ?? null;
+  }, [item.body, item.parent.icon_url] );
+
   if ( !item ) {
     return null;
   }
 
   return (
     <View className="flex-row items-center mx-3 my-2">
-      {item.parent.icon_url && (
+      {imgSrc && (
         <Image
-          source={{ uri: item.parent.icon_url }}
+          source={{ uri: imgSrc }}
           className={THUMBNAIL_CLASS}
           accessibilityRole="image"
           accessibilityIgnoresInvertColors


### PR DESCRIPTION
Closes MOB-1466

Follows the pattern of iNat Classic iOS to use the first `img` in the Journal/Blog post as preview image in the post list. I think regex works fine for this, but I'm open to suggestions of if we should use a legit xml / html parsing lib for safer validation. Here's a playground for the pattern w/ an example journal post: https://regexr.com/8no7d (also linked as comment).

It maintains the fallback to the iNat logo image for posts without images.

<img width="386" height="834" alt="image" src="https://github.com/user-attachments/assets/76d4f32e-c2a4-4681-85af-ddc82057edec" />
