### PR TITLE
MOB-1591: ExploreV2 keyboard shouldn't cover autocomplete results

### DIFF
--- a/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/UniversalSearch.tsx
@@ -1,3 +1,4 @@
+import { BottomTabBarHeightContext } from "@react-navigation/bottom-tabs";
 import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
 import DefaultSearchOptions
@@ -36,10 +37,13 @@ import {
   EXPLORE_V2_ACTION,
   useExploreV2,
 } from "providers/ExploreV2Context";
-import React, { useCallback, useRef, useState } from "react";
+import React, {
+  useCallback, useContext, useMemo, useRef, useState,
+} from "react";
 import type { ListRenderItem, TextInput as RNTextInput } from "react-native";
 import { FlatList, Keyboard } from "react-native";
 import useCurrentUser from "sharedHooks/useCurrentUser";
+import useKeyboardInfo from "sharedHooks/useKeyboardInfo";
 import useSearchField from "sharedHooks/useSearchField";
 import useTranslation from "sharedHooks/useTranslation";
 import { getShadow } from "styles/global";
@@ -86,6 +90,17 @@ const UniversalSearch = ( ) => {
   const currentUser = useCurrentUser( );
   const commonNameIsPrimary = currentUser?.prefers_common_names !== false
     && currentUser?.prefers_scientific_name_first !== true;
+
+  const { keyboardHeight, keyboardShown } = useKeyboardInfo( );
+  const tabBarHeight = useContext( BottomTabBarHeightContext ) ?? 0;
+  const [buttonBarHeight, setButtonBarHeight] = useState( 0 );
+  const listOverlap = keyboardShown
+    ? Math.max( 0, keyboardHeight - tabBarHeight - buttonBarHeight )
+    : 0;
+  const listContentStyle = useMemo(
+    ( ) => ( { paddingBottom: listOverlap } ),
+    [listOverlap],
+  );
 
   // Which field's result list is showing. tracks the last-focused field rather
   // than live focus. Subject autofocuses, so it's the initial value.
@@ -327,14 +342,22 @@ const UniversalSearch = ( ) => {
       <View className="flex-1">
         {/* One always-mounted list; its contents follow the focused field. */}
         <FlatList
+          contentContainerStyle={listContentStyle}
           data={listData}
           keyboardShouldPersistTaps="handled"
           keyExtractor={resultKey}
           renderItem={renderItem}
+          testID="UniversalSearch.results"
           ListEmptyComponent={listEmptyComponent}
         />
       </View>
-      <ButtonBar containerClass="bg-white border-t border-lightGray">
+      <ButtonBar
+        containerClass="bg-white border-t border-lightGray"
+        onLayout={
+          ( { nativeEvent } ) => setButtonBarHeight( nativeEvent.layout.height )
+        }
+        testID="UniversalSearch.buttonBar"
+      >
         <Button
           level="focus"
           onPress={handleSearch}

--- a/src/components/SharedComponents/ButtonBar.tsx
+++ b/src/components/SharedComponents/ButtonBar.tsx
@@ -25,6 +25,7 @@ interface Props extends PropsWithChildren {
   containerClass?: string;
   onLayout?: ( event: LayoutChangeEvent ) => void;
   sticky?: boolean;
+  testID?: string;
   buttonConfiguration?: ButtonConfiguration[];
 }
 
@@ -35,6 +36,7 @@ const ButtonBar = ( {
   buttonConfiguration,
   onLayout,
   sticky,
+  testID,
 }: Props ) => {
   const { bottom } = useSafeAreaInsets( );
   const layoutClassNames = sticky
@@ -55,6 +57,7 @@ const ButtonBar = ( {
       style={[DROP_SHADOW, sticky
         ? { paddingBottom: bottom }
         : undefined]}
+      testID={testID}
     >
       {buttonConfiguration && buttonConfiguration.map( button => {
         const {

--- a/tests/unit/components/Explore/ExploreV2/screens/UniversalSearch.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/UniversalSearch.test.js
@@ -1,4 +1,5 @@
 import { useNetInfo } from "@react-native-community/netinfo";
+import { BottomTabBarHeightContext } from "@react-navigation/bottom-tabs";
 import {
   act, fireEvent, screen, userEvent, waitFor,
 } from "@testing-library/react-native";
@@ -6,7 +7,7 @@ import UniversalSearch from "components/Explore/ExploreV2/screens/UniversalSearc
 import initI18next from "i18n/initI18next";
 import i18next from "i18next";
 import React from "react";
-import { Keyboard } from "react-native";
+import { Keyboard, StyleSheet } from "react-native";
 import { renderComponent } from "tests/helpers/render";
 
 const mockNavigate = jest.fn( );
@@ -70,6 +71,12 @@ jest.mock( "sharedHooks/useIconicTaxa", ( ) => ( {
   default: jest.fn( ),
 } ) );
 const useIconicTaxa = require( "sharedHooks/useIconicTaxa" ).default;
+
+jest.mock( "sharedHooks/useKeyboardInfo", ( ) => ( {
+  __esModule: true,
+  default: jest.fn( ),
+} ) );
+const useKeyboardInfo = require( "sharedHooks/useKeyboardInfo" ).default;
 
 const ICONIC_TAXA = [
   {
@@ -160,6 +167,18 @@ const focusLocation = ( ) => {
   fireEvent( screen.getByTestId( "UniversalSearch.locationInput" ), "focus" );
 };
 
+const KEYBOARD_HIDDEN = { keyboardHeight: 0, keyboardShown: false };
+
+const measureButtonBar = height => {
+  fireEvent( screen.getByTestId( "UniversalSearch.buttonBar" ), "layout", {
+    nativeEvent: { layout: { height } },
+  } );
+};
+
+const listPaddingBottom = ( ) => StyleSheet.flatten(
+  screen.getByTestId( "UniversalSearch.results" ).props.contentContainerStyle,
+)?.paddingBottom;
+
 beforeAll( async ( ) => {
   await initI18next( );
 } );
@@ -183,6 +202,7 @@ beforeEach( ( ) => {
   useIconicTaxa.mockReturnValue( ICONIC_TAXA );
   useUniversalSearch.mockReturnValue( { results: [], isLoading: false, refetch: jest.fn( ) } );
   useLocationSearch.mockReturnValue( { results: [], isLoading: false, refetch: jest.fn( ) } );
+  useKeyboardInfo.mockReturnValue( KEYBOARD_HIDDEN );
   // Default to online; the offline tests override this per-case.
   useNetInfo.mockReturnValue( { isConnected: true } );
 } );
@@ -623,6 +643,52 @@ describe( "UniversalSearch screen", ( ) => {
         expect( mockDispatch ).toHaveBeenCalledWith( { type: "SET_LOCATION_NEARBY" } );
       },
     );
+  } );
+
+  describe( "keeping results clear of the keyboard", ( ) => {
+    it( "adds no padding while the keyboard is dismissed", ( ) => {
+      useKeyboardInfo.mockReturnValue( { keyboardHeight: 300, keyboardShown: false } );
+      renderComponent( <UniversalSearch /> );
+
+      measureButtonBar( 80 );
+
+      expect( listPaddingBottom( ) ).toEqual( 0 );
+    } );
+
+    it( "pads the list by the keyboard height minus the button bar", ( ) => {
+      useKeyboardInfo.mockReturnValue( { keyboardHeight: 300, keyboardShown: true } );
+      renderComponent( <UniversalSearch /> );
+
+      expect( listPaddingBottom( ) ).toEqual( 300 );
+
+      measureButtonBar( 80 );
+      expect( listPaddingBottom( ) ).toEqual( 220 );
+    } );
+
+    it( "also subtracts the tab bar height when the screen has one", ( ) => {
+      useKeyboardInfo.mockReturnValue( { keyboardHeight: 300, keyboardShown: true } );
+      renderComponent(
+        <BottomTabBarHeightContext.Provider value={50}>
+          <UniversalSearch />
+        </BottomTabBarHeightContext.Provider>,
+      );
+
+      measureButtonBar( 80 );
+      expect( listPaddingBottom( ) ).toEqual( 170 );
+    } );
+
+    it( "never pads by a negative amount", ( ) => {
+      useKeyboardInfo.mockReturnValue( { keyboardHeight: 100, keyboardShown: true } );
+      renderComponent(
+        <BottomTabBarHeightContext.Provider value={50}>
+          <UniversalSearch />
+        </BottomTabBarHeightContext.Provider>,
+      );
+
+      measureButtonBar( 80 );
+
+      expect( listPaddingBottom( ) ).toEqual( 0 );
+    } );
   } );
 
   it( "navigates to Advanced Search", async ( ) => {


### PR DESCRIPTION
So you can always scroll to and select the last element