### PR TITLE
MOB-1354 defer sentinel logfile deletion

### DIFF
--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -14,7 +14,7 @@ import LinearGradient from "react-native-linear-gradient";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { VolumeManager } from "react-native-volume-manager";
 import convertScoreToConfidence from "sharedHelpers/convertScores";
-import { deleteSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
+import { completeSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
 import { logFirebaseEvent } from "sharedHelpers/tracking";
 import {
   useDebugMode,
@@ -197,7 +197,7 @@ const AICamera = ( {
   }, [handleTakePhoto, hasTakenPhoto, initialVolume] );
 
   const handleClose = async ( ) => {
-    await deleteSentinelFile( sentinelFileName );
+    await completeSentinelFile( sentinelFileName );
     navigation.navigate( "TabNavigator", {
       screen: "ObservationsTab",
       params: {
@@ -310,7 +310,7 @@ const AICamera = ( {
         zoomTextValue={zoomTextValue}
         useLocation={useLocation}
         toggleLocation={toggleLocation}
-        deleteSentinelFile={() => deleteSentinelFile( sentinelFileName )}
+        completeSentinelFile={() => completeSentinelFile( sentinelFileName )}
       />
     </>
   );

--- a/src/components/Camera/AICamera/AICameraButtons.tsx
+++ b/src/components/Camera/AICamera/AICameraButtons.tsx
@@ -32,7 +32,7 @@ interface Props {
   zoomTextValue: string;
   useLocation: boolean;
   toggleLocation: ( ) => void;
-  deleteSentinelFile: ( ) => Promise<void>;
+  completeSentinelFile: ( ) => Promise<void>;
 }
 
 const AICameraButtons = ( {
@@ -51,7 +51,7 @@ const AICameraButtons = ( {
   zoomTextValue,
   useLocation,
   toggleLocation,
-  deleteSentinelFile,
+  completeSentinelFile,
 }: Props ) => {
   const { bottom } = useSafeAreaInsets( );
   const { isDefaultMode } = useLayoutPrefs();
@@ -78,7 +78,7 @@ const AICameraButtons = ( {
         useLocation={useLocation}
         toggleLocation={toggleLocation}
         isDefaultMode={isDefaultMode}
-        deleteSentinelFile={deleteSentinelFile}
+        completeSentinelFile={completeSentinelFile}
       />
     );
   }
@@ -139,7 +139,7 @@ const AICameraButtons = ( {
           <PhotoLibraryIcon
             rotatableAnimatedStyle={rotatableAnimatedStyle}
             disabled={takingPhoto}
-            deleteSentinelFile={deleteSentinelFile}
+            completeSentinelFile={completeSentinelFile}
           />
         </View>
       </View>

--- a/src/components/Camera/Buttons/PhotoLibraryIcon.tsx
+++ b/src/components/Camera/Buttons/PhotoLibraryIcon.tsx
@@ -9,13 +9,13 @@ import colors from "styles/tailwindColors";
 
 interface Props {
   rotatableAnimatedStyle: ViewStyle;
-  deleteSentinelFile: ( ) => Promise<void>;
+  completeSentinelFile: ( ) => Promise<void>;
   disabled?: boolean;
 }
 
 const PhotoLibraryIcon = ( {
   rotatableAnimatedStyle,
-  deleteSentinelFile,
+  completeSentinelFile,
   disabled,
 }: Props ) => {
   const { t } = useTranslation( );
@@ -36,7 +36,7 @@ const PhotoLibraryIcon = ( {
           "rounded",
         )}
         onPress={() => {
-          deleteSentinelFile();
+          completeSentinelFile();
           navigation.push( "PhotoLibrary", {
             cmonBack: true,
             lastScreen: "Camera",

--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -20,7 +20,7 @@ import type {
 import fetchAccurateUserLocation from "sharedHelpers/fetchAccurateUserLocation";
 import { log } from "sharedHelpers/logger";
 import { hasWriteMediaPermission } from "sharedHelpers/permissions";
-import { createSentinelFile, deleteSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
+import { completeSentinelFile, createSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
 import { useTranslation } from "sharedHooks";
 import useLocationPermission from "sharedHooks/useLocationPermission";
 import { FIREBASE_TRACE_ATTRIBUTES, FIREBASE_TRACES } from "stores/createFirebaseTraceSlice";
@@ -80,9 +80,9 @@ const CameraContainer = ( ) => {
     await logStage( sentinelFileName, stageName, stageData );
   }, [cameraType, sentinelFileName] );
 
-  const deleteStageIfAICamera = useCallback( async ( ) => {
+  const completeStageIfAICamera = useCallback( async ( ) => {
     if ( cameraType !== "AI" ) { return; }
-    await deleteSentinelFile( sentinelFileName );
+    await completeSentinelFile( sentinelFileName );
   }, [cameraType, sentinelFileName] );
 
   const {
@@ -187,7 +187,7 @@ const CameraContainer = ( ) => {
         userLocation: accurateUserLocation,
         newPhotoState,
         logStageIfAICamera,
-        deleteStageIfAICamera,
+        completeStageIfAICamera,
         visionResult,
       } );
     } finally {
@@ -197,7 +197,7 @@ const CameraContainer = ( ) => {
   }, [
     prepareStoreAndNavigate,
     logStageIfAICamera,
-    deleteStageIfAICamera,
+    completeStageIfAICamera,
     startFirebaseTrace,
   ] );
 

--- a/src/components/Camera/TabletButtons.tsx
+++ b/src/components/Camera/TabletButtons.tsx
@@ -57,7 +57,7 @@ interface Props {
   useLocation: boolean;
   toggleLocation: ( ) => void;
   isDefaultMode: boolean;
-  deleteSentinelFile: ( ) => Promise<void>;
+  completeSentinelFile: ( ) => Promise<void>;
 }
 
 // Empty space where a camera button should be so buttons don't jump around
@@ -95,7 +95,7 @@ const TabletButtons = ( {
   useLocation,
   toggleLocation,
   isDefaultMode,
-  deleteSentinelFile,
+  completeSentinelFile,
 }: Props ) => {
   const tabletCameraOptionsClasses = [
     "absolute",
@@ -170,7 +170,7 @@ const TabletButtons = ( {
           <PhotoLibraryIcon
             rotatableAnimatedStyle={rotatableAnimatedStyle}
             disabled={disabledPhotoLibrary}
-            deleteSentinelFile={deleteSentinelFile}
+            completeSentinelFile={completeSentinelFile}
           />
         </View>
       ) }

--- a/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
+++ b/src/components/Camera/hooks/usePrepareStoreAndNavigate.ts
@@ -75,6 +75,7 @@ const usePrepareStoreAndNavigate = ( ) => {
     uris,
     userLocation,
     logStageIfAICamera,
+    completeStageIfAICamera,
     visionResult,
   ) => {
     const newObservation = await Observation.new( );
@@ -100,21 +101,30 @@ const usePrepareStoreAndNavigate = ( ) => {
       newObservation.taxon = visionResult.taxon;
     }
     setObservations( [newObservation] );
+    // Not awaited so navigation isn't blocked; .finally() keeps this after
+    // the stages logged above.
     handleSavingToPhotoLibrary(
       uris,
       userLocation,
       logStageIfAICamera,
-    ).catch( e => logger.error( "createObsWithCameraPhotos: error saving to photo library", e ) );
+    )
+      .catch( e => logger.error( "createObsWithCameraPhotos: error saving to photo library", e ) )
+      .finally( ( ) => {
+        completeStageIfAICamera( );
+        setSentinelFileName( null );
+      } );
   }, [
     isDefaultMode,
     screenAfterPhotoEvidence,
     setObservations,
+    setSentinelFileName,
     handleSavingToPhotoLibrary,
   ] );
 
   const updateObsWithCameraPhotos = useCallback( async (
     userLocation,
     logStageIfAICamera,
+    completeStageIfAICamera,
   ) => {
     const obsPhotos = await ObservationPhoto.createObsPhotosWithPosition(
       evidenceToAdd,
@@ -129,11 +139,18 @@ const usePrepareStoreAndNavigate = ( ) => {
     const updatedObservations = [...observations];
     updatedObservations[currentObservationIndex] = updatedCurrentObservation;
     updateObservations( updatedObservations );
+    // Not awaited so navigation isn't blocked; .finally() keeps this after
+    // the stages logged above.
     handleSavingToPhotoLibrary(
       evidenceToAdd,
       userLocation,
       logStageIfAICamera,
-    ).catch( e => logger.error( "updateObsWithCameraPhotos: error saving to photo library", e ) );
+    )
+      .catch( e => logger.error( "updateObsWithCameraPhotos: error saving to photo library", e ) )
+      .finally( ( ) => {
+        completeStageIfAICamera( );
+        setSentinelFileName( null );
+      } );
   }, [
     evidenceToAdd,
     numOfObsPhotos,
@@ -141,6 +158,7 @@ const usePrepareStoreAndNavigate = ( ) => {
     observations,
     currentObservationIndex,
     updateObservations,
+    setSentinelFileName,
     handleSavingToPhotoLibrary,
   ] );
 
@@ -148,7 +166,7 @@ const usePrepareStoreAndNavigate = ( ) => {
     userLocation,
     newPhotoState,
     logStageIfAICamera,
-    deleteStageIfAICamera,
+    completeStageIfAICamera,
     visionResult,
   } ) => {
     if ( userLocation !== null ) {
@@ -158,9 +176,7 @@ const usePrepareStoreAndNavigate = ( ) => {
     // new observation
     const uris = newPhotoState?.cameraUris || cameraUris;
     if ( addEvidence ) {
-      await updateObsWithCameraPhotos( userLocation, logStageIfAICamera );
-      await deleteStageIfAICamera( );
-      setSentinelFileName( null );
+      await updateObsWithCameraPhotos( userLocation, logStageIfAICamera, completeStageIfAICamera );
       return navigation.navigate( "ObsEdit", { lastScreen: "Camera" } );
     }
 
@@ -168,10 +184,9 @@ const usePrepareStoreAndNavigate = ( ) => {
       uris,
       userLocation,
       logStageIfAICamera,
+      completeStageIfAICamera,
       visionResult,
     );
-    await deleteStageIfAICamera( );
-    setSentinelFileName( null );
 
     // Camera (multicapture and ai) in default mode should only go to Match screen
     if ( isDefaultMode ) {
@@ -189,7 +204,6 @@ const usePrepareStoreAndNavigate = ( ) => {
     cameraUris,
     addEvidence,
     createObsWithCameraPhotos,
-    setSentinelFileName,
     navigation,
     updateObsWithCameraPhotos,
     screenAfterPhotoEvidence,

--- a/src/sharedHelpers/sentinelFiles.ts
+++ b/src/sharedHelpers/sentinelFiles.ts
@@ -8,6 +8,9 @@ import { sentinelFilePath } from "../appConstants/paths";
 
 const logger = log.extend( "sentinelFiles" );
 
+// a sentinel with this stage is considered "clean" and not in need of reporting
+const FLOW_COMPLETE_STAGE = "flow_complete";
+
 const accessFullFilePath = ( fileName: string ) => `${sentinelFilePath}/${fileName}`;
 
 const generateSentinelFileName = ( screenName: string ): string => {
@@ -59,14 +62,14 @@ const logStage = async (
   }
 };
 
-const deleteSentinelFile = async ( sentinelFileName: string ): Promise<void> => {
-  try {
-    const fullFilePath = accessFullFilePath( sentinelFileName );
-    await unlink( fullFilePath );
-  } catch ( error ) {
-    console.error( "Failed to delete sentinel file:", error, sentinelFileName );
-  }
-};
+// marks flow as complete / non-problematic. sentinel flow writes are fire-and-forget
+// by design so that we don't hang during the critical path. We might have in-flight
+// flow writes at the time of "success" so instead of deleting the sentinel file, mark
+// as complete and let startup handle cleanup
+const completeSentinelFile = ( sentinelFileName: string ): Promise<void> => logStage(
+  sentinelFileName,
+  FLOW_COMPLETE_STAGE,
+);
 
 const logSentinelFiles = async ( ) => {
   const directoryExists = await exists( sentinelFilePath );
@@ -74,19 +77,26 @@ const logSentinelFiles = async ( ) => {
   const files = await readDir( sentinelFilePath );
 
   files.forEach( async file => {
-    const existingContent = await readFile( file.path, "utf8" );
-
-    const sentinelData = JSON.parse( existingContent );
-    if ( sentinelData.stages && sentinelData.stages.length > 0 ) {
-      logger.error( "Camera flow error: ", existingContent );
+    try {
+      const existingContent = await readFile( file.path, "utf8" );
+      const sentinelData = JSON.parse( existingContent );
+      const stages = sentinelData.stages || [];
+      const completedNormally = stages
+        .some( stage => stage.name === FLOW_COMPLETE_STAGE );
+      if ( stages.length > 0 && !completedNormally ) {
+        logger.error( "Camera flow error: ", existingContent );
+      }
+    } catch ( error ) {
+      logger.error( "Failed to process sentinel file:", error, file.path );
+    } finally {
+      await unlink( file.path );
     }
-    await unlink( file.path );
   } );
 };
 
 export {
+  completeSentinelFile,
   createSentinelFile,
-  deleteSentinelFile,
   logSentinelFiles,
   logStage,
 };


### PR DESCRIPTION
Closes MOB-1354

low priority, I don't think this has a functional implication, it was just annoying me enough to take a stab.

We have these sentinel files to track steps/stages during a obs create. We write to the file adding each stage. We try to do this in a "fire-and-forget" manner. We delete the file once the flow is complete.

We introduced a sneaky regression earlier this year that meant a write "fire-and-forget" coincided with a delete "fire-and-forget". The race condition causes a reliable error for writing to a just-deleted file.

The file is non-critical so instead of fixing this by awaiting the sentinel operations, I swapped the deletion out for a "complete" stage.

Now: instead of deleting sentinels on flow completion (which conflicts with in-flight writes), we mark the sentinel as a new "complete" state. The existing sentinel cleanup process on deferred startup is updated to filter these out of reporting but still delete them.