### PR TITLE
MOB-1223: scroll to top in my observations after syncing remote

### DIFF
--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -83,7 +83,6 @@ const MyObservationsResults = ( ) => {
   const startManualSync = useStore( state => state.startManualSync );
   const startAutomaticSync = useStore( state => state.startAutomaticSync );
   const myObsOffsetToRestore = useStore( state => state.myObsOffsetToRestore );
-  const resetMyObsOffsetToRestore = useStore( state => state.resetMyObsOffsetToRestore );
   const setMyObsOffset = useStore( state => state.setMyObsOffset );
   const uploadStatus = useStore( state => state.uploadStatus );
   const justFinishedSignup: boolean = useStore( state => state.layout.justFinishedSignup );
@@ -163,10 +162,7 @@ const MyObservationsResults = ( ) => {
     if ( useServerOrder ) { return; }
     listRef.current?.scrollToOffset( { offset: 0, animated: true } );
     setMyObsOffset( 0 );
-    // Otherwise onListLayout could restore the pre-ObsEdit offset and undo the scroll
-    resetMyObsOffsetToRestore( );
   }, [
-    resetMyObsOffsetToRestore,
     setMyObsOffset,
     useServerOrder,
   ] );

--- a/src/components/MyObservations/MyObservationsResults.tsx
+++ b/src/components/MyObservations/MyObservationsResults.tsx
@@ -83,6 +83,7 @@ const MyObservationsResults = ( ) => {
   const startManualSync = useStore( state => state.startManualSync );
   const startAutomaticSync = useStore( state => state.startAutomaticSync );
   const myObsOffsetToRestore = useStore( state => state.myObsOffsetToRestore );
+  const resetMyObsOffsetToRestore = useStore( state => state.resetMyObsOffsetToRestore );
   const setMyObsOffset = useStore( state => state.setMyObsOffset );
   const uploadStatus = useStore( state => state.uploadStatus );
   const justFinishedSignup: boolean = useStore( state => state.layout.justFinishedSignup );
@@ -157,10 +158,24 @@ const MyObservationsResults = ( ) => {
     writeLayoutToStorage,
   ] );
 
+  // Scroll to the top when a sync pulls in observations we've never seen locally
+  const scrollToTopForNewRemoteObs = useCallback( ( ) => {
+    if ( useServerOrder ) { return; }
+    listRef.current?.scrollToOffset( { offset: 0, animated: true } );
+    setMyObsOffset( 0 );
+    // Otherwise onListLayout could restore the pre-ObsEdit offset and undo the scroll
+    resetMyObsOffsetToRestore( );
+  }, [
+    resetMyObsOffsetToRestore,
+    setMyObsOffset,
+    useServerOrder,
+  ] );
+
   const { startUploadObservations } = useUploadObservations( canUpload );
   const { syncManually } = useSyncObservations(
     currentUserId,
     startUploadObservations,
+    scrollToTopForNewRemoteObs,
   );
 
   const { refetch: refetchObservationsUpdates } = useObservationsUpdates( !!currentUser );

--- a/src/components/MyObservations/helpers/syncRemoteObservations.ts
+++ b/src/components/MyObservations/helpers/syncRemoteObservations.ts
@@ -24,7 +24,12 @@ async function syncRemoteObservations( realm, currentUserId: number, deletionsCo
   }
   const apiToken = await getJWT( );
   const { results } = await searchObservations( searchParams, { api_token: apiToken } );
+
+  const hasNewObservations = ( results || [] ).some(
+    ( obs: { uuid: string } ) => !realm.objectForPrimaryKey( "Observation", obs.uuid ),
+  );
   await Observation.upsertRemoteObservations( results, realm );
+  return hasNewObservations;
 }
 
 export default syncRemoteObservations;

--- a/src/components/MyObservations/hooks/useSyncObservations.ts
+++ b/src/components/MyObservations/hooks/useSyncObservations.ts
@@ -23,6 +23,8 @@ const { useRealm } = RealmContext;
 const useSyncObservations = (
   currentUserId: number,
   startUploadObservations: ( _skipSomeUuids: string[] | undefined ) => void,
+  // Called when a sync pulls in observations we'd never seen locally
+  onNewRemoteObservations?: ( ) => void,
 ) => {
   const { isConnected } = useNetInfo( );
   const loggedIn = !!( currentUserId );
@@ -124,7 +126,14 @@ const useSyncObservations = (
 
   const fetchRemoteObservations = useCallback( async ( ) => {
     try {
-      await syncRemoteObservations( realm, currentUserId, deletionsCompletedAt );
+      const hasNewObservations = await syncRemoteObservations(
+        realm,
+        currentUserId,
+        deletionsCompletedAt,
+      );
+      if ( hasNewObservations ) {
+        onNewRemoteObservations?.( );
+      }
       return true;
     } catch ( syncRemoteError ) {
       if (
@@ -139,6 +148,7 @@ const useSyncObservations = (
     realm,
     currentUserId,
     deletionsCompletedAt,
+    onNewRemoteObservations,
   ] );
 
   const signalAborted = autoSyncAbortController && autoSyncAbortController.signal.aborted;

--- a/tests/unit/components/MyObservations/useSyncObservations.test.js
+++ b/tests/unit/components/MyObservations/useSyncObservations.test.js
@@ -4,6 +4,7 @@ import inatjs from "inaturalistjs";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 import {
   BEGIN_AUTOMATIC_SYNC,
+  SYNC_PENDING,
 } from "stores/createSyncObservationsSlice";
 import useStore from "stores/useStore";
 import factory, { makeResponse } from "tests/factory";
@@ -209,6 +210,50 @@ describe( "automatic sync while user is logged in", ( ) => {
     renderHook( ( ) => useSyncObservations( currentUserId ) );
     await waitFor( ( ) => {
       expect( inatjs.observations.search ).toHaveBeenCalled( );
+    } );
+  } );
+
+  describe( "detecting new remote observations", ( ) => {
+    it( "should notify the caller when a search result is not in realm", async ( ) => {
+      const mockOnNewRemoteObservations = jest.fn( );
+      inatjs.observations.search.mockResolvedValue( makeResponse( [
+        factory( "RemoteObservation" ),
+      ] ) );
+      useStore.setState( { ...syncingStore, deleteQueue: [] } );
+      renderHook( ( ) => useSyncObservations(
+        currentUserId,
+        mockUpload,
+        mockOnNewRemoteObservations,
+      ) );
+
+      await waitFor( ( ) => {
+        expect( mockOnNewRemoteObservations ).toHaveBeenCalled( );
+      } );
+    } );
+
+    it( "should not notify the caller when results are already in realm", async ( ) => {
+      const mockOnNewRemoteObservations = jest.fn( );
+      const existingObservation = factory( "LocalObservation", {
+        _synced_at: faker.date.past( ),
+      } );
+      createObservations(
+        [existingObservation],
+        "write existingObservation, useSyncObservations test",
+      );
+      inatjs.observations.search.mockResolvedValue( makeResponse( [
+        factory( "RemoteObservation", { uuid: existingObservation.uuid } ),
+      ] ) );
+      useStore.setState( { ...syncingStore, deleteQueue: [] } );
+      renderHook( ( ) => useSyncObservations(
+        currentUserId,
+        mockUpload,
+        mockOnNewRemoteObservations,
+      ) );
+
+      await waitFor( ( ) => {
+        expect( useStore.getState( ).syncingStatus ).toEqual( SYNC_PENDING );
+      } );
+      expect( mockOnNewRemoteObservations ).not.toHaveBeenCalled( );
     } );
   } );
 


### PR DESCRIPTION
- return hasNewObservations from sync helper
- optional callback on sync hook
- if hasNewObservations and we're not using a list ordered by the server, scroll to the top

<details>
<summary>recording</summary>

https://github.com/user-attachments/assets/46447894-05ea-4e2b-9d60-8c161f07d169

</details>

