### PR TITLE
use start/end instead of left/right

### DIFF
--- a/src/components/Explore/ObservationsViewBar.tsx
+++ b/src/components/Explore/ObservationsViewBar.tsx
@@ -63,24 +63,24 @@ const ObservationsViewBar = ( {
         const isFirst = i === 0;
         const isLast = i === buttons.length - 1;
         const outerBorderStyle = {
-          borderTopLeftRadius: isFirst
+          borderTopStartRadius: isFirst
             ? 20
             : 0,
-          borderBottomLeftRadius: isFirst
+          borderBottomStartRadius: isFirst
             ? 20
             : 0,
-          borderTopRightRadius: isLast
+          borderTopEndRadius: isLast
             ? 20
             : 0,
-          borderBottomRightRadius: isLast
+          borderBottomEndRadius: isLast
             ? 20
             : 0,
         };
         const spacerStyle = {
-          borderRightWidth: isLast
+          borderEndWidth: isLast
             ? 0
             : 1,
-          borderRightColor: colors.lightGray,
+          borderEndColor: colors.lightGray,
         };
         const backgroundColor = {
           backgroundColor: checked


### PR DESCRIPTION
closes [MOB-1669](https://linear.app/inaturalist/issue/MOB-1669/explore-layout-button-group-shadow-looks-off-in-rtl)