### PR TITLE
Tapping x in the standard camera is not working when photos taken

### DIFF
--- a/src/components/Camera/StandardCamera/StandardCamera.js
+++ b/src/components/Camera/StandardCamera/StandardCamera.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import classnames from "classnames";
 import CameraView from "components/Camera/CameraView";
 import FadeInOutView from "components/Camera/FadeInOutView";
@@ -84,7 +84,6 @@ const StandardCamera = ( {
     rotatableAnimatedStyle,
     rotation,
   } = useRotation( );
-  const navigation = useNavigation( );
   const insets = useSafeAreaInsets();
 
   const cameraUris = useStore( state => state.cameraUris );
@@ -111,6 +110,7 @@ const StandardCamera = ( {
   const photosTaken = newPhotoUris.length > 0 && totalObsPhotoUris > 0;
   const {
     handleBackButtonPress,
+    navigateBackOrExitFlow,
     setShowDiscardSheet,
     showDiscardSheet,
   } = useBackPress( photosTaken );
@@ -148,8 +148,13 @@ const StandardCamera = ( {
       deletePhotoByUri( uri );
     } );
     setNewPhotoUris( [] );
-    navigation.goBack( );
-  }, [deletePhotoByUri, navigation, newPhotoUris, setNewPhotoUris] );
+    navigateBackOrExitFlow( );
+  }, [
+    deletePhotoByUri,
+    navigateBackOrExitFlow,
+    newPhotoUris,
+    setNewPhotoUris,
+  ] );
 
   const handleTakePhoto = useCallback( ( ) => {
     if ( disallowAddingPhotos ) {

--- a/src/components/Camera/StandardCamera/hooks/useBackPress.ts
+++ b/src/components/Camera/StandardCamera/hooks/useBackPress.ts
@@ -58,6 +58,7 @@ const useBackPress = ( shouldShowDiscardSheet: boolean ) => {
 
   return {
     handleBackButtonPress,
+    navigateBackOrExitFlow,
     setShowDiscardSheet,
     showDiscardSheet,
   };

--- a/src/components/Camera/StandardCamera/hooks/useBackPress.ts
+++ b/src/components/Camera/StandardCamera/hooks/useBackPress.ts
@@ -16,10 +16,8 @@ const useBackPress = ( shouldShowDiscardSheet: boolean ) => {
 
   const [showDiscardSheet, setShowDiscardSheet] = useState( false );
 
-  const handleBackButtonPress = useCallback( ( ) => {
-    if ( shouldShowDiscardSheet ) {
-      setShowDiscardSheet( true );
-    } else if ( params?.addEvidence ) {
+  const navigateBackOrExitFlow = useCallback( ( ) => {
+    if ( params?.addEvidence ) {
       navigation.navigate( "ObsEdit" );
     } else {
       exitObservationFlow( );
@@ -28,6 +26,16 @@ const useBackPress = ( shouldShowDiscardSheet: boolean ) => {
     exitObservationFlow,
     navigation,
     params?.addEvidence,
+  ] );
+
+  const handleBackButtonPress = useCallback( ( ) => {
+    if ( shouldShowDiscardSheet ) {
+      setShowDiscardSheet( true );
+    } else {
+      navigateBackOrExitFlow( );
+    }
+  }, [
+    navigateBackOrExitFlow,
     setShowDiscardSheet,
     shouldShowDiscardSheet,
   ] );

--- a/tests/integration/navigation/StandardCamera.test.js
+++ b/tests/integration/navigation/StandardCamera.test.js
@@ -81,6 +81,21 @@ describe( "StandardCamera navigation with advanced user layout", ( ) => {
         // expect( screen.getByText( /Use iNaturalist to identify/ ) ).toBeVisible( );
       } );
     } );
+
+    it( "should leave the camera when discard tapped after taking a photo", async ( ) => {
+      renderApp( );
+      await navigateToStandardCameraFromMyObs( );
+      const takePhotoButton = await screen.findByLabelText( /Take photo/ );
+      await actor.press( takePhotoButton );
+      const cameraNavButtons = await screen.findByTestId( "CameraNavButtons" );
+      const closeButton = await within( cameraNavButtons ).findByLabelText( "Close" );
+      await actor.press( closeButton );
+      const discardButton = await screen.findByText( "DISCARD" );
+      await actor.press( discardButton );
+      await waitFor( ( ) => {
+        expect( screen.queryByTestId( "CameraNavButtons" ) ).toBeNull( );
+      } );
+    } );
   } );
 
   it( "should advance to ObsEdit when photo taken and checkmark tapped", async () => {


### PR DESCRIPTION
Closes MOB-1597

Because we did switch to resetting the nav stack on starting a new camera session some time ago, there is no goBack for this screen. So, we have to re-use what we do when we press the X button without having taken photos.