### PR TITLE
Update react-native-sensitive-info to v6

### DIFF
--- a/__mocks__/react-native-sensitive-info.ts
+++ b/__mocks__/react-native-sensitive-info.ts
@@ -15,100 +15,77 @@ try {
   console.warn( "Could not import clearAuthCache, using no-op function", error );
 }
 
-class RNSInfo {
-  static stores = new Map();
+const stores = new Map();
 
-  static getServiceName( o = {} ) {
-    return o.sharedPreferencesName
-        || o.keychainService
+function getServiceName( o = {} ) {
+  return o.service
         || "default";
-  }
-
-  static validateString( s ) {
-    if ( typeof s !== "string" ) { throw new Error( "Invalid string:", s ); }
-  }
-
-  static clearAllStores = jest.fn( () => {
-    RNSInfo.stores.clear();
-    clearAuthCache();
-  } );
-
-  static clearAuthCache = jest.fn( () => {
-    clearAuthCache();
-  } );
-
-  static hasItem = jest.fn( async ( k, o ) => {
-    RNSInfo.validateString( k );
-
-    const serviceName = RNSInfo.getServiceName( o );
-    const service = RNSInfo.stores.get( serviceName );
-
-    if ( service ) { return service.has( k ); }
-    return false;
-  } );
-
-  static getItem = jest.fn( async ( k, o ) => {
-    RNSInfo.validateString( k );
-
-    const serviceName = RNSInfo.getServiceName( o );
-    const service = RNSInfo.stores.get( serviceName );
-
-    if ( service ) { return service.get( k ) || null; }
-    return null;
-  } );
-
-  static getAllItems = jest.fn( async o => {
-    const serviceName = RNSInfo.getServiceName( o );
-    const service = RNSInfo.stores.get( serviceName );
-    let mappedValues = [];
-
-    if ( service?.size ) {
-      mappedValues = Array.from( service.entries() ).map(
-        ( [key, value] ) => ( { key, value, service: serviceName } ),
-      );
-    }
-
-    return mappedValues;
-  } );
-
-  static setItem = jest.fn( async ( k, v, o ) => {
-    RNSInfo.validateString( k );
-    RNSInfo.validateString( v );
-
-    const serviceName = RNSInfo.getServiceName( o );
-    let service = RNSInfo.stores.get( serviceName );
-
-    if ( !service ) {
-      RNSInfo.stores.set( serviceName, new Map() );
-      service = RNSInfo.stores.get( serviceName );
-    }
-
-    service.set( k, v );
-
-    clearAuthCache( );
-
-    return null;
-  } );
-
-  static deleteItem = jest.fn( async ( k, o ) => {
-    RNSInfo.validateString( k );
-
-    const serviceName = RNSInfo.getServiceName( o );
-    const service = RNSInfo.stores.get( serviceName );
-
-    if ( service ) { service.delete( k ); }
-
-    clearAuthCache( );
-
-    return null;
-  } );
-
-  static hasEnrolledFingerprints = jest.fn( async () => true );
-
-  static setInvalidatedByBiometricEnrollment = jest.fn();
-
-  // "Touch ID" | "Face ID" | false
-  static isSensorAvailable = jest.fn( async () => "Face ID" );
 }
 
-module.exports = RNSInfo;
+function validateString( s ) {
+  if ( typeof s !== "string" ) { throw new Error( "Invalid string:", s ); }
+}
+
+const clearAuthCacheInternal = jest.fn( () => {
+  clearAuthCache();
+} );
+
+const hasItem = jest.fn( async ( k, o ) => {
+  validateString( k );
+
+  const serviceName = getServiceName( o );
+  const service = stores.get( serviceName );
+
+  if ( service ) { return service.has( k ); }
+  return false;
+} );
+
+const getItem = jest.fn( async ( k, o ) => {
+  validateString( k );
+
+  const serviceName = getServiceName( o );
+  const service = stores.get( serviceName );
+
+  if ( service ) { return service.get( k ) || null; }
+  return null;
+} );
+
+const setItem = jest.fn( async ( k, v, o ) => {
+  validateString( k );
+  validateString( v );
+
+  const serviceName = getServiceName( o );
+  let service = stores.get( serviceName );
+
+  if ( !service ) {
+    stores.set( serviceName, new Map() );
+    service = stores.get( serviceName );
+  }
+
+  service.set( k, v );
+
+  clearAuthCacheInternal( );
+
+  return null;
+} );
+
+const deleteItem = jest.fn( async ( k, o ) => {
+  validateString( k );
+
+  const serviceName = getServiceName( o );
+  const service = stores.get( serviceName );
+
+  if ( service ) { service.delete( k ); }
+
+  clearAuthCacheInternal( );
+
+  return null;
+} );
+
+module.exports = {
+  deleteItem,
+  setItem,
+  getItem,
+  hasItem,
+  stores,
+};

--- a/__mocks__/react-native-sensitive-info.ts
+++ b/__mocks__/react-native-sensitive-info.ts
@@ -46,7 +46,7 @@ const getItem = jest.fn( async ( k, o ) => {
   const serviceName = getServiceName( o );
   const service = stores.get( serviceName );
 
-  if ( service ) { return service.get( k ) || null; }
+  if ( service ) { return { value: service.get( k ) || null }; }
   return null;
 } );
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3919,17 +3919,19 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - SensitiveInfo (5.6.2):
+  - SensitiveInfo (6.1.5):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
+    - NitroModules
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
     - RCTTypeSafety
+    - React-callinvoker
     - React-Core
     - React-debug
     - React-Fabric
@@ -4561,7 +4563,7 @@ SPEC CHECKSUMS:
   RNStoreReview: 8f6061907efb6474757db004ee8faac728fd2ada
   RNSVG: c7b9ee1f2352f984e79d6e3238645b81ced60516
   RNWorklets: a3184955a41f2be46898a937e2821469c8c8da42
-  SensitiveInfo: 09107b865dc23b4e9c0a61ec01385387bf3391a8
+  SensitiveInfo: ddf05bc892a97c058f167057582e6a2d05e99c54
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
   VisionCameraPluginInatVision: 3b006a7a434ddfc23d789729b6d98e451f90c4e4

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "react-native-restart": "^0.0.27",
         "react-native-safe-area-context": "^5.8.0",
         "react-native-screens": "4.15.4",
-        "react-native-sensitive-info": "^5.6.2",
+        "react-native-sensitive-info": "^6.1.5",
         "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
         "react-native-store-review": "^0.4.3",
         "react-native-svg": "^15.15.0",
@@ -20218,16 +20218,17 @@
       }
     },
     "node_modules/react-native-sensitive-info": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/react-native-sensitive-info/-/react-native-sensitive-info-5.6.2.tgz",
-      "integrity": "sha512-crIx/ptLfk3nszFkfoGhuAqHOJcVYtI8VMIVTdwpcM0Jl0xuvOKVKpP8E+unQB1NC5wtkJbaLP3TP31v7jeZ9w==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/react-native-sensitive-info/-/react-native-sensitive-info-6.1.5.tgz",
+      "integrity": "sha512-HDeoC8pRb/PnkSGOcq33kKh0TqGhUyYtCNvPdGEov1rdEwjwrC0gzjM3x4ViMd5vQx2jAI46nmIr02W+Is9YKA==",
       "license": "MIT",
       "workspaces": [
         "example"
       ],
       "peerDependencies": {
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-nitro-modules": "*"
       }
     },
     "node_modules/react-native-share-menu": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "react-native-restart": "^0.0.27",
     "react-native-safe-area-context": "^5.8.0",
     "react-native-screens": "4.15.4",
-    "react-native-sensitive-info": "^5.6.2",
+    "react-native-sensitive-info": "^6.1.5",
     "react-native-share-menu": "github:inaturalist/react-native-share-menu#iNaturalistReactNative",
     "react-native-store-review": "^0.4.3",
     "react-native-svg": "^15.15.0",

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -19,9 +19,13 @@ import { Alert, Platform } from "react-native";
 import Config from "react-native-config";
 import * as RNLocalize from "react-native-localize";
 import RNRestart from "react-native-restart";
-import type { SensitiveInfoError } from "react-native-sensitive-info";
 import {
-  deleteItem, ErrorCode, getItem, hasItem, isSensitiveInfoError, setItem,
+  deleteItem,
+  ErrorCode,
+  getItem,
+  hasItem,
+  SensitiveInfoError,
+  setItem,
 } from "react-native-sensitive-info";
 import Realm, { UpdateMode } from "realm";
 import realmConfig from "realmModels/index";
@@ -97,10 +101,9 @@ async function getSensitiveItem(
   try {
     exists = await hasItem( key, options );
   } catch ( e ) {
-    if ( isSensitiveInfoError( e ) ) {
-      const hasItemError = e as SensitiveInfoError;
+    if ( e instanceof SensitiveInfoError ) {
       localLogger.info(
-        `hasItem error for ${key}: ${hasItemError.message}`,
+        `hasItem error for ${key}: ${e.message}`,
       );
     }
     throw e;
@@ -113,18 +116,15 @@ async function getSensitiveItem(
     const item = await getItem( key, options );
     return item?.value ?? null;
   } catch ( e ) {
-    if ( isSensitiveInfoError( e ) ) {
-      const getItemError = e as SensitiveInfoError;
-      if ( isDebugModeSync() ) {
-        switch ( getItemError.code ) {
-          case ErrorCode.NOT_FOUND:
-            // Value doesn't exist
-            localLogger.info( `getItem not available for ${key}` );
-            break;
-          default:
-            localLogger.info( `getItem unknown error for ${key}: ${getItemError.message}` );
-            break;
-        }
+    if ( e instanceof SensitiveInfoError && isDebugModeSync() ) {
+      switch ( e.code ) {
+        case ErrorCode.NotFound:
+          // Value doesn't exist
+          localLogger.info( `getItem not available for ${key}` );
+          break;
+        default:
+          localLogger.info( `getItem unknown error for ${key}: ${e.message}` );
+          break;
       }
     }
     throw e;
@@ -144,13 +144,10 @@ async function setSensitiveItem( key: string, value: string, options = {} ) {
     clearAuthCache( );
     return result;
   } catch ( e ) {
-    if ( isSensitiveInfoError( e ) ) {
-      const setItemError = e as SensitiveInfoError;
-      if ( isDebugModeSync( ) ) {
-        localLogger.info(
-          `setItem error for ${key}, ${setItemError.code} ${setItemError.message}`,
-        );
-      }
+    if ( e instanceof SensitiveInfoError && isDebugModeSync( ) ) {
+      localLogger.info(
+        `setItem error for ${key}, ${e.code} ${e.message}`,
+      );
     }
     throw e;
   }
@@ -167,13 +164,10 @@ async function deleteSensitiveItem(
     clearAuthCache( );
     return result;
   } catch ( e ) {
-    if ( isSensitiveInfoError( e ) ) {
-      const deleteItemError = e as SensitiveInfoError;
-      if ( isDebugModeSync() ) {
-        localLogger.info(
-          `deleteItem error for ${key}, ${deleteItemError.code} ${deleteItemError.message}`,
-        );
-      }
+    if ( e instanceof SensitiveInfoError && isDebugModeSync() ) {
+      localLogger.info(
+        `deleteItem error for ${key}, ${e.code} ${e.message}`,
+      );
     }
     throw e;
   }

--- a/src/components/LoginSignUp/AuthenticationService.ts
+++ b/src/components/LoginSignUp/AuthenticationService.ts
@@ -20,7 +20,9 @@ import Config from "react-native-config";
 import * as RNLocalize from "react-native-localize";
 import RNRestart from "react-native-restart";
 import type { SensitiveInfoError } from "react-native-sensitive-info";
-import RNSInfo, { ErrorCode, isSensitiveInfoError } from "react-native-sensitive-info";
+import {
+  deleteItem, ErrorCode, getItem, hasItem, isSensitiveInfoError, setItem,
+} from "react-native-sensitive-info";
 import Realm, { UpdateMode } from "realm";
 import realmConfig from "realmModels/index";
 import changeLanguage from "sharedHelpers/changeLanguage";
@@ -58,7 +60,7 @@ interface AuthCache {
 }
 
 /**
- * Cache for isLoggedIn, to avoid making too many calls to RNSInfo.getItem
+ * Cache for isLoggedIn, to avoid making too many calls to getItem
  */
 const authCache: AuthCache = {
   isLoggedIn: null,
@@ -88,17 +90,17 @@ const clearAuthCache = ( ): void => {
 async function getSensitiveItem(
   key: string,
   options = {
-    keychainService: "app" as const,
+    service: "app" as const,
   },
 ) {
   let exists;
   try {
-    exists = await RNSInfo.hasItem( key, options );
+    exists = await hasItem( key, options );
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const hasItemError = e as SensitiveInfoError;
       localLogger.info(
-        `RNSInfo.hasItem error for ${key}: ${hasItemError.message}`,
+        `hasItem error for ${key}: ${hasItemError.message}`,
       );
     }
     throw e;
@@ -108,7 +110,8 @@ async function getSensitiveItem(
   }
 
   try {
-    return await RNSInfo.getItem( key, options );
+    const item = await getItem( key, options );
+    return item?.value ?? null;
   } catch ( e ) {
     if ( isSensitiveInfoError( e ) ) {
       const getItemError = e as SensitiveInfoError;
@@ -116,10 +119,10 @@ async function getSensitiveItem(
         switch ( getItemError.code ) {
           case ErrorCode.NOT_FOUND:
             // Value doesn't exist
-            localLogger.info( `RNSInfo.getItem not available for ${key}` );
+            localLogger.info( `getItem not available for ${key}` );
             break;
           default:
-            localLogger.info( `RNSInfo.getItem unknown error for ${key}: ${getItemError.message}` );
+            localLogger.info( `getItem unknown error for ${key}: ${getItemError.message}` );
             break;
         }
       }
@@ -132,12 +135,12 @@ async function setSensitiveItem( key: string, value: string, options = {} ) {
   const actualOptions = {
     // I put the key as overridable by actual options propped in,
     // in case someone wants to build a separate slice at one point.
-    keychainService: "app" as const,
+    service: "app" as const,
     ...options,
     accessControl: "none" as const,
   };
   try {
-    const result = await RNSInfo.setItem( key, value, actualOptions );
+    const result = await setItem( key, value, actualOptions );
     clearAuthCache( );
     return result;
   } catch ( e ) {
@@ -145,7 +148,7 @@ async function setSensitiveItem( key: string, value: string, options = {} ) {
       const setItemError = e as SensitiveInfoError;
       if ( isDebugModeSync( ) ) {
         localLogger.info(
-          `RNSInfo.setItem error for ${key}, ${setItemError.code} ${setItemError.message}`,
+          `setItem error for ${key}, ${setItemError.code} ${setItemError.message}`,
         );
       }
     }
@@ -156,11 +159,11 @@ async function setSensitiveItem( key: string, value: string, options = {} ) {
 async function deleteSensitiveItem(
   key: string,
   options = {
-    keychainService: "app" as const,
+    service: "app" as const,
   },
 ) {
   try {
-    const result = await RNSInfo.deleteItem( key, options );
+    const result = await deleteItem( key, options );
     clearAuthCache( );
     return result;
   } catch ( e ) {
@@ -168,7 +171,7 @@ async function deleteSensitiveItem(
       const deleteItemError = e as SensitiveInfoError;
       if ( isDebugModeSync() ) {
         localLogger.info(
-          `RNSInfo.deleteItem error for ${key}, ${deleteItemError.code} ${deleteItemError.message}`,
+          `deleteItem error for ${key}, ${deleteItemError.code} ${deleteItemError.message}`,
         );
       }
     }

--- a/src/components/hooks/useDeferredStartup.ts
+++ b/src/components/hooks/useDeferredStartup.ts
@@ -10,6 +10,8 @@
  * runtime can interleave user interactions between them.
  */
 import { cleanupLogFiles } from "components/Developer/logManagementHelpers";
+import { isLoggedIn } from "components/LoginSignUp/AuthenticationService";
+import { navigationRef } from "navigation/navigationUtils";
 import { RealmContext } from "providers/contexts";
 import { useEffect } from "react";
 import User from "realmModels/User";
@@ -84,6 +86,13 @@ const useDeferredStartup = ( ) => {
   const { i18n } = useTranslation( );
 
   useEffect( ( ) => {
+    const id0 = deferTask( "checkLoggedInStatuses", async () => {
+      const currentUser = User.currentUser( realm );
+      if ( currentUser && !( await isLoggedIn() ) && navigationRef.isReady() ) {
+        logger.info( "currentUser and isLoggedIn contradict, routing to re-login" );
+        navigationRef.navigate( "LoginStackNavigator", { screen: "Login" } );
+      }
+    }, 500 );
     // Diagnostic tasks that we need to finish even on a busy thread
     // should have a timeout to ensure they run eventually.
     const id1 = deferTask( "checkForPreviousCrash", checkForPreviousCrash, 30000 );
@@ -118,6 +127,7 @@ const useDeferredStartup = ( ) => {
     }, 30000 );
 
     return ( ) => {
+      cancelIdleCallback( id0 );
       cancelIdleCallback( id1 );
       cancelIdleCallback( id2 );
       cancelIdleCallback( id3 );

--- a/tests/helpers/user.js
+++ b/tests/helpers/user.js
@@ -10,7 +10,7 @@ import { getInatLocaleFromSystemLocale } from "i18n/initI18next";
 import i18next from "i18next";
 import inatjs from "inaturalistjs";
 import nock from "nock";
-import RNSInfo from "react-native-sensitive-info";
+import { deleteItem, setItem } from "react-native-sensitive-info";
 import changeLanguage from "sharedHelpers/changeLanguage";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import { makeResponse } from "tests/factory";
@@ -18,7 +18,7 @@ import { makeResponse } from "tests/factory";
 const TEST_JWT = "test-json-web-token";
 const TEST_ACCESS_TOKEN = "test-access-token";
 const rnsiOptions = {
-  keychainService: "app",
+  service: "app",
 };
 
 async function signOut( options = {} ) {
@@ -35,20 +35,20 @@ async function signOut( options = {} ) {
   }, "deleting entire realm in signOut function, user.js" );
   const systemLocale = getInatLocaleFromSystemLocale( );
   changeLanguage( systemLocale );
-  await RNSInfo.deleteItem( "username", rnsiOptions );
-  await RNSInfo.deleteItem( "jwtToken", rnsiOptions );
-  await RNSInfo.deleteItem( "jwtGeneratedAt", rnsiOptions );
-  await RNSInfo.deleteItem( "accessToken", rnsiOptions );
+  await deleteItem( "username", rnsiOptions );
+  await deleteItem( "jwtToken", rnsiOptions );
+  await deleteItem( "jwtGeneratedAt", rnsiOptions );
+  await deleteItem( "accessToken", rnsiOptions );
   clearAuthCache( );
   inatjs.users.me.mockClear( );
 }
 
 async function signIn( user, options = {} ) {
   const realm = options.realm || global.realm;
-  await RNSInfo.setItem( "username", user.login, rnsiOptions );
-  await RNSInfo.setItem( "jwtToken", TEST_JWT, rnsiOptions );
-  await RNSInfo.setItem( "jwtGeneratedAt", Date.now( ).toString( ), rnsiOptions );
-  await RNSInfo.setItem( "accessToken", TEST_ACCESS_TOKEN, rnsiOptions );
+  await setItem( "username", user.login, rnsiOptions );
+  await setItem( "jwtToken", TEST_JWT, rnsiOptions );
+  await setItem( "jwtGeneratedAt", Date.now( ).toString( ), rnsiOptions );
+  await setItem( "accessToken", TEST_ACCESS_TOKEN, rnsiOptions );
   clearAuthCache( );
   inatjs.users.me.mockResolvedValue( makeResponse( [user] ) );
   user.signedIn = true;

--- a/tests/unit/components/LoginSignUp/AuthenticationService.test.js
+++ b/tests/unit/components/LoginSignUp/AuthenticationService.test.js
@@ -11,7 +11,7 @@ import {
 import inatjs from "inaturalistjs";
 import { navigationRef } from "navigation/navigationUtils";
 import nock from "nock";
-import RNSInfo from "react-native-sensitive-info";
+import RNSInfo, { deleteItem } from "react-native-sensitive-info";
 import factory, { makeResponse } from "tests/factory";
 import faker from "tests/helpers/faker";
 
@@ -123,7 +123,7 @@ describe( "getJWT 401 handling", ( ) => {
     navigationRef.isReady.mockReturnValue( true );
     navigationRef.navigate.mockClear( );
     // deleteItem is already a jest.fn() in the mock — clear its call history directly
-    RNSInfo.deleteItem.mockClear( );
+    deleteItem.mockClear( );
   } );
 
   afterEach( ( ) => {
@@ -139,7 +139,7 @@ describe( "getJWT 401 handling", ( ) => {
     await getJWT( );
 
     // signOut deletes "username" from storage; the 401 path should not
-    const deletedKeys = RNSInfo.deleteItem.mock.calls.map( ( [key] ) => key );
+    const deletedKeys = deleteItem.mock.calls.map( ( [key] ) => key );
     expect( deletedKeys ).not.toContain( "username" );
   } );
 


### PR DESCRIPTION
Closes MOB-1638 (also closes MOB-1160)

Summary
- Upgrade react-native-sensitive-info 5.6 → 6.1.5 (Nitro) and adapt auth storage wrappers/tests to the v6 API.
- On startup, if Realm still has a signed-in user but secure tokens are missing, send them through the existing “Please log in again” flow.

Test plan
- Fresh login / sign-out still stores and clears tokens
- Upgrade path: signed-in Realm + empty secure store → re-login screen for the same user