### PR TITLE
Traditional Projects: Hide info button on Add to Projects taxon search

### DIFF
--- a/src/components/AddToProjects/FieldInputs/TaxonFieldInput.tsx
+++ b/src/components/AddToProjects/FieldInputs/TaxonFieldInput.tsx
@@ -30,6 +30,7 @@ const TaxonFieldInput = ( { obsFieldId }: Props ) => {
       <ExploreTaxonSearchModal
         showModal={showModal}
         closeModal={( ) => setShowModal( false )}
+        hideInfoButton
         updateTaxon={updateTaxon}
       />
       {value && taxon

--- a/src/components/Explore/Modals/ExploreTaxonSearchModal.tsx
+++ b/src/components/Explore/Modals/ExploreTaxonSearchModal.tsx
@@ -7,6 +7,7 @@ import type { RealmTaxon } from "realmModels/types";
 
 interface Props {
   closeModal: ( ) => void;
+  hideInfoButton?: boolean;
   onPressInfo?: ( ) => void;
   showModal: boolean;
   updateTaxon: ( taxon: RealmTaxon | null ) => void;
@@ -14,6 +15,7 @@ interface Props {
 
 const ExploreTaxonSearchModal = ( {
   closeModal,
+  hideInfoButton = false,
   onPressInfo,
   showModal,
   updateTaxon,
@@ -28,6 +30,7 @@ const ExploreTaxonSearchModal = ( {
       modal={(
         <ExploreTaxonSearch
           closeModal={closeModal}
+          hideInfoButton={hideInfoButton}
           onPressInfo={( taxon: RealmTaxon | ApiTaxon ) => {
             navigation.push( "TaxonDetails", { id: taxon.id } );
             closeModal();

--- a/src/components/Explore/SearchScreens/ExploreTaxonSearch.tsx
+++ b/src/components/Explore/SearchScreens/ExploreTaxonSearch.tsx
@@ -16,12 +16,14 @@ import useTranslation from "sharedHooks/useTranslation";
 
 interface Props {
   closeModal: ( ) => void;
+  hideInfoButton?: boolean;
   onPressInfo?: ( taxon: RealmTaxon | ApiTaxon ) => void;
   updateTaxon: ( taxon: RealmTaxon | null ) => void;
 }
 
 const ExploreTaxonSearch = ( {
   closeModal,
+  hideInfoButton = false,
   onPressInfo,
   updateTaxon,
 }: Props ) => {
@@ -53,12 +55,14 @@ const ExploreTaxonSearch = ( {
         first={index === 0}
         fetchRemote={false}
         handleTaxonOrEditPress={() => onTaxonSelected( taxon )}
+        hideInfoButton={hideInfoButton}
         onPressInfo={onPressInfo}
         taxon={taxon}
         testID={`Search.taxa.${taxon.id}`}
       />
     ),
     [
+      hideInfoButton,
       onPressInfo,
       onTaxonSelected,
     ],


### PR DESCRIPTION
Closes MOB-1743

Hide the info button for searching taxa when Adding to Projects to avoid entering potential Adding IDs loops back to ObsEdit.