### PR TITLE
MOB-1622 upload photos at q90

### DIFF
--- a/__mocks__/@bam.tech/react-native-image-resizer.ts
+++ b/__mocks__/@bam.tech/react-native-image-resizer.ts
@@ -1,5 +1,7 @@
 import mockNodePath from "path";
 
+export const MOCK_RESIZER_CACHE_PATH = "/mock/cache";
+
 export default ( {
   createResizedImage: jest.fn(
     async (
@@ -12,7 +14,7 @@ export default ( {
       outputPath,
     ) => {
       const filename = mockNodePath.basename( path );
-      return { uri: mockNodePath.join( outputPath, filename ) };
+      return { uri: mockNodePath.join( outputPath || MOCK_RESIZER_CACHE_PATH, filename ) };
     },
   ),
 } );

--- a/src/appConstants/photos.ts
+++ b/src/appConstants/photos.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const PHOTO_MAX_WIDTH = 2048;

--- a/src/realmModels/ObservationPhoto.ts
+++ b/src/realmModels/ObservationPhoto.ts
@@ -38,12 +38,11 @@ class ObservationPhoto extends Realm.Object {
     return localObsPhoto;
   }
 
-  static mapPhotoForUpload( photo: RealmPhoto ) {
-    const uri = Photo.getLocalPhotoUri( photo.localFilePath );
+  static mapPhotoForUpload( photo: RealmPhoto, uploadUri?: string | null ) {
     return {
       file: new FileUpload( {
-        uri,
-        name: uri?.split( "/" ).pop( ),
+        uri: uploadUri || Photo.getLocalPhotoUri( photo.localFilePath ),
+        name: photo.localFilePath?.split( "/" ).pop( ),
         type: "image/jpeg",
       } ),
     };

--- a/src/realmModels/Photo.ts
+++ b/src/realmModels/Photo.ts
@@ -2,6 +2,7 @@ import { copyAssetsFileIOS, mkdir } from "@dr.pogodin/react-native-fs";
 import { Realm } from "@realm/react";
 import type { ApiPhoto } from "api/types";
 import { photoUploadPath } from "appConstants/paths";
+import { PHOTO_MAX_WIDTH } from "appConstants/photos";
 import { Platform } from "react-native";
 import type { RealmPhoto } from "realmModels/types";
 import resizeImage from "sharedHelpers/resizeImage";
@@ -26,7 +27,7 @@ class Photo extends Realm.Object {
   }
 
   static async resizeImageForUpload( pathOrUri: string ): Promise<string> {
-    const width = 2048;
+    const width = PHOTO_MAX_WIDTH;
     await mkdir( photoUploadPath );
     let outFilename = pathOrUri.split( "/" ).slice( -1 ).pop( );
 

--- a/src/sharedHelpers/compressPhotoForUpload.ts
+++ b/src/sharedHelpers/compressPhotoForUpload.ts
@@ -1,0 +1,18 @@
+import resizeImage from "sharedHelpers/resizeImage";
+
+// Photos in photoUploads/ are kept at q100 to optimize cv
+// for the upload image, we do more compression.
+// With no outputPath the resizer writes to the OS cache folder
+const UPLOAD_PHOTO_WIDTH = 2048;
+const UPLOAD_PHOTO_QUALITY = 90;
+
+const compressPhotoForUpload = async ( uri: string ): Promise<string> => resizeImage( uri, {
+  width: UPLOAD_PHOTO_WIDTH,
+  quality: UPLOAD_PHOTO_QUALITY,
+  imageOptions: {
+    mode: "contain",
+    onlyScaleDown: true,
+  },
+} );
+
+export default compressPhotoForUpload;

--- a/src/sharedHelpers/compressPhotoForUpload.ts
+++ b/src/sharedHelpers/compressPhotoForUpload.ts
@@ -1,13 +1,13 @@
+import { PHOTO_MAX_WIDTH } from "appConstants/photos";
 import resizeImage from "sharedHelpers/resizeImage";
 
 // Photos in photoUploads/ are kept at q100 to optimize cv
 // for the upload image, we do more compression.
 // With no outputPath the resizer writes to the OS cache folder
-const UPLOAD_PHOTO_WIDTH = 2048;
 const UPLOAD_PHOTO_QUALITY = 90;
 
 const compressPhotoForUpload = async ( uri: string ): Promise<string> => resizeImage( uri, {
-  width: UPLOAD_PHOTO_WIDTH,
+  width: PHOTO_MAX_WIDTH,
   quality: UPLOAD_PHOTO_QUALITY,
   imageOptions: {
     mode: "contain",

--- a/src/sharedHelpers/resizeImage.ts
+++ b/src/sharedHelpers/resizeImage.ts
@@ -5,6 +5,7 @@ const resizeImage = async (
   options: {
     width: number;
     height?: number;
+    quality?: number;
     rotation?: number;
     outputPath?: string;
     imageOptions?: {
@@ -16,6 +17,7 @@ const resizeImage = async (
   const {
     width,
     height,
+    quality = 100,
     rotation,
     outputPath,
     imageOptions,
@@ -28,7 +30,7 @@ const resizeImage = async (
     width, // maxWidth
     height || width, // maxHeight
     "JPEG", // compressFormat
-    100, // quality
+    quality, // quality
     rotation || 0, // rotation
     outputPath, // outputPath
     true, // keep metadata,

--- a/src/uploaders/dataTransformation/prepareMediaForUpload.ts
+++ b/src/uploaders/dataTransformation/prepareMediaForUpload.ts
@@ -7,10 +7,11 @@ function prepareMediaForUpload(
   type: EvidenceType,
   action: ActionType,
   observationId?: number | null,
+  uploadUri?: string | null,
 ): object {
   if ( type === "Photo" ) {
     if ( action === "upload" ) {
-      return ObservationPhoto.mapPhotoForUpload( media );
+      return ObservationPhoto.mapPhotoForUpload( media, uploadUri );
     }
   } else if ( type === "ObservationPhoto" ) {
     if ( action === "attach" ) {

--- a/src/uploaders/mediaUploader.ts
+++ b/src/uploaders/mediaUploader.ts
@@ -107,6 +107,14 @@ const compressPhotoUri = async ( evidence: Evidence ): Promise<string | null> =>
   }
 };
 
+const discardCompressedPhoto = async ( compressedUri: string | null ) => {
+  try {
+    await unlink( compressedUri );
+  } catch ( unlinkError ) {
+    logger.error( "Failed to remove compressed photo after upload", unlinkError );
+  }
+};
+
 const uploadSingleEvidence = async (
   evidence: Evidence,
   type: EvidenceType,
@@ -162,7 +170,7 @@ const uploadSingleEvidence = async (
 
     return response;
   } finally {
-    await unlink( compressedUri );
+    await discardCompressedPhoto( compressedUri );
   }
 };
 

--- a/src/uploaders/mediaUploader.ts
+++ b/src/uploaders/mediaUploader.ts
@@ -1,6 +1,7 @@
 import { createOrUpdateEvidence } from "api/observations";
 import inatjs from "inaturalistjs";
 import type Realm from "realm";
+import Photo from "realmModels/Photo";
 import type {
   RealmObservation,
   RealmObservationPhoto,
@@ -8,8 +9,13 @@ import type {
   RealmPhoto,
   RealmSound,
 } from "realmModels/types";
+import compressPhotoForUpload from "sharedHelpers/compressPhotoForUpload";
+import { log } from "sharedHelpers/logger";
+import { unlink } from "sharedHelpers/util";
 import { markRecordUploaded, prepareMediaForUpload } from "uploaders";
 import { trackEvidenceUpload } from "uploaders/utils/progressTracker";
+
+const logger = log.extend( "mediaUploader" );
 
 export type EvidenceType = "Photo" | "ObservationPhoto" | "Sound" | "ObservationSound";
 export type ActionType = "upload" | "attach" | "update";
@@ -87,6 +93,20 @@ interface MediaItems {
   unsyncedObservationSounds: RealmObservationSound[];
 }
 
+const compressPhotoUri = async ( evidence: Evidence ): Promise<string | null> => {
+  const localFilePath = "localFilePath" in evidence
+    ? evidence.localFilePath
+    : undefined;
+  const localUri = Photo.getLocalPhotoUri( localFilePath );
+  if ( !localUri ) return null;
+  try {
+    return await compressPhotoForUpload( localUri );
+  } catch ( compressionError ) {
+    logger.error( "Failed to compress photo for upload", compressionError );
+    return null;
+  }
+};
+
 const uploadSingleEvidence = async (
   evidence: Evidence,
   type: EvidenceType,
@@ -97,44 +117,53 @@ const uploadSingleEvidence = async (
   observationUUID: string,
   realm: Realm,
 ): Promise<MediaApiResponse | null> => {
-  const params = prepareMediaForUpload(
-    evidence,
-    type,
-    action,
-    observationId,
-  );
-  const evidenceUUID = evidence.uuid;
+  const compressedUri = ( type === "Photo" && action === "upload" )
+    ? await compressPhotoUri( evidence )
+    : null;
 
-  // Determine if this is an upload or an attachment operation
-  // for progress tracking
-  const isAttachOperation = observationId != null;
-  const evidenceProgress = trackEvidenceUpload( observationUUID );
+  try {
+    const params = prepareMediaForUpload(
+      evidence,
+      type,
+      action,
+      observationId,
+      compressedUri,
+    );
+    const evidenceUUID = evidence.uuid;
 
-  const response = await createOrUpdateEvidence(
-    apiEndpoint,
-    params,
-    options,
-  );
+    // Determine if this is an upload or an attachment operation
+    // for progress tracking
+    const isAttachOperation = observationId != null;
+    const evidenceProgress = trackEvidenceUpload( observationUUID );
 
-  if ( !response ) {
-    throw new Error( `Failed to upload ${type} ${evidenceUUID}: no response from server` );
-  }
+    const response = await createOrUpdateEvidence(
+      apiEndpoint,
+      params,
+      options,
+    );
 
-  if ( response && observationUUID ) {
-    // TODO: can't mark records as uploaded by primary key for ObsPhotos and ObsSound anymore
-    markRecordUploaded( observationUUID, evidenceUUID, type, response, realm, {
-      record: evidence,
-    } );
-    if ( isAttachOperation ) {
-      // This is attaching evidence to an observation
-      evidenceProgress.attached( );
-    } else {
-      // This is uploading evidence
-      evidenceProgress.uploaded( );
+    if ( !response ) {
+      throw new Error( `Failed to upload ${type} ${evidenceUUID}: no response from server` );
     }
-  }
 
-  return response;
+    if ( response && observationUUID ) {
+      // TODO: can't mark records as uploaded by primary key for ObsPhotos and ObsSound anymore
+      markRecordUploaded( observationUUID, evidenceUUID, type, response, realm, {
+        record: evidence,
+      } );
+      if ( isAttachOperation ) {
+        // This is attaching evidence to an observation
+        evidenceProgress.attached( );
+      } else {
+        // This is uploading evidence
+        evidenceProgress.uploaded( );
+      }
+    }
+
+    return response;
+  } finally {
+    await unlink( compressedUri );
+  }
 };
 
 interface Operation {

--- a/tests/unit/sharedHelpers/compressPhotoForUpload.test.js
+++ b/tests/unit/sharedHelpers/compressPhotoForUpload.test.js
@@ -1,0 +1,21 @@
+import ImageResizer, { MOCK_RESIZER_CACHE_PATH } from "@bam.tech/react-native-image-resizer";
+import compressPhotoForUpload from "sharedHelpers/compressPhotoForUpload";
+
+describe( "compressPhotoForUpload", ( ) => {
+  it( "compresses at q90 with no output path, so the copy lands in the OS cache", async ( ) => {
+    const uri = await compressPhotoForUpload( "file:///photoUploads/abc.jpg" );
+
+    expect( ImageResizer.createResizedImage ).toHaveBeenCalledWith(
+      "file:///photoUploads/abc.jpg",
+      2048, // maxWidth
+      2048, // maxHeight
+      "JPEG", // compressFormat
+      90, // quality
+      0, // rotation
+      undefined, // outputPath
+      true, // keep metadata
+      { mode: "contain", onlyScaleDown: true },
+    );
+    expect( uri ).toBe( `${MOCK_RESIZER_CACHE_PATH}/abc.jpg` );
+  } );
+} );

--- a/tests/unit/uploaders/dataTransformation/prepareMediaForUpload.test.js
+++ b/tests/unit/uploaders/dataTransformation/prepareMediaForUpload.test.js
@@ -94,6 +94,7 @@ describe( "prepareMediaForUpload", () => {
 
     expect( ObservationPhoto.mapPhotoForUpload ).toHaveBeenCalledWith(
       mockPhoto,
+      undefined,
     );
 
     expect( result ).toEqual( {
@@ -103,6 +104,22 @@ describe( "prepareMediaForUpload", () => {
         type: "image/jpeg",
       } ),
     } );
+  } );
+
+  test( "should pass a compressed upload uri through to the Photo mapper", () => {
+    const compressedUri = "file://compressedPhotoUploads/photo.jpg";
+    prepareMediaForUpload(
+      mockPhoto,
+      "Photo",
+      "upload",
+      null,
+      compressedUri,
+    );
+
+    expect( ObservationPhoto.mapPhotoForUpload ).toHaveBeenCalledWith(
+      mockPhoto,
+      compressedUri,
+    );
   } );
 
   test( "should map ObservationPhoto attachment", () => {

--- a/tests/unit/uploaders/mediaUploader.test.js
+++ b/tests/unit/uploaders/mediaUploader.test.js
@@ -1,17 +1,26 @@
 import { createOrUpdateEvidence } from "api/observations";
 import inatjs from "inaturalistjs";
+import compressPhotoForUpload from "sharedHelpers/compressPhotoForUpload";
+import { unlink } from "sharedHelpers/util";
 import { prepareMediaForUpload } from "uploaders";
 import { attachMediaToObservation, uploadObservationMedia } from "uploaders/mediaUploader";
 import { trackEvidenceUpload } from "uploaders/utils/progressTracker";
 
 jest.mock( "api/observations" );
 jest.mock( "inaturalistjs" );
+jest.mock( "sharedHelpers/compressPhotoForUpload" );
+jest.mock( "sharedHelpers/util", () => ( {
+  ...jest.requireActual( "sharedHelpers/util" ),
+  unlink: jest.fn(),
+} ) );
 jest.mock( "uploaders" );
 jest.mock( "uploaders/utils/progressTracker" );
 
 const mockedCreateOrUpdateEvidence = jest.mocked( createOrUpdateEvidence );
 const mockedPrepareMediaForUpload = jest.mocked( prepareMediaForUpload );
 const mockedTrackEvidenceUpload = jest.mocked( trackEvidenceUpload );
+const mockedCompressPhotoForUpload = jest.mocked( compressPhotoForUpload );
+const mockedUnlink = jest.mocked( unlink );
 
 describe( "mediaUploader", () => {
   beforeEach( () => {
@@ -156,6 +165,7 @@ describe( "mediaUploader", () => {
         "ObservationPhoto",
         "attach",
         observationUUID,
+        null,
       );
 
       expect( mockedPrepareMediaForUpload ).toHaveBeenCalledWith(
@@ -163,6 +173,7 @@ describe( "mediaUploader", () => {
         "ObservationSound",
         "attach",
         observationUUID,
+        null,
       );
 
       expect( mockedPrepareMediaForUpload ).toHaveBeenCalledWith(
@@ -170,6 +181,7 @@ describe( "mediaUploader", () => {
         "ObservationPhoto",
         "update",
         observationUUID,
+        null,
       );
 
       expect( mockedCreateOrUpdateEvidence ).toHaveBeenCalledWith(
@@ -291,6 +303,56 @@ describe( "mediaUploader", () => {
 
       expect( trackEvidenceUpload ).toHaveBeenCalledWith( "obs-uuid-123" );
       expect( mockProgress.attached ).toHaveBeenCalled();
+    } );
+  } );
+
+  describe( "photo compression", () => {
+    const compressedUri = "file://document/directory/path/compressedPhotoUploads/photo1.jpg";
+    const observationWithLocalPhoto = () => ( {
+      uuid: "obs-uuid-123",
+      observationPhotos: [
+        {
+          wasSynced: () => false,
+          photo: {
+            uuid: "photo-uuid-1",
+            localFilePath: "file://document/directory/path/photoUploads/photo1.jpg",
+          },
+        },
+      ],
+      observationSounds: [],
+    } );
+
+    it( "should delete the compressed copy once the photo has been uploaded", async () => {
+      mockedCompressPhotoForUpload.mockResolvedValue( compressedUri );
+
+      await uploadObservationMedia( observationWithLocalPhoto(), {}, {} );
+
+      expect( mockedUnlink ).toHaveBeenCalledWith( compressedUri );
+    } );
+
+    it( "should delete the compressed copy even when the upload fails", async () => {
+      mockedCompressPhotoForUpload.mockResolvedValue( compressedUri );
+      mockedCreateOrUpdateEvidence.mockRejectedValue( new Error( "API Error" ) );
+
+      await expect( uploadObservationMedia( observationWithLocalPhoto(), {}, {} ) )
+        .rejects.toThrow( "API Error" );
+
+      expect( mockedUnlink ).toHaveBeenCalledWith( compressedUri );
+    } );
+
+    it( "should still upload the original photo when compression fails", async () => {
+      mockedCompressPhotoForUpload.mockRejectedValue( new Error( "Resizer Error" ) );
+
+      await uploadObservationMedia( observationWithLocalPhoto(), {}, {} );
+
+      expect( createOrUpdateEvidence ).toHaveBeenCalledTimes( 1 );
+      expect( mockedPrepareMediaForUpload ).toHaveBeenCalledWith(
+        expect.anything(),
+        "Photo",
+        "upload",
+        null,
+        null,
+      );
     } );
   } );
 


### PR DESCRIPTION
Reconsidered the realm approach we looked at in standup. Not quite 1 line but looking better.

To recap the old system was 
```
source image -> maxWidth=2048 q100 JPEG for upload -> maxWidth=640 q100 JPEG for CV

```
and this pr is
```
source image -> maxWidth=2048 q100 JPEG for local persistence -> maxWidth=640 q100 JPEG for CV
                        ↳ maxWidth=2048 q90 JPEG for upload
```