### PR TITLE
MOB-1662 add osx 27 to gemfile platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Closes MOB-1662

I cannot overstate how much I regret the whim of committing to osx beta without understanding the irreversible consequences.

anyway, here's ~wonderwall~ something that we'd need to do eventually anyway