### PR TITLE
Mob 1663 tapping reset in search in myobs should not dismiss search

### DIFF
--- a/src/components/MyObservations/Search/SearchMyObservationsTaxon.tsx
+++ b/src/components/MyObservations/Search/SearchMyObservationsTaxon.tsx
@@ -71,8 +71,7 @@ const SearchMyObservationsTaxon = ( ) => {
   const resetSearch = useCallback( ( ) => {
     setTaxonQuery( "" );
     dispatch( { type: MY_OBSERVATIONS_ACTION.CLEAR_TAXON_SEARCH } );
-    closeScreen( );
-  }, [closeScreen, dispatch] );
+  }, [dispatch] );
 
   const renderItem = useCallback(
     // no-unused-prop-types failing for components defined at runtime seems to

--- a/src/components/MyObservations/Search/SearchMyObservationsTaxon.tsx
+++ b/src/components/MyObservations/Search/SearchMyObservationsTaxon.tsx
@@ -96,7 +96,7 @@ const SearchMyObservationsTaxon = ( ) => {
         onClose={closeScreen}
         headerText={t( "SEARCH" )}
         onReset={resetSearch}
-        resetDisabled={!searchedTaxon}
+        resetDisabled={!searchedTaxon && taxonQuery === ""}
         testID="SearchMyObservationsTaxon.close"
       />
       <TaxonSearch

--- a/src/components/SharedComponents/SearchBar.tsx
+++ b/src/components/SharedComponents/SearchBar.tsx
@@ -2,7 +2,9 @@ import { fontRegular } from "appConstants/fontFamilies";
 import classNames from "classnames";
 import { INatIcon, INatIconButton } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import React, { useCallback, useRef, useState } from "react";
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from "react";
 import type { TextInput as RNTextInput } from "react-native";
 import { Keyboard } from "react-native";
 import { TextInput, useTheme } from "react-native-paper";
@@ -44,6 +46,18 @@ const SearchBar = ( {
   const [localValue, setLocalValue] = useState( value );
 
   const debounceTimeout = useRef<ReturnType<typeof setTimeout>>( undefined );
+  const [previousValue, setPreviousValue] = useState( value );
+
+  // Let the parent change the text from the outside, e.g. if we want to reset the search.
+  if ( value !== previousValue ) {
+    setPreviousValue( value );
+    setLocalValue( value );
+  }
+
+  // Drop any debounce still in flight when the parent changes the value and on unmount.
+  useEffect( ( ) => ( ) => {
+    clearTimeout( debounceTimeout.current );
+  }, [previousValue] );
 
   const debouncedHandleTextChange = useCallback( ( text: string ) => {
     setLocalValue( text );


### PR DESCRIPTION
closes [MOB-1663](https://linear.app/inaturalist/issue/MOB-1663/tapping-reset-in-search-in-myobs-should-not-dismiss-search-screen)

Allowing `SearchBar` to honor an externally changed value will give us a behavior change for the `LocationPicker`, which I've explained and raised to product in the linear ticket (IMO, good changes & got Abhas's blessing)