### PR TITLE
DateTimePicker never stores the picked date

### DIFF
--- a/src/components/SharedComponents/DateTimePicker.tsx
+++ b/src/components/SharedComponents/DateTimePicker.tsx
@@ -22,7 +22,6 @@ const DatePicker = ( {
   onDatePicked,
   toggleDateTimePicker,
 }: Props ) => {
-  const [selectedDateNoTime, setSelectedDateNoTime] = React.useState<Date | undefined>( undefined );
   const [isTimeVisible, setisTimeVisible] = React.useState( false );
   const maxDateForTimePicker = new Date( );
   maxDateForTimePicker.setHours( 24, 0, 0, 0 );
@@ -47,7 +46,6 @@ const DatePicker = ( {
           onDatePicked( selectedDate );
           _toggleDateTimePicker( );
         }}
-        date={selectedDateNoTime}
       />
     );
   }
@@ -84,7 +82,6 @@ const DatePicker = ( {
       onCancel={_toggleDateTimePicker}
       onConfirm={selectedDate => {
         if ( mode === "datetime" ) {
-          setSelectedDateNoTime( selectedDateNoTime );
           setisTimeVisible( true );
         } else {
           onDatePicked( selectedDate );


### PR DESCRIPTION
Closes [MOB-1551](https://linear.app/inaturalist/issue/MOB-1551) which wasn't really a user-facing bug because the library modal stays open and keeps an inner state of the first date picked and so the date= of the second modal was never applied. Removed the React state to not confuse us.