### PR TITLE
Don't show the exploreV2 header back button when we're on RootExplore

### DIFF
--- a/src/components/Explore/ExploreV2/ExploreV2Container.tsx
+++ b/src/components/Explore/ExploreV2/ExploreV2Container.tsx
@@ -6,11 +6,11 @@ import { ExploreV2Provider, initialStateFromEntryParams } from "providers/Explor
 import React from "react";
 
 const ExploreV2Container = ( ) => {
-  const { params } = useRoute<TabStackScreenProps<"Explore" | "RootExplore">["route"]>( );
+  const { name, params } = useRoute<TabStackScreenProps<"Explore" | "RootExplore">["route"]>( );
 
   return (
     <ExploreV2Provider initialState={initialStateFromEntryParams( params )}>
-      <ExploreStackNavigator />
+      <ExploreStackNavigator showBackButton={name !== "RootExplore"} />
     </ExploreV2Provider>
   );
 };

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -169,7 +169,11 @@ const SubjectHeader = ( {
   </View>
 );
 
-const ExploreV2Header = ( ) => {
+interface Props {
+  showBackButton: boolean;
+}
+
+const ExploreV2Header = ( { showBackButton }: Props ) => {
   const { t } = useTranslation( );
   const { state } = useExploreV2( );
   const currentUser = useCurrentUser( );
@@ -219,7 +223,7 @@ const ExploreV2Header = ( ) => {
         onPress={() => navigation.navigate( searchScreen )}
         testID="ExploreV2Header.pressable"
       >
-        <BackButton />
+        {showBackButton && <BackButton />}
         {headerContent}
         <View>
           <ContainedSquareButton

--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -1,5 +1,5 @@
 import { refresh, useNetInfo } from "@react-native-community/netinfo";
-import { useFocusEffect } from "@react-navigation/native";
+import { useFocusEffect, useRoute } from "@react-navigation/native";
 import type { ApiTotalBounds } from "api/types";
 import {
   IDENTIFIERS_TAB,
@@ -38,6 +38,7 @@ import {
 } from "components/SharedComponents";
 import SortButton from "components/SharedComponents/Buttons/SortButton";
 import { View } from "components/styledComponents";
+import type { ExploreStackScreenProps } from "navigation/types";
 import { EXPLORE_V2_ACTION, EXPLORE_V2_PLACE_MODE, useExploreV2 } from "providers/ExploreV2Context";
 import React, { useCallback, useMemo, useState } from "react";
 import type { OBSERVATIONS_SORT } from "sharedHelpers/observationsSort";
@@ -71,6 +72,7 @@ interface SortOption<SortValue> {
 
 const ExploreResults = ( ) => {
   const { dispatch, state } = useExploreV2( );
+  const { params } = useRoute<ExploreStackScreenProps<"ExploreResults">["route"]>( );
   const currentUser = useCurrentUser( );
   const currentUserId = currentUser?.id;
   const {
@@ -327,7 +329,7 @@ const ExploreResults = ( ) => {
   return (
     <ViewWrapper testID="ExploreResults" wrapperClassName="overflow-hidden">
       <View className="flex-1 overflow-hidden">
-        <ExploreV2Header />
+        <ExploreV2Header showBackButton={Boolean( params?.showBackButton )} />
         <ExploreV2Tabs
           observationsCount={canFetch
             ? totalResults

--- a/src/navigation/StackNavigators/ExploreStackNavigator.tsx
+++ b/src/navigation/StackNavigators/ExploreStackNavigator.tsx
@@ -13,11 +13,16 @@ import React from "react";
 // useNavigation<ExploreStackScreenProps<"ExploreResults">["navigation"]>( );
 const Stack = createNativeStackNavigator<ExploreStackParamList>( );
 
-const ExploreStackNavigator = ( ) => (
+interface Props {
+  showBackButton: boolean;
+}
+
+const ExploreStackNavigator = ( { showBackButton }: Props ) => (
   <Stack.Navigator initialRouteName="ExploreResults">
     <Stack.Screen
       name="ExploreResults"
       component={ExploreResults}
+      initialParams={{ showBackButton }}
       options={hideHeader}
     />
     <Stack.Screen

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -219,7 +219,7 @@ export type OnboardingStackParamList = {
 // The type containing the mapping must be a type alias. It cannot be an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ExploreStackParamList = {
-  ExploreResults: undefined;
+  ExploreResults: { showBackButton?: boolean } | undefined;
   UniversalSearch: undefined;
   AdvancedSearch: undefined;
 };

--- a/tests/unit/components/Explore/ExploreV2/components/ExploreV2Header.test.js
+++ b/tests/unit/components/Explore/ExploreV2/components/ExploreV2Header.test.js
@@ -7,6 +7,7 @@ import useStore from "stores/useStore";
 import { renderComponent } from "tests/helpers/render";
 
 const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn( () => false );
 
 jest.mock( "@react-navigation/native", () => {
   const actualNav = jest.requireActual( "@react-navigation/native" );
@@ -16,7 +17,7 @@ jest.mock( "@react-navigation/native", () => {
       navigate: mockNavigate,
       goBack: jest.fn(),
       push: jest.fn(),
-      canGoBack: jest.fn( () => false ),
+      canGoBack: mockCanGoBack,
       dispatch: jest.fn(),
     } ),
   };
@@ -51,12 +52,13 @@ const setState = ( subject, location = PLACE_LOCATION, filters = defaultExploreV
 describe( "ExploreV2Header", () => {
   beforeEach( () => {
     mockNavigate.mockClear();
+    mockCanGoBack.mockReturnValue( false );
     useStore.getState().exploreV2AdvancedSearch.setAdvancedSearchMode( false );
   } );
 
   it( "renders a user subject with login and location", () => {
     setState( { type: "user", user: { id: 7, login: "seth_msp" } } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "seth_msp" ) ).toBeTruthy();
     expect( screen.getByText( "California" ) ).toBeTruthy();
@@ -67,7 +69,7 @@ describe( "ExploreV2Header", () => {
       type: "user",
       user: { id: 7, login: "seth_msp", icon_url: "https://example.com/u.jpg" },
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByTestId( "UserIcon.photo" ) ).toBeTruthy();
   } );
@@ -77,7 +79,7 @@ describe( "ExploreV2Header", () => {
       type: "project",
       project: { id: 9, title: "Backyard Birds", icon: "https://example.com/p.jpg" },
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "Backyard Birds" ) ).toBeTruthy();
     expect( screen.getByTestId( "ExploreV2Header.projectImage" ) ).toBeTruthy();
@@ -89,7 +91,7 @@ describe( "ExploreV2Header", () => {
       type: "project",
       project: { id: 9, title: "Backyard Birds" },
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "Backyard Birds" ) ).toBeTruthy();
     expect( screen.queryByTestId( "ExploreV2Header.projectImage" ) ).toBeNull();
@@ -106,7 +108,7 @@ describe( "ExploreV2Header", () => {
         iconic_taxon_name: "Aves",
       },
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByTestId( "ExploreV2Header.taxonImage" ) ).toBeTruthy();
     expect( screen.getByText( "California" ) ).toBeTruthy();
@@ -121,7 +123,7 @@ describe( "ExploreV2Header", () => {
         iconic_taxon_name: "Aves",
       },
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.queryByTestId( "ExploreV2Header.taxonImage" ) ).toBeNull();
     expect( screen.getByTestId( "IconicTaxonName.iconicTaxonIcon" ) ).toBeTruthy();
@@ -132,7 +134,7 @@ describe( "ExploreV2Header", () => {
       { type: "unobserved", user: { id: 7, login: "seth_msp" } },
       { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE },
     );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "Unobserved" ) ).toBeTruthy();
     expect( screen.getByText( "Worldwide" ) ).toBeTruthy();
@@ -142,7 +144,7 @@ describe( "ExploreV2Header", () => {
 
   it( "renders an unknown subject with the iconic-unknown icon and Unknown label", () => {
     setState( { type: "unknown" } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByTestId( "ExploreV2Header.subject" ) ).toBeTruthy();
     expect( screen.getByTestId( "IconicTaxonName.iconicTaxonIcon" ) ).toBeTruthy();
@@ -152,7 +154,7 @@ describe( "ExploreV2Header", () => {
 
   it( "renders only the place name when there is no subject", () => {
     setState( null );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "California" ) ).toBeTruthy();
     expect( screen.queryByTestId( "ExploreV2Header.subject" ) ).toBeNull();
@@ -160,14 +162,14 @@ describe( "ExploreV2Header", () => {
 
   it( "renders the Worldwide label when location is worldwide", () => {
     setState( null, { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "Worldwide" ) ).toBeTruthy();
   } );
 
   it( "renders the Nearby label when location is nearby", () => {
     setState( null, { placeMode: EXPLORE_V2_PLACE_MODE.NEARBY } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "Nearby" ) ).toBeTruthy();
   } );
@@ -179,7 +181,7 @@ describe( "ExploreV2Header", () => {
         swlat: 1, swlng: 2, nelat: 3, nelng: 4,
       },
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "Map Area" ) ).toBeTruthy();
   } );
@@ -187,7 +189,7 @@ describe( "ExploreV2Header", () => {
   it( "navigates to Universal Search when the header is tapped", async () => {
     const actor = userEvent.setup();
     setState( null );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     await actor.press( screen.getByTestId( "ExploreV2Header.pressable" ) );
 
@@ -197,7 +199,7 @@ describe( "ExploreV2Header", () => {
   it( "navigates to Universal Search when the search button is tapped", async () => {
     const actor = userEvent.setup();
     setState( null );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     await actor.press( screen.getByLabelText( "Search" ) );
 
@@ -208,12 +210,30 @@ describe( "ExploreV2Header", () => {
     const actor = userEvent.setup();
     useStore.getState().exploreV2AdvancedSearch.setAdvancedSearchMode( true );
     setState( null );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.queryByLabelText( "Search" ) ).toBeNull();
     await actor.press( screen.getByLabelText( "Filters" ) );
 
     expect( mockNavigate ).toHaveBeenCalledWith( "AdvancedSearch" );
+  } );
+
+  it( "renders no back button at the root of the Explore tab", () => {
+    // the bottom tabs' backBehavior="history" makes canGoBack true whenever
+    // the user arrived from another tab
+    mockCanGoBack.mockReturnValue( true );
+    setState( null );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
+
+    expect( screen.queryByTestId( "BackButton" ) ).toBeNull();
+  } );
+
+  it( "renders a back button when Explore was pushed onto another screen", () => {
+    mockCanGoBack.mockReturnValue( true );
+    setState( null );
+    renderComponent( <ExploreV2Header showBackButton /> );
+
+    expect( screen.getByTestId( "BackButton" ) ).toBeVisible();
   } );
 
   it( "badges the filters button with the number of filters applied", () => {
@@ -223,7 +243,7 @@ describe( "ExploreV2Header", () => {
       casual: true,
       media: MEDIA.SOUNDS,
     } );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect( screen.getByText( "2", { includeHiddenElements: true } ) ).toBeTruthy();
   } );
@@ -231,7 +251,7 @@ describe( "ExploreV2Header", () => {
   it( "shows no badge when the search has no filters", () => {
     useStore.getState().exploreV2AdvancedSearch.setAdvancedSearchMode( true );
     setState( null );
-    renderComponent( <ExploreV2Header /> );
+    renderComponent( <ExploreV2Header showBackButton={false} /> );
 
     expect(
       screen.queryByTestId( "ExploreV2Header.filterCount", { includeHiddenElements: true } ),

--- a/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
@@ -22,6 +22,7 @@ jest.mock( "@react-navigation/native", ( ) => {
   return {
     ...actualNav,
     useFocusEffect: cb => jest.requireActual( "react" ).useEffect( cb, [] ),
+    useRoute: ( ) => ( { params: {} } ),
   };
 } );
 


### PR DESCRIPTION
Little bug that came up during review. We can't rely on navigation's canGoBack because we really only want to show the back button when Explore has stuff underneath it in a stack, where navigation will report we can back navigate in the tabs.
