### PR TITLE
MOB-1735 remove test code validating testflight/admin feature flag setting

### DIFF
--- a/src/components/Developer/Developer.tsx
+++ b/src/components/Developer/Developer.tsx
@@ -17,10 +17,7 @@ import { t } from "i18next";
 import React, { useState } from "react";
 import { I18nManager, Platform, Text } from "react-native";
 import Config from "react-native-config";
-import DeviceInfo from "react-native-device-info";
 import RNRestart from "react-native-restart";
-import { useFeatureFlag } from "sharedHooks";
-import { FeatureFlag } from "stores/createFeatureFlagSlice";
 
 import {
   CODE, H1, H2, P,
@@ -259,30 +256,6 @@ const PathStats = () => {
   );
 };
 
-// Temporary diagnostic use of admin/testflight config.
-const TestFlightAdminFeatureFlagTest = () => {
-  const enabled = useFeatureFlag( FeatureFlag.TestFlightAdminMessageEnabled );
-  const label = `Test message "Feature Flags for Admins in TestFlight" is: ${enabled
-    ? "Enabled"
-    : "Disabled"}`;
-  // eslint-disable-next-line max-len
-  const description = "(Should be \"Enabled\" if user is logged in and this is a build installed from TestFlight OR if the feature flag is manually overridden above.)";
-  // eslint-disable-next-line max-len
-  const resolvedInstallerPackageName = `Resolved DeviceInfo.getInstallerPackageNameSync(): ${DeviceInfo.getInstallerPackageNameSync()}`;
-  return (
-    <>
-      <H1>Temporary Feature Flag Config Test</H1>
-      <P>
-        {label}
-      </P>
-      <P>{description}</P>
-      <P>
-        {resolvedInstallerPackageName}
-      </P>
-    </>
-  );
-};
-
 const Developer = () => {
   return (
     <ScrollViewWrapper>
@@ -293,8 +266,6 @@ const Developer = () => {
         <FeatureFlags />
         <PathStats />
         <AppFileSizes />
-        {/* TODO: remove once MOB-1573 is validated in TestFlight */}
-        <TestFlightAdminFeatureFlagTest />
       </View>
 
     </ScrollViewWrapper>

--- a/src/stores/createFeatureFlagSlice.ts
+++ b/src/stores/createFeatureFlagSlice.ts
@@ -16,7 +16,8 @@ import type { StateCreator } from "zustand";
 // overriding its default "live" status. This is done through the "Debug" / "Developer" screen.
 // These are not persisted so will be reset to their defaults on app start.
 
-// TODO: move this to more a more global type definition scope
+// When adding a new feature flag, consider creating a Linear ticket to track removing the
+// flag and obviated dead code
 export enum FeatureFlag {
   // flags should use positive language ending with `Enabled`
   // MyFeatureFlagEnabled = "myFeatureFlagEnabled",
@@ -26,13 +27,10 @@ export enum FeatureFlag {
   SearchMyObservationsEnabled = "searchMyObservationsEnabled",
   SortMyObservationsEnabled = "sortMyObservationsEnabled",
   MyObservationsMapViewEnabled = "myObservationsMapViewEnabled",
-  // TODO: remove once MOB-1573 is validated in TestFlight
-  TestFlightAdminMessageEnabled = "testFlightAdminMessageEnabled",
   MyObservationsSmallGridViewEnabled = "myObservationsSmallGridViewEnabled",
 }
 
 export const flagsEnabledForAdminsInTestFlight = [
-  FeatureFlag.TestFlightAdminMessageEnabled,
   FeatureFlag.ExploreV2Enabled,
 ];
 
@@ -44,7 +42,6 @@ const initialFeatureFlagConfig: Record<FeatureFlag, boolean> = {
   [FeatureFlag.SearchMyObservationsEnabled]: true,
   [FeatureFlag.SortMyObservationsEnabled]: true,
   [FeatureFlag.MyObservationsMapViewEnabled]: true,
-  [FeatureFlag.TestFlightAdminMessageEnabled]: false,
   [FeatureFlag.MyObservationsSmallGridViewEnabled]: false,
 };
 
@@ -56,7 +53,6 @@ const initialFeatureFlagDebugOverrides: Record<FeatureFlag, boolean | null> = {
   [FeatureFlag.SearchMyObservationsEnabled]: null,
   [FeatureFlag.SortMyObservationsEnabled]: null,
   [FeatureFlag.MyObservationsMapViewEnabled]: null,
-  [FeatureFlag.TestFlightAdminMessageEnabled]: null,
   [FeatureFlag.MyObservationsSmallGridViewEnabled]: null,
 };
 


### PR DESCRIPTION
closes MOB-1735

remove code testing the admin/testflight-only feature flag setting now that it's validated in test flight / prod.