### PR TITLE
MOB-1721 use url parsing to fix GH Security regex issue

### DIFF
--- a/src/components/SharedComponents/Map/helpers/mapHelpers.ts
+++ b/src/components/SharedComponents/Map/helpers/mapHelpers.ts
@@ -8,9 +8,20 @@ export const OBSCURATION_CELL_SIZE = 0.2;
 // tiles should be requested from tiles.inaturalist.org for better resource
 // balancing
 const API_URL = Config.API_URL || process.env.API_URL || "https://api.inaturalist.org/v2";
-export const TILE_URL = API_URL.match( /api\.inaturalist\.org/ )
-  ? API_URL.replace( "api.inaturalist", "tiles.inaturalist" )
-  : API_URL;
+
+function getTileUrl( apiUrl: string ) {
+  try {
+    const parsedUrl = new URL( apiUrl );
+    if ( parsedUrl.hostname === "api.inaturalist.org" ) {
+      parsedUrl.hostname = "tiles.inaturalist.org";
+      return parsedUrl.toString();
+    }
+    return apiUrl;
+  } catch {
+    return apiUrl;
+  }
+}
+export const TILE_URL = getTileUrl( API_URL );
 const POINT_TILES_ENDPOINT = `${TILE_URL}/points`;
 
 export function calculateZoom( width: number, delta: number ) {


### PR DESCRIPTION
addresses "High severity" GH security issue reported here: https://github.com/inaturalist/iNaturalistReactNative/pull/3987#discussion_r3866861127

I'm also fine just suppressing this issue since the relevant values are config driven.