### PR TITLE
MOB-1574 fix judder during navigation to Taxon Search

### DIFF
--- a/src/components/Match/MatchTaxonSearchScreen.tsx
+++ b/src/components/Match/MatchTaxonSearchScreen.tsx
@@ -78,6 +78,7 @@ const MatchTaxonSearchScreen = ( ) => {
 
   return (
     <TaxonSearch
+      focusAfterTransition
       isLoading={isLoading}
       isLocal={isLocal}
       query={taxonQuery}

--- a/src/components/MyObservations/Search/SearchMyObservationsTaxon.tsx
+++ b/src/components/MyObservations/Search/SearchMyObservationsTaxon.tsx
@@ -100,6 +100,7 @@ const SearchMyObservationsTaxon = ( ) => {
         testID="SearchMyObservationsTaxon.close"
       />
       <TaxonSearch
+        focusAfterTransition
         isLoading={isLoading}
         isLocal={isLocal}
         query={taxonQuery}

--- a/src/components/SharedComponents/TaxonSearch.tsx
+++ b/src/components/SharedComponents/TaxonSearch.tsx
@@ -1,3 +1,6 @@
+import type { ParamListBase } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import EmptySearchResults from "components/Explore/SearchScreens/EmptySearchResults";
 import {
   Body2,
@@ -7,8 +10,10 @@ import {
 import { ScreenShell } from "components/SharedComponents/ViewWrapper";
 import { View } from "components/styledComponents";
 import { useStackHost } from "navigation/StackHostContext";
-import React, { useMemo } from "react";
-import type { ListRenderItem } from "react-native";
+import React, {
+  useEffect, useEffectEvent, useMemo, useRef,
+} from "react";
+import type { ListRenderItem, TextInput } from "react-native";
 import { FlatList } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { RealmTaxon } from "realmModels/types";
@@ -24,6 +29,11 @@ const EMPTY_TAXA: RealmTaxon[] = [];
 interface Props {
   query?: string;
   setQuery: ( newQuery: string ) => void;
+  // Delay focusing (and thus showing the keyboard for) the search input
+  // until the screen's push/fade transition finishes, instead of focusing
+  // on mount, which makes the transition janky. Only meaningful when this
+  // component is rendered as its own navigation screen.
+  focusAfterTransition?: boolean;
   isLoading?: boolean;
   isLocal?: boolean;
   renderItem: ListRenderItem<RealmTaxon>;
@@ -31,6 +41,7 @@ interface Props {
 }
 
 const TaxonSearch = ( {
+  focusAfterTransition = false,
   isLoading = false,
   isLocal = false,
   query = "",
@@ -45,6 +56,29 @@ const TaxonSearch = ( {
     : 0;
   const { t } = useTranslation( );
   const { keyboardHeight, keyboardShown } = useKeyboardInfo( );
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>( );
+  const searchInputRef = useRef<TextInput>( null );
+
+  // onTransitionEnd here is defined as an effectEvent so that the listener
+  // is not redefined when `query` changes which would otherwise be an effect dep
+  // https://react.dev/reference/react/useEffectEvent#using-an-event-in-an-effect
+  const onTransitionEnd = useEffectEvent( ( e: { data: { closing: boolean } } ) => {
+    // the "closing" data is signaling this _is_ basically closing, i.e., "we're done"
+    if ( !e.data?.closing && query === "" ) {
+      searchInputRef.current?.focus( );
+    }
+  } );
+
+  useEffect( ( ) => {
+    if ( !focusAfterTransition ) {
+      return ( ) => {};
+    }
+    const unsubscribeTransitionEnd = navigation.addListener(
+      "transitionEnd",
+      onTransitionEnd,
+    );
+    return unsubscribeTransitionEnd;
+  }, [focusAfterTransition, navigation] );
 
   const emptyListComponent = useMemo( ( ) => (
     query.length > 0
@@ -76,7 +110,8 @@ const TaxonSearch = ( {
           handleTextChange={setQuery}
           value={query}
           testID="SearchTaxon"
-          autoFocus={query === ""}
+          autoFocus={!focusAfterTransition && query === ""}
+          input={searchInputRef}
         />
         { isLocal && (
           <View className="flex-row items-center space-x-[19px] mt-[21px]">

--- a/src/components/Suggestions/SuggestionsTaxonSearch.tsx
+++ b/src/components/Suggestions/SuggestionsTaxonSearch.tsx
@@ -31,6 +31,7 @@ const SuggestionsTaxonSearch = ( ) => {
 
   return (
     <TaxonSearch
+      focusAfterTransition
       isLoading={isLoading}
       isLocal={isLocal}
       query={taxonQuery}


### PR DESCRIPTION
SuggestionsScreen => TaxonSearchScreen judders during the screen transition as the latter slides in. This seems to be because the component is rendered w/ the text input autoFocused necessarily before the screen transition starts. We can instead wait until the screen transition is finished and _then_ focus to raise the keyboard once we're settled.

https://github.com/user-attachments/assets/6627eab3-51af-45dd-9513-b9150fc96474

note use of useEffectEvent here: to keep the previous logic, we need to check `query`, but we _don't_ want it to be an effect dependency for setting up the listener.