### PR TITLE
Mob 1629 images flash onoff as user selects them for cv

### DIFF
--- a/src/components/Suggestions/ObsPhotoSelectionList.tsx
+++ b/src/components/Suggestions/ObsPhotoSelectionList.tsx
@@ -31,7 +31,7 @@ const ObsPhotoSelectionList = ( {
     >
       <View
         className={classnames(
-          "rounded-lg overflow-hidden",
+          "w-[83px] h-[83px] rounded-lg",
           {
             "border-inatGreen border-[3px]": selectedPhotoUri === item,
           },

--- a/src/components/Suggestions/ObsPhotoSelectionList.tsx
+++ b/src/components/Suggestions/ObsPhotoSelectionList.tsx
@@ -41,7 +41,13 @@ const ObsPhotoSelectionList = ( {
         <Image
           source={{ uri: item }}
           accessibilityIgnoresInvertColors
-          className="w-full h-full"
+          className={classnames(
+            "w-full h-full",
+            // Match the inner edge of the selected border, i.e. rounded-lg minus 3px border width
+            selectedPhotoUri === item
+              ? "rounded-[5px]"
+              : "rounded-lg",
+          )}
         />
       </View>
     </Pressable>


### PR DESCRIPTION
closes [MOB-1629](https://linear.app/inaturalist/issue/MOB-1629/images-flash-onoff-as-user-selects-them-for-cv)

On Android, overflow: hidden + a border radius makes RN clip children against a path derived from the border box. So when border width on this view changed, the photo got clipped entirely, and came back if it was re-selected and the border returned.