### PR TITLE
widen gap between search and sync icons

### DIFF
--- a/src/components/MyObservations/MyObservationsSimpleHeader.tsx
+++ b/src/components/MyObservations/MyObservationsSimpleHeader.tsx
@@ -109,7 +109,7 @@ const MyObservationsSimpleHeader = ( {
           ? <HeaderUser user={currentUser} isConnected={isConnected} />
           : <Heading3>{ t( "My-Observations" ) }</Heading3>}
         {currentUser && (
-          <View className="flex-row items-center">
+          <View className="flex-row items-center gap-x-[7px]">
             {searchMyObservationsEnabled && (
               <INatIconButton
                 icon="magnifying-glass"


### PR DESCRIPTION
closes [MOB-1664](https://linear.app/inaturalist/issue/MOB-1664/increase-spacing-between-sync-button-and-search-button)