### PR TITLE
Mob 1679 show banners and announcements in the myobs map view

### DIFF
--- a/src/components/MyObservations/Announcements.tsx
+++ b/src/components/MyObservations/Announcements.tsx
@@ -46,11 +46,15 @@ type WebshellProps = ComponentProps<typeof Webshell>;
 
 const AutoheightWebView
 = ( webshellProps: WebshellProps ) => {
-  const { autoheightWebshellProps } = useAutoheight( {
+  const { autoheightWebshellProps, contentSize } = useAutoheight( {
     webshellProps,
   } );
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  return <Webshell {...autoheightWebshellProps} />;
+  return (
+    <View style={{ height: contentSize.height }}>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <Webshell {...autoheightWebshellProps} />
+    </View>
+  );
 };
 
 interface Props {

--- a/src/components/MyObservations/MyObservationsMapView.tsx
+++ b/src/components/MyObservations/MyObservationsMapView.tsx
@@ -5,9 +5,11 @@ import { useMyObservations } from "providers/MyObservationsContext";
 import React, { useMemo } from "react";
 import type { Region } from "react-native-maps";
 
+import Announcements from "./Announcements";
 import useMyObservationsMapBounds from "./hooks/useMyObservationsMapBounds";
 
 interface Props {
+  isConnected: boolean;
   userId?: number;
 }
 
@@ -22,9 +24,10 @@ const WORLDWIDE_REGION: Region = {
 
 const activityIndicatorSize = 50;
 
-const MyObservationsMapView = ( { userId }: Props ) => {
+const MyObservationsMapView = ( { isConnected, userId }: Props ) => {
   const { state: myObsState } = useMyObservations( );
   const searchedTaxonId = myObsState.searchedTaxon?.id;
+  const searchActive = !!myObsState.searchedTaxon;
   const { totalBounds, isLoading } = useMyObservationsMapBounds( userId, searchedTaxonId, true );
 
   const regionToAnimate = useMemo(
@@ -36,28 +39,31 @@ const MyObservationsMapView = ( { userId }: Props ) => {
 
   return (
     <View className="flex-1 overflow-hidden h-full">
-      <Map
-        initialRegion={WORLDWIDE_REGION}
-        isLoading={isLoading}
-        regionToAnimate={regionToAnimate}
-        showCurrentLocationButton
-        showSwitchMapTypeButton
-        showsUserLocation
-        switchMapTypeButtonClassName="right-5 bottom-20"
-        tileMapParams={{
-          user_id: userId,
-          ...( searchedTaxonId && { taxon_id: searchedTaxonId } ),
-        }}
-        withPressableObsTiles
-      />
-      {isLoading && (
-        <View
-          className="absolute inset-0 items-center justify-center"
-          testID="MyObservationsMapView.loading"
-        >
-          <ActivityIndicator size={activityIndicatorSize} />
-        </View>
-      )}
+      {!searchActive && <Announcements isConnected={isConnected} />}
+      <View className="flex-1 overflow-hidden">
+        <Map
+          initialRegion={WORLDWIDE_REGION}
+          isLoading={isLoading}
+          regionToAnimate={regionToAnimate}
+          showCurrentLocationButton
+          showSwitchMapTypeButton
+          showsUserLocation
+          switchMapTypeButtonClassName="right-5 bottom-20"
+          tileMapParams={{
+            user_id: userId,
+            ...( searchedTaxonId && { taxon_id: searchedTaxonId } ),
+          }}
+          withPressableObsTiles
+        />
+        {isLoading && (
+          <View
+            className="absolute inset-0 items-center justify-center"
+            testID="MyObservationsMapView.loading"
+          >
+            <ActivityIndicator size={activityIndicatorSize} />
+          </View>
+        )}
+      </View>
     </View>
   );
 };

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -395,7 +395,12 @@ const MyObservationsSimple = ( {
     if ( isConnected === false ) {
       return renderOfflineFallback( ( ) => refresh( ) );
     }
-    return <MyObservationsMapView userId={currentUser?.id} />;
+    return (
+      <MyObservationsMapView
+        isConnected={isConnected}
+        userId={currentUser?.id}
+      />
+    );
   };
 
   const renderSmallGridView = ( ) => {

--- a/tests/unit/components/MyObservations/MyObservationsMapView.test.js
+++ b/tests/unit/components/MyObservations/MyObservationsMapView.test.js
@@ -10,6 +10,17 @@ jest.mock( "components/MyObservations/hooks/useMyObservationsMapBounds", ( ) => 
   default: jest.fn( ),
 } ) );
 
+// Announcements fetches from the API and renders its body in a WebView. All we care about
+// here is whether the map view renders it, so stand in a marker we can query for.
+jest.mock( "components/MyObservations/Announcements", ( ) => {
+  const MockReact = require( "react" );
+  const { View } = require( "react-native" );
+  return {
+    __esModule: true,
+    default: ( ) => MockReact.createElement( View, { testID: "announcements" } ),
+  };
+} );
+
 jest.mock( "providers/MyObservationsContext", ( ) => ( {
   __esModule: true,
   useMyObservations: jest.fn( ),
@@ -24,7 +35,7 @@ describe( "MyObservationsMapView", ( ) => {
 
   it( "shows a loading indicator while bounds are loading", ( ) => {
     useMyObservationsMapBounds.mockReturnValue( { totalBounds: undefined, isLoading: true } );
-    renderComponent( <MyObservationsMapView userId={123} /> );
+    renderComponent( <MyObservationsMapView isConnected userId={123} /> );
 
     expect( screen.getByTestId( "MyObservationsMapView.loading" ) ).toBeTruthy( );
   } );
@@ -36,16 +47,31 @@ describe( "MyObservationsMapView", ( ) => {
       },
       isLoading: false,
     } );
-    renderComponent( <MyObservationsMapView userId={123} /> );
+    renderComponent( <MyObservationsMapView isConnected userId={123} /> );
 
     expect( screen.queryByTestId( "MyObservationsMapView.loading" ) ).toBeNull( );
+  } );
+
+  it( "shows announcements above the map", ( ) => {
+    renderComponent( <MyObservationsMapView isConnected userId={123} /> );
+
+    expect( screen.getByTestId( "announcements" ) ).toBeVisible( );
+  } );
+
+  it( "hides announcements while a search is active", ( ) => {
+    useMyObservations.mockReturnValue( {
+      state: { searchedTaxon: { id: 999, name: "Canis latrans" } },
+    } );
+    renderComponent( <MyObservationsMapView isConnected userId={123} /> );
+
+    expect( screen.queryByTestId( "announcements" ) ).toBeNull( );
   } );
 
   it( "passes the searched taxon into the map bounds hook", ( ) => {
     useMyObservations.mockReturnValue( {
       state: { searchedTaxon: { id: 999, name: "Canis latrans" } },
     } );
-    renderComponent( <MyObservationsMapView userId={123} /> );
+    renderComponent( <MyObservationsMapView isConnected userId={123} /> );
 
     expect( useMyObservationsMapBounds ).toHaveBeenCalledWith( 123, 999, true );
   } );


### PR DESCRIPTION
closes [MOB-1679](https://linear.app/inaturalist/issue/MOB-1679/show-banners-and-announcements-in-the-myobs-map-view)

Small change that would probably also be nice to include in the MyObs release so anyone that has the map view as their preferred view isn't missing announcements. I decided the banners are pretty meaningless in this view, so we care about announcements only; more context in ticket. There's still one open product question, but I think it would be fine to include this as is and address in a follow-up if we do want to make the map view scrollable.