### PR TITLE
Mob 1693 show iconic taxa instead of empty species grid

### DIFF
--- a/src/components/MyObservations/SimpleTaxonGridItem.tsx
+++ b/src/components/MyObservations/SimpleTaxonGridItem.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { Body4, DisplayTaxonName } from "components/SharedComponents";
+import { Body4, DisplayTaxonName, IconicTaxonIcon } from "components/SharedComponents";
 import INatIconButton from "components/SharedComponents/Buttons/INatIconButton";
 import {
   Image, LinearGradient, Pressable, View,
@@ -53,13 +53,23 @@ const SimpleTaxonGridItem = ( {
       className={classNames( imageClassNames )}
       style={style}
     >
-      <Image
-        source={source}
-        className="grow aspect-square"
-        testID="TaxonGridItem.photo"
-        accessibilityIgnoresInvertColors
-        fadeDuration={0}
-      />
+      <View className="absolute w-full h-full">
+        <IconicTaxonIcon
+          imageClassName={["grow", "aspect-square", "border-0"]}
+          iconicTaxonName={speciesCount?.taxon?.iconic_taxon_name}
+          isBackground
+          size={100}
+        />
+      </View>
+      { source?.uri && (
+        <Image
+          source={source}
+          className="grow aspect-square"
+          testID="TaxonGridItem.photo"
+          accessibilityIgnoresInvertColors
+          fadeDuration={0}
+        />
+      ) }
       <LinearGradient
         colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0.6) 100%)"]}
         className="absolute w-full h-full"

--- a/tests/unit/components/MyObservations/SimpleTaxonGridItem.test.js
+++ b/tests/unit/components/MyObservations/SimpleTaxonGridItem.test.js
@@ -9,6 +9,7 @@ const mockTaxon = factory( "RemoteTaxon", {
   id: 123,
   name: "Calidris alba",
   preferred_common_name: "Sanderling",
+  iconic_taxon_name: "Aves",
 } );
 
 const mockSpeciesCount = { count: 3, taxon: mockTaxon };
@@ -18,13 +19,16 @@ const mockSearchThisTaxon = jest.fn( );
 
 const actor = userEvent.setup( );
 
-const renderGridItem = ( { canSearchFromSpeciesTab = false } = {} ) => renderComponent(
+const renderGridItem = ( {
+  canSearchFromSpeciesTab = false,
+  source = { uri: "https://example.com/photo.jpg" },
+} = {} ) => renderComponent(
   <SimpleTaxonGridItem
     accessibleName="Sanderling"
     canSearchFromSpeciesTab={canSearchFromSpeciesTab}
     navToTaxonDetails={mockNavToTaxonDetails}
     searchThisTaxon={mockSearchThisTaxon}
-    source={{ uri: "https://example.com/photo.jpg" }}
+    source={source}
     speciesCount={mockSpeciesCount}
   />,
 );
@@ -39,6 +43,20 @@ beforeEach( ( ) => {
 } );
 
 describe( "SimpleTaxonGridItem", ( ) => {
+  it( "renders the iconic taxon icon behind the photo", ( ) => {
+    renderGridItem( );
+
+    expect( screen.getByTestId( "IconicTaxonName.iconicTaxonIcon" ) ).toBeVisible( );
+    expect( screen.getByTestId( "TaxonGridItem.photo" ) ).toBeVisible( );
+  } );
+
+  it( "renders the iconic taxon icon when there is no photo to show", ( ) => {
+    renderGridItem( { source: { uri: undefined } } );
+
+    expect( screen.getByTestId( "IconicTaxonName.iconicTaxonIcon" ) ).toBeVisible( );
+    expect( screen.queryByTestId( "TaxonGridItem.photo" ) ).toBeNull( );
+  } );
+
   describe( "when canSearchFromSpeciesTab is false", ( ) => {
     it( "navigates to taxon details when the card is pressed", async ( ) => {
       renderGridItem( { canSearchFromSpeciesTab: false } );


### PR DESCRIPTION
closes [MOB-1693](https://linear.app/inaturalist/issue/MOB-1693/show-iconic-taxa-instead-of-empty-species-grid)

<details>
<summary>screenshot</summary>

<img width="1170" height="2532" alt="IMG_5558" src="https://github.com/user-attachments/assets/d3d5507a-3002-4794-81b1-a9d5a63d0e3e" />

</details>
