### PR TITLE
MOB-1122 update react-compiler@1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,7 @@
         "@types/sanitize-html": "^2.16.1",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
         "babel-plugin-module-resolver": "^5.0.0",
-        "babel-plugin-react-compiler": "^19.1.0-rc.3",
+        "babel-plugin-react-compiler": "1.0.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "babel-plugin-transform-remove-console": "^6.9.4",
         "chalk": "^5.4.1",
@@ -8281,9 +8281,9 @@
       }
     },
     "node_modules/babel-plugin-react-compiler": {
-      "version": "19.1.0-rc.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.3.tgz",
-      "integrity": "sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "babel-plugin-module-resolver": "^5.0.0",
-    "babel-plugin-react-compiler": "^19.1.0-rc.3",
+    "babel-plugin-react-compiler": "1.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "chalk": "^5.4.1",


### PR DESCRIPTION
closes MOB-1122

Doesn't seem like there were any necessary changes / regressions on our side which makes sense since we were on the last rc before this 1.0. As far as I can tell, the only relevant changes between the RC and 1.0 were related to internal use of zod validation.

The following shows that we're still getting the "Memo ✨" badges in the Components Dev Tools tab that denote components automatically memoized by react-compiler.

<img width="448" height="467" alt="image" src="https://github.com/user-attachments/assets/69420835-0b5f-468e-a627-39cf71ecdfb9" />
<img width="322" height="489" alt="image" src="https://github.com/user-attachments/assets/d5cdb6bc-b5b5-46b9-8490-be9c9876d4aa" />

#3574 already got us square with the latest version of eslints react hooks, a companion to react-compiler