### PR TITLE
Update faker to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-react": "^7.24.1",
         "@babel/runtime": "^7.25.0",
-        "@faker-js/faker": "9.0.0",
+        "@faker-js/faker": "9.9.0",
         "@fluent/syntax": "^0.19.0",
         "@react-native-community/cli": "20.2.0",
         "@react-native-community/cli-platform-android": "20.2.0",
@@ -2797,10 +2797,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.0.tgz",
-      "integrity": "sha512-dTDHJSmz6c1OJ6HO7jiUiIb4sB20Dlkb3pxYsKm0qTXm2Bmj97rlXIhlvaFsW2rvCi+OLlwKLVSS6ZxFUVZvjQ==",
-      "deprecated": "Please update to a newer version",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-react": "^7.24.1",
         "@babel/runtime": "^7.25.0",
-        "@faker-js/faker": "^8.4.1",
+        "@faker-js/faker": "9.0.0",
         "@fluent/syntax": "^0.19.0",
         "@react-native-community/cli": "20.2.0",
         "@react-native-community/cli-platform-android": "20.2.0",
@@ -2797,9 +2797,10 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
-      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.0.tgz",
+      "integrity": "sha512-dTDHJSmz6c1OJ6HO7jiUiIb4sB20Dlkb3pxYsKm0qTXm2Bmj97rlXIhlvaFsW2rvCi+OLlwKLVSS6ZxFUVZvjQ==",
+      "deprecated": "Please update to a newer version",
       "dev": true,
       "funding": [
         {
@@ -2807,9 +2808,10 @@
           "url": "https://opencollective.com/fakerjs"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@firebase/ai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-react": "^7.24.1",
         "@babel/runtime": "^7.25.0",
-        "@faker-js/faker": "9.9.0",
+        "@faker-js/faker": "^9.9.0",
         "@fluent/syntax": "^0.19.0",
         "@react-native-community/cli": "20.2.0",
         "@react-native-community/cli-platform-android": "20.2.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-react": "^7.24.1",
     "@babel/runtime": "^7.25.0",
-    "@faker-js/faker": "9.9.0",
+    "@faker-js/faker": "^9.9.0",
     "@fluent/syntax": "^0.19.0",
     "@react-native-community/cli": "20.2.0",
     "@react-native-community/cli-platform-android": "20.2.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-react": "^7.24.1",
     "@babel/runtime": "^7.25.0",
-    "@faker-js/faker": "^8.4.1",
+    "@faker-js/faker": "9.0.0",
     "@fluent/syntax": "^0.19.0",
     "@react-native-community/cli": "20.2.0",
     "@react-native-community/cli-platform-android": "20.2.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-react": "^7.24.1",
     "@babel/runtime": "^7.25.0",
-    "@faker-js/faker": "9.0.0",
+    "@faker-js/faker": "9.9.0",
     "@fluent/syntax": "^0.19.0",
     "@react-native-community/cli": "20.2.0",
     "@react-native-community/cli-platform-android": "20.2.0",

--- a/tests/factories/LocalUser.js
+++ b/tests/factories/LocalUser.js
@@ -2,6 +2,6 @@ import { define } from "factoria";
 
 export default define( "LocalUser", faker => ( {
   id: faker.number.int( ),
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   roles: [],
 } ) );

--- a/tests/factories/RemoteUser.js
+++ b/tests/factories/RemoteUser.js
@@ -2,7 +2,7 @@ import { define } from "factoria";
 
 export default define( "RemoteUser", faker => ( {
   name: faker.person.fullName(),
-  login: faker.internet.userName(),
+  login: faker.internet.username(),
   email: faker.internet.email(),
   id: faker.number.int(),
   icon_url: faker.image.url(),

--- a/tests/integration/ExploreV2RecentSearches.test.js
+++ b/tests/integration/ExploreV2RecentSearches.test.js
@@ -19,7 +19,7 @@ import { signIn, signOut } from "tests/helpers/user";
 jest.unmock( "@react-navigation/native" );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   locale: "en",
 } );
 

--- a/tests/integration/MyObservations.test.js
+++ b/tests/integration/MyObservations.test.js
@@ -76,7 +76,7 @@ const mockSyncedObservations = [
 ];
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
 } );

--- a/tests/integration/MyObservationsLocalization.test.js
+++ b/tests/integration/MyObservationsLocalization.test.js
@@ -33,13 +33,13 @@ afterAll( uniqueRealmAfterAll );
 // /UNIQUE REALM SETUP
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
 } );
 
 // const mockSpanishUser = factory( "LocalUser", {
-//   login: faker.internet.userName( ),
+//   login: faker.internet.username( ),
 //   iconUrl: faker.image.url( ),
 //   locale: "es"
 // } );

--- a/tests/integration/MyObservationsUploadQueue.test.js
+++ b/tests/integration/MyObservationsUploadQueue.test.js
@@ -39,7 +39,7 @@ const mockUnsyncedObservations = [
 ];
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
 } );

--- a/tests/integration/ObsEditOffline.test.js
+++ b/tests/integration/ObsEditOffline.test.js
@@ -39,7 +39,7 @@ afterAll( uniqueRealmAfterAll );
 beforeEach( async ( ) => {
   useStore.setState( initialStoreState, true );
   const mockUser = factory( "LocalUser", {
-    login: faker.internet.userName( ),
+    login: faker.internet.username( ),
     iconUrl: faker.image.url( ),
     locale: "en",
   } );

--- a/tests/integration/SavedMatch.test.js
+++ b/tests/integration/SavedMatch.test.js
@@ -57,7 +57,7 @@ const mockObservation = factory( "LocalObservation", {
     },
   } ),
   user: factory( "LocalUser", {
-    login: faker.internet.userName( ),
+    login: faker.internet.username( ),
     iconUrl: faker.image.url( ),
     locale: "en",
   } ),

--- a/tests/integration/navigation/Explore.test.js
+++ b/tests/integration/navigation/Explore.test.js
@@ -20,7 +20,7 @@ import { signIn, signOut, TEST_JWT } from "tests/helpers/user";
 jest.unmock( "@react-navigation/native" );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
   species_count: faker.number.int(),

--- a/tests/integration/navigation/ExploreV2EntryPoints.test.js
+++ b/tests/integration/navigation/ExploreV2EntryPoints.test.js
@@ -22,7 +22,7 @@ import { signIn, signOut, TEST_JWT } from "tests/helpers/user";
 jest.unmock( "@react-navigation/native" );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
   species_count: faker.number.int( ),

--- a/tests/integration/navigation/MyObservations.test.js
+++ b/tests/integration/navigation/MyObservations.test.js
@@ -50,7 +50,7 @@ const mockUnsyncedObservations = [
 ];
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
 } );

--- a/tests/integration/navigation/ObsEdit.test.js
+++ b/tests/integration/navigation/ObsEdit.test.js
@@ -110,7 +110,7 @@ describe( "ObsEdit", ( ) => {
   }
 
   const mockUser = factory( "LocalUser", {
-    login: faker.internet.userName( ),
+    login: faker.internet.username( ),
     iconUrl: faker.image.url( ),
     locale: "en",
   } );

--- a/tests/integration/navigation/Suggestions.test.js
+++ b/tests/integration/navigation/Suggestions.test.js
@@ -93,7 +93,7 @@ const makeUnsyncedObservations = options => ( [
 ] );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
 } );

--- a/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
+++ b/tests/unit/components/BottomTabNavigator/CustomTabBar.test.js
@@ -14,7 +14,7 @@ import setStoreStateLayout from "tests/helpers/setStoreStateLayout";
 const initialPersistedStoreState = useStore.getState( );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   icon_url: faker.image.url( ),
 } );
 

--- a/tests/unit/components/ObsDetailsSharedComponents/ActivityTab/ActivityHeaderKebabMenu.test.js
+++ b/tests/unit/components/ObsDetailsSharedComponents/ActivityTab/ActivityHeaderKebabMenu.test.js
@@ -8,7 +8,7 @@ import { renderComponent } from "tests/helpers/render";
 
 const mockUser = factory( "LocalUser", {
   id: 0,
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
 } );
 

--- a/tests/unit/components/ObsDetailsSharedComponents/ObsDetailsContainer.test.js
+++ b/tests/unit/components/ObsDetailsSharedComponents/ObsDetailsContainer.test.js
@@ -37,7 +37,7 @@ const mockObservation = factory( "LocalObservation", {
     },
   } ),
   user: factory( "LocalUser", {
-    login: faker.internet.userName( ),
+    login: faker.internet.username( ),
     iconUrl: faker.image.url( ),
     locale: "en",
   } ),
@@ -60,7 +60,7 @@ const mockNoEvidenceObservation = factory( "LocalObservation", {
     },
   } ),
   user: factory( "LocalUser", {
-    login: faker.internet.userName( ),
+    login: faker.internet.username( ),
     iconUrl: faker.image.url( ),
     locale: "en",
   } ),
@@ -69,7 +69,7 @@ const mockNoEvidenceObservation = factory( "LocalObservation", {
 mockNoEvidenceObservation.observationPhotos = [];
 mockNoEvidenceObservation.observationSounds = [];
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   id: "1234",
 } );

--- a/tests/unit/components/ObsDetailsSharedComponents/ObsDetailsModeSwitcher.test.js
+++ b/tests/unit/components/ObsDetailsSharedComponents/ObsDetailsModeSwitcher.test.js
@@ -39,7 +39,7 @@ const mockObservation = factory( "LocalObservation", {
     },
   } ),
   user: factory( "LocalUser", {
-    login: faker.internet.userName( ),
+    login: faker.internet.username( ),
     iconUrl: faker.image.url( ),
     locale: "en",
   } ),
@@ -47,7 +47,7 @@ const mockObservation = factory( "LocalObservation", {
 } );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   id: "1234",
 } );

--- a/tests/unit/components/ObsDetailsSharedComponents/ObsDetailsScreen.test.js
+++ b/tests/unit/components/ObsDetailsSharedComponents/ObsDetailsScreen.test.js
@@ -12,7 +12,7 @@ const mockUuid = "test-123";
 
 const mockCurrentUser = factory( "LocalUser", {
   id: 123,
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
 } );
 
 const mockLocalObservation = factory( "LocalObservation", {

--- a/tests/unit/components/Settings/TaxonNamesSetting.test.js
+++ b/tests/unit/components/Settings/TaxonNamesSetting.test.js
@@ -5,7 +5,7 @@ import factory from "tests/factory";
 import faker from "tests/helpers/faker";
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   iconUrl: faker.image.url( ),
   locale: "en",
   prefers_common_names: true,

--- a/tests/unit/components/TaxonDetails/TaxonDetails.test.js
+++ b/tests/unit/components/TaxonDetails/TaxonDetails.test.js
@@ -44,7 +44,7 @@ jest.mock( "@react-navigation/native", ( ) => {
 } );
 
 const mockUser = factory( "LocalUser", {
-  login: faker.internet.userName( ),
+  login: faker.internet.username( ),
   icon_url: faker.image.url( ),
 } );
 


### PR DESCRIPTION
Updating faker to the next major version.

No changes were required, but one deprecation notice to a renamed function call.