### PR TITLE
MOB-1570 fix exclude user search params

### DIFF
--- a/src/components/Explore/ObservationsView.js
+++ b/src/components/Explore/ObservationsView.js
@@ -3,22 +3,14 @@
 import {
   useNetInfo,
 } from "@react-native-community/netinfo";
-import {
-  searchObservations,
-} from "api/observations";
 import useInfiniteExploreScroll from "components/Explore/hooks/useInfiniteExploreScroll";
 import ObservationsFlashList from "components/ObservationsFlashList/ObservationsFlashList";
 import { View } from "components/styledComponents";
-import {
-  useExplore,
-} from "providers/ExploreContext";
 import type { Node } from "react";
 import React, { useEffect } from "react";
 import { Dimensions } from "react-native";
 import {
-  useCurrentUser,
   useDeviceOrientation,
-  useQuery,
 } from "sharedHooks";
 
 import MapView from "./MapView";
@@ -46,25 +38,6 @@ const ObservationsView = ( {
   renderLocationPermissionsGate,
   requestLocationPermissions,
 }: Props ): Node => {
-  const currentUser = useCurrentUser( );
-  const { state } = useExplore();
-  const { excludeUser } = state;
-
-  // get total count of current users obs
-  // TODO: enable fields if it makes sense? I dont know if {} equals all fields or no fields
-  const { data: currentUserObs } = useQuery(
-    ["fetchCurrentUserObservations"],
-    ( ) => searchObservations( {
-      user_id: currentUser?.id,
-      ...queryParams,
-      fields: {
-      },
-    } ),
-    {
-      enabled: ( !!currentUser && !!excludeUser ),
-    },
-  );
-
   const {
     fetchNextPage,
     isFetchingNextPage,
@@ -75,11 +48,6 @@ const ObservationsView = ( {
     isLoading,
   } = useInfiniteExploreScroll( { params: queryParams, enabled: canFetch } );
 
-  const curUserObsCount = currentUserObs?.total_results;
-  const totalCount = ( excludeUser && currentUserObs && observations.length > 0 )
-    ? totalResults - curUserObsCount
-    : totalResults;
-
   const {
     isLandscapeMode,
     isTablet,
@@ -88,8 +56,8 @@ const ObservationsView = ( {
   } = useDeviceOrientation( );
 
   useEffect( ( ) => {
-    handleUpdateCount( "observations", totalCount );
-  }, [handleUpdateCount, totalCount] );
+    handleUpdateCount( "observations", totalResults );
+  }, [handleUpdateCount, totalResults] );
 
   const { isConnected } = useNetInfo( );
 

--- a/src/components/Explore/helpers/mapParamsToAPI.js
+++ b/src/components/Explore/helpers/mapParamsToAPI.js
@@ -116,11 +116,16 @@ const mapParamsToAPI = ( params: Object, currentUser: Object ): Object => {
     filteredParams.photo_license = licenseParams[params.photoLicense];
   }
 
+  if ( params.excludeUser?.id ) {
+    filteredParams.not_user_id = params.excludeUser.id;
+  }
+
   delete filteredParams.taxon;
   delete filteredParams.place_guess;
   delete filteredParams.placeMode;
   delete filteredParams.user;
   delete filteredParams.project;
+  delete filteredParams.excludeUser;
   delete filteredParams.sortBy;
   delete filteredParams.researchGrade;
   delete filteredParams.needsID;

--- a/src/components/Explore/hooks/useInfiniteExploreScroll.ts
+++ b/src/components/Explore/hooks/useInfiniteExploreScroll.ts
@@ -17,12 +17,8 @@ import {
   getNextPageParamForExplore,
 } from "../helpers/exploreParams";
 
-interface ExcludeUser {
-  id: number;
-}
-
 interface UseInfiniteExploreScrollParams {
-  params: ApiObservationsSearchParams & { excludeUser?: ExcludeUser };
+  params: ApiObservationsSearchParams;
   enabled: boolean;
 }
 
@@ -48,7 +44,9 @@ const useInfiniteExploreScroll = (
       // the most data we display in the UI on any Observations view in Explore
       // is the same amount of data we show for the Advanced list mode in MyObservations
       ...Observation.ADVANCED_MODE_LIST_FIELDS,
-      user: { // included here for "exclude by current user" in explore filters
+      // login is needed so ObsListItem can tell whether an observation belongs
+      // to the current user (geoprivacy/obscured handling differs in that case)
+      user: {
         id: true,
         uuid: true,
         login: true,
@@ -56,8 +54,6 @@ const useInfiniteExploreScroll = (
     },
     ttl: -1,
   } ), [newInputParams] );
-
-  const excludedUser: ExcludeUser | undefined = newInputParams.excludeUser;
 
   const queryKey = ["useInfiniteExploreScroll", newInputParams];
 
@@ -96,15 +92,8 @@ const useInfiniteExploreScroll = (
 
   const pages = data?.pages as ApiObservationsSearchResponse[] | undefined;
 
-  let observations: ApiObservation[] = flatten( pages?.map( r => r.results ) ) || [];
+  const observations: ApiObservation[] = flatten( pages?.map( r => r.results ) ) || [];
   let totalResults: number | null | undefined = pages?.[0]?.total_results;
-  let filtered = [];
-
-  // filter out obs from excluded user and adjust count
-  if ( excludedUser && observations ) {
-    filtered = observations.filter( observation => observation?.user?.id !== excludedUser.id );
-    observations = filtered;
-  }
 
   if ( totalResults !== 0 && !totalResults ) {
     totalResults = null;


### PR DESCRIPTION
closes MOB-1570 & MOB-1626

We were trying to pass the `excludeUser` options object (`{id: 1234}`) as a query string. For whatever reason, that made the tiling server return unstyled pins. The fix is to pull out the id pass it as the _actual_ search field on the API:  `not_user_id`. 

We were making this work by doing client side filtering, but that's not actually necessary since they're filtered by the API. I tried to keep those changes as minimal as possible.

This mirrors the correct implementation in ExploreV2's https://github.com/inaturalist/iNaturalistReactNative/blob/463329092343cfae3fd7a2292fdafa9a03fee768/src/components/Explore/ExploreV2/helpers/filtersToApiParams.ts#L109, but I think still worth correcting.

Here's this working now:

https://github.com/user-attachments/assets/6f03c2cc-4fc3-4793-9dc0-4248421e9687

