### PR TITLE
update AGENTS.md to encourage honest ts typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ npm run lint:tsc        # TypeScript checking
 
 **Note on `lint:tsc`:** The repo has a large pre-existing TypeScript error baseline (over 1,000 errors), so a clean run is not expected. The standard is to add no new errors in files you touch — verify by filtering the tsc output for your filenames and comparing against the pre-change state. TS7016 implicit-`any` errors from importing untyped `.js` modules are part of the accepted baseline; do not add `@ts-ignore` comments for them.
 
+**Never silence a type error you can't honestly fix.** Casts (`as unknown as X`), non-null `!`, and widening a type to `object`/`Function` quiet `tsc` while leaving the mismatch in shipped code. If an error is a legitimate mismatch that can't be resolved within the scope of your change, leave it reported
+
 ### Translations
 ```bash
 # Build translation JSON from Fluent files

--- a/agent-docs/conventions/typescript.md
+++ b/agent-docs/conventions/typescript.md
@@ -15,6 +15,14 @@ The codebase is **partway through a Flow → TypeScript migration** and both coe
 | `npm run lint:tsc` | TypeScript (`tsconfig.json`) |
 | `npm run lint:flow` | Flow (`.js` files with `// @flow`) |
 
+## Honest types
+
+**If a `tsc` error is a legitimate type mismatch you can't fix within the scope of your change, leave it reported.** A visible error is an honest TODO; a cast is a lie that survives the migration. The baseline is the record — reviewers diff `lint:tsc` before and after to see what a change cost.
+
+When you *can* fix an error in scope, fix the producer, not the call site — type the Realm query (`realm.objects<RealmTaxon>( "Taxon" )`) rather than casting its result. Defer when the root is somewhere your change doesn't reach; that's its own PR.
+
+**Converting `.js` → `.ts`/`.tsx`:** `lint:tsc` runs with `--allowJs false`, so Flow `.js` files aren't checked at all. Converting one adds it to the program for the first time and pre-existing mismatches surface as new errors. Expected — fix the ones your change is about, especially in files it already touches, and leave the rest visible.
+
 ## `interface` vs `type`
 
 - Use **`interface`** for object shapes — component props, data models, API response objects, state objects, hook return values. Props are declared as `interface Props { ... }` directly above the component.
@@ -32,6 +40,6 @@ type ScreenAfterPhotoEvidence = "Match" | "Suggestions" | "ObsEdit";
 ## Other guidance
 
 - Prefer type **inference** over redundant annotations; annotate at boundaries (params, returns, exported values).
-- Avoid `any`; reach for `unknown` when a value is genuinely untyped, then narrow. TS7016 implicit-`any` from importing untyped `.js` modules is part of the accepted baseline — don't paper over it with `@ts-ignore`.
+- Avoid `any`; reach for `unknown` when a value is genuinely untyped, then narrow. TS7016 implicit-`any` from importing untyped `.js` modules is part of the accepted baseline — leave it alone (see [Honest types](#honest-types)).
 - **Realm** models use their own class-based `ObjectSchema` type system rather than plain interfaces.
 - **Navigation** params are typed via the param-list types (`RootStackParamList`, etc.) — see `agent-docs/architecture/navigation-patterns.md`.


### PR DESCRIPTION
AGENTS.md update to try to give claude permission to leave ts errors that are outside the scope of the current work.

I was seeing output that relied on dishonest casting to achieve zero ts errors