### PR TITLE
Traditional projects: Hide required fields success banner when none are

### DIFF
--- a/src/components/AddToProjects/AddToProjects.tsx
+++ b/src/components/AddToProjects/AddToProjects.tsx
@@ -217,44 +217,50 @@ const AddToProjects = ( ) => {
   ] );
 
   const renderExpanded = useCallback(
-    ( item: RealmProject, projectValid: boolean ) => (
-      <View className="bg-lightGrayOpaque">
-        {!projectValid
-          ? (
-            <View className="px-4 py-2.5 flex-row justify-center items-center">
-              <INatIcon
-                name="triangle-exclamation"
-                color={colors.warningRed}
-                size={19}
-              />
-              <Body3 className="ml-2.5">
-                {t( "To-add-to-this-project-all-required-fields-must-be-filled" )}
-              </Body3>
-            </View>
-          )
-          : (
-            <View className="px-4 py-2.5 flex-row justify-center items-center">
-              <INatIcon
-                name="checkmark-circle"
-                color={colors.inatGreen}
-                size={19}
-              />
-              <Body3 className="ml-2.5">
-                {t( "All-required-fields-have-been-filled" )}
-              </Body3>
-            </View>
+    ( item: RealmProject, projectValid: boolean ) => {
+      const hasRequiredFields = item.projectObservationFields.some( pof => pof.required );
+
+      return (
+        <View className="bg-lightGrayOpaque">
+          {hasRequiredFields && (
+            !projectValid
+              ? (
+                <View className="px-4 py-2.5 flex-row justify-center items-center">
+                  <INatIcon
+                    name="triangle-exclamation"
+                    color={colors.warningRed}
+                    size={19}
+                  />
+                  <Body3 className="ml-2.5">
+                    {t( "To-add-to-this-project-all-required-fields-must-be-filled" )}
+                  </Body3>
+                </View>
+              )
+              : (
+                <View className="px-4 py-2.5 flex-row justify-center items-center">
+                  <INatIcon
+                    name="checkmark-circle"
+                    color={colors.inatGreen}
+                    size={19}
+                  />
+                  <Body3 className="ml-2.5">
+                    {t( "All-required-fields-have-been-filled" )}
+                  </Body3>
+                </View>
+              )
           )}
-        {item.projectObservationFields.map( pof => (
-          <ObservationFieldInput
-            key={pof.id}
-            projectObservationField={pof}
-            isValid={!validationResult.errors.some(
-              error => error.obsFieldId === pof.obsField?.id,
-            )}
-          />
-        ) )}
-      </View>
-    ),
+          {item.projectObservationFields.map( pof => (
+            <ObservationFieldInput
+              key={pof.id}
+              projectObservationField={pof}
+              isValid={!validationResult.errors.some(
+                error => error.obsFieldId === pof.obsField?.id,
+              )}
+            />
+          ) )}
+        </View>
+      );
+    },
     [validationResult, t],
   );
 

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -295,6 +295,33 @@ describe( "AddToProjects", ( ) => {
       ).toBeVisible( );
     } );
 
+    it( "shows completed required-fields banner when all required fields are filled", async ( ) => {
+      const requiredObsFieldId = mockProjects[1].projectObservationFields[0].obsField.id;
+      useStore.setState( {
+        currentObservation: {
+          ...factory( "LocalObservation" ),
+          observationFieldValues: [
+            factory( "LocalObservationFieldValue", {
+              obsFieldId: requiredObsFieldId,
+              value: "completed-value",
+            } ),
+          ],
+          projectObservations: [factory( "LocalProjectObservation", {
+            projectId: mockProjects[0].id,
+            _synced_at: new Date( ),
+          } )],
+        },
+      } );
+
+      renderAddToProjects( );
+
+      await actor.press( screen.getByText( mockProjects[1].title ) );
+
+      expect(
+        screen.getByText( "All required fields have been filled" ),
+      ).toBeVisible( );
+    } );
+
     it( "shows Missing info sheet when SAVE is pressed with an empty required field", async ( ) => {
       renderAddToProjects( );
 

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -285,6 +285,16 @@ describe( "AddToProjects", ( ) => {
       ).toBeVisible( );
     } );
 
+    it( "shows the incomplete required-fields banner when a required field is empty", async ( ) => {
+      renderAddToProjects( );
+
+      await actor.press( screen.getByText( mockProjects[1].title ) );
+
+      expect(
+        screen.getByText( "To add to this project, all required fields must be filled" ),
+      ).toBeVisible( );
+    } );
+
     it( "shows Missing info sheet when SAVE is pressed with an empty required field", async ( ) => {
       renderAddToProjects( );
 

--- a/tests/unit/components/AddToProjects/AddToProjects.test.js
+++ b/tests/unit/components/AddToProjects/AddToProjects.test.js
@@ -104,6 +104,22 @@ describe( "AddToProjects", ( ) => {
     ).toBeVisible();
   } );
 
+  it( "does not show status banner when a selected project has only optional fields", async ( ) => {
+    renderAddToProjects( );
+
+    await actor.press( screen.getByText( mockProjects[1].title ) );
+
+    expect(
+      screen.getByText( mockProjects[1].projectObservationFields[0].obsField.name ),
+    ).toBeVisible( );
+    expect(
+      screen.queryByText( "All required fields have been filled" ),
+    ).toBeNull( );
+    expect(
+      screen.queryByText( "To add to this project, all required fields must be filled" ),
+    ).toBeNull( );
+  } );
+
   describe( "when a selected project has fields out of position order", ( ) => {
     const originalFields = mockProjects[0].projectObservationFields;
     const unsortedFields = [


### PR DESCRIPTION
Closes MOB-1742

Came up when iterating on the design files. When there are no required field do not show the text saying that there are required fields.
Only added one condition the rest is indentation.