### PR TITLE
Mob 1330 explore v2 empty results state

### DIFF
--- a/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
+++ b/src/components/Explore/ExploreV2/screens/ExploreResults.tsx
@@ -222,7 +222,8 @@ const ExploreResults = ( ) => {
 
   const renderTabContent = ( ) => {
     switch ( state.activeTab ) {
-      case OBSERVATIONS_TAB:
+      case OBSERVATIONS_TAB: {
+        const hasNoResults = canFetch && totalResults === 0;
         return (
           <>
             {showMap
@@ -257,7 +258,7 @@ const ExploreResults = ( ) => {
                   hideObsUploadStatus={layout !== "list"}
                   obsListKey="ExploreV2Observations"
                   onEndReached={fetchNextPage}
-                  showNoResults={canFetch && totalResults === 0}
+                  showNoResults={hasNoResults}
                   testID="ExploreV2ObservationsList"
                 />
               )}
@@ -266,7 +267,8 @@ const ExploreResults = ( ) => {
               updateObservationsView={writeLayoutToStorage}
               viewOptions={["map", "grid", "list"]}
             />
-            {!showMap && (
+            {/* Nothing to sort when there are no results */}
+            {!showMap && !hasNoResults && (
               <SortButton
                 onPress={() => setShowSortSheet( true )}
                 accessibilityLabel={t( "Change-observations-sort-order" )}
@@ -274,7 +276,9 @@ const ExploreResults = ( ) => {
             )}
           </>
         );
-      case SPECIES_TAB:
+      }
+      case SPECIES_TAB: {
+        const speciesHasNoResults = canFetch && speciesCount === 0;
         return (
           <>
             <ExploreV2SpeciesView
@@ -282,12 +286,16 @@ const ExploreResults = ( ) => {
               isConnected={isConnected}
               params={speciesListParams}
             />
-            <SortButton
-              onPress={() => setShowSortSheet( true )}
-              accessibilityLabel={t( "Change-species-sort-order" )}
-            />
+            {/* Nothing to sort when there are no results */}
+            {!speciesHasNoResults && (
+              <SortButton
+                onPress={() => setShowSortSheet( true )}
+                accessibilityLabel={t( "Change-species-sort-order" )}
+              />
+            )}
           </>
         );
+      }
       case OBSERVERS_TAB:
       case IDENTIFIERS_TAB:
         return (

--- a/src/components/MyObservations/MyObservationsSimple.tsx
+++ b/src/components/MyObservations/MyObservationsSimple.tsx
@@ -434,7 +434,6 @@ const MyObservationsSimple = ( {
         onLayout={onListLayout}
         onScroll={onScroll}
         ref={listRef}
-        showObservationsEmptyScreen
         showNoResults={showNoResults}
         testID="MyObservationsAnimatedList"
         listHeaderContent={observationsHeader}

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -27,6 +27,7 @@ import {
   useNavigateToObsEdit,
   useTranslation,
 } from "sharedHooks";
+import { HALF_GUTTER } from "sharedHooks/useGridLayout";
 import useStore from "stores/useStore";
 
 import ObsPressable from "./ObsPressable";
@@ -230,10 +231,18 @@ const ObservationsFlashList = ( {
   ] );
 
   const emptyContent = useMemo( ( ) => {
+    // correct for grid layout's gutter to prevent layout
+    // change on empty state going between grid & list
+    const emptyContentStyle = {
+      marginTop: layout === "list"
+        ? 150
+        : 150 - HALF_GUTTER,
+    };
+
     const showEmptyScreen = showObservationsEmptyScreen
       ? null
       : (
-        <Body3 className="self-center mt-[150px]">
+        <Body3 className="self-center" style={emptyContentStyle}>
           {t( "No-results-found-try-different-search" )}
         </Body3>
       );
@@ -241,11 +250,12 @@ const ObservationsFlashList = ( {
     return showNoResults
       ? showEmptyScreen
       : (
-        <View className="self-center mt-[150px]">
+        <View className="self-center" style={emptyContentStyle}>
           <ActivityIndicator size={50} testID="ObservationsFlashList.loading" />
         </View>
       );
   }, [
+    layout,
     showObservationsEmptyScreen,
     showNoResults,
     t,

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -27,7 +27,6 @@ import {
   useNavigateToObsEdit,
   useTranslation,
 } from "sharedHooks";
-import { HALF_GUTTER } from "sharedHooks/useGridLayout";
 import useStore from "stores/useStore";
 
 import ObsPressable from "./ObsPressable";
@@ -65,7 +64,6 @@ interface Props {
   ref?: React.Ref<FlashListRef<( { uuid: string} )>>;
   listHeaderContent?: React.ReactElement | null;
   showNoResults?: boolean;
-  showObservationsEmptyScreen?: boolean;
   testID: string;
 }
 
@@ -92,7 +90,6 @@ const ObservationsFlashList = ( {
   ref,
   listHeaderContent,
   showNoResults,
-  showObservationsEmptyScreen,
   testID,
 }: Props ) => {
   const {
@@ -218,45 +215,51 @@ const ObservationsFlashList = ( {
     layout,
   ] );
 
+  const isEmpty = data.length === 0;
+
   const contentContainerStyle = useMemo( ( ) => {
-    if ( layout === "list" ) { return contentContainerStyleProp; }
+    // flexGrow so the content container fills the available height when
+    // there's no data -- otherwise it shrinks to fit only the empty state,
+    // and the centering below has no room to center within.
+    // Grid's extra padding (item gutters, tab bar clearance) only matters
+    // when there are grid items to space out -- skip it while empty so the
+    // empty state doesn't need to compensate for padding it doesn't need.
+    if ( layout === "list" || isEmpty ) {
+      return { flexGrow: 1, ...contentContainerStyleProp };
+    }
     return {
+      flexGrow: 1,
       ...flashListStyle,
       ...contentContainerStyleProp,
     };
   }, [
     contentContainerStyleProp,
     flashListStyle,
+    isEmpty,
     layout,
   ] );
 
   const emptyContent = useMemo( ( ) => {
-    // correct for grid layout's gutter to prevent layout
-    // change on empty state going between grid & list
     const emptyContentStyle = {
-      marginTop: layout === "list"
-        ? 150
-        : 150 - HALF_GUTTER,
+      flex: 1,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
     };
 
-    const showEmptyScreen = showObservationsEmptyScreen
-      ? null
-      : (
-        <Body3 className="self-center" style={emptyContentStyle}>
-          {t( "No-results-found-try-different-search" )}
-        </Body3>
-      );
-
     return showNoResults
-      ? showEmptyScreen
+      ? (
+        <View style={emptyContentStyle}>
+          <Body3 className="text-center px-10">
+            {t( "No-results-found-try-different-search" )}
+          </Body3>
+        </View>
+      )
       : (
-        <View className="self-center" style={emptyContentStyle}>
+        <View style={emptyContentStyle}>
           <ActivityIndicator size={50} testID="ObservationsFlashList.loading" />
         </View>
       );
   }, [
-    layout,
-    showObservationsEmptyScreen,
     showNoResults,
     t,
   ] );

--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -239,27 +239,19 @@ const ObservationsFlashList = ( {
     layout,
   ] );
 
-  const emptyContent = useMemo( ( ) => {
-    const emptyContentStyle = {
-      flex: 1,
-      alignItems: "center" as const,
-      justifyContent: "center" as const,
-    };
-
-    return showNoResults
-      ? (
-        <View style={emptyContentStyle}>
+  const emptyContent = useMemo( ( ) => (
+    <View className="flex-1 items-center justify-center">
+      {showNoResults
+        ? (
           <Body3 className="text-center px-10">
             {t( "No-results-found-try-different-search" )}
           </Body3>
-        </View>
-      )
-      : (
-        <View style={emptyContentStyle}>
+        )
+        : (
           <ActivityIndicator size={50} testID="ObservationsFlashList.loading" />
-        </View>
-      );
-  }, [
+        )}
+    </View>
+  ), [
     showNoResults,
     t,
   ] );

--- a/src/sharedHooks/useGridLayout.ts
+++ b/src/sharedHooks/useGridLayout.ts
@@ -3,7 +3,7 @@ import { BREAKPOINTS } from "sharedHelpers/breakpoint";
 import { useDeviceOrientation } from "sharedHooks";
 
 const GUTTER = 15;
-export const HALF_GUTTER = GUTTER / 2;
+const HALF_GUTTER = GUTTER / 2;
 const TAB_BAR_HEIGHT = 80;
 
 const flashListStyle = {

--- a/src/sharedHooks/useGridLayout.ts
+++ b/src/sharedHooks/useGridLayout.ts
@@ -3,7 +3,7 @@ import { BREAKPOINTS } from "sharedHelpers/breakpoint";
 import { useDeviceOrientation } from "sharedHooks";
 
 const GUTTER = 15;
-const HALF_GUTTER = GUTTER / 2;
+export const HALF_GUTTER = GUTTER / 2;
 const TAB_BAR_HEIGHT = 80;
 
 const flashListStyle = {

--- a/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/ExploreResults.test.js
@@ -58,7 +58,11 @@ jest.mock( "components/Explore/hooks/useInfiniteExploreScroll", ( ) => ( {
   default: args => mockUseInfiniteExploreScroll( args ),
 } ) );
 
-jest.mock( "sharedHooks/useSpeciesCount", ( ) => ( { __esModule: true, default: ( ) => 0 } ) );
+const mockUseSpeciesCount = jest.fn( );
+jest.mock( "sharedHooks/useSpeciesCount", ( ) => ( {
+  __esModule: true,
+  default: ( ...args ) => mockUseSpeciesCount( ...args ),
+} ) );
 
 const mockExploreV2SpeciesView = jest.fn( ( ) => null );
 jest.mock( "components/Explore/ExploreV2/screens/ExploreV2SpeciesView", ( ) => ( {
@@ -126,6 +130,8 @@ beforeEach( ( ) => {
     observations: [],
     totalResults: 0,
   } );
+  mockUseSpeciesCount.mockReset( );
+  mockUseSpeciesCount.mockReturnValue( 0 );
 } );
 
 describe( "ExploreResults nearby resolution", ( ) => {
@@ -296,6 +302,12 @@ describe( "ExploreResults species sort", ( ) => {
     activeTab: SPECIES_TAB,
   };
 
+  beforeEach( ( ) => {
+    // These tests exercise the sort UI itself, not the zero-results state
+    // (see "ExploreResults species tab - no results" below).
+    mockUseSpeciesCount.mockReturnValue( 1 );
+  } );
+
   const lastSpeciesViewProps = ( ) => mockExploreV2SpeciesView.mock.calls.at( -1 )[0];
 
   it( "passes default most-observed sort params to the species view", async ( ) => {
@@ -345,12 +357,44 @@ describe( "ExploreResults species sort", ( ) => {
   } );
 } );
 
+describe( "ExploreResults species tab - no results", ( ) => {
+  const speciesTabState = {
+    ...mockState( { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } ),
+    activeTab: SPECIES_TAB,
+  };
+
+  beforeEach( ( ) => {
+    mockUseSpeciesCount.mockReturnValue( 0 );
+    useExploreV2.mockReturnValue( { state: speciesTabState, dispatch: mockDispatch } );
+  } );
+
+  it( "hides the sort button when there are no species results", async ( ) => {
+    renderComponent( <ExploreResults /> );
+
+    await waitFor( ( ) => {
+      expect( mockExploreV2SpeciesView ).toHaveBeenCalled( );
+    } );
+    expect( screen.queryByLabelText( "Change species sort order" ) ).toBeNull( );
+  } );
+} );
+
 describe( "ExploreResults observations view", ( ) => {
   beforeEach( ( ) => {
     mockHasPermissions = true;
     useExploreV2.mockReturnValue( {
       state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } ),
       dispatch: mockDispatch,
+    } );
+    // These tests exercise the map/list views themselves, not the
+    // zero-results state (see "ExploreResults observations view - no
+    // results" below) -- give them a non-zero default so the map isn't
+    // replaced by the no-results message out from under them.
+    mockUseInfiniteExploreScroll.mockReturnValue( {
+      fetchNextPage: jest.fn( ),
+      isFetchingNextPage: false,
+      handlePullToRefresh: jest.fn( ),
+      observations: [],
+      totalResults: 1,
     } );
   } );
 
@@ -472,6 +516,51 @@ describe( "ExploreResults observations view", ( ) => {
         swlat: 1, swlng: 2, nelat: 3, nelng: 4,
       },
     } );
+  } );
+} );
+
+describe( "ExploreResults observations view - no results", ( ) => {
+  beforeEach( ( ) => {
+    mockHasPermissions = true;
+    useExploreV2.mockReturnValue( {
+      state: mockState( { placeMode: EXPLORE_V2_PLACE_MODE.WORLDWIDE } ),
+      dispatch: mockDispatch,
+    } );
+    mockUseInfiniteExploreScroll.mockReturnValue( {
+      fetchNextPage: jest.fn( ),
+      isFetchingNextPage: false,
+      isLoading: false,
+      handlePullToRefresh: jest.fn( ),
+      observations: [],
+      totalResults: 0,
+    } );
+  } );
+
+  it( "still renders the map with no no-results message when there are no results", async ( ) => {
+    renderComponent( <ExploreResults /> );
+
+    expect( await screen.findByTestId( "Map.MapView" ) ).toBeTruthy( );
+    expect( screen.queryByText( /No results found/ ) ).toBeNull( );
+  } );
+
+  it( "hides the sort button in map view when there are no results", async ( ) => {
+    renderComponent( <ExploreResults /> );
+
+    await screen.findByTestId( "Map.MapView" );
+    expect( screen.queryByLabelText( "Change observations sort order" ) ).toBeNull( );
+  } );
+
+  it( "still shows the segmented view buttons when there are no results", async ( ) => {
+    renderComponent( <ExploreResults /> );
+
+    expect( await screen.findByTestId( "SegmentedButton.map" ) ).toBeTruthy( );
+  } );
+
+  it( "shows the no-results message in grid view too", async ( ) => {
+    mockLayout = "grid";
+    renderComponent( <ExploreResults /> );
+
+    expect( await screen.findByText( /No results found/ ) ).toBeVisible( );
   } );
 } );
 

--- a/tests/unit/components/Explore/ObservationsView.test.js
+++ b/tests/unit/components/Explore/ObservationsView.test.js
@@ -18,6 +18,7 @@ describe( "ObservationsView", () => {
   it( "should show a footer loading wheel when new observations are fetched", ( ) => {
     renderComponent(
       <ObservationsFlashList
+        data={[]}
         hideLoadingWheel={false}
         isConnected
       />,
@@ -30,6 +31,7 @@ describe( "ObservationsView", () => {
   it( "should show no internet text when user is offline", ( ) => {
     renderComponent(
       <ObservationsFlashList
+        data={[]}
         hideLoadingWheel={false}
         isConnected={false}
       />,
@@ -42,6 +44,7 @@ describe( "ObservationsView", () => {
   it( "should show a footer view when loading wheel is hidden", ( ) => {
     renderComponent(
       <ObservationsFlashList
+        data={[]}
         hideLoadingWheel
         isConnected
       />,


### PR DESCRIPTION
fixes MOB-1330

sorry this held over so long @sepeterson, I tossed my earlier refactor attempt which didn't make sense to do before removing v1 & old myobs anyway. Learned from it tho and was able to simplify anyway.

Confirmed this don't break any other empty states or Explore V1


https://github.com/user-attachments/assets/f5044571-a6af-4bf4-b091-6e3a1e4d7485


