### PR TITLE
DateTimePicker never stores the picked date, Android shows two date pickers

### DIFF
--- a/src/components/SharedComponents/DateTimePicker.tsx
+++ b/src/components/SharedComponents/DateTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Platform } from "react-native";
 import DateTimePicker from "react-native-modal-datetime-picker";
 
 type PickerMode = "date" | "time" | "datetime";
@@ -30,6 +31,25 @@ const DatePicker = ( {
     setisTimeVisible( false );
     toggleDateTimePicker( );
   };
+
+  if ( Platform.OS === "android" && mode === "datetime" ) {
+    return (
+      <DateTimePicker
+        display="spinner"
+        isDarkModeEnabled={false}
+        themeVariant="light"
+        isVisible={isDateTimePickerVisible}
+        maximumDate={new Date( )}
+        mode="datetime"
+        onCancel={toggleDateTimePicker}
+        onConfirm={selectedDate => {
+          onDatePicked( selectedDate );
+          toggleDateTimePicker( );
+        }}
+        date={date || new Date( )}
+      />
+    );
+  }
 
   if ( mode === "datetime" && isTimeVisible ) {
     return (

--- a/src/components/SharedComponents/DateTimePicker.tsx
+++ b/src/components/SharedComponents/DateTimePicker.tsx
@@ -22,7 +22,6 @@ const DatePicker = ( {
   onDatePicked,
   toggleDateTimePicker,
 }: Props ) => {
-  const [selectedDateNoTime, setSelectedDateNoTime] = React.useState<Date | undefined>( undefined );
   const [isTimeVisible, setisTimeVisible] = React.useState( false );
   const maxDateForTimePicker = new Date( );
   maxDateForTimePicker.setHours( 24, 0, 0, 0 );
@@ -47,7 +46,6 @@ const DatePicker = ( {
           onDatePicked( selectedDate );
           _toggleDateTimePicker( );
         }}
-        date={selectedDateNoTime}
       />
     );
   }
@@ -84,7 +82,6 @@ const DatePicker = ( {
       onCancel={_toggleDateTimePicker}
       onConfirm={selectedDate => {
         if ( mode === "datetime" ) {
-          setSelectedDateNoTime( selectedDateNoTime );
           setisTimeVisible( true );
         } else {
           onDatePicked( selectedDate );


### PR DESCRIPTION
Firt commit closes MOB-1551
Second commit closes MOB-1635

MOB-1551 wasn't really a user-facing bug because the library modal stays open and keeps an inner state of the first date picked and so the date= of the second modal was never applied. Removed the React state to not confuse us.

While I was in there I fixed the second bug of two date pickers showing on Android (or one picker showing and on close no further interaction on some manufacturer) instead of one for date and one for time.
Before right, after left:

https://github.com/user-attachments/assets/6902cf69-2512-49e5-9443-787901eea148

