### PR TITLE
MOB-1713 disable android font padding for glyphs

### DIFF
--- a/src/components/SharedComponents/INatIcon/index.tsx
+++ b/src/components/SharedComponents/INatIcon/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from "react-native";
 import colors from "styles/tailwindColors";
 
 import Icon from "./INatIcon";
@@ -83,13 +84,16 @@ const ALIASES: Aliases = {
 const INatIcon = ( {
   testID, name, color, size, dropShadow,
 }: Props ) => {
-  const style = dropShadow
-    ? {
+  const style = {
+    // Android has a default line padding that we should disable
+    // for glyph based icons to prevent them from affecting layout
+    ...( Platform.OS === "android" && { includeFontPadding: false } ),
+    ...( dropShadow && {
       shadowOpacity: 2,
       textShadowRadius: 4,
       textShadowOffset: { width: 2, height: 2 },
-    }
-    : null;
+    } ),
+  };
   return (
     <Icon
       testID={testID}

--- a/tests/unit/components/AddObsBottomSheet/__snapshots__/AddObsButton.test.js.snap
+++ b/tests/unit/components/AddObsBottomSheet/__snapshots__/AddObsButton.test.js.snap
@@ -172,7 +172,7 @@ exports[`AddObsButton renders correctly 1`] = `
                         "color": "#ffffff",
                         "fontSize": 20,
                       },
-                      null,
+                      {},
                       {
                         "fontFamily": "INatIcon",
                         "fontStyle": "normal",
@@ -337,7 +337,7 @@ exports[`AddObsButton renders correctly 1`] = `
                         "color": "#ffffff",
                         "fontSize": 20,
                       },
-                      null,
+                      {},
                       {
                         "fontFamily": "INatIcon",
                         "fontStyle": "normal",
@@ -488,7 +488,7 @@ exports[`AddObsButton renders correctly 1`] = `
                         "color": "#ffffff",
                         "fontSize": 20,
                       },
-                      null,
+                      {},
                       {
                         "fontFamily": "INatIcon",
                         "fontStyle": "normal",
@@ -581,7 +581,7 @@ exports[`AddObsButton renders correctly 1`] = `
                     "color": "#454545",
                     "fontSize": 24,
                   },
-                  null,
+                  {},
                   {
                     "fontFamily": "INatIcon",
                     "fontStyle": "normal",
@@ -707,7 +707,7 @@ exports[`AddObsButton renders correctly 1`] = `
                   "color": "#ffffff",
                   "fontSize": 47,
                 },
-                null,
+                {},
                 {
                   "fontFamily": "INatIcon",
                   "fontStyle": "normal",

--- a/tests/unit/components/BottomTabNavigator/__snapshots__/CustomTabBar.test.js.snap
+++ b/tests/unit/components/BottomTabNavigator/__snapshots__/CustomTabBar.test.js.snap
@@ -102,7 +102,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                   "color": "#454545",
                   "fontSize": 26,
                 },
-                null,
+                {},
                 {
                   "fontFamily": "INatIcon",
                   "fontStyle": "normal",
@@ -194,7 +194,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                   "color": "#454545",
                   "fontSize": 26,
                 },
-                null,
+                {},
                 {
                   "fontFamily": "INatIcon",
                   "fontStyle": "normal",
@@ -394,7 +394,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                               "color": "#ffffff",
                               "fontSize": 20,
                             },
-                            null,
+                            {},
                             {
                               "fontFamily": "INatIcon",
                               "fontStyle": "normal",
@@ -559,7 +559,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                               "color": "#ffffff",
                               "fontSize": 20,
                             },
-                            null,
+                            {},
                             {
                               "fontFamily": "INatIcon",
                               "fontStyle": "normal",
@@ -710,7 +710,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                               "color": "#ffffff",
                               "fontSize": 20,
                             },
-                            null,
+                            {},
                             {
                               "fontFamily": "INatIcon",
                               "fontStyle": "normal",
@@ -803,7 +803,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                           "color": "#454545",
                           "fontSize": 24,
                         },
-                        null,
+                        {},
                         {
                           "fontFamily": "INatIcon",
                           "fontStyle": "normal",
@@ -929,7 +929,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                         "color": "#ffffff",
                         "fontSize": 31,
                       },
-                      null,
+                      {},
                       {
                         "fontFamily": "INatIcon",
                         "fontStyle": "normal",
@@ -1008,7 +1008,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                   "color": "#74AC00",
                   "fontSize": 32,
                 },
-                null,
+                {},
                 {
                   "fontFamily": "INatIcon",
                   "fontStyle": "normal",
@@ -1107,7 +1107,7 @@ exports[`CustomTabBar with advanced user layout should render correctly 1`] = `
                     "color": "#454545",
                     "fontSize": 26,
                   },
-                  null,
+                  {},
                   {
                     "fontFamily": "INatIcon",
                     "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/ActivityCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/ActivityCount.test.js.snap
@@ -20,7 +20,7 @@ exports[`ActivityCount renders reliably 1`] = `
           "color": "#454545",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/CommentsCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/CommentsCount.test.js.snap
@@ -20,7 +20,7 @@ exports[`CommentsCount renders default reliably 1`] = `
           "color": "#454545",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",
@@ -70,7 +70,7 @@ exports[`CommentsCount renders filled reliably 1`] = `
           "color": "#454545",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",
@@ -120,7 +120,7 @@ exports[`CommentsCount renders white reliably 1`] = `
           "color": "#ffffff",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/IdentificationsCount.test.js.snap
+++ b/tests/unit/components/SharedComponents/ActivityCount/__snapshots__/IdentificationsCount.test.js.snap
@@ -20,7 +20,7 @@ exports[`IdentificationsCount renders default reliably 1`] = `
           "color": "#454545",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",
@@ -70,7 +70,7 @@ exports[`IdentificationsCount renders filled reliably 1`] = `
           "color": "#454545",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",
@@ -120,7 +120,7 @@ exports[`IdentificationsCount renders white reliably 1`] = `
           "color": "#ffffff",
           "fontSize": 14,
         },
-        null,
+        {},
         {
           "fontFamily": "INatIcon",
           "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/ContainedSquareButton.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/ContainedSquareButton.test.js.snap
@@ -72,7 +72,7 @@ exports[`ContainedSquareButton renders correctly 1`] = `
               "color": "#ffffff",
               "fontSize": 20,
             },
-            null,
+            {},
             {
               "fontFamily": "INatIcon",
               "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/Buttons/__snapshots__/INatIconButton.test.js.snap
+++ b/tests/unit/components/SharedComponents/Buttons/__snapshots__/INatIconButton.test.js.snap
@@ -60,7 +60,7 @@ exports[`INatIconButton renders correctly 1`] = `
             "color": "#454545",
             "fontSize": 18,
           },
-          null,
+          {},
           {
             "fontFamily": "INatIcon",
             "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/InlineUser/__snapshots__/InlineUser.test.js.snap
+++ b/tests/unit/components/SharedComponents/InlineUser/__snapshots__/InlineUser.test.js.snap
@@ -136,7 +136,7 @@ exports[`InlineUser when offline renders reliably 1`] = `
             "color": "#454545",
             "fontSize": 22,
           },
-          null,
+          {},
           {
             "fontFamily": "INatIcon",
             "fontStyle": "normal",
@@ -231,7 +231,7 @@ exports[`InlineUser when user has no icon set renders reliably 1`] = `
             "color": "#454545",
             "fontSize": 22,
           },
-          null,
+          {},
           {
             "fontFamily": "INatIcon",
             "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/ObservationsFlashList/__snapshots__/ObsGridItem.test.js.snap
+++ b/tests/unit/components/SharedComponents/ObservationsFlashList/__snapshots__/ObsGridItem.test.js.snap
@@ -54,7 +54,7 @@ exports[`ObsGridItem for an observation with a photo should render 1`] = `
                 "color": "#BFBFBF33",
                 "fontSize": 100,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",
@@ -198,7 +198,7 @@ exports[`ObsGridItem for an observation without a photo should render 1`] = `
                 "color": "#BFBFBF33",
                 "fontSize": 100,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/UploadStatus/__snapshots__/UploadStatus.test.js.snap
+++ b/tests/unit/components/SharedComponents/UploadStatus/__snapshots__/UploadStatus.test.js.snap
@@ -71,7 +71,7 @@ exports[`UploadStatus displays complete icon when progress is 1 1`] = `
                 "color": "#74AC00",
                 "fontSize": 28,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",
@@ -135,7 +135,7 @@ exports[`UploadStatus displays progress bar when progress is greater than 5% 1`]
                 "color": "#454545",
                 "fontSize": 15,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",
@@ -207,7 +207,7 @@ exports[`UploadStatus displays rotating circle progress when upload is queued bu
                 "color": "#454545",
                 "fontSize": 15,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",
@@ -261,7 +261,7 @@ exports[`UploadStatus displays rotating circle progress when upload is queued bu
                 "color": "#454545",
                 "fontSize": 33,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",
@@ -374,7 +374,7 @@ exports[`UploadStatus displays start icon when upload is unsynced and not queued
                     "color": "#454545",
                     "fontSize": 15,
                   },
-                  null,
+                  {},
                   {
                     "fontFamily": "INatIcon",
                     "fontStyle": "normal",
@@ -428,7 +428,7 @@ exports[`UploadStatus displays start icon when upload is unsynced and not queued
                     "color": "#454545",
                     "fontSize": 33,
                   },
-                  null,
+                  {},
                   {
                     "fontFamily": "INatIcon",
                     "fontStyle": "normal",

--- a/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
+++ b/tests/unit/components/SharedComponents/__snapshots__/TaxonResult.test.js.snap
@@ -126,7 +126,7 @@ exports[`TaxonResult should render correctly 1`] = `
                       "color": "#454545",
                       "fontSize": 22,
                     },
-                    null,
+                    {},
                     {
                       "fontFamily": "INatIcon",
                       "fontStyle": "normal",
@@ -279,7 +279,7 @@ exports[`TaxonResult should render correctly 1`] = `
                 "color": "#454545",
                 "fontSize": 22,
               },
-              null,
+              {},
               {
                 "fontFamily": "INatIcon",
                 "fontStyle": "normal",

--- a/tests/unit/components/__snapshots__/INatIcon.test.js.snap
+++ b/tests/unit/components/__snapshots__/INatIcon.test.js.snap
@@ -10,7 +10,7 @@ exports[`INatIcon renders correctly 1`] = `
         "color": "#4F8EF7",
         "fontSize": 20,
       },
-      null,
+      {},
       {
         "fontFamily": "INatIcon",
         "fontStyle": "normal",


### PR DESCRIPTION
Fixes MOB-1713, a regression from the nativewind@4 upgrade.

note clipping of ✅ icon in lower right

|Before|After|
|---|---|
|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/0b9f38ad-6ac2-423c-98f2-a1a01abef249" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/23cd7d89-3cae-4e1b-8211-2ce5b5f30e84" />|

This is a general fix for our glyph based icons on Android because this also manifested in more subtle layout regressions.

Camera Icon:
|Before (lens off center)|After (lens centered)|iOS Reference (lens centered)|
|---|---|---|
|<img width="586" height="1308" alt="image" src="https://github.com/user-attachments/assets/3e09fae8-531f-4da2-a7ad-d2691830d4e7" />|<img width="589" height="1314" alt="image" src="https://github.com/user-attachments/assets/972d182f-2f31-4c42-b447-194c58da5937" />|<img width="583" height="1263" alt="image" src="https://github.com/user-attachments/assets/1409e1e7-e563-49c6-b868-f614316be896" />|

Menu layout:
|Before (extra space) |After (less space)|Side by Side split (right is After)
|---|---|---|
|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/a4df491b-1e52-4e49-b9cd-8aba1976a6c7" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6a32b30b-111d-4859-89a7-0f3198e27a3b" />|<img width="427" height="949" alt="image" src="https://github.com/user-attachments/assets/f14c61d2-0505-44a9-a007-2a4f31573a69" />|