### PR TITLE
Fix CI: lightningcss native dependency

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -30,16 +30,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v5
-        id: cache
-        with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install node dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
       # Need this for pre-commit linting of Ruby
       - name: Install Ruby and gems

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -99,8 +99,7 @@ jobs:
         gradle-version: '9.0.0'
 
     - name: Install JS dependencies
-      run: |
-        npm install
+      run: npm ci
 
     - name: Download the small example cv and geomodel
       run: |
@@ -159,24 +158,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v5
-        id: cache
-        with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('**/package-lock.json') }}
-
-      # supposedly our current cache includes native modules like Realm
-      # that have compiled binaries specific to the environment where they were installed
-      # which might not be the same as the github actions environment
-      # so we need to rebuild them
-      - name: Rebuild native modules
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: npm rebuild
-
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
       # This will be available for all subsequent steps

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -151,7 +151,8 @@ jobs:
         with:
           name: release-androidTest-apk
           path: android/app/build/outputs/apk/androidTest/release
-
+          
+          path: android/app/build/outputs/apk/androidTest/release
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -151,8 +151,7 @@ jobs:
         with:
           name: release-androidTest-apk
           path: android/app/build/outputs/apk/androidTest/release
-          
-          path: android/app/build/outputs/apk/androidTest/release
+
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -59,28 +59,8 @@ jobs:
       run: |
         echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
 
-    - name: Cache node modules
-      uses: actions/cache@v5
-      id: cache
-      with:
-        path: node_modules
-        key: node-modules-${{ hashFiles('**/package-lock.json') }}
-
-    - name: Rebuild detox from cache
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npx detox clean-framework-cache && npx detox build-framework-cache
-
-    # supposedly our current cache includes native modules like Realm
-    # that have compiled binaries specific to the environment where they were installed
-    # which might not be the same as the github actions environment
-    # so we need to rebuild them
-    - name: Rebuild native modules
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npm rebuild
-
     - name: Install Dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: npm install
+      run: npm ci
 
     - name: Cache Pods
       uses: actions/cache@v5
@@ -167,28 +147,8 @@ jobs:
         node-version-file: '.nvmrc'
         cache: 'npm'
 
-    - name: Cache node modules
-      uses: actions/cache@v5
-      id: cache
-      with:
-        path: node_modules
-        key: node-modules-${{ hashFiles('**/package-lock.json') }}
-
-    - name: Rebuild detox from cache
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npx detox clean-framework-cache && npx detox build-framework-cache
-
-    # supposedly our current cache includes native modules like Realm
-    # that have compiled binaries specific to the environment where they were installed
-    # which might not be the same as the github actions environment
-    # so we need to rebuild them
-    - name: Rebuild native modules
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npm rebuild
-
     - name: Install Dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: npm install
+      run: npm ci
 
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
     # This will be available for all subsequent steps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,24 +24,8 @@ jobs:
         node-version-file: '.nvmrc'
         cache: 'npm'
 
-    - name: Cache node modules
-      uses: actions/cache@v5
-      id: cache
-      with:
-        path: node_modules
-        key: node-modules-${{ hashFiles('**/package-lock.json') }}
-
-    # supposedly our current cache includes native modules like Realm
-    # that have compiled binaries specific to the environment where they were installed
-    # which might not be the same as the github actions environment
-    # so we need to rebuild them
-    - name: Rebuild native modules
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: npm rebuild
-
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: npm install
+      run: npm ci
 
     # Need this for linting Ruby
     - name: Install Ruby and gems


### PR DESCRIPTION
Stop caching node_modules across workflows and always run npm ci, relying on actions/setup-node's per-OS npm tarball cache instead.

This fixes iOS CI failures where Metro could not load lightningcss.darwin-arm64.node because Ubuntu-filled node_modules caches were reused on macOS and npm rebuild did not install missing optional native packages.