### PR TITLE
Fix post list images in dev mode

### DIFF
--- a/src/components/Journal/PostListItem.tsx
+++ b/src/components/Journal/PostListItem.tsx
@@ -31,7 +31,7 @@ const PostListItem = ( {
     const match = item.body.match( imgSrcPattern );
     return match
       ? match[1]
-      : item.parent.icon_url ?? null;
+      : item.parent.icon_url?.replace( "staticdev", "static" ) ?? null;
   }, [item.body, item.parent.icon_url] );
 
   return (


### PR DESCRIPTION
Staging API often returns staticdev hosts that 403 for project icons; match ProjectListItem / User.uri and rewrite to the public static CDN.