### PR TITLE
MOB-1621 use screen tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import "react-native-get-random-values";
 import "react-native-url-polyfill/auto";
 
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
-import { Alert, AppRegistry } from "react-native";
+import { Alert, AppRegistry, LogBox } from "react-native";
 import { getCurrentRoute } from "navigation/navigationUtils";
 import zustandMMKVBackingStorage from "stores/zustandMMKVBackingStorage";
 import {
@@ -41,6 +41,11 @@ import { log } from "./react-native-logs.config";
 import { getUserAgent } from "./src/api/userAgent";
 
 const logger = log.extend( "index.js" );
+
+LogBox.ignoreLogs( [
+  // ignore deprecation warning from Firebase. Will be handled with MOB-1630.
+  /Firebase Web modular SDK API/,
+] );
 
 // Log all unhandled promise rejections in release builds. Otherwise they will
 // die in silence. Debug builds have a more useful UI w/ desymbolicated stack

--- a/src/sharedHelpers/tracking.ts
+++ b/src/sharedHelpers/tracking.ts
@@ -1,5 +1,7 @@
 import {
-  getAnalytics, logEvent,
+  getAnalytics,
+  logEvent,
+  logScreenView,
   setAnalyticsCollectionEnabled,
 } from "@react-native-firebase/analytics";
 import { getPerformance } from "@react-native-firebase/perf";
@@ -37,9 +39,11 @@ export const logFirebaseScreenView = (
 ) => {
   try {
     const analytics = getAnalytics();
-    logEvent( analytics, "screen_view", {
-      firebase_screen: screenName,
-      firebase_screen_class: screenName,
+    logScreenView( analytics, {
+      screen_name: screenName,
+      // Firebase automatically reports screen_class, the native class e.g., MainActivity.java.
+      // In a pure RN app, this could be misleading so we _explicitly_ override this with "NA"
+      screen_class: "NA",
     } );
   } catch ( error ) {
     logger.error( "Error logging firebase screen view", JSON.stringify( error ) );


### PR DESCRIPTION
closes MOB-1621

Previously, firebase didn't like that we were using the reserved namespacing prefix in `firebase_screen` so it discarded those attrs. 

We now explicitly use `@react-native-firebase/analytics`'s `logScreenView` for screen tracking. 

We intentionally shifted away from this to satisfy a deprecation warning here: https://github.com/inaturalist/iNaturalistReactNative/commit/86430591fcc38aad73510fd795975db6490b35a1 However, we now have an owner of the Analytics concern and we would like these to present as best as possible to give an accurate landscape. 

I've created MOB-1630 to deal with the eventual package upgrade and handle the deprecation warnings. Those warnings are ignored in LogBox at least for now.