### PR TITLE
Traditional Projects: Keep synced project metadata on re-select; skip child upload without uuid

### DIFF
--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -299,8 +299,7 @@ class Observation extends Realm.Object {
     }
 
     const isNew = !existingEmbed;
-    const wasReactivated = existingEmbed?._pending_deletion && !embed._pending_deletion;
-    if ( isNew || wasReactivated ) {
+    if ( isNew ) {
       return {
         ...embed,
         _synced_at: null,

--- a/src/uploaders/observationUploader.ts
+++ b/src/uploaders/observationUploader.ts
@@ -190,7 +190,9 @@ async function uploadObservation(
     const childrenStartTime = Date.now( );
     const childOptions = { ...opts, api_token: apiToken };
     await syncProjectChildDeletions( observation, childOptions, realm );
-    await uploadProjectChildren( obsUUID, observation, childOptions, realm );
+    if ( obsUUID ) {
+      await uploadProjectChildren( obsUUID, observation, childOptions, realm );
+    }
     childrenDuration = Date.now( ) - childrenStartTime;
   } catch ( error ) {
     const {

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -228,9 +228,11 @@ describe( "Observation", ( ) => {
       const obsUuid = uuid.v4( );
       const syncedAt = new Date( "2020-01-02" );
       const poUuid = uuid.v4( ).toLowerCase( );
+      const poId = 4242;
 
       const mockPO = factory( "LocalProjectObservation", {
         uuid: poUuid,
+        id: poId,
         _synced_at: syncedAt,
         _pending_deletion: true,
       } );
@@ -255,7 +257,9 @@ describe( "Observation", ( ) => {
 
       const obs = global.realm.objectForPrimaryKey( "Observation", obsUuid );
       expect( obs.projectObservations[0]._pending_deletion ).toBeFalsy( );
-      expect( obs.projectObservations[0]._synced_at ).toBeNull( );
+      expect( obs.projectObservations[0].uuid ).toBe( poUuid );
+      expect( obs.projectObservations[0].id ).toBe( poId );
+      expect( obs.projectObservations[0]._synced_at ).toEqual( syncedAt );
     } );
 
     it( "leaves unchanged synced embed timestamps intact on re-edit", async ( ) => {

--- a/tests/unit/uploaders/observationUploader.test.js
+++ b/tests/unit/uploaders/observationUploader.test.js
@@ -178,6 +178,18 @@ describe( "uploadObservation", () => {
     );
   } );
 
+  it( "should skip project children create when observation upload returns no uuid", async () => {
+    apiObservations.createObservation.mockResolvedValue( {
+      results: [{ id: 12345 }],
+    } );
+
+    await uploadObservation( mockObservation, mockRealm );
+
+    expect( syncProjectChildDeletions ).toHaveBeenCalled( );
+    expect( projectChildrenUploader.uploadProjectChildren ).not.toHaveBeenCalled( );
+    expect( uploaders.markRecordUploaded ).toHaveBeenCalled( );
+  } );
+
   it( "should call uploadProjectChildren after media is attached", async () => {
     await uploadObservation( mockObservation, mockRealm );
 


### PR DESCRIPTION
Closes MOB-1513

## Summary
- Re-selecting a tombstoned PO/OFV before upload keeps `uuid` / `id` / `_synced_at`, so we do not POST a membership the server still has.
- PO/OFV create/update still uses the observation uuid (API v2). If create/update returns no uuid, skip child create; deletions still run.

## Test plan
- [ ] Remove a project from a synced obs, SAVE, re-add the same project, SAVE, upload — no extra PO POST
- [ ] New obs with projects uploads OFVs then POs using the observation uuid

Other items of the ticket are not needed