### PR TITLE
DateTimePicker on Android shows two date pickers

### DIFF
--- a/src/components/SharedComponents/DateTimePicker.tsx
+++ b/src/components/SharedComponents/DateTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Platform } from "react-native";
 import DateTimePicker from "react-native-modal-datetime-picker";
 
 type PickerMode = "date" | "time" | "datetime";
@@ -31,6 +32,25 @@ const DatePicker = ( {
     setisTimeVisible( false );
     toggleDateTimePicker( );
   };
+
+  if ( Platform.OS === "android" && mode === "datetime" ) {
+    return (
+      <DateTimePicker
+        display="spinner"
+        isDarkModeEnabled={false}
+        themeVariant="light"
+        isVisible={isDateTimePickerVisible}
+        maximumDate={new Date( )}
+        mode="datetime"
+        onCancel={toggleDateTimePicker}
+        onConfirm={selectedDate => {
+          onDatePicked( selectedDate );
+          toggleDateTimePicker( );
+        }}
+        date={date || new Date( )}
+      />
+    );
+  }
 
   if ( mode === "datetime" && isTimeVisible ) {
     return (


### PR DESCRIPTION
Closes MOB-1635, also closes MOB-315.

Fixes a bug where on Android we were showing the date picker twice. The modal was closing after the first pick and recreated for the second pick, so without isTimeVisible.
On some manufacturer there was only one picker showing and on close no further interaction was possible, instead of one picker for date and then one for time.

Before right, after left:

https://github.com/user-attachments/assets/1c1d88d3-a192-45c5-a354-422a92fb4332

