### PR TITLE
MOB-1653 reintroduce max age for Android location checks

### DIFF
--- a/src/sharedHelpers/geolocationWrapper.ts
+++ b/src/sharedHelpers/geolocationWrapper.ts
@@ -49,18 +49,23 @@ export function clearWatch( watchID: number ) {
 // Known bug in react-native-geolocation: getCurrentPosition does not work on
 // Android when enableHighAccuracy: true and maximumAge: 0.
 // See: https://github.com/michalchudziak/react-native-geolocation/issues/272
-// Added OS-specific conditions to both options below
-// to handle this issue and make it work properly on Android.
+// we also need to provide Android a max age here which can impact `getLastLocation` calls
+const ANDROID_MAXIMUM_AGE_MS = 5000;
+
 export const highAccuracyOptions = {
   enableHighAccuracy: true,
   timeout: 10000,
-  ...( Platform.OS === "ios" && { maximumAge: 0 } ),
+  maximumAge: Platform.OS === "ios"
+    ? 0
+    : ANDROID_MAXIMUM_AGE_MS,
 } as const;
 
 export const lowAccuracyOptions = {
   enableHighAccuracy: false,
   timeout: 2000,
-  ...( Platform.OS === "ios" && { maximumAge: 0 } ),
+  maximumAge: Platform.OS === "ios"
+    ? 0
+    : ANDROID_MAXIMUM_AGE_MS,
 } as const;
 
 export const getCurrentPositionWithOptions = (


### PR DESCRIPTION
MOB-1653

I haven't been able to reproduce the stale loc issue, but this seems to be the cause of Tony's issue: I too eagerly removed a maxAge Android "fix" when I last refactored useWatch / geolocation. That wasn't important for the listener but it _does_ apparently impact the cache age of subsequent `getLastLocation` calls.