### PR TITLE
Link to observation, project, and taxon in-app from UserText

### DIFF
--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -213,9 +213,10 @@ const UserText = ( {
           navigation.push( "UserProfile", { login } );
           return;
         }
-        if ( parseInatUrl( href ) ) {
+        const parsed = parseInatUrl( href );
+        if ( parsed ) {
           event.preventDefault( );
-          openInatUrl( href, navigation );
+          openInatUrl( parsed, navigation );
           return;
         }
         // This is any other regular link

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -202,7 +202,7 @@ const UserText = ( {
 
   const renderersProps: Partial<RenderersProps> = {
     a: {
-      onPress: ( event, href, htmlAttribs ) => {
+      onPress: async ( event, href, htmlAttribs ) => {
         if ( htmlAttribs.title && htmlAttribs.title.includes( MENTION_TITLE ) ) {
           event.preventDefault( );
           // This is a mention, so we want to navigate to user profile screen
@@ -216,8 +216,11 @@ const UserText = ( {
         const parsed = parseInatUrl( href );
         if ( parsed ) {
           event.preventDefault( );
-          openInatUrl( parsed, navigation );
-          return;
+          const handled = await openInatUrl( parsed, navigation );
+          if ( handled ) {
+            return;
+          }
+          // If not handled fall through to use Linking
         }
         // This is any other regular link
         Linking.openURL( href );

--- a/src/components/SharedComponents/UserText.tsx
+++ b/src/components/SharedComponents/UserText.tsx
@@ -18,6 +18,7 @@ import { Linking, useWindowDimensions } from "react-native";
 import WebView from "react-native-webview";
 import type { IOptions } from "sanitize-html";
 import sanitizeHtml from "sanitize-html";
+import { openInatUrl, parseInatUrl } from "sharedHelpers/inatUrlNavigation";
 import colors from "styles/tailwindColors";
 
 // Keep aligned with Post::ALLOWED_TAGS in inaturalist/inaturalist (Rails);
@@ -210,6 +211,11 @@ const UserText = ( {
             .replace( MENTION_TITLE, "" )
             .replace( /^@/, "" );
           navigation.push( "UserProfile", { login } );
+          return;
+        }
+        if ( parseInatUrl( href ) ) {
+          event.preventDefault( );
+          openInatUrl( href, navigation );
           return;
         }
         // This is any other regular link

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -1,4 +1,6 @@
 import type { NavigationProp, ParamListBase } from "@react-navigation/native";
+import { searchObservations } from "api/observations";
+import { getJWT } from "components/LoginSignUp/AuthenticationService";
 
 const ALLOWED_HOSTS = [
   "www.inaturalist.org",
@@ -64,6 +66,24 @@ export async function openInatUrl(
       const projectId = parseNumericId( id );
       if ( projectId ) {
         navigation.push( "ProjectDetails", { id: projectId } );
+        return true;
+      }
+      return false;
+    }
+    case "observation": {
+      const observationId = parseNumericId( id );
+      // Currently, ObsDetails can only handle a uuid as nav param. So, we do the same thing we do
+      // in useLinking, get a UUID for the ID from the link via the API.
+      const searchParams = { id: observationId };
+      const apiToken = await getJWT( );
+      const options = {
+        api_token: apiToken,
+      };
+      const { results } = await searchObservations( searchParams, options );
+      const uuid = results?.[0]?.uuid;
+
+      if ( uuid ) {
+        navigation.push( "ObsDetails", { uuid } );
         return true;
       }
       return false;

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -1,5 +1,6 @@
 import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 import { searchObservations } from "api/observations";
+import { searchProjects } from "api/projects";
 import { getJWT } from "components/LoginSignUp/AuthenticationService";
 
 const ALLOWED_HOSTS = [
@@ -66,6 +67,24 @@ export async function openInatUrl(
       const projectId = parseNumericId( id );
       if ( projectId ) {
         navigation.push( "ProjectDetails", { id: projectId } );
+        return true;
+      }
+      // Currently, ProjectDetails can not handle slugs as nav param to display a project.
+      // Lookup of a project ID by a given slug is adapted from observations below.
+      const searchParams = {
+        q: id,
+        fields: {
+          slug: true,
+        },
+      };
+      const apiToken = await getJWT( );
+      const options = {
+        api_token: apiToken,
+      };
+      const { results } = await searchProjects( searchParams, options );
+      const project = results?.find( ( result: { slug?: string } ) => result.slug === id );
+      if ( project?.id ) {
+        navigation.push( "ProjectDetails", { id: project.id } );
         return true;
       }
       return false;

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -26,7 +26,7 @@ export function parseInatUrl( href: string ): InatUrlTarget | null {
     return null;
   }
 
-  const segments = pathname.split( "/" );
+  const segments = pathname.split( "/" ).filter( Boolean );
   if ( segments.length < 2 ) {
     return null;
   }

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -59,6 +59,14 @@ export async function openInatUrl(
       }
       return false;
     }
+    case "project": {
+      const projectId = parseNumericId( id );
+      if ( projectId ) {
+        navigation.push( "ProjectDetails", { id: projectId } );
+        return true;
+      }
+      return false;
+    }
     default:
       return false;
   }

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -13,11 +13,10 @@ export type InatUrlTarget =
   | { type: "project"; id: string };
 
 function parseNumericId( segment: string ): number | null {
-  const match = segment.match( /^(\d+)/ );
-  if ( !match ) {
+  if ( !/^\d+$/.test( segment ) ) {
     return null;
   }
-  return Number( match[1] );
+  return Number( segment );
 }
 
 export function parseInatUrl( href: string ): InatUrlTarget | null {

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -13,10 +13,12 @@ export type InatUrlTarget =
   | { type: "project"; id: string };
 
 function parseNumericId( segment: string ): number | null {
-  if ( !/^\d+$/.test( segment ) ) {
+  // Matches IDs like "1234" and also slugs that start with a number ID "1234-taxon-name"
+  const match = segment.match( /^(\d+)/ );
+  if ( !match ) {
     return null;
   }
-  return Number( segment );
+  return Number( match[1] );
 }
 
 export function parseInatUrl( href: string ): InatUrlTarget | null {

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -11,16 +11,32 @@ export type InatUrlTarget =
   | { type: "observation"; id: string }
   | { type: "taxon"; id: string }
   | { type: "project"; id: string };
+
+function parseNumericId( segment: string ): number | null {
+  const match = segment.match( /^(\d+)/ );
+  if ( !match ) {
+    return null;
+  }
+  return Number( match[1] );
+}
+
 export function parseInatUrl( href: string ): InatUrlTarget | null {
   const { host, pathname } = new URL( href );
   if ( !ALLOWED_HOSTS.includes( host ) ) {
     return null;
   }
+
   const segments = pathname.split( "/" );
   if ( segments.length < 2 ) {
     return null;
   }
-  console.log( "segments", segments );
+
+  const [resource, firstSegment] = segments;
+  const numericId = parseNumericId( firstSegment );
+  if ( !numericId ) {
+    return null;
+  }
+  console.log( "resource", resource );
   return null;
 }
 

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -8,9 +8,9 @@ const ALLOWED_HOSTS = [
 ];
 
 export type InatUrlTarget =
-  | { type: "observation"; id: number }
-  | { type: "taxon"; id: number }
-  | { type: "project"; id: number };
+  | { type: "observation"; id: string }
+  | { type: "taxon"; id: string }
+  | { type: "project"; id: string };
 
 function parseNumericId( segment: string ): number | null {
   const match = segment.match( /^(\d+)/ );
@@ -32,18 +32,14 @@ export function parseInatUrl( href: string ): InatUrlTarget | null {
   }
 
   const [resource, firstSegment] = segments;
-  const numericId = parseNumericId( firstSegment );
-  if ( !numericId ) {
-    return null;
-  }
 
   switch ( resource ) {
     case "observations":
-      return { type: "observation", id: numericId };
+      return { type: "observation", id: firstSegment };
     case "taxa":
-      return { type: "taxon", id: numericId };
+      return { type: "taxon", id: firstSegment };
     case "projects":
-      return { type: "project", id: numericId };
+      return { type: "project", id: firstSegment };
     default:
       return null;
   }
@@ -56,7 +52,11 @@ export async function openInatUrl(
   const { type, id } = parsed;
   switch ( type ) {
     case "taxon": {
-      navigation.push( "TaxonDetails", { id } );
+      const taxonID = parseNumericId( id );
+      if ( taxonID ) {
+        navigation.push( "TaxonDetails", { id: taxonID } );
+        return true;
+      }
       return true;
     }
     default:

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -16,7 +16,11 @@ export function parseInatUrl( href: string ): InatUrlTarget | null {
   if ( !ALLOWED_HOSTS.includes( host ) ) {
     return null;
   }
-  console.log( "pathname", pathname );
+  const segments = pathname.split( "/" );
+  if ( segments.length < 2 ) {
+    return null;
+  }
+  console.log( "segments", segments );
   return null;
 }
 

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -10,7 +10,7 @@ const ALLOWED_HOSTS = [
 export type InatUrlTarget =
   | { type: "observation"; id: string }
   | { type: "taxon"; id: string }
-  | { type: "project"; id: string }
+  | { type: "project"; id: string };
 export function parseInatUrl( href: string ): InatUrlTarget | null {
   const { host, pathname } = new URL( href );
   if ( !ALLOWED_HOSTS.includes( host ) ) {

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -36,8 +36,17 @@ export function parseInatUrl( href: string ): InatUrlTarget | null {
   if ( !numericId ) {
     return null;
   }
-  console.log( "resource", resource );
-  return null;
+
+  switch ( resource ) {
+    case "observations":
+      return { type: "observation", id: firstSegment };
+    case "taxa":
+      return { type: "taxon", id: firstSegment };
+    case "projects":
+      return { type: "project", id: firstSegment };
+    default:
+      return null;
+  }
 }
 
 export async function openInatUrl(

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -50,9 +50,16 @@ export function parseInatUrl( href: string ): InatUrlTarget | null {
 }
 
 export async function openInatUrl(
-  href: string,
+  parsed: InatUrlTarget,
   navigation: NavigationProp<ParamListBase>,
 ): Promise<boolean> {
-  console.log( "href", href );
-  console.log( "navigation", navigation );
+  const { type, id } = parsed;
+  switch ( type ) {
+    case "taxon": {
+      navigation.push( "TaxonDetails", { id } );
+      return true;
+    }
+    default:
+      return false;
+  }
 }

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -1,0 +1,17 @@
+import type { NavigationProp, ParamListBase } from "@react-navigation/native";
+
+export type InatUrlTarget =
+  | { type: "observation"; id: string }
+  | { type: "taxon"; id: string }
+  | { type: "project"; id: string }
+export function parseInatUrl( href: string ): InatUrlTarget | null {
+  console.log( "href", href );
+}
+
+export async function openInatUrl(
+  href: string,
+  navigation: NavigationProp<ParamListBase>,
+): Promise<boolean> {
+  console.log( "href", href );
+  console.log( "navigation", navigation );
+}

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -8,9 +8,9 @@ const ALLOWED_HOSTS = [
 ];
 
 export type InatUrlTarget =
-  | { type: "observation"; id: string }
-  | { type: "taxon"; id: string }
-  | { type: "project"; id: string };
+  | { type: "observation"; id: number }
+  | { type: "taxon"; id: number }
+  | { type: "project"; id: number };
 
 function parseNumericId( segment: string ): number | null {
   const match = segment.match( /^(\d+)/ );
@@ -39,11 +39,11 @@ export function parseInatUrl( href: string ): InatUrlTarget | null {
 
   switch ( resource ) {
     case "observations":
-      return { type: "observation", id: firstSegment };
+      return { type: "observation", id: numericId };
     case "taxa":
-      return { type: "taxon", id: firstSegment };
+      return { type: "taxon", id: numericId };
     case "projects":
-      return { type: "project", id: firstSegment };
+      return { type: "project", id: numericId };
     default:
       return null;
   }

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -57,7 +57,7 @@ export async function openInatUrl(
         navigation.push( "TaxonDetails", { id: taxonID } );
         return true;
       }
-      return true;
+      return false;
     }
     default:
       return false;

--- a/src/sharedHelpers/inatUrlNavigation.ts
+++ b/src/sharedHelpers/inatUrlNavigation.ts
@@ -1,11 +1,23 @@
 import type { NavigationProp, ParamListBase } from "@react-navigation/native";
 
+const ALLOWED_HOSTS = [
+  "www.inaturalist.org",
+  "inaturalist.org",
+  "api.inaturalist.org",
+  "staging.inaturalist.org",
+];
+
 export type InatUrlTarget =
   | { type: "observation"; id: string }
   | { type: "taxon"; id: string }
   | { type: "project"; id: string }
 export function parseInatUrl( href: string ): InatUrlTarget | null {
-  console.log( "href", href );
+  const { host, pathname } = new URL( href );
+  if ( !ALLOWED_HOSTS.includes( host ) ) {
+    return null;
+  }
+  console.log( "pathname", pathname );
+  return null;
 }
 
 export async function openInatUrl(


### PR DESCRIPTION
Closes MOB-440

ProjectDetails is not setup to handle slugs as nav params, ObsDetails is not setup to handle numeric IDs as nav params, so I added an inline lookup to get the numeric ID and UUID, respectively (following existing code).
Then we can route to the details screens as required by the ticket.