### PR TITLE
Traditional projects: deletion sync for POs and OFVs

### DIFF
--- a/src/api/observationFieldValues.ts
+++ b/src/api/observationFieldValues.ts
@@ -56,13 +56,13 @@ const updateObservationFieldValue = async <T = ApiDefaultResult>(
   }
 };
 
-const deleteObservationFieldValue = async (
+const deleteObservationFieldValue = async <T = ApiDefaultResult>(
   id: string, // uuid
   opts: ApiOpts = {},
-): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.observation_field_values.delete( { id }, opts );
-    return results;
+    const response = await inatjs.observation_field_values.delete( { id }, opts );
+    return response;
   } catch ( e ) {
     return handleError(
       e as ErrorWithResponse,

--- a/src/api/projectObservations.ts
+++ b/src/api/projectObservations.ts
@@ -37,13 +37,13 @@ const createProjectObservation = async <T = ApiDefaultResult>(
   }
 };
 
-const updateProjectObservation = async (
+const updateProjectObservation = async <T = ApiDefaultResult>(
   params: ProjectObservationUpdateParams,
   opts: ApiOpts = {},
-): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.project_observations.update( { ...PARAMS, ...params }, opts );
-    return results;
+    const response = await inatjs.project_observations.update( { ...PARAMS, ...params }, opts );
+    return response;
   } catch ( e ) {
     return handleError(
       e as ErrorWithResponse,
@@ -52,13 +52,13 @@ const updateProjectObservation = async (
   }
 };
 
-const deleteProjectObservation = async (
+const deleteProjectObservation = async <T = ApiDefaultResult>(
   id: string, // uuid
   opts: ApiOpts = {},
-): Promise<Record<string, unknown> | null | ErrorWithResponse | INatApiError> => {
+): Promise<ApiResponse<T> | null | ErrorWithResponse | INatApiError> => {
   try {
-    const { results } = await inatjs.project_observations.delete( { id }, opts );
-    return results;
+    const response = await inatjs.project_observations.delete( { id }, opts );
+    return response;
   } catch ( e ) {
     return handleError(
       e as ErrorWithResponse,

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -33,7 +33,9 @@ export const UNSYNCED_FILTER
   + " || ANY observationPhotos._synced_at == null"
   + " || ANY observationSounds._synced_at == null"
   + " || ANY projectObservations._synced_at == null"
-  + " || ANY observationFieldValues._synced_at == null";
+  + " || ANY observationFieldValues._synced_at == null"
+  + " || ANY projectObservations._pending_deletion == true"
+  + " || ANY observationFieldValues._pending_deletion == true";
 
 // noting that methods like .toJSON( ) are only accessible when the model
 // class is extended with Realm.Object per this issue:

--- a/src/sharedHelpers/installData.e2e-mock
+++ b/src/sharedHelpers/installData.e2e-mock
@@ -4,6 +4,7 @@ import * as uuid from "uuid";
 const INSTALL_ID = "installID";
 const ONBOARDING_SHOWN = "onboardingShown";
 export const IS_FRESH_INSTALL = "isFreshInstall";
+const ENVIRONMENT_OVERRIDE = "environmentOverride";
 
 const data = new Map();
 
@@ -23,6 +24,18 @@ export function getInstallID( ) {
   // Skip setting IS_FRESH_INSTALL in e2e to avoid triggering
   // RNRestart.restart() which kills the Detox instrumentation process
   return newID;
+}
+
+export function getEnvironmentOverride( ) {
+  return store.getString( ENVIRONMENT_OVERRIDE );
+}
+
+export function setEnvironmentOverride( prefix ) {
+  if ( prefix ) {
+    store.set( ENVIRONMENT_OVERRIDE, prefix );
+  } else {
+    store.delete( ENVIRONMENT_OVERRIDE );
+  }
 }
 
 // Subscribers that get notified when onboardingShown changes, so all

--- a/src/sharedHelpers/installData.e2e-mock
+++ b/src/sharedHelpers/installData.e2e-mock
@@ -4,7 +4,6 @@ import * as uuid from "uuid";
 const INSTALL_ID = "installID";
 const ONBOARDING_SHOWN = "onboardingShown";
 export const IS_FRESH_INSTALL = "isFreshInstall";
-const ENVIRONMENT_OVERRIDE = "environmentOverride";
 
 const data = new Map();
 
@@ -24,18 +23,6 @@ export function getInstallID( ) {
   // Skip setting IS_FRESH_INSTALL in e2e to avoid triggering
   // RNRestart.restart() which kills the Detox instrumentation process
   return newID;
-}
-
-export function getEnvironmentOverride( ) {
-  return store.getString( ENVIRONMENT_OVERRIDE );
-}
-
-export function setEnvironmentOverride( prefix ) {
-  if ( prefix ) {
-    store.set( ENVIRONMENT_OVERRIDE, prefix );
-  } else {
-    store.delete( ENVIRONMENT_OVERRIDE );
-  }
 }
 
 // Subscribers that get notified when onboardingShown changes, so all

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -15,6 +15,7 @@ import {
   attachMediaToObservation,
   uploadObservationMedia,
 } from "uploaders/mediaUploader";
+import syncProjectChildDeletions from "uploaders/projectChildrenDeleter";
 import { uploadProjectChildren } from "uploaders/projectChildrenUploader";
 import { RecoverableError, RECOVERY_BY } from "uploaders/utils/errorHandling";
 import { trackObservationUpload } from "uploaders/utils/progressTracker";
@@ -188,6 +189,7 @@ async function uploadObservation(
     const apiToken = await validateAndGetToken( );
     const childrenStartTime = Date.now( );
     const childOptions = { ...opts, api_token: apiToken };
+    await syncProjectChildDeletions( observation, childOptions, realm );
     await uploadProjectChildren( obsUUID, observation, childOptions, realm );
     childrenDuration = Date.now( ) - childrenStartTime;
   } catch ( error ) {

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -187,12 +187,8 @@ async function uploadObservation(
   try {
     const apiToken = await validateAndGetToken( );
     const childrenStartTime = Date.now( );
-    await uploadProjectChildren(
-      obsUUID,
-      observation,
-      { ...opts, api_token: apiToken },
-      realm,
-    );
+    const childOptions = { ...opts, api_token: apiToken };
+    await uploadProjectChildren( obsUUID, observation, childOptions, realm );
     childrenDuration = Date.now( ) - childrenStartTime;
   } catch ( error ) {
     const {

--- a/src/uploaders/projectChildrenDeleter.ts
+++ b/src/uploaders/projectChildrenDeleter.ts
@@ -1,8 +1,10 @@
 import { INatApiError } from "api/error";
+import { deleteObservationFieldValue } from "api/observationFieldValues";
 import { deleteProjectObservation } from "api/projectObservations";
 import type Realm from "realm";
 import type {
   RealmObservation,
+  RealmObservationFieldValue,
   RealmProjectObservation,
 } from "realmModels/types";
 import safeRealmWrite from "sharedHelpers/safeRealmWrite";
@@ -35,6 +37,22 @@ async function deleteRemoteProjectObservation(
   }
 }
 
+async function deleteRemoteObservationFieldValue(
+  ofv: RealmObservationFieldValue,
+  options: DeleteOptions,
+): Promise<void> {
+  if ( !ofv.wasSynced( ) ) {
+    return;
+  }
+  try {
+    await deleteObservationFieldValue( ofv.uuid, options );
+  } catch ( error ) {
+    if ( !isDeleteSuccess( error ) ) {
+      throw error;
+    }
+  }
+}
+
 export default async function syncProjectChildDeletions(
   observation: RealmObservation,
   options: DeleteOptions,
@@ -43,9 +61,10 @@ export default async function syncProjectChildDeletions(
   const posToDelete = observation.projectObservations.filter( po => po._pending_deletion );
   const ofvsToDelete = observation.observationFieldValues.filter( ofv => ofv._pending_deletion );
 
-  console.log( "ofvsToDelete", ofvsToDelete );
-  console.log( "realm", realm );
-
+  // The two batches need to be in sequence; OFV phase waits until all POs settle.
+  // Because some OFVs might be required for some POs, so deleteing a PO in such a case
+  // will error out 422.
+  // Can be parallel within each phase.
   await Promise.all(
     posToDelete.map( po => deleteRemoteProjectObservation( po, options ) ),
   );
@@ -53,4 +72,12 @@ export default async function syncProjectChildDeletions(
   posToDelete.forEach( po => safeRealmWrite( realm, ( ) => {
     realm.delete( po );
   }, "deleting synced project observation from Realm" ) );
+
+  await Promise.all(
+    ofvsToDelete.map( ofv => deleteRemoteObservationFieldValue( ofv, options ) ),
+  );
+  // Remove realm entry
+  ofvsToDelete.forEach( ofv => safeRealmWrite( realm, ( ) => {
+    realm.delete( ofv );
+  }, "deleting synced observation field value from Realm" ) );
 }

--- a/src/uploaders/projectChildrenDeleter.ts
+++ b/src/uploaders/projectChildrenDeleter.ts
@@ -1,3 +1,4 @@
+import { INatApiError } from "api/error";
 import { deleteProjectObservation } from "api/projectObservations";
 import type Realm from "realm";
 import type {
@@ -10,6 +11,11 @@ interface DeleteOptions {
   signal: AbortSignal;
 }
 
+function isDeleteSuccess( error: unknown ): boolean {
+  return error instanceof INatApiError
+    && ( error.status === 404 || error.status === 403 );
+}
+
 async function deleteRemoteProjectObservation(
   po: RealmProjectObservation,
   options: DeleteOptions,
@@ -19,7 +25,13 @@ async function deleteRemoteProjectObservation(
   if ( !po.wasSynced( ) ) {
     return;
   }
-  await deleteProjectObservation( po.uuid, options );
+  try {
+    await deleteProjectObservation( po.uuid, options );
+  } catch ( error ) {
+    if ( !isDeleteSuccess( error ) ) {
+      throw error;
+    }
+  }
 }
 
 export default async function syncProjectChildDeletions(
@@ -31,7 +43,6 @@ export default async function syncProjectChildDeletions(
   const ofvsToDelete = observation.observationFieldValues.filter( ofv => ofv._pending_deletion );
 
   console.log( "ofvsToDelete", ofvsToDelete );
-  console.log( "options", options );
   console.log( "realm", realm );
 
   await Promise.all(

--- a/src/uploaders/projectChildrenDeleter.ts
+++ b/src/uploaders/projectChildrenDeleter.ts
@@ -1,11 +1,25 @@
+import { deleteProjectObservation } from "api/projectObservations";
 import type Realm from "realm";
 import type {
   RealmObservation,
+  RealmProjectObservation,
 } from "realmModels/types";
 
 interface DeleteOptions {
   api_token?: string;
   signal: AbortSignal;
+}
+
+async function deleteRemoteProjectObservation(
+  po: RealmProjectObservation,
+  options: DeleteOptions,
+): Promise<void> {
+  // Android Classic is: PO DELETE runs only when the row has a server id
+  // this should be comparable. We don't need to delete on server if it was never synced.
+  if ( !po.wasSynced( ) ) {
+    return;
+  }
+  await deleteProjectObservation( po.uuid, options );
 }
 
 export default async function syncProjectChildDeletions(
@@ -16,8 +30,11 @@ export default async function syncProjectChildDeletions(
   const posToDelete = observation.projectObservations.filter( po => po._pending_deletion );
   const ofvsToDelete = observation.observationFieldValues.filter( ofv => ofv._pending_deletion );
 
-  console.log( "posToDelete", posToDelete );
   console.log( "ofvsToDelete", ofvsToDelete );
   console.log( "options", options );
   console.log( "realm", realm );
+
+  await Promise.all(
+    posToDelete.map( po => deleteRemoteProjectObservation( po, options ) ),
+  );
 }

--- a/src/uploaders/projectChildrenDeleter.ts
+++ b/src/uploaders/projectChildrenDeleter.ts
@@ -1,0 +1,23 @@
+import type Realm from "realm";
+import type {
+  RealmObservation,
+} from "realmModels/types";
+
+interface DeleteOptions {
+  api_token?: string;
+  signal: AbortSignal;
+}
+
+export default async function syncProjectChildDeletions(
+  observation: RealmObservation,
+  options: DeleteOptions,
+  realm: Realm,
+): Promise<void> {
+  const posToDelete = observation.projectObservations.filter( po => po._pending_deletion );
+  const ofvsToDelete = observation.observationFieldValues.filter( ofv => ofv._pending_deletion );
+
+  console.log( "posToDelete", posToDelete );
+  console.log( "ofvsToDelete", ofvsToDelete );
+  console.log( "options", options );
+  console.log( "realm", realm );
+}

--- a/src/uploaders/projectChildrenDeleter.ts
+++ b/src/uploaders/projectChildrenDeleter.ts
@@ -5,6 +5,7 @@ import type {
   RealmObservation,
   RealmProjectObservation,
 } from "realmModels/types";
+import safeRealmWrite from "sharedHelpers/safeRealmWrite";
 
 interface DeleteOptions {
   api_token?: string;
@@ -48,4 +49,8 @@ export default async function syncProjectChildDeletions(
   await Promise.all(
     posToDelete.map( po => deleteRemoteProjectObservation( po, options ) ),
   );
+  // Remove realm entry
+  posToDelete.forEach( po => safeRealmWrite( realm, ( ) => {
+    realm.delete( po );
+  }, "deleting synced project observation from Realm" ) );
 }

--- a/src/uploaders/projectChildrenUploader.ts
+++ b/src/uploaders/projectChildrenUploader.ts
@@ -15,6 +15,7 @@ interface UploadOptions {
   api_token?: string;
   signal: AbortSignal;
 }
+
 function filterDirtyOfvs( observation: RealmObservation ): RealmObservationFieldValue[] {
   // Single upload-time gate combining timestamp dirty (needsSync),
   // not tombstoned (_pending_deletion), and non-empty value.
@@ -53,7 +54,6 @@ async function uploadSingleObservationFieldValue(
 
   let response;
   if ( ofv.wasSynced( ) && ofv.id ) {
-    console.log( "update branch" );
     response = await updateObservationFieldValue(
       { id: ofv.uuid, ...params },
       options,

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -157,6 +157,27 @@ describe( "uploadObservation", () => {
     },
   );
 
+  it( "should call syncProjectChildDeletions before uploadProjectChildren", async () => {
+    await uploadObservation( mockObservation, mockRealm );
+
+    expect( syncProjectChildDeletions ).toHaveBeenCalledWith(
+      mockObservation,
+      expect.objectContaining( { api_token: "test-json-web-token" } ),
+      mockRealm,
+    );
+    expect( projectChildrenUploader.uploadProjectChildren ).toHaveBeenCalledWith(
+      mockObservation.uuid,
+      mockObservation,
+      expect.objectContaining( { api_token: "test-json-web-token" } ),
+      mockRealm,
+    );
+    expect(
+      syncProjectChildDeletions.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      projectChildrenUploader.uploadProjectChildren.mock.invocationCallOrder[0],
+    );
+  } );
+
   it( "should call uploadProjectChildren after media is attached", async () => {
     await uploadObservation( mockObservation, mockRealm );
 

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -4,12 +4,14 @@ import factory from "tests/factory";
 import * as uploaders from "uploaders";
 import * as mediaUploader from "uploaders/mediaUploader";
 import uploadObservation from "uploaders/observationUploader";
+import projectChildrenDeleter from "uploaders/projectChildrenDeleter";
 import * as projectChildrenUploader from "uploaders/projectChildrenUploader";
 import * as progressTracker from "uploaders/utils/progressTracker";
 
 jest.mock( "components/LoginSignUp/AuthenticationService" );
 jest.mock( "uploaders/utils/progressTracker" );
 jest.mock( "uploaders/mediaUploader" );
+jest.mock( "uploaders/projectChildrenDeleter" );
 jest.mock( "uploaders/projectChildrenUploader" );
 jest.mock( "uploaders" );
 jest.mock( "api/observations" );
@@ -70,6 +72,7 @@ describe( "uploadObservation", () => {
       results: [{ uuid: mockObservation.uuid, id: 12345 }],
     } );
 
+    projectChildrenDeleter.syncProjectChildDeletions.mockResolvedValue( undefined );
     projectChildrenUploader.uploadProjectChildren.mockResolvedValue( undefined );
   } );
 

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -4,7 +4,7 @@ import factory from "tests/factory";
 import * as uploaders from "uploaders";
 import * as mediaUploader from "uploaders/mediaUploader";
 import uploadObservation from "uploaders/observationUploader";
-import projectChildrenDeleter from "uploaders/projectChildrenDeleter";
+import syncProjectChildDeletions from "uploaders/projectChildrenDeleter";
 import * as projectChildrenUploader from "uploaders/projectChildrenUploader";
 import * as progressTracker from "uploaders/utils/progressTracker";
 
@@ -72,7 +72,7 @@ describe( "uploadObservation", () => {
       results: [{ uuid: mockObservation.uuid, id: 12345 }],
     } );
 
-    projectChildrenDeleter.syncProjectChildDeletions.mockResolvedValue( undefined );
+    syncProjectChildDeletions.mockResolvedValue( undefined );
     projectChildrenUploader.uploadProjectChildren.mockResolvedValue( undefined );
   } );
 
@@ -183,6 +183,16 @@ describe( "uploadObservation", () => {
       .mock.invocationCallOrder[0];
     const markCallOrder = uploaders.markRecordUploaded.mock.invocationCallOrder[0];
     expect( childrenCallOrder ).toBeLessThan( markCallOrder );
+  } );
+
+  it( "should throw an error if project children delete fails", async () => {
+    syncProjectChildDeletions
+      .mockRejectedValue( new Error( "Project Children Delete Error" ) );
+
+    await expect( uploadObservation( mockObservation, mockRealm ) )
+      .rejects.toThrow( "Project Children Delete Error" );
+    expect( projectChildrenUploader.uploadProjectChildren ).not.toHaveBeenCalled( );
+    expect( uploaders.markRecordUploaded ).not.toHaveBeenCalled( );
   } );
 
   it( "should throw an error if project children upload fails", async () => {

--- a/tests/unit/uploaders/projectChildrenDeleter.test.js
+++ b/tests/unit/uploaders/projectChildrenDeleter.test.js
@@ -1,0 +1,195 @@
+import { INatApiError } from "api/error";
+import * as observationFieldValuesApi from "api/observationFieldValues";
+import * as projectObservationsApi from "api/projectObservations";
+import factory from "tests/factory";
+import syncProjectChildDeletions from "uploaders/projectChildrenDeleter";
+
+jest.mock( "api/observationFieldValues" );
+jest.mock( "api/projectObservations" );
+
+const mockOpts = { api_token: "test-token", signal: new AbortController().signal };
+let mockRealm;
+
+const dirtyOfv = ( overrides = {} ) => factory( "LocalObservationFieldValue", {
+  id: null,
+  needsSync: jest.fn( () => true ),
+  wasSynced: jest.fn( () => false ),
+  _pending_deletion: false,
+  ...overrides,
+} );
+
+const dirtyPo = ( overrides = {} ) => factory( "LocalProjectObservation", {
+  needsSync: jest.fn( () => true ),
+  wasSynced: jest.fn( () => false ),
+  _pending_deletion: false,
+  ...overrides,
+} );
+
+const createMockRealm = ( ) => ( {
+  isClosed: false,
+  isInTransaction: false,
+  beginTransaction: jest.fn( ),
+  commitTransaction: jest.fn( ),
+  cancelTransaction: jest.fn( ),
+  delete: jest.fn( ),
+} );
+
+beforeEach( () => {
+  jest.clearAllMocks();
+  mockRealm = createMockRealm( );
+  observationFieldValuesApi.deleteObservationFieldValue.mockResolvedValue( {} );
+  projectObservationsApi.deleteProjectObservation.mockResolvedValue( {} );
+} );
+
+describe( "projectChildrenDeleter", () => {
+  describe( "syncProjectChildDeletions", () => {
+    it( "only DELETEs tombstoned embeds", async () => {
+      const tombstonedPo = dirtyPo( {
+        uuid: "po-delete-uuid",
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+      } );
+      const activePo = dirtyPo( {
+        uuid: "po-active-uuid",
+        wasSynced: jest.fn( () => true ),
+      } );
+      const tombstonedOfv = dirtyOfv( {
+        uuid: "ofv-delete-uuid",
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+        value: "old",
+      } );
+      const activeOfv = dirtyOfv( {
+        uuid: "ofv-active-uuid",
+        wasSynced: jest.fn( () => true ),
+        value: "current",
+      } );
+      const observation = factory( "LocalObservation", {
+        projectObservations: [activePo, tombstonedPo],
+        observationFieldValues: [activeOfv, tombstonedOfv],
+      } );
+
+      await syncProjectChildDeletions( observation, mockOpts, mockRealm );
+
+      expect( projectObservationsApi.deleteProjectObservation ).toHaveBeenCalledTimes( 1 );
+      expect( projectObservationsApi.deleteProjectObservation ).toHaveBeenCalledWith(
+        "po-delete-uuid",
+        mockOpts,
+      );
+      expect( observationFieldValuesApi.deleteObservationFieldValue ).toHaveBeenCalledTimes( 1 );
+      expect( observationFieldValuesApi.deleteObservationFieldValue ).toHaveBeenCalledWith(
+        "ofv-delete-uuid",
+        mockOpts,
+      );
+      expect( mockRealm.delete ).toHaveBeenCalledTimes( 2 );
+      expect( mockRealm.delete ).toHaveBeenCalledWith( tombstonedPo );
+      expect( mockRealm.delete ).toHaveBeenCalledWith( tombstonedOfv );
+    } );
+
+    it( "DELETEs tombstoned POs before OFVs and removes local embeds", async () => {
+      const tombstonedPo = dirtyPo( {
+        uuid: "po-delete-uuid",
+        id: 99,
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+      } );
+      const tombstonedOfv = dirtyOfv( {
+        uuid: "ofv-delete-uuid",
+        id: 88,
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+        value: "old",
+      } );
+      const observation = factory( "LocalObservation", {
+        projectObservations: [tombstonedPo],
+        observationFieldValues: [tombstonedOfv],
+      } );
+
+      await syncProjectChildDeletions( observation, mockOpts, mockRealm );
+
+      expect( projectObservationsApi.deleteProjectObservation ).toHaveBeenCalledWith(
+        "po-delete-uuid",
+        mockOpts,
+      );
+      expect( observationFieldValuesApi.deleteObservationFieldValue ).toHaveBeenCalledWith(
+        "ofv-delete-uuid",
+        mockOpts,
+      );
+      expect(
+        projectObservationsApi.deleteProjectObservation.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        observationFieldValuesApi.deleteObservationFieldValue.mock.invocationCallOrder[0],
+      );
+      expect( mockRealm.delete ).toHaveBeenCalledTimes( 2 );
+      expect( mockRealm.delete ).toHaveBeenCalledWith( tombstonedPo );
+      expect( mockRealm.delete ).toHaveBeenCalledWith( tombstonedOfv );
+    } );
+
+    it( "treats 404 and 403 as success and still removes local embeds", async () => {
+      const tombstonedPo = dirtyPo( {
+        uuid: "po-delete-uuid",
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+      } );
+      const tombstonedOfv = dirtyOfv( {
+        uuid: "ofv-delete-uuid",
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+        value: "old",
+      } );
+      const observation = factory( "LocalObservation", {
+        projectObservations: [tombstonedPo],
+        observationFieldValues: [tombstonedOfv],
+      } );
+
+      projectObservationsApi.deleteProjectObservation.mockRejectedValue(
+        new INatApiError( { error: "Not found" }, 404 ),
+      );
+      observationFieldValuesApi.deleteObservationFieldValue.mockRejectedValue(
+        new INatApiError( { error: "Forbidden" }, 403 ),
+      );
+
+      await syncProjectChildDeletions( observation, mockOpts, mockRealm );
+
+      expect( mockRealm.delete ).toHaveBeenCalledTimes( 2 );
+    } );
+
+    it( "throws on other delete errors and does not remove local embeds", async () => {
+      const tombstonedPo = dirtyPo( {
+        uuid: "po-delete-uuid",
+        wasSynced: jest.fn( () => true ),
+        _pending_deletion: true,
+      } );
+      const observation = factory( "LocalObservation", {
+        projectObservations: [tombstonedPo],
+        observationFieldValues: [],
+      } );
+
+      projectObservationsApi.deleteProjectObservation.mockRejectedValue(
+        new INatApiError( { error: "Server error" }, 500 ),
+      );
+
+      await expect(
+        syncProjectChildDeletions( observation, mockOpts, mockRealm ),
+      ).rejects.toThrow( INatApiError );
+      expect( mockRealm.delete ).not.toHaveBeenCalled( );
+    } );
+
+    it( "skips remote DELETE for never-synced tombstones but removes locally", async () => {
+      const tombstonedPo = dirtyPo( {
+        uuid: "po-delete-uuid",
+        wasSynced: jest.fn( () => false ),
+        _pending_deletion: true,
+      } );
+      const observation = factory( "LocalObservation", {
+        projectObservations: [tombstonedPo],
+        observationFieldValues: [],
+      } );
+
+      await syncProjectChildDeletions( observation, mockOpts, mockRealm );
+
+      expect( projectObservationsApi.deleteProjectObservation ).not.toHaveBeenCalled( );
+      expect( mockRealm.delete ).toHaveBeenCalledWith( tombstonedPo );
+    } );
+  } );
+} );


### PR DESCRIPTION
Closes MOB-1511

Remark for testing: There is a bit of a known bug that only removing an OFV (by removing all text from an input) does not enable the SAVE button. So, you'd need to also select a new project for SAVE to get enabled. This should not affect the delete sync though.

PR includes:
Syncs removal of traditional project links (POs) and field values (OFVs) to the server before create/update uploads.
- Adds: DELETE tombstoned POs, then OFVs; 404/403 treated as success; local Realm embeds removed after sync; skips remote DELETE for never-synced rows
- Calls deleter from observationUploader immediately before uploadProjectChildren
- Extends UNSYNCED_FILTER so observations with pending PO/OFV deletions stay in the upload queue

Before:
<img width="526" height="224" alt="Screenshot 2026-08-25 at 11 10 37" src="https://github.com/user-attachments/assets/eab1b99b-7403-4040-8ed0-b27ace258e04" />
<img width="189" height="151" alt="Screenshot 2026-08-25 at 11 44 24" src="https://github.com/user-attachments/assets/185bb5f6-d6c9-4fe2-944b-c90bb783550d" />

After: Removing a project from the Add to Project screen (which was previously uploaded):
<img width="507" height="160" alt="Screenshot 2026-08-25 at 11 11 15" src="https://github.com/user-attachments/assets/aab085e1-4b64-4f6f-9118-0dfd94e93dab" />

After: Removing an observation field value from one of the inputs of a project which was previously synced to server:
<img width="146" height="109" alt="Screenshot 2026-08-25 at 11 47 48" src="https://github.com/user-attachments/assets/67bf977a-dcfd-439d-baf1-823f2dad90fc" />