### PR TITLE
Mob 1610 observation and species counts should reflect search results

### DIFF
--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -428,10 +428,15 @@ const MyObservationsResults = ( ) => {
 
   const numTotalObservations = totalResultsRemote || observationIds.length;
 
-  // When a search is active, we want to show a live, search-informed total
+  // When a search is active, we want to show a live, search-informed total for observation and
+  // species counts, otherwise, fallback to the values from zustand
   const displayedObservationsCount = hasActiveSearch
     ? searchTotalResults
     : numOfUserObservations;
+
+  const displayedSpeciesCount = hasActiveSearch
+    ? numTotalTaxa
+    : numOfUserSpecies;
 
   // Pagination for the rendered list follows whichever source is authoritative:
   const isFetchingNextPageForList = useServerOrder
@@ -530,7 +535,7 @@ const MyObservationsResults = ( ) => {
       loggedInWhileInDefaultMode={loggedInWhileInDefaultMode}
       taxaListRef={taxaListRef}
       numTotalObservations={displayedObservationsCount}
-      numTotalTaxa={numOfUserSpecies}
+      numTotalTaxa={displayedSpeciesCount}
       numUnuploadedObservations={numUnuploadedObservations}
       numObsMissingBasics={numObsMissingBasics}
       observationIds={observationIds}

--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -112,6 +112,7 @@ const MyObservationsResults = ( ) => {
     isFetchingNextPage: isFetchingNextPageFromQuery,
     fetchNextPage: fetchNextPageFromQuery,
     refetch: refetchFromQuery,
+    totalResults: searchTotalResults,
   } = useMyObservationsQuery( );
   // Only use server-ordered result when at least one of the features that needs it is enabled;
   // when neither is, we use the plain local list anyway
@@ -427,6 +428,11 @@ const MyObservationsResults = ( ) => {
 
   const numTotalObservations = totalResultsRemote || observationIds.length;
 
+  // When a search is active, we want to show a live, search-informed total
+  const displayedObservationsCount = hasActiveSearch
+    ? searchTotalResults
+    : numOfUserObservations;
+
   // Pagination for the rendered list follows whichever source is authoritative:
   const isFetchingNextPageForList = useServerOrder
     ? isFetchingNextPageFromQuery
@@ -523,7 +529,7 @@ const MyObservationsResults = ( ) => {
       listRef={listRef}
       loggedInWhileInDefaultMode={loggedInWhileInDefaultMode}
       taxaListRef={taxaListRef}
-      numTotalObservations={numOfUserObservations}
+      numTotalObservations={displayedObservationsCount}
       numTotalTaxa={numOfUserSpecies}
       numUnuploadedObservations={numUnuploadedObservations}
       numObsMissingBasics={numObsMissingBasics}

--- a/src/components/MyObservations/hooks/useMyObservationsQuery.ts
+++ b/src/components/MyObservations/hooks/useMyObservationsQuery.ts
@@ -18,6 +18,7 @@ interface UseMyObservationsQueryResult {
   isLoading: boolean;
   isFetchingNextPage: boolean;
   error: Error | null;
+  totalResults?: number;
   refetch: ( ) => void;
   fetchNextPage: ( ) => void;
 }
@@ -49,6 +50,7 @@ const useMyObservationsQuery = ( ): UseMyObservationsQueryResult => {
     isLoading,
     isFetchingNextPage,
     error,
+    totalResults,
     fetchNextPage,
     refetch,
   } = useServerOrderedObservations( {
@@ -104,6 +106,9 @@ const useMyObservationsQuery = ( ): UseMyObservationsQueryResult => {
     error: isServerAuthoritative
       ? error
       : null,
+    totalResults: isServerAuthoritative
+      ? totalResults
+      : undefined,
     // pagination only applies to the server-authoritative case; the default sort is handled by
     // useInfiniteObservationsScroll, and locally-sorted data for logged-out users loads from Realm
     refetch: isServerAuthoritative

--- a/tests/unit/components/MyObservations/hooks/useMyObservationsQuery.test.js
+++ b/tests/unit/components/MyObservations/hooks/useMyObservationsQuery.test.js
@@ -64,6 +64,7 @@ const defaultServerResult = {
   isLoading: false,
   isFetchingNextPage: false,
   error: null,
+  totalResults: undefined,
   fetchNextPage: jest.fn( ),
   refetch: jest.fn( ),
 };
@@ -97,6 +98,7 @@ describe( "useMyObservationsQuery", ( ) => {
       isLoading: true,
       isFetchingNextPage: true,
       error: new Error( "should be suppressed for default sort" ),
+      totalResults: 99,
       refetch: serverRefetch,
       fetchNextPage: serverFetchNextPage,
     } );
@@ -110,6 +112,7 @@ describe( "useMyObservationsQuery", ( ) => {
     expect( result.current.isLoading ).toEqual( false );
     expect( result.current.isFetchingNextPage ).toEqual( false );
     expect( result.current.error ).toBeNull( );
+    expect( result.current.totalResults ).toBeUndefined( );
     expect( result.current.refetch ).not.toBe( serverRefetch );
     expect( result.current.fetchNextPage ).not.toBe( serverFetchNextPage );
     expect( useServerOrderedObservations ).toHaveBeenCalledWith(
@@ -127,6 +130,7 @@ describe( "useMyObservationsQuery", ( ) => {
       ...defaultServerResult,
       observationIds: [serverObs],
       isFetchingNextPage: true,
+      totalResults: 7,
       fetchNextPage: serverFetchNextPage,
     } );
     const unsyncedObs = factory( "LocalObservation", { needs_sync: true } );
@@ -140,6 +144,7 @@ describe( "useMyObservationsQuery", ( ) => {
     ] );
     expect( result.current.isServerAuthoritative ).toEqual( true );
     expect( result.current.isFetchingNextPage ).toEqual( true );
+    expect( result.current.totalResults ).toEqual( 7 );
     expect( result.current.fetchNextPage ).toBe( serverFetchNextPage );
     expect( useServerOrderedObservations ).toHaveBeenCalledWith(
       expect.objectContaining( { enabled: true } ),
@@ -178,12 +183,14 @@ describe( "useMyObservationsQuery", ( ) => {
     useServerOrderedObservations.mockReturnValue( {
       ...defaultServerResult,
       observationIds: [serverObs],
+      totalResults: 6,
     } );
 
     const { result } = renderHook( ( ) => useMyObservationsQuery( ) );
 
     expect( result.current.isServerAuthoritative ).toEqual( true );
     expect( result.current.observationIds ).toEqual( [serverObs] );
+    expect( result.current.totalResults ).toEqual( 6 );
     expect( useServerOrderedObservations ).toHaveBeenCalledWith(
       expect.objectContaining( { enabled: true, taxonId: searchedTaxon.id } ),
     );
@@ -201,6 +208,7 @@ describe( "useMyObservationsQuery", ( ) => {
     useServerOrderedObservations.mockReturnValue( {
       ...defaultServerResult,
       observationIds: [{ uuid: "should-be-ignored-when-logged-out" }],
+      totalResults: 6,
     } );
     const localObs = factory( "LocalObservation", { needs_sync: false } );
     createObservation( localObs );
@@ -209,6 +217,7 @@ describe( "useMyObservationsQuery", ( ) => {
 
     expect( result.current.isServerAuthoritative ).toEqual( false );
     expect( result.current.observationIds ).toEqual( [{ uuid: localObs.uuid }] );
+    expect( result.current.totalResults ).toBeUndefined( );
     expect( useServerOrderedObservations ).toHaveBeenCalledWith(
       expect.objectContaining( { enabled: false } ),
     );


### PR DESCRIPTION
closes [MOB-1610](https://linear.app/inaturalist/issue/MOB-1610/observation-and-species-counts-should-reflect-search-results)