### PR TITLE
prevent redo search in map area from also opening an observation

### DIFF
--- a/src/components/Explore/MapView.tsx
+++ b/src/components/Explore/MapView.tsx
@@ -208,21 +208,6 @@ const MapView = ( {
 
   return (
     <View className="flex-1 overflow-hidden h-full">
-      <View className="z-10">
-        {showRedoSearchButton && (
-          <View
-            className="mx-auto"
-            style={DROP_SHADOW}
-          >
-            <Button
-              text={t( "REDO-SEARCH-IN-MAP-AREA" )}
-              level="focus"
-              className="top-[60px] absolute self-center"
-              onPress={handleRedoSearch}
-            />
-          </View>
-        )}
-      </View>
       <Map
         ref={mapRef}
         currentLocationButtonClassName="left-5 bottom-20"
@@ -239,6 +224,20 @@ const MapView = ( {
         onCurrentLocationPress={handleCurrentLocationPress}
         isLoading={isLoading}
       />
+      {showRedoSearchButton && (
+        <View
+          className="absolute top-[60px] left-0 right-0 items-center z-10"
+          pointerEvents="box-none"
+        >
+          <View style={DROP_SHADOW}>
+            <Button
+              text={t( "REDO-SEARCH-IN-MAP-AREA" )}
+              level="focus"
+              onPress={handleRedoSearch}
+            />
+          </View>
+        </View>
+      )}
       {isLoading && (
         <View style={centeredLoadingWheel} testID="activity-indicator">
           <ActivityIndicator size={activityIndicatorSize} />


### PR DESCRIPTION
closes [MOB-1571](https://linear.app/inaturalist/issue/MOB-1571/tapping-redo-search-in-map-area-in-android-also-opens-an-observation)

This was happening because the button was positioned outside its container's bounds. React still registered button taps, but Android's native touch handling skipped the empty container entirely and passed the same tap through to the map underneath, so we did both the search redo and obs taps on the map. Also added `box-none` so only the button itself handles touches.

@sepeterson this seems to be working just fine in explore v2, but we might want to add the `box-none` since trying to pan around the redo search button does not work. v minor but I thought I'd flag, since the code touched here is about to be irrelevant