### PR TITLE
Replace helper fct result with direct lat long check

### DIFF
--- a/src/components/ObsEdit/EvidenceSection.js
+++ b/src/components/ObsEdit/EvidenceSection.js
@@ -57,7 +57,7 @@ const EvidenceSection = ( {
 
   const latitude = currentObservation?.privateLatitude || currentObservation?.latitude;
   const longitude = currentObservation?.privateLongitude || currentObservation?.longitude;
-  const missingCoords = currentObservation?.missing_coords;
+  const hasLocation = latitude && longitude;
 
   const displayPlaceName = ( ) => {
     let placeName = "";
@@ -65,17 +65,17 @@ const EvidenceSection = ( {
       placeName = currentObservation?.place_guess;
     } else if ( isFetchingLocation ) {
       placeName = t( "Fetching-location" );
-    } else if ( missingCoords ) {
+    } else if ( !hasLocation ) {
       return t( "Add-Location" );
     }
     return placeName;
   };
 
   const displayLocation = ( ) => {
-    if ( isFetchingLocation && missingCoords ) {
+    if ( isFetchingLocation && !hasLocation ) {
       return t( "Stay-on-this-screen" );
     }
-    if ( missingCoords ) {
+    if ( !hasLocation ) {
       return t( "No-Location" );
     }
     return t( "Lat-Lon-Acc", {

--- a/src/components/ObsEdit/EvidenceSectionContainer.js
+++ b/src/components/ObsEdit/EvidenceSectionContainer.js
@@ -49,8 +49,7 @@ const EvidenceSectionContainer = ( {
 
   const latitude = currentObservation?.privateLatitude || currentObservation?.latitude;
   const longitude = currentObservation?.privateLongitude || currentObservation?.longitude;
-
-  const missingCoords = currentObservation?.missing_coords;
+  const hasLocation = latitude && longitude;
 
   const hasPhotoOrSound = useMemo( ( ) => {
     if ( currentObservation?.observationPhotos?.length > 0
@@ -130,7 +129,7 @@ const EvidenceSectionContainer = ( {
     setPassesEvidenceTest,
   ] );
 
-  const locationTextClassNames = missingCoords
+  const locationTextClassNames = !hasLocation
     ? ["color-warningRed mr-8"]
     : ["mr-8"];
 
@@ -156,12 +155,12 @@ const EvidenceSectionContainer = ( {
         setCurrentPlaceGuess( placeGuess );
       }
     }
-    if ( !missingCoords && !currentObservation?.place_guess ) {
+    if ( hasLocation && !currentObservation?.place_guess ) {
       setPlaceGuess( );
     }
   }, [
     currentObservation?.place_guess,
-    missingCoords,
+    hasLocation,
     latitude,
     longitude,
     updateObservationKeys,

--- a/src/components/ObsEdit/ObsEdit.js
+++ b/src/components/ObsEdit/ObsEdit.js
@@ -88,7 +88,9 @@ const ObsEdit = ( ): Node => {
     navigation.navigate( "LocationPicker" );
   };
 
-  const hasLocation = !currentObservation.missing_coords;
+  const latitude = currentObservation?.privateLatitude || currentObservation?.latitude;
+  const longitude = currentObservation?.privateLongitude || currentObservation?.longitude;
+  const hasLocation = latitude && longitude;
   const onLocationPress = ( ) => {
     if ( !hasLocation && !hasLocationPermission ) {
       requestLocationPermission( );

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -423,9 +423,6 @@ class Observation extends Realm.Object {
         : null,
       comments_viewed: obs.comments_viewed,
       identifications_viewed: obs.identifications_viewed,
-      missing_coords: typeof obs.missingCoords === "function"
-        ? obs.missingCoords( )
-        : undefined,
       missing_basics: typeof obs.missingBasics === "function"
         ? obs.missingBasics( )
         : undefined,


### PR DESCRIPTION
Closes MOB-1686

Another victim of the RealmObs vs UI = PojoObs divide that is untyped. When starting a new obs by importing a photo we do not have a realm representation yet and do not have the result of the missing_coords fct check in the object. The true culprit of the bug was me applying poor coding standards though, switching from a state that checks for false = !hasLocation to a true = missingCoords, so that seeing an undefined was flowing the wrong path.