### PR TITLE
flatten logging _extraData for readability

### DIFF
--- a/src/api/log/enhanceLoggerWithExtra.ts
+++ b/src/api/log/enhanceLoggerWithExtra.ts
@@ -56,8 +56,8 @@ import { isObjectWithPrimitiveValues } from "sharedHelpers/runtimeTypeUtil";
 // input. That is:
 // log.infoWithExtra(1, 2, 3, { userId: 0 })
 // becomes
-// [1, 2, 3, { [magicExtraKey]: { userId: 0 }}]
-// The trasport looks at its args, sees if the last one is a `{ [magicKey]: {} }` and if so,
+// [1, 2, 3, { [magicExtraKey]: true, userId: 0 }]
+// The trasport looks at its args, sees if the last one is a `{ [magicKey]: true, ... }` and if so,
 // separates that value from the rest of the log args as if it was indeed passed separately. The log
 // API would receive: { message, "1 2 3", extra: { userId: 0 } }
 
@@ -94,7 +94,7 @@ const extractExtraForLogWrapper = ( rawMsg: unknown ) => {
   ) {
     return null;
   }
-  return { [extraSentinelKey]: extraCandidate };
+  return { [extraSentinelKey]: true, ...extraCandidate };
 };
 
 const wrapLogFunctionWithExtra = (

--- a/src/api/log/index.ts
+++ b/src/api/log/index.ts
@@ -32,10 +32,11 @@ function isError( value: unknown ): value is { message?: string; stack?: string 
 }
 
 // If we have anything that looks like:
-// [someObj, 'asdfasdf', 3, { [extraSentinelKey]: { id: 1, ... } }]
-// where the _last_ rest param is an obj w/ exactly this sentinel property w/ primitive fields,
-// we infer that last item as intended for the special `extra` API field
-// we return that separately and strip it from the "normal" rest params for later handling
+// [someObj, 'asdfasdf', 3, { [extraSentinelKey]: true, id: 1, ... }]
+// where the _last_ rest param is an obj flagged w/ this sentinel property and otherwise
+// has only primitive fields, we infer that last item as intended for the special `extra`
+// API field. we return that separately and strip it from the "normal" rest params for
+// later handling
 function extractExtra( rawMsg: unknown ) {
   const nonExtraResult = {
     messageParams: rawMsg,
@@ -46,18 +47,17 @@ function extractExtra( rawMsg: unknown ) {
   if ( !Array.isArray( rawMsg ) || rawMsg.length < 2 ) {
     return nonExtraResult;
   }
-  // make sure maybeExtra looks like { extra: ??? }
+  // make sure maybeExtra looks like { [extraSentinelKey]: true, ... }
   const extraWrapperCandidate = rawMsg.at( -1 );
   if (
     !isObject( extraWrapperCandidate )
-    // limit to _exactly_ just this property to minimize accidentally classifying `extra`
-    || Object.keys( extraWrapperCandidate ).length !== 1
     || !( extraSentinelKey in extraWrapperCandidate )
+    || extraWrapperCandidate[extraSentinelKey] !== true
   ) {
     return nonExtraResult;
   }
   // make sure our extra is actually valid for the API
-  const extraCandidate = extraWrapperCandidate[extraSentinelKey];
+  const { [extraSentinelKey]: _sentinel, ...extraCandidate } = extraWrapperCandidate;
   if ( !isObjectWithPrimitiveValues( extraCandidate ) ) {
     console.warn( "[ERROR log.ts] `extra` must be a non-nested object with primitive values" );
     return nonExtraResult;


### PR DESCRIPTION
Closes MOB-1463 to clean up triage.

instead of:

```
{ 
  extraData: {
    id: 1,
    obsCount: 100,
  }
}
 ```

We're now _logging_

```
{
  _extraData: true,
  id:1,
  obsCount: 100
}
```

In both cases, we're only ever sending the following to `api/log`:

```
{ 
  id: 1, 
  obsCount: 100 
}
```