### PR TITLE
Traditional projects: ObsEdit save persists PO and OFV to realm

### DIFF
--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -142,17 +142,13 @@ const AddToProjects = ( ) => {
   }, [] );
 
   const onSave = useCallback( ( ) => {
-    const {
-      projectObservations,
-      projectObservationUuidsToDelete,
-    } = buildProjectObservationSelection(
+    const { projectObservations } = buildProjectObservationSelection(
       currentObservation?.projectObservations,
       currentObservation?.projectObservationUuidsToDelete,
       selectedProjectIds,
     );
     updateObservationKeys( {
       projectObservations,
-      projectObservationUuidsToDelete,
     } );
     navigation.goBack( );
   }, [

--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -144,7 +144,6 @@ const AddToProjects = ( ) => {
   const onSave = useCallback( ( ) => {
     const { projectObservations } = buildProjectObservationSelection(
       currentObservation?.projectObservations,
-      currentObservation?.projectObservationUuidsToDelete,
       selectedProjectIds,
     );
     updateObservationKeys( {

--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -60,6 +60,7 @@ const AddToProjects = ( ) => {
 
   const initialSelectedProjectIds = new Set(
     ( currentObservation?.projectObservations ?? [] )
+      .filter( po => !po._pendingRemoval && !po._pending_deletion )
       .map( po => po.projectId ),
   );
 

--- a/src/components/AddToProjects/hooks/useObservationFieldValue.ts
+++ b/src/components/AddToProjects/hooks/useObservationFieldValue.ts
@@ -3,34 +3,28 @@ import ObservationFieldValue from "realmModels/ObservationFieldValue";
 import type { RealmObservationFieldValuePojo, RealmObservationPojo } from "realmModels/types";
 import useStore from "stores/useStore";
 
-function isActiveOfv( ofv: RealmObservationFieldValuePojo ): boolean {
-  return !ofv._pendingRemoval && !ofv._pending_deletion;
-}
-
-function findActiveOfv(
-  observationFieldValues: RealmObservationFieldValuePojo[],
-  obsFieldId: number,
-) {
-  return observationFieldValues.find(
-    ofv => ofv.obsFieldId === obsFieldId && isActiveOfv( ofv ),
-  );
-}
-
 const useObservationFieldValue = ( obsFieldId: number ) => {
-  const observationFieldValues = useStore(
+  const currentObservation = useStore(
     // currentObs is typed as this | null in createObservationFlowSlice.ts but null means the
     // obs create flow has not been initialized yet. The screen that uses this hook to add obs
     // to projects should only be reachable after currentObs has been initialized in zustand.
     // If it isn't I'd prefer us to error out here to notice it.
-    state => ( state.currentObservation as RealmObservationPojo ).observationFieldValues,
+    state => state.currentObservation as RealmObservationPojo,
   );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );
+  const { observationFieldValues } = currentObservation;
 
-  const existingOfv = findActiveOfv( observationFieldValues, obsFieldId );
+  const existingOfv = ObservationFieldValue.findActiveForObsField(
+    currentObservation,
+    obsFieldId,
+  );
   const value = existingOfv?.value ?? "";
 
   const setValue = useCallback( ( newValue: string | null ) => {
-    const existingRow = observationFieldValues.find( ofv => ofv.obsFieldId === obsFieldId );
+    const existingRow = ObservationFieldValue.findForObsField(
+      currentObservation,
+      obsFieldId,
+    );
 
     let updatedOfvs: RealmObservationFieldValuePojo[];
 
@@ -65,7 +59,7 @@ const useObservationFieldValue = ( obsFieldId: number ) => {
     }
 
     updateObservationKeys( { observationFieldValues: updatedOfvs } );
-  }, [obsFieldId, observationFieldValues, updateObservationKeys] );
+  }, [currentObservation, obsFieldId, observationFieldValues, updateObservationKeys] );
 
   return { value, setValue };
 };

--- a/src/components/AddToProjects/hooks/useObservationFieldValue.ts
+++ b/src/components/AddToProjects/hooks/useObservationFieldValue.ts
@@ -35,8 +35,15 @@ const useObservationFieldValue = ( obsFieldId: number ) => {
     let updatedOfvs: RealmObservationFieldValuePojo[];
 
     if ( !newValue || newValue.trim( ) === "" ) {
-      // If newValue is from a selection being removed (null | "") remove OFV from the list
-      updatedOfvs = observationFieldValues.filter( ofv => ofv.obsFieldId !== obsFieldId );
+      if ( existingRow?._synced_at != null ) {
+        updatedOfvs = observationFieldValues.map( ofv => (
+          ofv.obsFieldId === obsFieldId
+            ? { ...ofv, _pendingRemoval: true }
+            : ofv
+        ) );
+      } else {
+        updatedOfvs = observationFieldValues.filter( ofv => ofv.obsFieldId !== obsFieldId );
+      }
     } else if ( existingRow ) {
       updatedOfvs = observationFieldValues.map( ofv => (
         ofv.obsFieldId === obsFieldId

--- a/src/components/AddToProjects/hooks/useObservationFieldValue.ts
+++ b/src/components/AddToProjects/hooks/useObservationFieldValue.ts
@@ -3,6 +3,18 @@ import ObservationFieldValue from "realmModels/ObservationFieldValue";
 import type { RealmObservationFieldValuePojo, RealmObservationPojo } from "realmModels/types";
 import useStore from "stores/useStore";
 
+function isActiveOfv( ofv: RealmObservationFieldValuePojo ): boolean {
+  return !ofv._pendingRemoval && !ofv._pending_deletion;
+}
+
+function findActiveOfv(
+  observationFieldValues: RealmObservationFieldValuePojo[],
+  obsFieldId: number,
+) {
+  return observationFieldValues.find(
+    ofv => ofv.obsFieldId === obsFieldId && isActiveOfv( ofv ),
+  );
+}
 const useObservationFieldValue = ( obsFieldId: number ) => {
   const observationFieldValues = useStore(
     // currentObs is typed as this | null in createObservationFlowSlice.ts but null means the
@@ -13,9 +25,7 @@ const useObservationFieldValue = ( obsFieldId: number ) => {
   );
   const updateObservationKeys = useStore( state => state.updateObservationKeys );
 
-  const existingOfv = observationFieldValues.find(
-    ofv => ofv.obsFieldId === obsFieldId,
-  );
+  const existingOfv = findActiveOfv( observationFieldValues, obsFieldId );
   const value = existingOfv?.value ?? "";
 
   const setValue = useCallback( ( newValue: string | null ) => {

--- a/src/components/AddToProjects/hooks/useObservationFieldValue.ts
+++ b/src/components/AddToProjects/hooks/useObservationFieldValue.ts
@@ -15,6 +15,7 @@ function findActiveOfv(
     ofv => ofv.obsFieldId === obsFieldId && isActiveOfv( ofv ),
   );
 }
+
 const useObservationFieldValue = ( obsFieldId: number ) => {
   const observationFieldValues = useStore(
     // currentObs is typed as this | null in createObservationFlowSlice.ts but null means the
@@ -29,21 +30,25 @@ const useObservationFieldValue = ( obsFieldId: number ) => {
   const value = existingOfv?.value ?? "";
 
   const setValue = useCallback( ( newValue: string | null ) => {
-    const index = observationFieldValues.findIndex( ofv => ofv.obsFieldId === obsFieldId );
+    const existingRow = observationFieldValues.find( ofv => ofv.obsFieldId === obsFieldId );
 
     let updatedOfvs: RealmObservationFieldValuePojo[];
 
     if ( !newValue || newValue.trim( ) === "" ) {
       // If newValue is from a selection being removed (null | "") remove OFV from the list
       updatedOfvs = observationFieldValues.filter( ofv => ofv.obsFieldId !== obsFieldId );
-    } else if ( index >= 0 ) {
-      // Update existing OFV
-      updatedOfvs = [...observationFieldValues];
-      updatedOfvs[index] = {
-        ...updatedOfvs[index],
-        value: newValue,
-        _updated_at: new Date( ),
-      };
+    } else if ( existingRow ) {
+      updatedOfvs = observationFieldValues.map( ofv => (
+        ofv.obsFieldId === obsFieldId
+          ? {
+            ...ofv,
+            value: newValue,
+            _updated_at: new Date( ),
+            _pendingRemoval: undefined,
+            _pending_deletion: undefined,
+          }
+          : ofv
+      ) );
     } else {
       // Create new OFV
       updatedOfvs = [

--- a/src/components/ObsEdit/OtherDataSection.tsx
+++ b/src/components/ObsEdit/OtherDataSection.tsx
@@ -76,7 +76,9 @@ const OtherDataSection = ( {
 
   const traditionalProjectsEnabled = useFeatureFlag( FeatureFlag.TraditionalProjectsEnabled );
 
-  const projectCount = currentObservation?.projectObservations?.length ?? 0;
+  const projectCount = ( currentObservation?.projectObservations ?? [] )
+    .filter( po => !po._pendingRemoval && !po._pending_deletion )
+    .length;
   const projectsLabel = projectCount > 0
     ? t( "Added-to-X-Projects", { count: projectCount } )
     : t( "Add-to-Projects" );

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -297,7 +297,6 @@ class Observation extends Realm.Object {
 
     const isNew = !existingEmbed;
     const wasReactivated = existingEmbed?._pending_deletion && !embed._pending_deletion;
-
     if ( isNew || wasReactivated ) {
       return {
         ...embed,

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -280,6 +280,19 @@ class Observation extends Realm.Object {
     return localObs;
   }
 
+  static prepareEmbedForLocalSave( embed ) {
+    if ( !embed ) {
+      return embed;
+    }
+    return embed;
+  }
+
+  static prepareEmbedsForLocalSave( embeds ) {
+    return ( embeds || [] ).map( embed => Observation.prepareEmbedForLocalSave(
+      embed,
+    ) );
+  }
+
   static async saveLocalObservationForUpload( obs, realm ) {
     // make sure local observations have user details for ObsDetail
     const currentUser = User.currentUser( realm );
@@ -308,6 +321,12 @@ class Observation extends Realm.Object {
     const taxon = obs.taxon || null;
     const observationPhotos = addTimestampsToEvidence( obs.observationPhotos );
     const observationSounds = addTimestampsToEvidence( obs.observationSounds );
+    const projectObservations = Observation.prepareEmbedsForLocalSave(
+      obs.projectObservations,
+    );
+    const observationFieldValues = Observation.prepareEmbedsForLocalSave(
+      obs.observationFieldValues,
+    );
 
     const obsToSave = {
       // just ...obs causes problems when obs is a realm object
@@ -318,6 +337,8 @@ class Observation extends Realm.Object {
       taxon,
       observationPhotos,
       observationSounds,
+      projectObservations,
+      observationFieldValues,
     };
 
     safeRealmWrite( realm, ( ) => {

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -284,6 +284,15 @@ class Observation extends Realm.Object {
     if ( !embed ) {
       return embed;
     }
+
+    const { _pendingRemoval, ...restWithoutPendingRemoval } = embed;
+
+    if ( _pendingRemoval || embed._pending_deletion ) {
+      return {
+        ...restWithoutPendingRemoval,
+        _pending_deletion: true,
+      };
+    }
     return embed;
   }
 

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -280,7 +280,7 @@ class Observation extends Realm.Object {
     return localObs;
   }
 
-  static prepareEmbedForLocalSave( embed, now ) {
+  static prepareEmbedForLocalSave( embed, now, existingEmbed ) {
     if ( !embed ) {
       return embed;
     }
@@ -294,14 +294,26 @@ class Observation extends Realm.Object {
         _updated_at: now,
       };
     }
+
+    const isNew = !existingEmbed;
+    const wasReactivated = existingEmbed?._pending_deletion && !embed._pending_deletion;
+
+    if ( isNew || wasReactivated ) {
+      return {
+        ...embed,
+        _synced_at: null,
+        _updated_at: now,
+      };
+    }
+
     return embed;
   }
 
-  static prepareEmbedsForLocalSave( embeds, now ) {
-    return ( embeds || [] ).map( embed => Observation.prepareEmbedForLocalSave(
-      embed,
-      now,
-    ) );
+  static prepareEmbedsForLocalSave( embeds, now, existingEmbeds ) {
+    return ( embeds || [] ).map( embed => {
+      const existingEmbed = existingEmbeds?.find( e => e.uuid === embed.uuid );
+      return Observation.prepareEmbedForLocalSave( embed, now, existingEmbed );
+    } );
   }
 
   static async saveLocalObservationForUpload( obs, realm ) {
@@ -335,10 +347,12 @@ class Observation extends Realm.Object {
     const projectObservations = Observation.prepareEmbedsForLocalSave(
       obs.projectObservations,
       timestamps._updated_at,
+      existingObservation?.projectObservations,
     );
     const observationFieldValues = Observation.prepareEmbedsForLocalSave(
       obs.observationFieldValues,
       timestamps._updated_at,
+      existingObservation?.observationFieldValues,
     );
 
     const obsToSave = {

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -280,7 +280,7 @@ class Observation extends Realm.Object {
     return localObs;
   }
 
-  static prepareEmbedForLocalSave( embed ) {
+  static prepareEmbedForLocalSave( embed, now ) {
     if ( !embed ) {
       return embed;
     }
@@ -291,14 +291,16 @@ class Observation extends Realm.Object {
       return {
         ...restWithoutPendingRemoval,
         _pending_deletion: true,
+        _updated_at: now,
       };
     }
     return embed;
   }
 
-  static prepareEmbedsForLocalSave( embeds ) {
+  static prepareEmbedsForLocalSave( embeds, now ) {
     return ( embeds || [] ).map( embed => Observation.prepareEmbedForLocalSave(
       embed,
+      now,
     ) );
   }
 
@@ -332,9 +334,11 @@ class Observation extends Realm.Object {
     const observationSounds = addTimestampsToEvidence( obs.observationSounds );
     const projectObservations = Observation.prepareEmbedsForLocalSave(
       obs.projectObservations,
+      timestamps._updated_at,
     );
     const observationFieldValues = Observation.prepareEmbedsForLocalSave(
       obs.observationFieldValues,
+      timestamps._updated_at,
     );
 
     const obsToSave = {

--- a/src/realmModels/ObservationFieldValue.ts
+++ b/src/realmModels/ObservationFieldValue.ts
@@ -10,6 +10,8 @@ class ObservationFieldValue extends Realm.Object {
 
   _updated_at?: Date;
 
+  _pending_deletion?: boolean;
+
   needsSync( ) {
     return !this._synced_at || this._synced_at <= this._updated_at;
   }
@@ -61,6 +63,7 @@ class ObservationFieldValue extends Realm.Object {
       _synced_at: "date?",
       // datetime the OFV was updated on the device (i.e. edited locally)
       _updated_at: "date?",
+      _pending_deletion: "bool?",
       uuid: "string",
       id: "int?",
       obsFieldId: "int",

--- a/src/realmModels/ObservationFieldValue.ts
+++ b/src/realmModels/ObservationFieldValue.ts
@@ -1,6 +1,9 @@
 import { Realm } from "@realm/react";
 import type { ApiObservationFieldValue } from "api/types";
-import type { RealmObservationPojo } from "realmModels/types";
+import type {
+  RealmObservationFieldValuePojo,
+  RealmObservationPojo,
+} from "realmModels/types";
 import * as uuid from "uuid";
 
 class ObservationFieldValue extends Realm.Object {
@@ -33,12 +36,25 @@ class ObservationFieldValue extends Realm.Object {
     };
   }
 
+  static isActive( ofv: RealmObservationFieldValuePojo ) {
+    return !ofv._pendingRemoval && !ofv._pending_deletion;
+  }
+
   static findForObsField(
     observation: RealmObservationPojo,
     obsFieldId: number,
   ) {
     return observation.observationFieldValues.find(
       ofv => ofv.obsFieldId === obsFieldId,
+    );
+  }
+
+  static findActiveForObsField(
+    observation: RealmObservationPojo,
+    obsFieldId: number,
+  ) {
+    return observation.observationFieldValues.find(
+      ofv => ofv.obsFieldId === obsFieldId && ObservationFieldValue.isActive( ofv ),
     );
   }
 

--- a/src/realmModels/ProjectObservation.ts
+++ b/src/realmModels/ProjectObservation.ts
@@ -9,6 +9,8 @@ class ProjectObservation extends Realm.Object {
 
   _updated_at?: Date;
 
+  _pending_deletion?: boolean;
+
   needsSync( ) {
     return !this._synced_at || this._synced_at <= this._updated_at;
   }
@@ -47,6 +49,7 @@ class ProjectObservation extends Realm.Object {
       _synced_at: "date?",
       // datetime the PO was updated on the device (i.e. edited locally)
       _updated_at: "date?",
+      _pending_deletion: "bool?",
       uuid: "string",
       id: "int?",
       projectId: "int",

--- a/src/realmModels/index.ts
+++ b/src/realmModels/index.ts
@@ -43,7 +43,7 @@ export default {
     User,
     Vote,
   ],
-  schemaVersion: 71,
+  schemaVersion: 72,
   path: `${DocumentDirectoryPath}/db.realm`,
   // https://github.com/realm/realm-js/pull/6076 embedded constraints
   migrationOptions: {

--- a/src/realmModels/types.d.ts
+++ b/src/realmModels/types.d.ts
@@ -84,6 +84,7 @@ export interface RealmProjectObservationPojo extends RealmObject {
   _created_at?: Date;
   _synced_at?: Date;
   _updated_at?: Date;
+  _pending_deletion?: boolean;
   uuid: string;
   id?: number | null;
   projectId: number;
@@ -98,6 +99,7 @@ export interface RealmObservationFieldValuePojo extends RealmObject {
   _created_at?: Date;
   _synced_at?: Date;
   _updated_at?: Date;
+  _pending_deletion?: boolean;
   uuid: string;
   id?: number;
   obsFieldId: number;

--- a/src/realmModels/types.d.ts
+++ b/src/realmModels/types.d.ts
@@ -85,6 +85,9 @@ export interface RealmProjectObservationPojo extends RealmObject {
   _synced_at?: Date;
   _updated_at?: Date;
   _pending_deletion?: boolean;
+  // TODO: we are conflating types of different purposes: this key is Zustand relevant only,
+  // not added to realm
+  _pendingRemoval?: boolean;
   uuid: string;
   id?: number | null;
   projectId: number;

--- a/src/realmModels/types.d.ts
+++ b/src/realmModels/types.d.ts
@@ -103,6 +103,9 @@ export interface RealmObservationFieldValuePojo extends RealmObject {
   _synced_at?: Date;
   _updated_at?: Date;
   _pending_deletion?: boolean;
+  // TODO: we are conflating types of different purposes: this key is Zustand relevant only,
+  // not added to realm
+  _pendingRemoval?: boolean;
   uuid: string;
   id?: number;
   obsFieldId: number;

--- a/src/sharedHelpers/buildProjectObservationSelection.ts
+++ b/src/sharedHelpers/buildProjectObservationSelection.ts
@@ -18,7 +18,6 @@ export function areProjectIdSetsEqual(
 
 export default function buildProjectObservationSelection(
   existingProjectObservations: RealmProjectObservationPojo[] | undefined,
-  existingUuidsToDelete: string[] | undefined,
   selectedProjectIds: Set<number>,
 ): BuildProjectObservationSelectionResult {
   const priorProjectObservations = existingProjectObservations ?? [];

--- a/src/sharedHelpers/buildProjectObservationSelection.ts
+++ b/src/sharedHelpers/buildProjectObservationSelection.ts
@@ -3,7 +3,6 @@ import type { RealmProjectObservationPojo } from "realmModels/types";
 
 export interface BuildProjectObservationSelectionResult {
   projectObservations: RealmProjectObservationPojo[];
-  projectObservationUuidsToDelete: string[];
 }
 
 export function areProjectIdSetsEqual(

--- a/src/sharedHelpers/buildProjectObservationSelection.ts
+++ b/src/sharedHelpers/buildProjectObservationSelection.ts
@@ -19,6 +19,12 @@ function isSyncedOrTombstonedPo( po: RealmProjectObservationPojo ): boolean {
   return po._synced_at != null || po._pending_deletion === true;
 }
 
+function activatePo( po: RealmProjectObservationPojo ): RealmProjectObservationPojo {
+  // eslint-disable-next-line camelcase
+  const { _pendingRemoval, _pending_deletion, ...rest } = po;
+  return rest;
+}
+
 export default function buildProjectObservationSelection(
   existingProjectObservations: RealmProjectObservationPojo[] | undefined,
   selectedProjectIds: Set<number>,
@@ -26,13 +32,10 @@ export default function buildProjectObservationSelection(
   const priorProjectObservations = existingProjectObservations ?? [];
   const nextProjectObservations: RealmProjectObservationPojo[] = [];
 
-  // When pressing Save, for each project that is selected we need to check if there
-  // already exists a PO (e.g. on ObsEdit by not changing this one while adding another)
-  // or if we need to create a new PO
   selectedProjectIds.forEach( projectId => {
     const existingPo = priorProjectObservations.find( po => po.projectId === projectId );
     if ( existingPo ) {
-      nextProjectObservations.push( existingPo );
+      nextProjectObservations.push( activatePo( existingPo ) );
     } else {
       nextProjectObservations.push( ProjectObservation.new( projectId ) );
     }

--- a/src/sharedHelpers/buildProjectObservationSelection.ts
+++ b/src/sharedHelpers/buildProjectObservationSelection.ts
@@ -22,8 +22,6 @@ export default function buildProjectObservationSelection(
   selectedProjectIds: Set<number>,
 ): BuildProjectObservationSelectionResult {
   const priorProjectObservations = existingProjectObservations ?? [];
-  const priorUuidsToDelete = existingUuidsToDelete ?? [];
-
   const nextProjectObservations: RealmProjectObservationPojo[] = [];
 
   // When pressing Save, for each project that is selected we need to check if there
@@ -46,18 +44,8 @@ export default function buildProjectObservationSelection(
       uuidsToDelete.push( po.uuid );
     }
   } );
-  const keptUuids = new Set( nextProjectObservations.map( po => po.uuid ) );
-  const nextUuidsToDelete = [
-    ...new Set( [
-      // If a PO that was marked as deleted in a prior ObsEdit session, is now re-selected for
-      // addition, we need to keep it out of the to-be-deleted list
-      ...priorUuidsToDelete.filter( uuid => !keptUuids.has( uuid ) ),
-      ...uuidsToDelete,
-    ] ),
-  ];
 
   return {
     projectObservations: nextProjectObservations,
-    projectObservationUuidsToDelete: nextUuidsToDelete,
   };
 }

--- a/src/sharedHelpers/buildProjectObservationSelection.ts
+++ b/src/sharedHelpers/buildProjectObservationSelection.ts
@@ -15,6 +15,10 @@ export function areProjectIdSetsEqual(
   return [...first].every( projectId => second.has( projectId ) );
 }
 
+function isSyncedOrTombstonedPo( po: RealmProjectObservationPojo ): boolean {
+  return po._synced_at != null || po._pending_deletion === true;
+}
+
 export default function buildProjectObservationSelection(
   existingProjectObservations: RealmProjectObservationPojo[] | undefined,
   selectedProjectIds: Set<number>,
@@ -34,12 +38,15 @@ export default function buildProjectObservationSelection(
     }
   } );
 
-  const uuidsToDelete: string[] = [];
   priorProjectObservations.forEach( po => {
-    // If a PO was already synced (= is on remote) but is deselected during
-    // an ObsEdit session, we need to mark it for deletion.
-    if ( !selectedProjectIds.has( po.projectId ) && po._synced_at != null ) {
-      uuidsToDelete.push( po.uuid );
+    if ( selectedProjectIds.has( po.projectId ) ) {
+      return;
+    }
+    if ( isSyncedOrTombstonedPo( po ) ) {
+      nextProjectObservations.push( {
+        ...po,
+        _pendingRemoval: true,
+      } );
     }
   } );
 

--- a/src/sharedHelpers/validateProjectFieldsForObservation.ts
+++ b/src/sharedHelpers/validateProjectFieldsForObservation.ts
@@ -89,7 +89,7 @@ export default function validateProjectFieldsForObservation(
     project.projectObservationFields.forEach( pof => {
       const { obsField } = pof;
       if ( !obsField ) { return; }
-      const ofv = ObservationFieldValue.findForObsField( observation, obsField.id );
+      const ofv = ObservationFieldValue.findActiveForObsField( observation, obsField.id );
       const reason = validateProjectFieldValue( pof, ofv?.value );
       if ( reason ) {
         errors.push( {

--- a/src/stores/createObservationFlowSlice.ts
+++ b/src/stores/createObservationFlowSlice.ts
@@ -39,15 +39,10 @@ interface PhotoImporterOptions {
   firstObservationDefaults?: Partial<RealmObservationPojo>;
 }
 
-// Observation-flow only; not Realm schema properties.
-interface CurrentObservation extends RealmObservationPojo {
-  projectObservationUuidsToDelete?: string[];
-}
-
 interface ObservationFlowState {
   aICameraSuggestion: ApiSuggestion | null;
   cameraRollUris: string[];
-  currentObservation: CurrentObservation | null;
+  currentObservation: RealmObservationPojo | null;
   currentObservationIndex: number;
   evidenceToAdd: string[];
   photoLibraryUris: string[];
@@ -80,7 +75,7 @@ interface ObservationFlowActions {
   setPhotoImporterState: ( options: PhotoImporterOptions ) => void;
   setSavedOrUploadedMultiObsFlow: ( ) => void;
   updateObservations: ( updatedObservations: RealmObservationPojo[] ) => void;
-  updateObservationKeys: ( keysAndValues: Partial<CurrentObservation> ) => void;
+  updateObservationKeys: ( keysAndValues: Partial<RealmObservationPojo> ) => void;
   getCurrentObservation: ( ) => RealmObservationPojo | null;
   prepareObsEdit: ( observation: RealmObservationPojo ) => void;
   prepareCamera: ( ) => void;

--- a/tests/factories/LocalObservationFieldValue.js
+++ b/tests/factories/LocalObservationFieldValue.js
@@ -1,0 +1,7 @@
+import { define } from "factoria";
+
+export default define( "LocalObservationFieldValue", faker => ( {
+  id: faker.number.int( ),
+  obsFieldId: faker.number.int( ),
+  value: faker.person.firstName( ),
+} ) );

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -57,6 +57,7 @@ beforeEach( ( ) => {
       observationFieldValues: [],
       projectObservations: [factory( "LocalProjectObservation", {
         projectId: mockProjects[0].id,
+        _synced_at: new Date( ),
       } )],
     },
   } );
@@ -144,7 +145,7 @@ describe( "AddToProjects", ( ) => {
     expect( mockGoBack ).toHaveBeenCalled( );
   } );
 
-  it( "stages synced project observation uuids for deletion", async ( ) => {
+  it( "soft-deletes synced project observations when deselected", async ( ) => {
     renderAddToProjects();
 
     // deselect 0
@@ -152,11 +153,11 @@ describe( "AddToProjects", ( ) => {
     await actor.press( screen.getByText( "SAVE" ) );
 
     expect( useStore.getState().currentObservation?.projectObservations ).toEqual(
-      [],
+      [expect.objectContaining( {
+        projectId: mockProjects[0].id,
+        _pendingRemoval: true,
+      } )],
     );
-    expect(
-      useStore.getState().currentObservation?.projectObservationUuidsToDelete,
-    ).toEqual( [mockProjects[0].uuid] );
     expect( mockGoBack ).toHaveBeenCalled();
   } );
 

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -55,7 +55,6 @@ beforeEach( ( ) => {
     currentObservation: {
       ...factory( "LocalObservation" ),
       observationFieldValues: [],
-      projectObservationUuidsToDelete: [],
       projectObservations: [factory( "LocalProjectObservation", {
         projectId: mockProjects[0].id,
       } )],
@@ -167,7 +166,6 @@ describe( "AddToProjects", ( ) => {
       currentObservation: {
         ...factory( "LocalObservation" ),
         observationFieldValues: [],
-        projectObservationUuidsToDelete: ["prior-session-uuid"],
         projectObservations: [
           factory( "LocalProjectObservation", {
             projectId: mockProjects[0].id,

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -161,8 +161,7 @@ describe( "AddToProjects", ( ) => {
     expect( mockGoBack ).toHaveBeenCalled();
   } );
 
-  it( "merges newly deselected synced PO uuids with a prior delete list on SAVE", async ( ) => {
-    // Same as before each but with a prior uuid t delete
+  it( "soft-deletes only the deselected synced project observation", async ( ) => {
     useStore.setState( {
       currentObservation: {
         ...factory( "LocalObservation" ),
@@ -170,6 +169,13 @@ describe( "AddToProjects", ( ) => {
         projectObservations: [
           factory( "LocalProjectObservation", {
             projectId: mockProjects[0].id,
+            uuid: "po-0-uuid",
+            _synced_at: new Date( ),
+          } ),
+          factory( "LocalProjectObservation", {
+            projectId: mockProjects[1].id,
+            uuid: "po-1-uuid",
+            _synced_at: new Date( ),
           } ),
         ],
       },
@@ -180,12 +186,24 @@ describe( "AddToProjects", ( ) => {
     await actor.press( screen.getByText( mockProjects[0].title ) );
     await actor.press( screen.getByTestId( "AddToProjects.saveButton" ) );
 
-    expect( useStore.getState( ).currentObservation?.projectObservations ).toEqual( [] );
-    expect( useStore.getState( ).currentObservation?.projectObservationUuidsToDelete )
-      .toEqual( [
-        "prior-session-uuid",
-        mockProjects[0].uuid,
-      ] );
+    const savedProjectObservations = useStore.getState( )
+      .currentObservation?.projectObservations;
+
+    expect( savedProjectObservations ).toEqual( expect.arrayContaining( [
+      expect.objectContaining( {
+        projectId: mockProjects[0].id,
+        uuid: "po-0-uuid",
+        _pendingRemoval: true,
+      } ),
+      expect.objectContaining( {
+        projectId: mockProjects[1].id,
+        uuid: "po-1-uuid",
+      } ),
+    ] ) );
+    expect( savedProjectObservations ).toHaveLength( 2 );
+    expect(
+      savedProjectObservations?.find( po => po.projectId === mockProjects[1].id )?._pendingRemoval,
+    ).toBeUndefined( );
     expect( mockGoBack ).toHaveBeenCalled( );
   } );
 } );

--- a/tests/unit/components/AddToProjects/ObservationFieldInput.test.js
+++ b/tests/unit/components/AddToProjects/ObservationFieldInput.test.js
@@ -86,7 +86,6 @@ describe( "ObservationFieldInput", ( ) => {
       currentObservation: {
         ...factory( "LocalObservation" ),
         observationFieldValues: [],
-        projectObservationUuidsToDelete: [],
         projectObservations: [],
       },
     } );

--- a/tests/unit/components/ObsEdit/OtherDataSection.test.js
+++ b/tests/unit/components/ObsEdit/OtherDataSection.test.js
@@ -106,6 +106,21 @@ describe( "OtherDataSection", () => {
       expect( screen.getByText( "Add to Projects" ) ).toBeVisible( );
     } );
 
+    it( "excludes pending-removal projects from the count", ( ) => {
+      renderOtherDataSection( {
+        currentObservation: {
+          ...factory( "LocalObservation" ),
+          projectObservations: [
+            { projectId: 1 },
+            { projectId: 2, _pendingRemoval: true },
+          ],
+        },
+      } );
+
+      expect( screen.getByLabelText( /Added to 1 Project/ ) ).toBeVisible( );
+      expect( screen.getByText( "Added to 1 Project" ) ).toBeVisible( );
+    } );
+
     it( "shows Added to N Projects when projects are selected", ( ) => {
       renderOtherDataSection( {
         currentObservation: {

--- a/tests/unit/helpers/validateProjectFieldsForObservation.test.js
+++ b/tests/unit/helpers/validateProjectFieldsForObservation.test.js
@@ -152,6 +152,30 @@ describe( "validateProjectFieldsForObservation", () => {
       expect( result.errors[0].reason ).toBe( MISSING_REQUIRED );
     } );
 
+    it( "should return MISSING_REQUIRED when a required field OFV is pending removal", () => {
+      const mockProject = {
+        title: "Mushrooms of Bavaria",
+        projectObservationFields: [{
+          required: true,
+          obsField: {
+            allowedValues: [],
+            id: 10,
+            name: "Habitat",
+          },
+        }],
+      };
+      const mockObservation = {
+        observationFieldValues: [{
+          obsFieldId: 10,
+          value: "shrubland",
+          _pendingRemoval: true,
+        }],
+      };
+      const result = validateProjectFieldsForObservation( mockObservation, [mockProject] );
+      expect( result.valid ).toBe( false );
+      expect( result.errors[0].reason ).toBe( MISSING_REQUIRED );
+    } );
+
     it( "should be valid when a required field's OFV is non-empty after trim", () => {
       const mockProject = {
         projectObservationFields: [{

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -223,5 +223,39 @@ describe( "Observation", ( ) => {
       expect( obs.observationFieldValues[0]._pending_deletion ).toBe( true );
       expect( obs.observationFieldValues[0].uuid ).toBe( ofvUuid );
     } );
+
+    it( "writes re-selected POs as active embeds without tombstones", async ( ) => {
+      const obsUuid = uuid.v4( );
+      const syncedAt = new Date( "2020-01-02" );
+      const poUuid = uuid.v4( ).toLowerCase( );
+
+      const mockPO = factory( "LocalProjectObservation", {
+        uuid: poUuid,
+        _synced_at: syncedAt,
+        _pending_deletion: true,
+      } );
+
+      safeRealmWrite( global.realm, ( ) => {
+        global.realm.create( "Observation", {
+          uuid: obsUuid,
+          _synced_at: syncedAt,
+          _updated_at: syncedAt,
+          projectObservations: [mockPO],
+        } );
+      }, "seed tombstoned PO for re-select save test" );
+
+      delete mockPO._pending_deletion;
+      await Observation.saveLocalObservationForUpload( {
+        uuid: obsUuid,
+        projectObservations: [mockPO],
+        observationFieldValues: [],
+        observationPhotos: [],
+        observationSounds: [],
+      }, global.realm );
+
+      const obs = global.realm.objectForPrimaryKey( "Observation", obsUuid );
+      expect( obs.projectObservations[0]._pending_deletion ).toBeFalsy( );
+      expect( obs.projectObservations[0]._synced_at ).toBeNull( );
+    } );
   } );
 } );

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -199,5 +199,29 @@ describe( "Observation", ( ) => {
       expect( obs.projectObservations[0].uuid ).toBe( poUuid );
       expect( obs.projectObservations[0]._synced_at ).toEqual( syncedAt );
     } );
+
+    it( "creates Realm tombstones from pending-removal OFVs", async ( ) => {
+      const obsUuid = uuid.v4( );
+      const syncedAt = new Date( "2020-01-02" );
+      const ofvUuid = uuid.v4( ).toLowerCase( );
+
+      const mockOFV = factory( "LocalObservationFieldValue", {
+        uuid: ofvUuid,
+        _synced_at: syncedAt,
+        _pendingRemoval: true,
+      } );
+      await Observation.saveLocalObservationForUpload( {
+        uuid: obsUuid,
+        projectObservations: [],
+        observationFieldValues: [mockOFV],
+        observationPhotos: [],
+        observationSounds: [],
+      }, global.realm );
+
+      const obs = global.realm.objectForPrimaryKey( "Observation", obsUuid );
+      expect( obs.observationFieldValues ).toHaveLength( 1 );
+      expect( obs.observationFieldValues[0]._pending_deletion ).toBe( true );
+      expect( obs.observationFieldValues[0].uuid ).toBe( ofvUuid );
+    } );
   } );
 } );

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -173,4 +173,32 @@ describe( "Observation", ( ) => {
       expect( unsynced.filtered( `uuid == "${obsUuid}"` ).length ).toBe( 1 );
     } );
   } );
+
+  describe( "saveLocalObservationForUpload", ( ) => {
+    it( "creates Realm tombstones from pending-removal POs", async ( ) => {
+      const obsUuid = uuid.v4( );
+      const syncedAt = new Date( "2020-01-02" );
+      const poUuid = uuid.v4( ).toLowerCase( );
+
+      await Observation.saveLocalObservationForUpload( {
+        uuid: obsUuid,
+        projectObservations: [{
+          uuid: poUuid,
+          projectId: 10,
+          id: 99,
+          _synced_at: syncedAt,
+          _pendingRemoval: true,
+        }],
+        observationFieldValues: [],
+        observationPhotos: [],
+        observationSounds: [],
+      }, global.realm );
+
+      const obs = global.realm.objectForPrimaryKey( "Observation", obsUuid );
+      expect( obs.projectObservations ).toHaveLength( 1 );
+      expect( obs.projectObservations[0]._pending_deletion ).toBe( true );
+      expect( obs.projectObservations[0].uuid ).toBe( poUuid );
+      expect( obs.projectObservations[0]._synced_at ).toEqual( syncedAt );
+    } );
+  } );
 } );

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -180,15 +180,14 @@ describe( "Observation", ( ) => {
       const syncedAt = new Date( "2020-01-02" );
       const poUuid = uuid.v4( ).toLowerCase( );
 
+      const mockPO = factory( "LocalProjectObservation", {
+        uuid: poUuid,
+        _synced_at: syncedAt,
+        _pendingRemoval: true,
+      } );
       await Observation.saveLocalObservationForUpload( {
         uuid: obsUuid,
-        projectObservations: [{
-          uuid: poUuid,
-          projectId: 10,
-          id: 99,
-          _synced_at: syncedAt,
-          _pendingRemoval: true,
-        }],
+        projectObservations: [mockPO],
         observationFieldValues: [],
         observationPhotos: [],
         observationSounds: [],

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -257,5 +257,38 @@ describe( "Observation", ( ) => {
       expect( obs.projectObservations[0]._pending_deletion ).toBeFalsy( );
       expect( obs.projectObservations[0]._synced_at ).toBeNull( );
     } );
+
+    it( "leaves unchanged synced embed timestamps intact on re-edit", async ( ) => {
+      const obsUuid = uuid.v4( );
+      const syncedAt = new Date( "2020-01-02" );
+      const poUuid = uuid.v4( ).toLowerCase( );
+      const ofvUuid = uuid.v4( ).toLowerCase( );
+
+      const mockPO = factory( "LocalProjectObservation", {
+        uuid: poUuid,
+        _synced_at: syncedAt,
+      } );
+      const mockOFV = factory( "LocalObservationFieldValue", {
+        uuid: ofvUuid,
+        _synced_at: syncedAt,
+      } );
+      const mockObs = factory( "LocalObservation", {
+        uuid: obsUuid,
+        projectObservations: [mockPO],
+        observationFieldValues: [mockOFV],
+        observationPhotos: [],
+        observationSounds: [],
+      } );
+
+      safeRealmWrite( global.realm, ( ) => {
+        global.realm.create( "Observation", mockObs );
+      }, "seed synced PO/OFV for unchanged re-edit save test" );
+
+      await Observation.saveLocalObservationForUpload( mockObs, global.realm );
+
+      const obs = global.realm.objectForPrimaryKey( "Observation", obsUuid );
+      expect( obs.projectObservations[0]._synced_at ).toEqual( syncedAt );
+      expect( obs.observationFieldValues[0]._synced_at ).toEqual( syncedAt );
+    } );
   } );
 } );

--- a/tests/unit/models/ObservationFieldValue.test.js
+++ b/tests/unit/models/ObservationFieldValue.test.js
@@ -37,6 +37,17 @@ describe( "ObservationFieldValue", () => {
       expect( ObservationFieldValue.findForObsField( obs, 10 )?.value ).toBe( "a" );
       expect( ObservationFieldValue.findForObsField( obs, 99 ) ).toBeUndefined();
     } );
+
+    it( "should find an OFV pending removal or deletion", () => {
+      const obs = {
+        observationFieldValues: [
+          { obsFieldId: 10, value: "a", _pendingRemoval: true },
+          { obsFieldId: 20, value: "b", _pending_deletion: true },
+        ],
+      };
+      expect( ObservationFieldValue.findForObsField( obs, 10 )?.value ).toBe( "a" );
+      expect( ObservationFieldValue.findForObsField( obs, 20 )?.value ).toBe( "b" );
+    } );
   } );
 
   describe( "mapApiToRealm", () => {

--- a/tests/unit/models/ObservationFieldValue.test.js
+++ b/tests/unit/models/ObservationFieldValue.test.js
@@ -50,6 +50,18 @@ describe( "ObservationFieldValue", () => {
     } );
   } );
 
+  describe( "isActive", () => {
+    it( "should return false when pending removal or deletion", () => {
+      expect( ObservationFieldValue.isActive( { obsFieldId: 1, _pendingRemoval: true } ) )
+        .toBe( false );
+      expect( ObservationFieldValue.isActive( { obsFieldId: 1, _pending_deletion: true } ) )
+        .toBe( false );
+    } );
+
+    it( "should return true for a normal OFV", () => {
+      expect( ObservationFieldValue.isActive( { obsFieldId: 1, value: "x" } ) ).toBe( true );
+    } );
+  } );
   describe( "mapApiToRealm", () => {
     it( "should map API OFV with sync metadata", () => {
       const mockRemoteOfv = factory( "RemoteObservationFieldValue" );

--- a/tests/unit/models/ObservationFieldValue.test.js
+++ b/tests/unit/models/ObservationFieldValue.test.js
@@ -62,6 +62,23 @@ describe( "ObservationFieldValue", () => {
       expect( ObservationFieldValue.isActive( { obsFieldId: 1, value: "x" } ) ).toBe( true );
     } );
   } );
+
+  describe( "findActiveForObsField", () => {
+    it( "should find an active OFV by obsFieldId", () => {
+      const obs = {
+        observationFieldValues: [
+          { obsFieldId: 10, value: "a" },
+          { obsFieldId: 20, value: "b", _pendingRemoval: true },
+          { obsFieldId: 30, value: "c", _pending_deletion: true },
+        ],
+      };
+      expect( ObservationFieldValue.findActiveForObsField( obs, 10 )?.value ).toBe( "a" );
+      expect( ObservationFieldValue.findActiveForObsField( obs, 20 ) ).toBeUndefined();
+      expect( ObservationFieldValue.findActiveForObsField( obs, 30 ) ).toBeUndefined();
+      expect( ObservationFieldValue.findActiveForObsField( obs, 99 ) ).toBeUndefined();
+    } );
+  } );
+
   describe( "mapApiToRealm", () => {
     it( "should map API OFV with sync metadata", () => {
       const mockRemoteOfv = factory( "RemoteObservationFieldValue" );

--- a/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
+++ b/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
@@ -91,6 +91,28 @@ describe( "areProjectIdSetsEqual", ( ) => {
       } )] );
     } );
 
+    it( "clears pending deletion when re-selecting a tombstoned PO", ( ) => {
+      const tombstonedPo = factory( "LocalProjectObservation", {
+        projectId: 10,
+        uuid: "tombstoned-po-uuid",
+        id: 99,
+        _synced_at: new Date( ),
+        _pending_deletion: true,
+      } );
+
+      const result = buildProjectObservationSelection(
+        [tombstonedPo],
+        new Set( [10] ),
+      );
+
+      expect( result.projectObservations[0] ).toEqual( expect.objectContaining( {
+        projectId: 10,
+        uuid: "tombstoned-po-uuid",
+        id: 99,
+        _synced_at: tombstonedPo._synced_at,
+      } ) );
+      expect( result.projectObservations[0]._pending_deletion ).toBeUndefined( );
+    } );
     it( "handles missing arrays on brand-new observations", ( ) => {
       const result = buildProjectObservationSelection(
         undefined,

--- a/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
+++ b/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
@@ -23,21 +23,18 @@ describe( "areProjectIdSetsEqual", ( ) => {
 
       const result = buildProjectObservationSelection(
         [existingPo],
-        [],
         new Set( [10] ),
       );
 
       expect( result.projectObservations ).toEqual( [existingPo] );
-      expect( result.projectObservationUuidsToDelete ).toEqual( [] );
     } );
 
     it( "creates a new PO for newly selected projects", ( ) => {
-      const result = buildProjectObservationSelection( [], [], new Set( [42] ) );
+      const result = buildProjectObservationSelection( [], new Set( [42] ) );
 
       expect( result.projectObservations ).toHaveLength( 1 );
       expect( result.projectObservations[0].projectId ).toBe( 42 );
       expect( result.projectObservations[0].uuid ).toBeTruthy( );
-      expect( result.projectObservationUuidsToDelete ).toEqual( [] );
     } );
 
     it( "stages synced PO uuids when deselected during an ObsEdit session", ( ) => {
@@ -65,14 +62,10 @@ describe( "areProjectIdSetsEqual", ( ) => {
 
       const result = buildProjectObservationSelection(
         [unsyncedPo],
-        [],
         new Set( ),
       );
 
       expect( result.projectObservations ).toEqual( [] );
-      expect( result.projectObservationUuidsToDelete ).toEqual( [] );
-
-      // TODO: MOB-1508 test that the local realm PO get's deleted in this case
     } );
 
     it( "removes re-selected PO uuid from a prior ObsEdit session delete list", ( ) => {
@@ -120,13 +113,11 @@ describe( "areProjectIdSetsEqual", ( ) => {
     it( "handles missing arrays on brand-new observations", ( ) => {
       const result = buildProjectObservationSelection(
         undefined,
-        undefined,
         new Set( [5] ),
       );
 
       expect( result.projectObservations ).toHaveLength( 1 );
       expect( result.projectObservations[0].projectId ).toBe( 5 );
-      expect( result.projectObservationUuidsToDelete ).toEqual( [] );
     } );
   } );
 } );

--- a/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
+++ b/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
@@ -91,31 +91,6 @@ describe( "areProjectIdSetsEqual", ( ) => {
       } )] );
     } );
 
-    it( "carries forward prior session delete uuids and adds newly deselected synced POs", ( ) => {
-      const reselectedPo = factory( "LocalProjectObservation", {
-        projectId: 10,
-        uuid: "reselected-po-uuid",
-        _synced_at: new Date( ),
-      } );
-      const deselectedPo = factory( "LocalProjectObservation", {
-        projectId: 20,
-        uuid: "deselected-po-uuid",
-        _synced_at: new Date( ),
-      } );
-
-      const result = buildProjectObservationSelection(
-        [reselectedPo, deselectedPo],
-        ["prior-session-uuid"],
-        new Set( [10] ),
-      );
-
-      expect( result.projectObservations ).toEqual( [reselectedPo] );
-      expect( result.projectObservationUuidsToDelete ).toEqual( [
-        "prior-session-uuid",
-        "deselected-po-uuid",
-      ] );
-    } );
-
     it( "handles missing arrays on brand-new observations", ( ) => {
       const result = buildProjectObservationSelection(
         undefined,

--- a/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
+++ b/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
@@ -113,6 +113,34 @@ describe( "areProjectIdSetsEqual", ( ) => {
       } ) );
       expect( result.projectObservations[0]._pending_deletion ).toBeUndefined( );
     } );
+
+    it( "keeps other pending-removal POs when selection changes", ( ) => {
+      const activePo = factory( "LocalProjectObservation", {
+        projectId: 10,
+        uuid: "active-po-uuid",
+        _synced_at: new Date( ),
+      } );
+      const pendingRemovalPo = factory( "LocalProjectObservation", {
+        projectId: 20,
+        uuid: "pending-removal-po-uuid",
+        _synced_at: new Date( ),
+        _pendingRemoval: true,
+      } );
+
+      const result = buildProjectObservationSelection(
+        [activePo, pendingRemovalPo],
+        new Set( [10] ),
+      );
+
+      expect( result.projectObservations ).toEqual( [
+        activePo,
+        {
+          ...pendingRemovalPo,
+          _pendingRemoval: true,
+        },
+      ] );
+    } );
+
     it( "handles missing arrays on brand-new observations", ( ) => {
       const result = buildProjectObservationSelection(
         undefined,

--- a/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
+++ b/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
@@ -37,7 +37,7 @@ describe( "areProjectIdSetsEqual", ( ) => {
       expect( result.projectObservations[0].uuid ).toBeTruthy( );
     } );
 
-    it( "stages synced PO uuids when deselected during an ObsEdit session", ( ) => {
+    it( "soft-deletes synced POs when deselected during an ObsEdit session", ( ) => {
       const syncedPo = factory( "LocalProjectObservation", {
         projectId: 10,
         uuid: "synced-po-uuid",
@@ -46,12 +46,13 @@ describe( "areProjectIdSetsEqual", ( ) => {
 
       const result = buildProjectObservationSelection(
         [syncedPo],
-        [],
         new Set( ),
       );
 
-      expect( result.projectObservations ).toEqual( [] );
-      expect( result.projectObservationUuidsToDelete ).toEqual( ["synced-po-uuid"] );
+      expect( result.projectObservations ).toEqual( [{
+        ...syncedPo,
+        _pendingRemoval: true,
+      }] );
     } );
 
     it( "drops never-synced POs without staging deletion", ( ) => {

--- a/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
+++ b/tests/unit/sharedHelpers/buildProjectObservationSelection.test.js
@@ -69,21 +69,26 @@ describe( "areProjectIdSetsEqual", ( ) => {
       expect( result.projectObservations ).toEqual( [] );
     } );
 
-    it( "removes re-selected PO uuid from a prior ObsEdit session delete list", ( ) => {
-      const reselectedPo = factory( "LocalProjectObservation", {
+    it( "preserves uuid when re-selecting after soft-delete", ( ) => {
+      const deselectedPo = factory( "LocalProjectObservation", {
         projectId: 10,
         uuid: "reselected-po-uuid",
+        id: 99,
         _synced_at: new Date( ),
+        _pendingRemoval: true,
       } );
 
       const result = buildProjectObservationSelection(
-        [reselectedPo],
-        ["reselected-po-uuid"],
+        [deselectedPo],
         new Set( [10] ),
       );
 
-      expect( result.projectObservations ).toEqual( [reselectedPo] );
-      expect( result.projectObservationUuidsToDelete ).toEqual( [] );
+      expect( result.projectObservations ).toEqual( [expect.objectContaining( {
+        projectId: 10,
+        uuid: "reselected-po-uuid",
+        id: 99,
+        _synced_at: deselectedPo._synced_at,
+      } )] );
     } );
 
     it( "carries forward prior session delete uuids and adds newly deselected synced POs", ( ) => {


### PR DESCRIPTION
Closes MOB-1508

This PR:
- Replace MOB-1498s projectObservationUuidsToDelete with in-array _pendingRemoval soft-delete (POs + cleared synced OFVs).
- On SAVE, saveLocalObservationForUpload writes active embeds and Realm _pending_deletion tombstones; selective dirty for changed embeds only.
- Need Realm schema bump; v72: _pending_deletion on PO/OFV embeds.