### PR TITLE
add myobs sort, search, and map view feature flags to enabled for admins array

### DIFF
--- a/src/stores/createFeatureFlagSlice.ts
+++ b/src/stores/createFeatureFlagSlice.ts
@@ -33,6 +33,9 @@ export enum FeatureFlag {
 
 export const flagsEnabledForAdminsInTestFlight = [
   FeatureFlag.TestFlightAdminMessageEnabled,
+  FeatureFlag.SearchMyObservationsEnabled,
+  FeatureFlag.SortMyObservationsEnabled,
+  FeatureFlag.MyObservationsMapViewEnabled,
 ];
 
 const initialFeatureFlagConfig: Record<FeatureFlag, boolean> = {


### PR DESCRIPTION
[MOB-1655](https://linear.app/inaturalist/issue/MOB-1655/add-new-myobs-features-to-admin-testing-pool)

if we stick with the current release plan, we will want to have new myobs features under test by admins in the internal build available ~Aug 12-25, so this is a PR to enabled that for the parts that seem ready (small grid view tbd, but seeming unlikely). 

One call out from the testing notes of Ryan's ticket:

> We may want to do a production release with a no-op flag to make sure that the "AppStore" vs "TestFlight" check works as expected in our app. Like an "Installer source: [App Store | Testflight]" label in Debug

So, if that's the case, maybe we want to wait an additional cycle to ensure everything is working as expected in production? Open to thoughts, but teeing up the PR just in case we want to proceed.