### PR TITLE
Use the device's calendar date in Explore date filters

### DIFF
--- a/src/components/Explore/Modals/FilterModal.tsx
+++ b/src/components/Explore/Modals/FilterModal.tsx
@@ -42,6 +42,7 @@ import {
 } from "providers/ExploreContext";
 import React, { useState } from "react";
 import type { RealmTaxon } from "realmModels/types";
+import { formatISODate } from "sharedHelpers/dateAndTime";
 import { useCurrentUser, useTranslation } from "sharedHooks";
 import type { LocationPermissionCallbacks } from "sharedHooks/useLocationPermission";
 import { getShadow } from "styles/global";
@@ -534,7 +535,7 @@ const FilterModal = ( {
   const updateDateObserved = ( {
     newDateObserved, newObservedOn, newD1, newD2, newMonths,
   } ) => {
-    const today = new Date( ).toISOString( ).split( "T" )[0];
+    const today = formatISODate( new Date( ) );
     // Array with the numbers from 1 to 12
     const allMonths = new Array( 12 ).fill( 0 ).map( ( _, i ) => i + 1 );
 
@@ -564,14 +565,14 @@ const FilterModal = ( {
   const updateObservedExact = date => {
     updateDateObserved( {
       newDateObserved: DATE_OBSERVED.EXACT_DATE,
-      newObservedOn: date.toISOString().split( "T" )[0],
+      newObservedOn: formatISODate( date ),
     } );
   };
 
   const updateObservedStart = date => {
     updateDateObserved( {
       newDateObserved: DATE_OBSERVED.DATE_RANGE,
-      newD1: date.toISOString().split( "T" )[0],
+      newD1: formatISODate( date ),
       newD2: d2,
     } );
   };
@@ -580,7 +581,7 @@ const FilterModal = ( {
     updateDateObserved( {
       newDateObserved: DATE_OBSERVED.DATE_RANGE,
       newD1: d1,
-      newD2: date.toISOString().split( "T" )[0],
+      newD2: formatISODate( date ),
     } );
   };
 
@@ -595,7 +596,7 @@ const FilterModal = ( {
   };
 
   const updateDateUploaded = ( { newDateUploaded, newD1, newD2 } ) => {
-    const today = new Date().toISOString().split( "T" )[0];
+    const today = formatISODate( new Date( ) );
     if ( newDateUploaded === DATE_UPLOADED.ALL ) {
       dispatch( {
         type: EXPLORE_ACTION.SET_DATE_UPLOADED_ALL,
@@ -617,7 +618,7 @@ const FilterModal = ( {
   const updateUploadedStart = date => {
     updateDateUploaded( {
       newDateUploaded: DATE_UPLOADED.DATE_RANGE,
-      newD1: date.toISOString().split( "T" )[0],
+      newD1: formatISODate( date ),
       newD2: createdD2,
     } );
   };
@@ -626,7 +627,7 @@ const FilterModal = ( {
     updateDateUploaded( {
       newDateUploaded: DATE_UPLOADED.DATE_RANGE,
       newD1: createdD1,
-      newD2: date.toISOString().split( "T" )[0],
+      newD2: formatISODate( date ),
     } );
   };
 
@@ -1064,7 +1065,7 @@ const FilterModal = ( {
                   toggleDateTimePicker={() => setOpenSheet( NONE )}
                   onDatePicked={date => updateDateUploaded( {
                     newDateUploaded: DATE_UPLOADED.EXACT_DATE,
-                    newD1: date.toISOString().split( "T" )[0],
+                    newD1: formatISODate( date ),
                   } )}
                 />
               </View>

--- a/src/sharedHelpers/dateAndTime.ts
+++ b/src/sharedHelpers/dateAndTime.ts
@@ -481,12 +481,20 @@ function formatProjectsApiDatetimeLong(
   return formatDateString( dateString, i18n.t( "date-format-long" ), i18n, options );
 }
 
-function formatObsFieldDate( date: Date ): string {
+// The calendar date on the device (just "2022-12-31"), e.g. for API params that
+// take a date. Note that Date#toISOString can't be used for this: it converts to
+// UTC first, so for part of every day it returns the wrong date for anyone whose
+// device is not on UTC.
+function formatISODate( date: Date ): string {
   return formatInTimeZone(
     date,
     Intl.DateTimeFormat( ).resolvedOptions( ).timeZone,
     "yyyy-MM-dd",
   );
+}
+
+function formatObsFieldDate( date: Date ): string {
+  return formatISODate( date );
 }
 
 function formatObsFieldTime( date: Date ): string {
@@ -509,6 +517,7 @@ export {
   formatApiDatetime,
   formatDateStringFromTimestamp,
   formatDifferenceForHumans,
+  formatISODate,
   formatISONoSeconds,
   formatISONoTimezone,
   formatLongDate,

--- a/tests/unit/components/Explore/Modals/FilterModal.test.js
+++ b/tests/unit/components/Explore/Modals/FilterModal.test.js
@@ -1,26 +1,78 @@
-import { screen } from "@testing-library/react-native";
+import { fireEvent, screen } from "@testing-library/react-native";
 import FilterModal from "components/Explore/Modals/FilterModal";
 import { ExploreProvider } from "providers/ExploreContext";
 import React from "react";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
 import { renderComponent } from "tests/helpers/render";
 
 const mockCloseModal = jest.fn( );
 const mockUpdateTaxon = jest.fn( );
 
+const renderFilterModal = ( ) => renderComponent(
+  <ExploreProvider>
+    <FilterModal
+      closeModal={mockCloseModal}
+      updateTaxon={mockUpdateTaxon}
+    />
+  </ExploreProvider>,
+);
+
+const chooseExactDate = async ( filterLabel, pickedDate ) => {
+  fireEvent.press( await screen.findByLabelText( filterLabel ) );
+  fireEvent.press( await screen.findByText( "Exact Date" ) );
+  fireEvent.press( screen.getByText( "CONFIRM" ) );
+  await screen.findByLabelText( "Change date" );
+
+  const datePickers = screen.UNSAFE_getAllByType( DateTimePickerModal );
+  expect( datePickers.length ).toEqual( 1 );
+  fireEvent( datePickers[0], "onConfirm", pickedDate );
+};
+
 describe( "FilterModal", () => {
   test( "should not have accessibility errors", async () => {
-    renderComponent(
-      <ExploreProvider>
-        <FilterModal
-          closeModal={mockCloseModal}
-          updateTaxon={mockUpdateTaxon}
-        />
-      </ExploreProvider>,
-    );
+    renderFilterModal( );
 
     const filterModal = await screen.findByTestId( "filter-modal" );
     // TODO: this errors because RadioButton from react-native-paper is not accessible
     console.log( "typeof filterModal :>> ", typeof filterModal );
     // expect( filterModal ).toBeAccessible();
+  } );
+
+  describe( "in Europe/Berlin", ( ) => {
+    // Berlin is already Feb 14 while UTC is still Feb 13
+    const picked = new Date( "2026-02-13T23:30:00Z" );
+    let resolvedOptionsSpy;
+
+    beforeAll( ( ) => {
+      resolvedOptionsSpy = jest.spyOn(
+        Intl.DateTimeFormat.prototype,
+        "resolvedOptions",
+      ).mockReturnValue( {
+        calendar: "gregory",
+        locale: "en-US",
+        numberingSystem: "latn",
+        timeZone: "Europe/Berlin",
+      } );
+    } );
+
+    afterAll( ( ) => {
+      resolvedOptionsSpy.mockRestore( );
+    } );
+
+    it( "filters on the date observed on the device, not the UTC date", async ( ) => {
+      renderFilterModal( );
+
+      await chooseExactDate( "Date observed", picked );
+
+      expect( await screen.findByText( "2026-02-14" ) ).toBeVisible( );
+    } );
+
+    it( "filters on the date uploaded on the device, not the UTC date", async ( ) => {
+      renderFilterModal( );
+
+      await chooseExactDate( "Date uploaded", picked );
+
+      expect( await screen.findByText( "2026-02-14" ) ).toBeVisible( );
+    } );
   } );
 } );

--- a/tests/unit/helpers/dateAndTime.test.js
+++ b/tests/unit/helpers/dateAndTime.test.js
@@ -10,6 +10,7 @@ import i18next from "i18next";
 import {
   formatApiDatetime,
   formatDifferenceForHumans,
+  formatISODate,
   formatISONoSeconds,
   formatObsFieldDate,
   formatObsFieldDatetime,
@@ -232,6 +233,41 @@ describe( "formatObsFieldDate/Time/Datetime", ( ) => {
 
     it( "stores datetime as UTC date and time", ( ) => {
       expect( formatObsFieldDatetime( picked ) ).toEqual( "2026-01-01 03:30" );
+    } );
+  } );
+} );
+
+describe( "formatISODate", ( ) => {
+  // UTC is already Jan 1, 2026 while New York is still Dec 31, 2025
+  const picked = new Date( "2026-01-01T03:30:00Z" );
+
+  describe( "in America/New_York", ( ) => {
+    let resolvedOptionsSpy;
+
+    beforeAll( () => {
+      resolvedOptionsSpy = jest.spyOn(
+        Intl.DateTimeFormat.prototype,
+        "resolvedOptions",
+      ).mockReturnValue( {
+        calendar: "gregory",
+        locale: "en-US",
+        numberingSystem: "latn",
+        timeZone: "America/New_York",
+      } );
+    } );
+
+    afterAll( () => {
+      resolvedOptionsSpy.mockRestore( );
+    } );
+
+    it( "returns the calendar date on the device, not the UTC date", ( ) => {
+      expect( formatISODate( picked ) ).toEqual( "2025-12-31" );
+    } );
+  } );
+
+  describe( "in UTC", ( ) => {
+    it( "returns the UTC calendar date", ( ) => {
+      expect( formatISODate( picked ) ).toEqual( "2026-01-01" );
     } );
   } );
 } );


### PR DESCRIPTION
This PR proposes fixing the Explore date filters so they use the calendar date on the device rather than the UTC date, which is wrong for part of every day for anyone not on UTC (Fixes #2482). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/203. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

`FilterModal` turned every date coming out of the picker into an API param with `date.toISOString( ).split( "T" )[0]`, which converts the instant to UTC before taking the calendar date off the front of it. On a device ahead of UTC that is yesterday's date from local midnight until the offset has elapsed — the Germany report in #2482, where picking 14 February stores and displays 13 February — and on a device behind UTC it is tomorrow's date late in the evening, which is the "you have the 9th of April, the picker starts on the 8th" case noted in the same issue. The same conversion produced the `today` value the observed and uploaded filters default to, so the filter could open on the wrong date before the user touched anything.

Eight call sites were affected: observed exact / range start / range end, uploaded exact / range start / range end, and the two `today` defaults.

## Reproducing it on main

The two new specs in `tests/unit/components/Explore/Modals/FilterModal.test.js` drive the real filter modal, pin the device to `Europe/Berlin`, and confirm a date whose Berlin day and UTC day differ. Against `f18cd0473` with only the specs applied:

```
$ npx jest tests/unit/components/Explore/Modals/FilterModal.test.js
  ✓ should not have accessibility errors (2994 ms)
  ✕ filters on the date observed on the device, not the UTC date (4525 ms)
  ✕ filters on the date uploaded on the device, not the UTC date (2869 ms)

  Unable to find an element with text: 2026-02-14
Tests: 2 failed, 1 passed, 3 total
```

The modal shows `2026-02-13` for an instant that is half past midnight on 14 February in Berlin. Both specs pass with the change applied.

## The change

`formatISODate` in `sharedHelpers/dateAndTime` formats a `Date` as `yyyy-MM-dd` in the device's time zone. Its body is the one `formatObsFieldDate` already used, since obs fields solved this same problem; `formatObsFieldDate` now delegates to it, so nothing about that helper's behavior changes and its existing specs still cover it. `FilterModal` uses the helper for all eight conversions.

The specs pin the time zone by spying on `Intl.DateTimeFormat.prototype.resolvedOptions`, the way `tests/unit/helpers/dateAndTime.test.js` already does, because `tests/jest.globalSetup.js` runs the suite in UTC and jest can't move a running worker to another zone. `formatISODate` also gets direct coverage there, in `America/New_York` (behind UTC) and in UTC.

## Verification

- `npm run test:unit` on unmodified `main`: 199 of 200 suites pass, the only failure being the new specs above. With the change: 200 suites, 1123 tests, no failures — no test that passed before fails now.
- `npx jest tests/integration/Explore.test.js tests/integration/navigation/Explore.test.js`: 2 suites, 12 tests, pass.
- `npx eslint` on the four changed files: clean.
- `npm run lint:tsc`: the pre-existing baseline is identical before and after the change (1301 both times), with no new error in either touched file — the ones already reported in `FilterModal.tsx` are unchanged apart from two arguments that now report as `string` instead of `any`.

Branch naming: I kept the `agile-board/` prefix rather than the issue-number convention in CONTRIBUTING, because pushing a branch or commit that names the issue posts a cross-reference onto it before there is a PR to look at. Happy to rename if you'd rather have the convention.

## How this was managed

This work was tracked on a board imported from this repository's own issues, pull requests and milestones (3308 stories, 33 labels), where it maps to [Explore filters date picker doesn't account for device time zone](https://eastagiletracker.com/projects/203/stories/69865). The whole board is at https://eastagiletracker.com/projects/203.

![board](https://raw.githubusercontent.com/eastagiletracker/iNaturalistReactNative/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
