### PR TITLE
Private location not shown in ObsEdit

### DIFF
--- a/src/components/LocationPicker/types.ts
+++ b/src/components/LocationPicker/types.ts
@@ -1,10 +1,8 @@
 export interface LocationPickerObservation {
   latitude?: number;
   longitude?: number;
-
   privateLatitude?: number;
   privateLongitude?: number;
-
   positional_accuracy?: number;
 }
 

--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -223,7 +223,7 @@ const MyObservationsResults = ( ) => {
       ? {
         skipSomeUploads: Observation
           .filterUnsyncedObservations( realm )
-          .filter( ( obs: Observation ) => obs.missingBasics() )
+          .filter( ( obs: Observation ) => obs.missingBasics( ) )
           .map( obs => obs.uuid ),
       }
       : { };

--- a/src/components/ObsEdit/DatePicker.tsx
+++ b/src/components/ObsEdit/DatePicker.tsx
@@ -68,7 +68,6 @@ const DatePicker = ( { currentObservation, updateObservationKeys }: Props ) => {
         <View className="w-[30px] items-center mr-1">
           <INatIcon size={14} name="clock-outline" />
         </View>
-        {/* $FlowIgnore */}
         <Body2 testID="ObsEdit.time" className={!displayDate( ) && "color-warningRed"}>
           {displayDate( ) || t( "Add-Date-Time" )}
         </Body2>

--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -55,8 +55,8 @@ const EvidenceSection = ( {
   const obsPhotos = currentObservation?.observationPhotos || currentObservation?.observation_photos;
   const obsSounds = currentObservation?.observationSounds || currentObservation?.observation_sounds;
 
-  const latitude = currentObservation?.latitude;
-  const longitude = currentObservation?.longitude;
+  const latitude = currentObservation?.privateLatitude || currentObservation?.latitude;
+  const longitude = currentObservation?.privateLongitude || currentObservation?.longitude;
   const missingCoords = currentObservation?.missing_coords;
 
   const displayPlaceName = ( ) => {

--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -57,6 +57,7 @@ const EvidenceSection = ( {
 
   const latitude = currentObservation?.latitude;
   const longitude = currentObservation?.longitude;
+  const missingCoords = currentObservation?.missing_coords;
 
   const displayPlaceName = ( ) => {
     let placeName = "";
@@ -64,17 +65,17 @@ const EvidenceSection = ( {
       placeName = currentObservation?.place_guess;
     } else if ( isFetchingLocation ) {
       placeName = t( "Fetching-location" );
-    } else if ( !latitude || !longitude ) {
+    } else if ( missingCoords ) {
       return t( "Add-Location" );
     }
     return placeName;
   };
 
   const displayLocation = ( ) => {
-    if ( isFetchingLocation && ( !latitude || !longitude ) ) {
+    if ( isFetchingLocation && missingCoords ) {
       return t( "Stay-on-this-screen" );
     }
-    if ( !latitude || !longitude ) {
+    if ( missingCoords ) {
       return t( "No-Location" );
     }
     return t( "Lat-Lon-Acc", {

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -47,8 +47,8 @@ const EvidenceSectionContainer = ( {
   const [showAddEvidenceSheet, setShowAddEvidenceSheet] = useState( false );
   const [currentPlaceGuess, setCurrentPlaceGuess] = useState( );
 
-  const latitude = currentObservation?.latitude;
-  const longitude = currentObservation?.longitude;
+  const latitude = currentObservation?.privateLatitude || currentObservation?.latitude;
+  const longitude = currentObservation?.privateLongitude || currentObservation?.longitude;
 
   const hasPhotoOrSound = useMemo( ( ) => {
     if ( currentObservation?.observationPhotos?.length > 0

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -50,6 +50,8 @@ const EvidenceSectionContainer = ( {
   const latitude = currentObservation?.privateLatitude || currentObservation?.latitude;
   const longitude = currentObservation?.privateLongitude || currentObservation?.longitude;
 
+  const missingCoords = currentObservation?.missing_coords;
+
   const hasPhotoOrSound = useMemo( ( ) => {
     if ( currentObservation?.observationPhotos?.length > 0
       || currentObservation?.observationSounds?.length > 0 ) {
@@ -128,7 +130,7 @@ const EvidenceSectionContainer = ( {
     setPassesEvidenceTest,
   ] );
 
-  const locationTextClassNames = ( !latitude || !longitude )
+  const locationTextClassNames = missingCoords
     ? ["color-warningRed mr-8"]
     : ["mr-8"];
 
@@ -154,11 +156,12 @@ const EvidenceSectionContainer = ( {
         setCurrentPlaceGuess( placeGuess );
       }
     }
-    if ( ( latitude && longitude ) && !currentObservation?.place_guess ) {
+    if ( !missingCoords && !currentObservation?.place_guess ) {
       setPlaceGuess( );
     }
   }, [
     currentObservation?.place_guess,
+    missingCoords,
     latitude,
     longitude,
     updateObservationKeys,

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -88,9 +88,7 @@ const ObsEdit = ( ): Node => {
     navigation.navigate( "LocationPicker" );
   };
 
-  const latitude = currentObservation?.latitude;
-  const longitude = currentObservation?.longitude;
-  const hasLocation = !!( latitude && longitude );
+  const hasLocation = !currentObservation.missing_coords;
   const onLocationPress = ( ) => {
     if ( !hasLocation && !hasLocationPermission ) {
       requestLocationPermission( );

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -375,6 +375,9 @@ class Observation extends Realm.Object {
         : null,
       comments_viewed: obs.comments_viewed,
       identifications_viewed: obs.identifications_viewed,
+      missing_coords: typeof obs.missingCoords === "function"
+        ? obs.missingCoords( )
+        : undefined,
       missing_basics: typeof obs.missingBasics === "function"
         ? obs.missingBasics( )
         : undefined,

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -376,10 +376,10 @@ class Observation extends Realm.Object {
       comments_viewed: obs.comments_viewed,
       identifications_viewed: obs.identifications_viewed,
       missing_basics: typeof obs.missingBasics === "function"
-        ? obs.missingBasics()
+        ? obs.missingBasics( )
         : undefined,
       needs_sync: typeof obs.needsSync === "function"
-        ? obs.needsSync()
+        ? obs.needsSync( )
         : obs.needs_sync,
     };
   }
@@ -632,11 +632,17 @@ class Observation extends Realm.Object {
     return this.votes.filter( vote => vote?.vote_scope === null );
   }
 
+  missingCoords() {
+    const missingCoords = typeof this.latitude !== "number"
+      && typeof this.longitude !== "number"
+      && typeof this.privateLatitude !== "number"
+      && typeof this.privateLongitude !== "number";
+    return missingCoords;
+  }
+
   missingBasics() {
     const missingDate = !Date.parse( this.observed_on_string ) && !this.time_observed_at;
-    const missingCoords = typeof ( this.latitude ) !== "number"
-      && typeof ( this.privateLatitude ) !== "number";
-    return missingDate || missingCoords;
+    return missingDate || this.missingCoords( );
   }
 }
 

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -134,6 +134,7 @@ class Observation extends Realm.Object {
     observed_on: true,
     observed_time_zone: true,
     place_guess: true,
+    private_geojson: true,
     private_place_guess: true,
     taxon_geoprivacy: true,
     project_observations: PROJECT_OBSERVATION_FIELDS,

--- a/src/realmModels/types.d.ts
+++ b/src/realmModels/types.d.ts
@@ -192,6 +192,7 @@ export interface RealmObservationPojo {
 }
 
 export interface RealmObservation extends RealmObservationPojo {
+  missingCoords: ( ) => boolean;
   missingBasics: ( ) => boolean;
   needsSync: ( ) => boolean;
   observationFieldValues: RealmObservationFieldValue[];

--- a/tests/factories/LocalObservation.js
+++ b/tests/factories/LocalObservation.js
@@ -5,6 +5,7 @@ export default define( "LocalObservation", faker => ( {
   // This is a Realm object method that we use to see if a record was deleted or not
   isValid: jest.fn( ( ) => true ),
   wasSynced: jest.fn( ( ) => false ),
+  missingCoords: jest.fn( ( ) => false ),
   missingBasics: jest.fn( ( ) => false ),
   needsSync: jest.fn( ( ) => true ),
   observationPhotos: [],


### PR DESCRIPTION
Closes MOB-1603

Fix Obs Edit showing "No Location" for private observations after upload/sync.

After sync, true coordinates live in privateLatitude/privateLongitude while public lat/lng are null. ObsEdit only read the public fields. This aligns edit UI, upload mapping, and list sync with the existing detail/LocationPicker fallback pattern.