### PR TITLE
MOB-1605 bottom padding to menu items to account for overflow/overlap

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -334,7 +334,7 @@ const Menu = ( ) => {
         </Pressable>
 
         {/* Menu Items */}
-        <View>
+        <View className="pb-[128px]">
           {Object.entries( menuItems ).map( ( [key, item] ) => (
             <MenuItem
               key={key}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -272,8 +272,7 @@ const Menu = ( ) => {
   }, [currentUser, isConnected, layoutPrefs, realm, t] );
 
   return (
-    <ScrollView
-      bounces={false}
+    <View
       className="bg-white h-full"
       style={{ paddingTop: top, paddingBottom: bottom }}
     >
@@ -288,7 +287,7 @@ const Menu = ( ) => {
               ? t( "Navigates-to-user-profile" )
               : t( "Navigates-to-log-in-screen" )
           }
-          className="px-[26px] pt-[68px] pb-[31px] border-b border-lightGray"
+          className="px-[26px] py-[31px] border-b border-lightGray"
           onPress={( ) => {
             if ( !currentUser ) {
               navigation.navigate( "LoginStackNavigator" );
@@ -334,7 +333,10 @@ const Menu = ( ) => {
         </Pressable>
 
         {/* Menu Items */}
-        <View className="pb-[128px]">
+        <ScrollView
+          bounces={false}
+          contentContainerClassName="pb-[128px]"
+        >
           {Object.entries( menuItems ).map( ( [key, item] ) => (
             <MenuItem
               key={key}
@@ -352,7 +354,7 @@ const Menu = ( ) => {
               }}
             />
           ) )}
-        </View>
+        </ScrollView>
       </View>
 
       {modalState === MenuModalState.ConfirmLogout && (
@@ -377,7 +379,7 @@ const Menu = ( ) => {
           maxLength={1000}
         />
       )}
-    </ScrollView>
+    </View>
   );
 };
 


### PR DESCRIPTION
closes MOB-1605 "can't scroll to last menu option"

I wasn't able to replicate the last option being unselectable, but I shimmed some menu items & padding to force a situation where it's at least awkward with the ObsButton overlap and the BottomTabs obscuring the BottomSeparator:

<img width="414" height="293" alt="image" src="https://github.com/user-attachments/assets/49065ca1-e61b-4461-974b-16a240924c35" />

Fix is just to provide some bottom padding to the items container that's generous to account for about half a menu item and the bottom overlap

Before:

https://github.com/user-attachments/assets/a2928820-9cfe-443e-bc87-bb0fc92affe6

After:

https://github.com/user-attachments/assets/0f87fe1c-41a3-4a65-a08c-4c18efda5e2e

