### PR TITLE
MOB-1542 fallback to GMT with correct offset when timezone is unsupported

### DIFF
--- a/src/sharedHelpers/dateAndTime.ts
+++ b/src/sharedHelpers/dateAndTime.ts
@@ -4,6 +4,7 @@
 // names that are specific to particular views,
 // like "myObsDateFormat"
 
+import type { Locale } from "date-fns";
 import {
   differenceInDays,
   differenceInHours,
@@ -301,13 +302,17 @@ const ZONE_ABBREVIATION_TOKEN = /z+/;
 // won't extend that data, so detect the failure per call: a bare "GMT" abbreviation for a zone
 // whose real offset (computed via a separate, unaffected code path) isn't
 // actually zero.
-function timeZoneAbbreviationIsUnreliable( date: Date, timeZone: string ): boolean {
-  const offset = formatInTimeZone( date, timeZone, "xxx" );
+function timeZoneAbbreviationIsUnreliable(
+  date: Date,
+  timeZone: string,
+  locale: Locale,
+): boolean {
+  const offset = formatInTimeZone( date, timeZone, "xxx", { locale } );
   if ( offset === "+00:00" ) {
     // Actually UTC/GMT, so a "GMT" abbreviation would be correct
     return false;
   }
-  return formatInTimeZone( date, timeZone, "zzz" ) === "GMT";
+  return formatInTimeZone( date, timeZone, "zzz", { locale } ) === "GMT";
 }
 
 interface FormatDateStringOptions {
@@ -371,10 +376,11 @@ function formatDateString(
   }
 
   try {
+    const locale = dateFnsLocale( i18n.language );
     let formatString = fmt;
     if (
       ZONE_ABBREVIATION_TOKEN.test( formatString )
-      && timeZoneAbbreviationIsUnreliable( parsedDate, timeZone )
+      && timeZoneAbbreviationIsUnreliable( parsedDate, timeZone, locale )
     ) {
       // Fall back to a numeric offset (e.g. "GMT+10") instead of an
       // abbreviation Hermes can't reliably resolve for this zone
@@ -384,7 +390,7 @@ function formatDateString(
       parsedDate,
       timeZone,
       formatString,
-      { locale: dateFnsLocale( i18n.language ) },
+      { locale },
     );
   } catch ( error ) {
     console.warn( "Error formatting date", error );

--- a/src/sharedHelpers/dateAndTime.ts
+++ b/src/sharedHelpers/dateAndTime.ts
@@ -290,6 +290,26 @@ function formatDifferenceForHumans( date: Date | string, i18n: i18next ) {
   return format( d, i18n.t( "date-format-month-day" ), formatOpts );
 }
 
+const ZONE_ABBREVIATION_TOKEN = /z+/;
+
+// Hermes' Intl.DateTimeFormat has incomplete ICU time zone name data for
+// some zones (seen so far: Australia/Sydney, Asia/Kolkata, Asia/Singapore)
+// and silently resolves the abbreviated zone name to the literal string
+// "GMT" instead of the real timezone abbreviation (like "AEST") - see
+// https://github.com/facebook/hermes/issues/1601 and
+// https://github.com/marnusw/date-fns-tz/issues/306. Hermes has said they
+// won't extend that data, so detect the failure per call: a bare "GMT" abbreviation for a zone
+// whose real offset (computed via a separate, unaffected code path) isn't
+// actually zero.
+function timeZoneAbbreviationIsUnreliable( date: Date, timeZone: string ): boolean {
+  const offset = formatInTimeZone( date, timeZone, "xxx" );
+  if ( offset === "+00:00" ) {
+    // Actually UTC/GMT, so a "GMT" abbreviation would be correct
+    return false;
+  }
+  return formatInTimeZone( date, timeZone, "zzz" ) === "GMT";
+}
+
 interface FormatDateStringOptions {
   // Display the time as literally expressed in the dateString, i.e. don't
   // assume it's in any time zone
@@ -351,10 +371,19 @@ function formatDateString(
   }
 
   try {
+    let formatString = fmt;
+    if (
+      ZONE_ABBREVIATION_TOKEN.test( formatString )
+      && timeZoneAbbreviationIsUnreliable( parsedDate, timeZone )
+    ) {
+      // Fall back to a numeric offset (e.g. "GMT+10") instead of an
+      // abbreviation Hermes can't reliably resolve for this zone
+      formatString = formatString.replace( ZONE_ABBREVIATION_TOKEN, "O" );
+    }
     return formatInTimeZone(
       parsedDate,
       timeZone,
-      fmt,
+      formatString,
       { locale: dateFnsLocale( i18n.language ) },
     );
   } catch ( error ) {

--- a/tests/unit/helpers/dateAndTime.test.js
+++ b/tests/unit/helpers/dateAndTime.test.js
@@ -89,6 +89,53 @@ describe( "formatApiDatetime", ( ) => {
       "should return a localized datetime for a local observation created_at date",
     );
     it.todo( "should optionally show the date in the original time zone" );
+
+    describe( "when Intl mis-resolves the zone abbreviation (Hermes bug)", () => {
+      let formatToPartsSpy;
+
+      beforeAll( () => {
+        const original = Intl.DateTimeFormat.prototype.formatToParts;
+        // Simulates https://github.com/facebook/hermes/issues/1601: Hermes
+        // resolves timeZoneName to the literal string "GMT" for *some*
+        // zones (here, only the one under test) instead of the real
+        // abbreviation, while other zones keep resolving correctly
+        formatToPartsSpy = jest.spyOn(
+          Intl.DateTimeFormat.prototype,
+          "formatToParts",
+        ).mockImplementation( function mockFormatToParts( date ) {
+          const parts = original.call( this, date );
+          const resolvedOptions = this.resolvedOptions( );
+          if ( !resolvedOptions.timeZoneName || resolvedOptions.timeZone !== "Australia/Sydney" ) {
+            return parts;
+          }
+          return parts.map( part => (
+            part.type === "timeZoneName"
+              ? { ...part, value: "GMT" }
+              : part
+          ) );
+        } );
+      } );
+
+      afterAll( () => {
+        formatToPartsSpy.mockRestore( );
+      } );
+
+      it( "falls back to a numeric offset instead of the unreliable abbreviation", () => {
+        expect(
+          formatApiDatetime(
+            "2023-01-02T08:00:00+01:00",
+            i18next,
+            { timeZone: "Australia/Sydney" },
+          ),
+        ).toEqual( "1/2/23 6:00 PM GMT+11" );
+      } );
+
+      it( "still shows a real GMT/UTC abbreviation for an actually-zero offset", () => {
+        expect(
+          formatApiDatetime( "2023-01-02T08:00:00+01:00", i18next, { timeZone: "UTC" } ),
+        ).toEqual( "1/2/23 7:00 AM UTC" );
+      } );
+    } );
   } );
 
   describe( "in es-MX", ( ) => {


### PR DESCRIPTION
The app misrepresents datetimes for certain time zones due to limited `Intl` support in Hermes which they've said they're unlikely to work on. https://github.com/facebook/hermes/issues/1601 https://github.com/marnusw/date-fns-tz/issues/306

For these unsupported timezones / locale strings, date-fns-tz gives us back our local time, but with a "default" GMT short time zone string.

Example:

https://www.inaturalist.org/observations/348588955

This obs occurred at 14:00 IST ("India Standard Time", IANA: "Asia/Kolkata"). Asia/Kolkata has a +5:30 utc offset, no DST. The website correctly reports this in `en-US` as "2:00 PM IST" but mobile shows "2:00 PM GMT" which is a _different instant in time_, incorrectly representing 7:30 PM local IST.

---

_thankfully_ we can detect this error case because the obs from the server includes both the IANA tz and the `time_observed_at` as a Date Time **_Offset_**: `{ observed_time_zone: "Asia/Kolkata", time_observed_at: "2024-01-10T14:00:25+05:30" }`.

If we format a DTO with a non-"00:00" offset and get back a GMT short timezone, we know this is wrong. That is: `{ observed_time_zone: "Etc/GMT", time_observed_at: "2024-01-10T14:00:25+05:30" }` is an _invalid combination of tz & DTO_.

So in this error case, we instead fallback to just formatting it as "Etc/GMT".

Result: we're at least referencing the correct instant in time even though we can't report the localized short time zone.

|Before (wrong instant)|After|
|---|---|
|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/4f131e26-f2f1-4adb-9fe5-4b310bdb2067" />|<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/9c12f3f2-8404-44c5-a8ac-b41f4952db15" />|