### PR TITLE
Traditional projects: per project field form polish

### DIFF
--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -319,6 +319,7 @@ const AddToProjects = ( ) => {
         ListFooterComponent={listFooterComponent}
         data={joinedProjects}
         keyExtractor={( project: RealmProject ) => String( project.id )}
+        keyboardDismissMode="on-drag"
         renderItem={renderProject}
         ItemSeparatorComponent={ItemSeparator}
       />

--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -318,6 +318,7 @@ const AddToProjects = ( ) => {
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent}
         data={joinedProjects}
+        extraData={validationResult}
         keyExtractor={( project: RealmProject ) => String( project.id )}
         keyboardDismissMode="on-drag"
         renderItem={renderProject}

--- a/src/realmModels/Project.ts
+++ b/src/realmModels/Project.ts
@@ -40,12 +40,15 @@ class Project extends Realm.Object {
   }
 
   static mapRealmToPojo( realmProject: RealmProject ) {
+    const pojoPOFs = realmProject.projectObservationFields
+      .map( pof => ProjectObservationField.mapRealmToPojo( pof ) );
     return {
       icon: realmProject.icon,
       id: realmProject.id,
-      projectObservationFields: realmProject.projectObservationFields.length > 0
-        ? realmProject.projectObservationFields
-          .map( pof => ProjectObservationField.mapRealmToPojo( pof ) )
+      projectObservationFields: pojoPOFs.length > 0
+        ? pojoPOFs
+          // Add to projects screen should display them in this order
+          .sort( ( a, b ) => a.position - b.position )
         : [],
       project_type: realmProject.project_type,
       title: realmProject.title,

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -258,6 +258,17 @@ describe( "AddToProjects", ( ) => {
       } );
     } );
 
+    it( "shows a pencil icon on the project row", async ( ) => {
+      renderAddToProjects( );
+
+      await actor.press( screen.getByText( mockProjects[1].title ) );
+
+      expect(
+        within( screen.getByTestId( `AddToProjects.project.${mockProjects[1].id}` ) )
+          .getByText( iconGlyph( "circle-dots-pencil" ) ),
+      ).toBeVisible( );
+    } );
+
     it( "shows Missing info sheet when SAVE is pressed with an empty required field", async ( ) => {
       renderAddToProjects( );
 

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -104,6 +104,41 @@ describe( "AddToProjects", ( ) => {
     ).toBeVisible();
   } );
 
+  describe( "when a selected project has fields out of position order", ( ) => {
+    const originalFields = mockProjects[0].projectObservationFields;
+    const unsortedFields = [
+      factory( "LocalProjectObservationField", {
+        position: 2,
+        obsField: factory( "LocalObservationField", { name: "Field C" } ),
+      } ),
+      factory( "LocalProjectObservationField", {
+        position: 0,
+        obsField: factory( "LocalObservationField", { name: "Field A" } ),
+      } ),
+      factory( "LocalProjectObservationField", {
+        position: 1,
+        obsField: factory( "LocalObservationField", { name: "Field B" } ),
+      } ),
+    ];
+
+    beforeAll( ( ) => {
+      mockProjects[0].projectObservationFields = unsortedFields;
+    } );
+
+    afterAll( ( ) => {
+      mockProjects[0].projectObservationFields = originalFields;
+    } );
+
+    it( "renders fields sorted by position", ( ) => {
+      renderAddToProjects( );
+
+      const fieldNames = screen.getAllByText( /Field [ABC]/ ).map(
+        node => node.props.children,
+      );
+      expect( fieldNames ).toEqual( ["Field A", "Field B", "Field C"] );
+    } );
+  } );
+
   it( "renders existing project observations as checked", ( ) => {
     renderAddToProjects( );
 

--- a/tests/unit/models/Project.test.js
+++ b/tests/unit/models/Project.test.js
@@ -2,6 +2,22 @@ import Project from "realmModels/Project";
 import factory from "tests/factory";
 
 describe( "Project", ( ) => {
+  describe( "mapRealmToPojo", ( ) => {
+    it( "sorts project observation fields by position", ( ) => {
+      const mockProject = factory( "LocalProject" );
+      mockProject.projectObservationFields = [
+        factory( "LocalProjectObservationField", { position: 2 } ),
+        factory( "LocalProjectObservationField", { position: 0 } ),
+        factory( "LocalProjectObservationField", { position: 1 } ),
+      ];
+
+      const mappedProject = Project.mapRealmToPojo( mockProject );
+
+      expect( mappedProject.projectObservationFields.map( pof => pof.position ) )
+        .toEqual( [0, 1, 2] );
+    } );
+  } );
+
   describe( "mapApiToRealm", ( ) => {
     it( "maps summary fields and POFs", ( ) => {
       const mockRemoteProject = factory( "RemoteProject" );


### PR DESCRIPTION
Closes MOB-1550

This PR adds:
- Sort per-project observation fields by position when mapping Realm to the chooser.
- Test that a selected project with an empty required field shows the pencil icon.
- Dismiss the keyboard on scroll; pass validationResult as FlashList extraData so check/pencil icons update with OFVs.

We specifically do not add expand/collapse animation because I didn't get anywhere meaningful in the timebox.