### PR TITLE
Traditional projects: OFV and PO upload

### DIFF
--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -25,11 +25,11 @@ const createObservationFieldValue = async <T = ApiDefaultResult>(
   opts: ApiOpts = {},
 ): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.observation_field_values.create(
+    const response = await inatjs.observation_field_values.create(
       { ...PARAMS, ...params },
       opts,
     );
-    return results;
+    return response;
   } catch ( e ) {
     return handleError(
       e as ErrorWithResponse,

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -38,10 +38,10 @@ const createObservationFieldValue = async <T = ApiDefaultResult>(
   }
 };
 
-const updateObservationFieldValue = async (
+const updateObservationFieldValue = async <T = ApiDefaultResult>(
   params: ObservationFieldValueUpdateParams,
   opts: ApiOpts = {},
-): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
     const { results } = await inatjs.observation_field_values.update(
       { ...PARAMS, ...params },

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -43,11 +43,11 @@ const updateObservationFieldValue = async <T = ApiDefaultResult>(
   opts: ApiOpts = {},
 ): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.observation_field_values.update(
+    const response = await inatjs.observation_field_values.update(
       { ...PARAMS, ...params },
       opts,
     );
-    return results;
+    return response;
   } catch ( e ) {
     return handleError(
       e as ErrorWithResponse,

--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -1,7 +1,7 @@
 import type { ErrorWithResponse, INatApiError } from "api/error";
 import handleError from "api/error";
 import { OBSERVATION_FIELD_VALUE_FIELDS } from "api/fields";
-import type { ApiOpts } from "api/types";
+import type { ApiDefaultResult, ApiOpts, ApiResponse } from "api/types";
 import inatjs from "inaturalistjs";
 
 const PARAMS = {
@@ -20,10 +20,10 @@ export interface ObservationFieldValueUpdateParams extends ObservationFieldValue
   id: string; // uuid
 }
 
-const createObservationFieldValue = async (
+const createObservationFieldValue = async <T = ApiDefaultResult>(
   params: ObservationFieldValueAttributes,
   opts: ApiOpts = {},
-): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
     const { results } = await inatjs.observation_field_values.create(
       { ...PARAMS, ...params },

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -27,8 +27,8 @@ const createProjectObservation = async (
   opts: ApiOpts = {},
 ): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.project_observations.create( { ...PARAMS, ...params }, opts );
-    return results;
+    const response = await inatjs.project_observations.create( { ...PARAMS, ...params }, opts );
+    return response;
   } catch ( e ) {
     return handleError(
       e as ErrorWithResponse,

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -12,7 +12,6 @@ export interface ProjectObservationWriteParams {
   project_observation: {
     observation_id: string;
     project_id: number;
-    uuid: string;
   };
 }
 

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -1,7 +1,7 @@
 import type { ErrorWithResponse, INatApiError } from "api/error";
 import handleError from "api/error";
 import { PROJECT_OBSERVATION_FIELDS } from "api/fields";
-import type { ApiOpts } from "api/types";
+import type { ApiDefaultResult, ApiOpts, ApiResponse } from "api/types";
 import inatjs from "inaturalistjs";
 
 const PARAMS = {
@@ -22,10 +22,10 @@ export interface ProjectObservationUpdateParams {
   };
 }
 
-const createProjectObservation = async (
+const createProjectObservation = async <T = ApiDefaultResult>(
   params: ProjectObservationWriteParams,
   opts: ApiOpts = {},
-): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
     const response = await inatjs.project_observations.create( { ...PARAMS, ...params }, opts );
     return response;

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -12,6 +12,7 @@ export interface ProjectObservationWriteParams {
   project_observation: {
     observation_id: string;
     project_id: number;
+    uuid: string;
   };
 }
 

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -15,6 +15,7 @@ import {
   attachMediaToObservation,
   uploadObservationMedia,
 } from "uploaders/mediaUploader";
+import { uploadProjectChildren } from "uploaders/projectChildrenUploader";
 import { RecoverableError, RECOVERY_BY } from "uploaders/utils/errorHandling";
 import { trackObservationUpload } from "uploaders/utils/progressTracker";
 
@@ -186,10 +187,12 @@ async function uploadObservation(
   try {
     const apiToken = await validateAndGetToken( );
     const childrenStartTime = Date.now( );
-    console.log( "apiToken", apiToken );
-    console.log( "obsUUID", obsUUID );
-    console.log( "observation.observationFieldValues", observation.observationFieldValues );
-    console.log( "observation.projectObservations", observation.projectObservations );
+    await uploadProjectChildren(
+      obsUUID,
+      observation,
+      { ...opts, api_token: apiToken },
+      realm,
+    );
     childrenDuration = Date.now( ) - childrenStartTime;
   } catch ( error ) {
     const {

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -153,6 +153,7 @@ async function uploadObservation(
     throw error;
   }
 
+  // Server UUID
   const { uuid: obsUUID } = response.results[0];
 
   // Step 3: attach media to observation with revalidated token
@@ -180,7 +181,30 @@ async function uploadObservation(
     throw error;
   }
 
-  // Step 4: mark observation as uploaded in realm
+  // Step 4: upload project field values and project observations
+  let childrenDuration = 0;
+  try {
+    const apiToken = await validateAndGetToken( );
+    const childrenStartTime = Date.now( );
+    console.log( "apiToken", apiToken );
+    console.log( "obsUUID", obsUUID );
+    console.log( "observation.observationFieldValues", observation.observationFieldValues );
+    console.log( "observation.projectObservations", observation.projectObservations );
+    childrenDuration = Date.now( ) - childrenStartTime;
+  } catch ( error ) {
+    const {
+      errorContext, totalDuration,
+    } = createErrorContext( "project_children_upload", uploadStartTime );
+    logger.error(
+      `Upload: Failed ${observation.uuid} after ${totalDuration}ms - ${errorContext}`
+      + ": Project children upload failed",
+      error,
+    );
+    error.message = `Project children upload failed: ${error.message}`;
+    throw error;
+  }
+
+  // Step 5: mark observation as uploaded in realm
   try {
     markRecordUploaded( observation.uuid, null, "Observation", response, realm );
   } catch ( error ) {
@@ -201,6 +225,7 @@ async function uploadObservation(
   logger.info(
     `Upload: Completed ${observation.uuid} - total: ${totalDuration}ms`
       + `, media: ${mediaDuration}ms, obs: ${obsDuration}ms, attach: ${attachDuration}ms`
+      + `, children: ${childrenDuration}ms`
       + `, uploaded items: ${uploadedMediaCount}`,
   );
 

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -1,3 +1,4 @@
+import { createProjectObservation } from "api/projectObservations";
 import type Realm from "realm";
 import type {
   RealmObservation,
@@ -30,6 +31,30 @@ function filterDirtyPos( observation: RealmObservation ): RealmProjectObservatio
   );
 }
 
+async function uploadSingleProjectObservation(
+  po: RealmProjectObservation,
+  obsUUID: string,
+  observationUUID: string,
+  options: UploadOptions,
+  realm: Realm,
+): Promise<void> {
+  const params = {
+    project_observation: {
+      observation_id: obsUUID,
+      project_id: po.projectId,
+      uuid: po.uuid,
+    },
+  };
+  const response = await createProjectObservation( params, options );
+
+  console.log( "response", response );
+
+  // TODO: update realm
+  console.log( "observationUUID", observationUUID );
+  console.log( "realm", realm );
+  // );
+}
+
 async function uploadProjectChildren(
   obsUUID: string,
   observation: RealmObservation,
@@ -40,11 +65,16 @@ async function uploadProjectChildren(
   const dirtyPos = filterDirtyPos( observation );
 
   console.log( "dirtyOfvs", dirtyOfvs );
-  console.log( "dirtyPos", dirtyPos );
 
-  console.log( "obsUUID", obsUUID );
-  console.log( "options", options );
-  console.log( "realm", realm );
+  await Promise.all(
+    dirtyPos.map( po => uploadSingleProjectObservation(
+      po,
+      obsUUID,
+      observation.uuid,
+      options,
+      realm,
+    ) ),
+  );
 }
 
 export {

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -5,6 +5,7 @@ import type {
   RealmObservationFieldValue,
   RealmProjectObservation,
 } from "realmModels/types";
+import { markRecordUploaded } from "uploaders";
 
 interface UploadOptions {
   api_token?: string;
@@ -45,12 +46,13 @@ async function uploadSingleProjectObservation(
   };
   const response = await createProjectObservation( params, options );
 
-  console.log( "response", response );
-
-  // TODO: update realm
-  console.log( "observationUUID", observationUUID );
-  console.log( "realm", realm );
-  // );
+  markRecordUploaded(
+    observationUUID,
+    po.uuid,
+    "ProjectObservation",
+    response,
+    realm,
+  );
 }
 
 async function uploadProjectChildren(

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -33,14 +33,13 @@ function filterDirtyPos( observation: RealmObservation ): RealmProjectObservatio
 
 async function uploadSingleProjectObservation(
   po: RealmProjectObservation,
-  obsUUID: string,
   observationUUID: string,
   options: UploadOptions,
   realm: Realm,
 ): Promise<void> {
   const params = {
     project_observation: {
-      observation_id: obsUUID,
+      observation_id: observationUUID,
       project_id: po.projectId,
     },
   };
@@ -69,7 +68,6 @@ async function uploadProjectChildren(
     dirtyPos.map( po => uploadSingleProjectObservation(
       po,
       obsUUID,
-      observation.uuid,
       options,
       realm,
     ) ),

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -10,11 +10,24 @@ interface UploadOptions {
   signal: AbortSignal;
 }
 function filterDirtyOfvs( observation: RealmObservation ): RealmObservationFieldValue[] {
-  return observation.observationFieldValues;
+  // Single upload-time gate combining timestamp dirty (needsSync),
+  // not tombstoned (_pending_deletion), and non-empty value.
+  return observation.observationFieldValues.filter(
+    ofv => ofv.needsSync( )
+    && !ofv._pending_deletion
+    && ofv.value != null
+    && ofv.value !== "",
+  );
 }
 
 function filterDirtyPos( observation: RealmObservation ): RealmProjectObservation[] {
-  return observation.projectObservations;
+  // Single upload-time gate combining timestamp dirty (needsSync),
+  // not tombstoned (_pending_deletion), and non-empty value.
+  return observation.projectObservations.filter(
+    po => po.needsSync( )
+      && !po._pending_deletion
+      && !po.wasSynced( ),
+  );
 }
 
 async function uploadProjectChildren(

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -1,3 +1,6 @@
+import {
+  createObservationFieldValue,
+} from "api/observationFieldValues";
 import { createProjectObservation } from "api/projectObservations";
 import type Realm from "realm";
 import type {
@@ -29,6 +32,37 @@ function filterDirtyPos( observation: RealmObservation ): RealmProjectObservatio
     po => po.needsSync( )
       && !po._pending_deletion
       && !po.wasSynced( ),
+  );
+}
+
+async function uploadSingleObservationFieldValue(
+  ofv: RealmObservationFieldValue,
+  observationUUID: string,
+  options: UploadOptions,
+  realm: Realm,
+): Promise<void> {
+  const params = {
+    observation_field_value: {
+      observation_id: observationUUID,
+      observation_field_id: ofv.obsFieldId,
+      // We have filtered out empty OFVs in previous step, so type is string
+      value: ofv.value as string,
+    },
+  };
+
+  let response;
+  if ( ofv.wasSynced( ) && ofv.id ) {
+    console.log( "update branch" );
+  } else {
+    response = await createObservationFieldValue( params, options );
+  }
+
+  markRecordUploaded(
+    observationUUID,
+    ofv.uuid,
+    "ObservationFieldValue",
+    response,
+    realm,
   );
 }
 
@@ -64,7 +98,17 @@ async function uploadProjectChildren(
   const dirtyOfvs = filterDirtyOfvs( observation );
   const dirtyPos = filterDirtyPos( observation );
 
-  console.log( "dirtyOfvs", dirtyOfvs );
+  // The two batches need to be in sequence; PO phase waits until all OFVs settle.
+  // Because some POs might need a just uploaded OFV to not 422
+  // Can be parallel within each phase.
+  await Promise.all(
+    dirtyOfvs.map( ofv => uploadSingleObservationFieldValue(
+      ofv,
+      obsUUID,
+      options,
+      realm,
+    ) ),
+  );
 
   await Promise.all(
     dirtyPos.map( po => uploadSingleProjectObservation(

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -42,7 +42,6 @@ async function uploadSingleProjectObservation(
     project_observation: {
       observation_id: obsUUID,
       project_id: po.projectId,
-      uuid: po.uuid,
     },
   };
   const response = await createProjectObservation( params, options );

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -1,5 +1,6 @@
 import {
   createObservationFieldValue,
+  updateObservationFieldValue,
 } from "api/observationFieldValues";
 import { createProjectObservation } from "api/projectObservations";
 import type Realm from "realm";
@@ -53,6 +54,10 @@ async function uploadSingleObservationFieldValue(
   let response;
   if ( ofv.wasSynced( ) && ofv.id ) {
     console.log( "update branch" );
+    response = await updateObservationFieldValue(
+      { id: ofv.uuid, ...params },
+      options,
+    );
   } else {
     response = await createObservationFieldValue( params, options );
   }

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -1,0 +1,41 @@
+import type Realm from "realm";
+import type {
+  RealmObservation,
+  RealmObservationFieldValue,
+  RealmProjectObservation,
+} from "realmModels/types";
+
+interface UploadOptions {
+  api_token?: string;
+  signal: AbortSignal;
+}
+function filterDirtyOfvs( observation: RealmObservation ): RealmObservationFieldValue[] {
+  return observation.observationFieldValues;
+}
+
+function filterDirtyPos( observation: RealmObservation ): RealmProjectObservation[] {
+  return observation.projectObservations;
+}
+
+async function uploadProjectChildren(
+  obsUUID: string,
+  observation: RealmObservation,
+  options: UploadOptions,
+  realm: Realm,
+): Promise<void> {
+  const dirtyOfvs = filterDirtyOfvs( observation );
+  const dirtyPos = filterDirtyPos( observation );
+
+  console.log( "dirtyOfvs", dirtyOfvs );
+  console.log( "dirtyPos", dirtyPos );
+
+  console.log( "obsUUID", obsUUID );
+  console.log( "options", options );
+  console.log( "realm", realm );
+}
+
+export {
+  filterDirtyOfvs,
+  filterDirtyPos,
+  uploadProjectChildren,
+};

--- a/src/uploaders/utils/realmSync.ts
+++ b/src/uploaders/utils/realmSync.ts
@@ -26,6 +26,10 @@ function findRecordInRealm(
     return observation.observationPhotos?.find( op => op.uuid === recordUUID ) || null;
   } if ( type === "ObservationSound" ) {
     return observation.observationSounds?.find( os => os.uuid === recordUUID ) || null;
+  } if ( type === "ObservationFieldValue" ) {
+    return observation.observationFieldValues?.find( ofv => ofv.uuid === recordUUID ) || null;
+  } if ( type === "ProjectObservation" ) {
+    return observation.projectObservations?.find( po => po.uuid === recordUUID ) || null;
   }
 
   return null;

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -4,11 +4,13 @@ import factory from "tests/factory";
 import * as uploaders from "uploaders";
 import * as mediaUploader from "uploaders/mediaUploader";
 import uploadObservation from "uploaders/observationUploader";
+import * as projectChildrenUploader from "uploaders/projectChildrenUploader";
 import * as progressTracker from "uploaders/utils/progressTracker";
 
 jest.mock( "components/LoginSignUp/AuthenticationService" );
 jest.mock( "uploaders/utils/progressTracker" );
 jest.mock( "uploaders/mediaUploader" );
+jest.mock( "uploaders/projectChildrenUploader" );
 jest.mock( "uploaders" );
 jest.mock( "api/observations" );
 jest.mock( "sharedHelpers/safeRealmWrite", () => jest.fn() );
@@ -61,12 +63,14 @@ describe( "uploadObservation", () => {
     } );
 
     apiObservations.createObservation.mockResolvedValue( {
-      results: [{ uuid: mockObservation.uuid }],
+      results: [{ uuid: mockObservation.uuid, id: 12345 }],
     } );
 
     apiObservations.updateObservation.mockResolvedValue( {
-      results: [{ uuid: mockObservation.uuid }],
+      results: [{ uuid: mockObservation.uuid, id: 12345 }],
     } );
+
+    projectChildrenUploader.uploadProjectChildren.mockResolvedValue( undefined );
   } );
 
   it( "should start and complete progress tracking", async () => {
@@ -150,6 +154,16 @@ describe( "uploadObservation", () => {
     },
   );
 
+  it( "should call uploadProjectChildren after media is attached", async () => {
+    await uploadObservation( mockObservation, mockRealm );
+
+    expect( projectChildrenUploader.uploadProjectChildren ).toHaveBeenCalledWith(
+      mockObservation.uuid,
+      mockObservation,
+      expect.objectContaining( { api_token: "test-json-web-token" } ),
+      mockRealm,
+    );
+  } );
   it( "should mark the record as uploaded after media is attached", async () => {
     await uploadObservation( mockObservation, mockRealm );
 

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -164,6 +164,23 @@ describe( "uploadObservation", () => {
       mockRealm,
     );
   } );
+
+  it( "should mark the record as uploaded after project children upload", async () => {
+    await uploadObservation( mockObservation, mockRealm );
+
+    expect( projectChildrenUploader.uploadProjectChildren ).toHaveBeenCalled();
+    expect( uploaders.markRecordUploaded ).toHaveBeenCalledWith(
+      mockObservation.uuid,
+      null,
+      "Observation",
+      expect.anything(),
+      mockRealm,
+    );
+    const childrenCallOrder = projectChildrenUploader.uploadProjectChildren
+      .mock.invocationCallOrder[0];
+    const markCallOrder = uploaders.markRecordUploaded.mock.invocationCallOrder[0];
+    expect( childrenCallOrder ).toBeLessThan( markCallOrder );
+  } );
   it( "should mark the record as uploaded after media is attached", async () => {
     await uploadObservation( mockObservation, mockRealm );
 

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -181,6 +181,16 @@ describe( "uploadObservation", () => {
     const markCallOrder = uploaders.markRecordUploaded.mock.invocationCallOrder[0];
     expect( childrenCallOrder ).toBeLessThan( markCallOrder );
   } );
+
+  it( "should throw an error if project children upload fails", async () => {
+    projectChildrenUploader.uploadProjectChildren
+      .mockRejectedValue( new Error( "Project Children Error" ) );
+
+    await expect( uploadObservation( mockObservation, mockRealm ) )
+      .rejects.toThrow( "Project Children Error" );
+    expect( uploaders.markRecordUploaded ).not.toHaveBeenCalled();
+  } );
+
   it( "should mark the record as uploaded after media is attached", async () => {
     await uploadObservation( mockObservation, mockRealm );
 

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -1,4 +1,5 @@
 import * as observationFieldValuesApi from "api/observationFieldValues";
+import * as projectObservationsApi from "api/projectObservations";
 import factory, { makeResponse } from "tests/factory";
 import { markRecordUploaded } from "uploaders";
 import {
@@ -8,6 +9,7 @@ import {
 } from "uploaders/projectChildrenUploader";
 
 jest.mock( "api/observationFieldValues" );
+jest.mock( "api/projectObservations" );
 jest.mock( "uploaders" );
 
 const mockOpts = { api_token: "test-token", signal: new AbortController().signal };
@@ -36,6 +38,9 @@ beforeEach( () => {
   );
   observationFieldValuesApi.updateObservationFieldValue.mockResolvedValue(
     makeResponse( [{ id: 102 }] ),
+  );
+  projectObservationsApi.createProjectObservation.mockResolvedValue(
+    makeResponse( [{ id: 201 }] ),
   );
 } );
 
@@ -82,6 +87,60 @@ describe( "projectChildrenUploader", () => {
   } );
 
   describe( "uploadProjectChildren", () => {
+    it( "POSTs dirty OFVs then POSTs dirty POs using the observation uuid", async () => {
+      const ofv = dirtyOfv( {
+        uuid: "ofv-uuid",
+        obsFieldId: 10,
+        value: "male",
+      } );
+      const po = dirtyPo( {
+        uuid: "po-uuid",
+        projectId: 508,
+      } );
+      const observation = factory( "LocalObservation", {
+        uuid: "obs-uuid",
+        observationFieldValues: [ofv],
+        projectObservations: [po],
+      } );
+
+      await uploadProjectChildren( "obs-uuid", observation, mockOpts, mockRealm );
+
+      expect( observationFieldValuesApi.createObservationFieldValue ).toHaveBeenCalledWith(
+        {
+          observation_field_value: {
+            observation_id: "obs-uuid",
+            observation_field_id: 10,
+            value: "male",
+          },
+        },
+        mockOpts,
+      );
+      expect( projectObservationsApi.createProjectObservation ).toHaveBeenCalledWith(
+        {
+          project_observation: {
+            observation_id: "obs-uuid",
+            project_id: 508,
+          },
+        },
+        mockOpts,
+      );
+      expect( markRecordUploaded ).toHaveBeenCalledTimes( 2 );
+      expect( markRecordUploaded ).toHaveBeenCalledWith(
+        "obs-uuid",
+        "ofv-uuid",
+        "ObservationFieldValue",
+        makeResponse( [{ id: 101 }] ),
+        mockRealm,
+      );
+      expect( markRecordUploaded ).toHaveBeenCalledWith(
+        "obs-uuid",
+        "po-uuid",
+        "ProjectObservation",
+        makeResponse( [{ id: 201 }] ),
+        mockRealm,
+      );
+    } );
+
     it( "POSTs multiple dirty OFVs in parallel", async () => {
       const ofvOne = dirtyOfv( {
         uuid: "ofv-uuid-1",

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -1,70 +1,62 @@
+import factory from "tests/factory";
 import {
   filterDirtyOfvs,
   filterDirtyPos,
 } from "uploaders/projectChildrenUploader";
 
+const dirtyOfv = ( overrides = {} ) => factory( "LocalObservationFieldValue", {
+  id: null,
+  needsSync: jest.fn( () => true ),
+  wasSynced: jest.fn( () => false ),
+  _pending_deletion: false,
+  ...overrides,
+} );
+
+const dirtyPo = ( overrides = {} ) => factory( "LocalProjectObservation", {
+  needsSync: jest.fn( () => true ),
+  wasSynced: jest.fn( () => false ),
+  _pending_deletion: false,
+  ...overrides,
+} );
+
 describe( "projectChildrenUploader", () => {
   describe( "filterDirtyOfvs", () => {
     it( "includes unsynced OFVs with a value", () => {
-      const ofv = {
-        needsSync: () => true,
-        _pending_deletion: false,
-        value: "shrubland",
-      };
-      const observation = { observationFieldValues: [ofv] };
+      const ofv = dirtyOfv( { value: "shrubland" } );
+      const observation = factory( "LocalObservation", {
+        observationFieldValues: [ofv],
+      } );
       expect( filterDirtyOfvs( observation ) ).toEqual( [ofv] );
     } );
 
     it( "excludes tombstoned and empty OFVs", () => {
-      const observation = {
+      const observation = factory( "LocalObservation", {
         observationFieldValues: [
-          {
-            needsSync: () => true,
-            _pending_deletion: true,
-            value: "x",
-          },
-          {
-            needsSync: () => true,
-            _pending_deletion: false,
-            value: "",
-          },
-          {
-            needsSync: () => false,
-            _pending_deletion: false,
-            value: "y",
-          },
+          dirtyOfv( { _pending_deletion: true, value: "x" } ),
+          dirtyOfv( { value: "" } ),
+          dirtyOfv( { needsSync: jest.fn( () => false ), value: "y" } ),
         ],
-      };
+      } );
       expect( filterDirtyOfvs( observation ) ).toEqual( [] );
     } );
   } );
 
   describe( "filterDirtyPos", () => {
     it( "includes never-synced POs that need sync", () => {
-      const po = {
-        needsSync: () => true,
-        _pending_deletion: false,
-        wasSynced: () => false,
-      };
-      const observation = { projectObservations: [po] };
+      const po = dirtyPo( );
+      const observation = factory( "LocalObservation", {
+        projectObservations: [po],
+      } );
       expect( filterDirtyPos( observation ) ).toEqual( [po] );
     } );
 
     it( "excludes tombstoned and already-synced POs", () => {
-      const observation = {
+      const observation = factory( "LocalObservation", {
         projectObservations: [
-          {
-            needsSync: () => true,
-            _pending_deletion: true,
-            wasSynced: () => false,
-          },
-          {
-            needsSync: () => true,
-            _pending_deletion: false,
-            wasSynced: () => true,
-          },
+          dirtyPo( { _pending_deletion: true } ),
+          dirtyPo( { wasSynced: jest.fn( () => true ) } ),
         ],
-      };
+      } );
       expect( filterDirtyPos( observation ) ).toEqual( [] );
     } );
   } );

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -1,0 +1,17 @@
+import {
+  filterDirtyOfvs,
+} from "uploaders/projectChildrenUploader";
+
+describe( "projectChildrenUploader", () => {
+  describe( "filterDirtyOfvs", () => {
+    it( "includes unsynced OFVs with a value", () => {
+      const ofv = {
+        needsSync: () => true,
+        _pending_deletion: false,
+        value: "shrubland",
+      };
+      const observation = { observationFieldValues: [ofv] };
+      expect( filterDirtyOfvs( observation ) ).toEqual( [ofv] );
+    } );
+  } );
+} );

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -13,6 +13,29 @@ describe( "projectChildrenUploader", () => {
       };
       const observation = { observationFieldValues: [ofv] };
       expect( filterDirtyOfvs( observation ) ).toEqual( [ofv] );
+
+      it( "excludes tombstoned and empty OFVs", () => {
+        const observation = {
+          observationFieldValues: [
+            {
+              needsSync: () => true,
+              _pending_deletion: true,
+              value: "x",
+            },
+            {
+              needsSync: () => true,
+              _pending_deletion: false,
+              value: "",
+            },
+            {
+              needsSync: () => false,
+              _pending_deletion: false,
+              value: "y",
+            },
+          ],
+        };
+        expect( filterDirtyOfvs( observation ) ).toEqual( [] );
+      } );
       describe( "filterDirtyPos", () => {
         it( "includes never-synced POs that need sync", () => {
           const po = {

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -1,5 +1,6 @@
 import * as observationFieldValuesApi from "api/observationFieldValues";
 import factory, { makeResponse } from "tests/factory";
+import { markRecordUploaded } from "uploaders";
 import {
   filterDirtyOfvs,
   filterDirtyPos,
@@ -7,6 +8,8 @@ import {
 } from "uploaders/projectChildrenUploader";
 
 jest.mock( "api/observationFieldValues" );
+jest.mock( "uploaders" );
+
 const mockOpts = { api_token: "test-token", signal: new AbortController().signal };
 let mockRealm;
 
@@ -79,6 +82,49 @@ describe( "projectChildrenUploader", () => {
   } );
 
   describe( "uploadProjectChildren", () => {
+    it( "POSTs multiple dirty OFVs in parallel", async () => {
+      const ofvOne = dirtyOfv( {
+        uuid: "ofv-uuid-1",
+        obsFieldId: 10,
+        value: "male",
+      } );
+      const ofvTwo = dirtyOfv( {
+        uuid: "ofv-uuid-2",
+        obsFieldId: 20,
+        value: "shrubland",
+      } );
+      const observation = factory( "LocalObservation", {
+        uuid: "obs-uuid",
+        observationFieldValues: [ofvOne, ofvTwo],
+        projectObservations: [],
+      } );
+
+      await uploadProjectChildren( "obs-uuid", observation, mockOpts, mockRealm );
+
+      expect( observationFieldValuesApi.createObservationFieldValue ).toHaveBeenCalledTimes( 2 );
+      expect( observationFieldValuesApi.createObservationFieldValue ).toHaveBeenCalledWith(
+        {
+          observation_field_value: {
+            observation_id: "obs-uuid",
+            observation_field_id: 10,
+            value: "male",
+          },
+        },
+        mockOpts,
+      );
+      expect( observationFieldValuesApi.createObservationFieldValue ).toHaveBeenCalledWith(
+        {
+          observation_field_value: {
+            observation_id: "obs-uuid",
+            observation_field_id: 20,
+            value: "shrubland",
+          },
+        },
+        mockOpts,
+      );
+      expect( markRecordUploaded ).toHaveBeenCalledTimes( 2 );
+    } );
+
     it( "PUTs OFVs that were previously synced", async () => {
       const ofv = dirtyOfv( {
         uuid: "ofv-uuid",

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -1,5 +1,6 @@
 import {
   filterDirtyOfvs,
+  filterDirtyPos,
 } from "uploaders/projectChildrenUploader";
 
 describe( "projectChildrenUploader", () => {
@@ -12,6 +13,17 @@ describe( "projectChildrenUploader", () => {
       };
       const observation = { observationFieldValues: [ofv] };
       expect( filterDirtyOfvs( observation ) ).toEqual( [ofv] );
+      describe( "filterDirtyPos", () => {
+        it( "includes never-synced POs that need sync", () => {
+          const po = {
+            needsSync: () => true,
+            _pending_deletion: false,
+            wasSynced: () => false,
+          };
+          const observation = { projectObservations: [po] };
+          expect( filterDirtyPos( observation ) ).toEqual( [po] );
+        } );
+      } );
     } );
   } );
 } );

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -13,40 +13,59 @@ describe( "projectChildrenUploader", () => {
       };
       const observation = { observationFieldValues: [ofv] };
       expect( filterDirtyOfvs( observation ) ).toEqual( [ofv] );
+    } );
 
-      it( "excludes tombstoned and empty OFVs", () => {
-        const observation = {
-          observationFieldValues: [
-            {
-              needsSync: () => true,
-              _pending_deletion: true,
-              value: "x",
-            },
-            {
-              needsSync: () => true,
-              _pending_deletion: false,
-              value: "",
-            },
-            {
-              needsSync: () => false,
-              _pending_deletion: false,
-              value: "y",
-            },
-          ],
-        };
-        expect( filterDirtyOfvs( observation ) ).toEqual( [] );
-      } );
-      describe( "filterDirtyPos", () => {
-        it( "includes never-synced POs that need sync", () => {
-          const po = {
+    it( "excludes tombstoned and empty OFVs", () => {
+      const observation = {
+        observationFieldValues: [
+          {
+            needsSync: () => true,
+            _pending_deletion: true,
+            value: "x",
+          },
+          {
             needsSync: () => true,
             _pending_deletion: false,
+            value: "",
+          },
+          {
+            needsSync: () => false,
+            _pending_deletion: false,
+            value: "y",
+          },
+        ],
+      };
+      expect( filterDirtyOfvs( observation ) ).toEqual( [] );
+    } );
+  } );
+
+  describe( "filterDirtyPos", () => {
+    it( "includes never-synced POs that need sync", () => {
+      const po = {
+        needsSync: () => true,
+        _pending_deletion: false,
+        wasSynced: () => false,
+      };
+      const observation = { projectObservations: [po] };
+      expect( filterDirtyPos( observation ) ).toEqual( [po] );
+    } );
+
+    it( "excludes tombstoned and already-synced POs", () => {
+      const observation = {
+        projectObservations: [
+          {
+            needsSync: () => true,
+            _pending_deletion: true,
             wasSynced: () => false,
-          };
-          const observation = { projectObservations: [po] };
-          expect( filterDirtyPos( observation ) ).toEqual( [po] );
-        } );
-      } );
+          },
+          {
+            needsSync: () => true,
+            _pending_deletion: false,
+            wasSynced: () => true,
+          },
+        ],
+      };
+      expect( filterDirtyPos( observation ) ).toEqual( [] );
     } );
   } );
 } );

--- a/tests/unit/uploaders/projectChildrenUploader.test.js
+++ b/tests/unit/uploaders/projectChildrenUploader.test.js
@@ -1,8 +1,14 @@
-import factory from "tests/factory";
+import * as observationFieldValuesApi from "api/observationFieldValues";
+import factory, { makeResponse } from "tests/factory";
 import {
   filterDirtyOfvs,
   filterDirtyPos,
+  uploadProjectChildren,
 } from "uploaders/projectChildrenUploader";
+
+jest.mock( "api/observationFieldValues" );
+const mockOpts = { api_token: "test-token", signal: new AbortController().signal };
+let mockRealm;
 
 const dirtyOfv = ( overrides = {} ) => factory( "LocalObservationFieldValue", {
   id: null,
@@ -17,6 +23,17 @@ const dirtyPo = ( overrides = {} ) => factory( "LocalProjectObservation", {
   wasSynced: jest.fn( () => false ),
   _pending_deletion: false,
   ...overrides,
+} );
+
+beforeEach( () => {
+  jest.clearAllMocks();
+  mockRealm = { isClosed: false };
+  observationFieldValuesApi.createObservationFieldValue.mockResolvedValue(
+    makeResponse( [{ id: 101 }] ),
+  );
+  observationFieldValuesApi.updateObservationFieldValue.mockResolvedValue(
+    makeResponse( [{ id: 102 }] ),
+  );
 } );
 
 describe( "projectChildrenUploader", () => {
@@ -58,6 +75,38 @@ describe( "projectChildrenUploader", () => {
         ],
       } );
       expect( filterDirtyPos( observation ) ).toEqual( [] );
+    } );
+  } );
+
+  describe( "uploadProjectChildren", () => {
+    it( "PUTs OFVs that were previously synced", async () => {
+      const ofv = dirtyOfv( {
+        uuid: "ofv-uuid",
+        obsFieldId: 10,
+        value: "female",
+        id: 55,
+        wasSynced: jest.fn( () => true ),
+      } );
+      const observation = factory( "LocalObservation", {
+        uuid: "obs-uuid",
+        observationFieldValues: [ofv],
+        projectObservations: [],
+      } );
+
+      await uploadProjectChildren( "obs-uuid", observation, mockOpts, mockRealm );
+
+      expect( observationFieldValuesApi.updateObservationFieldValue ).toHaveBeenCalledWith(
+        {
+          id: "ofv-uuid",
+          observation_field_value: {
+            observation_id: "obs-uuid",
+            observation_field_id: 10,
+            value: "female",
+          },
+        },
+        mockOpts,
+      );
+      expect( observationFieldValuesApi.createObservationFieldValue ).not.toHaveBeenCalled();
     } );
   } );
 } );

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -96,12 +96,18 @@ describe( "markRecordUploaded", () => {
   test( "should update an ObservationFieldValue record correctly", () => {
     markRecordUploaded( "obs123", "ofv123", "ObservationFieldValue", mockResponse, mockRealm );
 
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
+
     expect( mockOfv.id ).toBe( 12345 );
     expect( mockOfv._synced_at ).toBeInstanceOf( Date );
   } );
 
   test( "should update a ProjectObservation record correctly", () => {
     markRecordUploaded( "obs123", "po123", "ProjectObservation", mockResponse, mockRealm );
+
+    expect( mockRealm.objectForPrimaryKey ).toHaveBeenCalledWith( "Observation", "obs123" );
+    expect( safeRealmWrite ).toHaveBeenCalledTimes( 1 );
 
     expect( mockPo.id ).toBe( 12345 );
     expect( mockPo._synced_at ).toBeInstanceOf( Date );

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -8,6 +8,7 @@ describe( "markRecordUploaded", () => {
   let mockObservation;
   let mockObsPhoto;
   let mockObsSound;
+  let mockOfv;
   let mockPhoto;
   let mockSound;
   let mockResponse;
@@ -17,6 +18,7 @@ describe( "markRecordUploaded", () => {
 
     mockObsPhoto = { uuid: "photo123", id: null, _synced_at: null };
     mockObsSound = { uuid: "sound123", id: null, _synced_at: null };
+    mockOfv = { uuid: "ofv123", id: null, _synced_at: null };
     mockPhoto = { id: null, _synced_at: null };
     mockSound = { id: null, _synced_at: null };
 
@@ -27,6 +29,7 @@ describe( "markRecordUploaded", () => {
       needs_sync: true,
       observationPhotos: [mockObsPhoto],
       observationSounds: [mockObsSound],
+      observationFieldValues: [mockOfv],
     };
 
     mockResponse = {
@@ -85,6 +88,13 @@ describe( "markRecordUploaded", () => {
     expect( mockObsSound._synced_at ).toBeInstanceOf( Date );
     // needs_sync should not be modified for ObservationSound
     expect( mockObsSound.needs_sync ).toBeUndefined();
+  } );
+
+  test( "should update an ObservationFieldValue record correctly", () => {
+    markRecordUploaded( "obs123", "ofv123", "ObservationFieldValue", mockResponse, mockRealm );
+
+    expect( mockOfv.id ).toBe( 12345 );
+    expect( mockOfv._synced_at ).toBeInstanceOf( Date );
   } );
 
   test( "should update a Photo record correctly with options.record", () => {

--- a/tests/unit/uploaders/utils/realmSync.test.js
+++ b/tests/unit/uploaders/utils/realmSync.test.js
@@ -9,6 +9,7 @@ describe( "markRecordUploaded", () => {
   let mockObsPhoto;
   let mockObsSound;
   let mockOfv;
+  let mockPo;
   let mockPhoto;
   let mockSound;
   let mockResponse;
@@ -19,6 +20,7 @@ describe( "markRecordUploaded", () => {
     mockObsPhoto = { uuid: "photo123", id: null, _synced_at: null };
     mockObsSound = { uuid: "sound123", id: null, _synced_at: null };
     mockOfv = { uuid: "ofv123", id: null, _synced_at: null };
+    mockPo = { uuid: "po123", id: null, _synced_at: null };
     mockPhoto = { id: null, _synced_at: null };
     mockSound = { id: null, _synced_at: null };
 
@@ -30,6 +32,7 @@ describe( "markRecordUploaded", () => {
       observationPhotos: [mockObsPhoto],
       observationSounds: [mockObsSound],
       observationFieldValues: [mockOfv],
+      projectObservations: [mockPo],
     };
 
     mockResponse = {
@@ -95,6 +98,13 @@ describe( "markRecordUploaded", () => {
 
     expect( mockOfv.id ).toBe( 12345 );
     expect( mockOfv._synced_at ).toBeInstanceOf( Date );
+  } );
+
+  test( "should update a ProjectObservation record correctly", () => {
+    markRecordUploaded( "obs123", "po123", "ProjectObservation", mockResponse, mockRealm );
+
+    expect( mockPo.id ).toBe( 12345 );
+    expect( mockPo._synced_at ).toBeInstanceOf( Date );
   } );
 
   test( "should update a Photo record correctly with options.record", () => {


### PR DESCRIPTION
Closes MOB-1510

Adds a project-children upload step to the observation upload pipeline. After media is attached, dirty observation field values (OFVs) and project observations (POs) sync to the API in sequence — OFVs first, then POs — with parallel uploads within each phase. New code is massively following obs media upload step.


Before: One obs project state on staging (website)
<img width="511" height="437" alt="Screenshot 2026-08-24 at 16 15 08" src="https://github.com/user-attachments/assets/96b1150c-ee62-4b42-a850-05d2b58f2f63" />

After: filling out the "Add to Projects" form in the app and pressing obs sync => POs and OFVs all uploaded
<img width="543" height="764" alt="Screenshot 2026-08-24 at 16 19 27" src="https://github.com/user-attachments/assets/2411720b-bc60-4cc6-9655-460fd28b59c6" />
<img width="502" height="361" alt="Screenshot 2026-08-24 at 16 19 41" src="https://github.com/user-attachments/assets/078b22e9-bd2d-4c94-9315-d656e017ab72" />
