### PR TITLE
MOB-1619 temporary workaround for Android 36+ back dismissing app

### DIFF
--- a/android/app/src/main/java/com/inaturalistreactnative/MainActivity.kt
+++ b/android/app/src/main/java/com/inaturalistreactnative/MainActivity.kt
@@ -4,6 +4,7 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import android.os.Build
 import android.os.Bundle
 
 class MainActivity : ReactActivity() {
@@ -27,4 +28,20 @@ class MainActivity : ReactActivity() {
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate =
       DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+  /**
+   * https://github.com/facebook/react-native/issues/54887
+   * workaround from that thread for a bug in Android 36+ & RN < 0.84 where
+   * the app would get in a state where back gesture/press from anywhere in the 
+   * app would dismiss. This skips the buggy React behavior and is gated to the
+   * API version that introduced it.
+   * TODO: remove and validate upstream fix after 0.84 upgrade (MOB-1740)
+   */
+  override fun invokeDefaultOnBackPressed() {
+    if (Build.VERSION.SDK_INT >= 36) {
+      moveTaskToBack(true)
+    } else {
+      super.invokeDefaultOnBackPressed()
+    }
+  }
 }


### PR DESCRIPTION
closes MOB-1619 

Pulls a workaround from the RN issue on this here: https://github.com/facebook/react-native/issues/54887

can confirm on a Pixel 8 Pro, API 36+ I can reproduce issue on main and it is fixed with this. All other application navigation seems unaffected.

This is fixed in RN 0.84. I would be fine to skip this workaround and just wait for RN 0.84, but I'm not sure how long that'll be (I created a stub ticket to track it though)