### PR TITLE
correct in-camera sugg result layout for nativewind4 rule preference

### DIFF
--- a/src/components/Camera/AICamera/AICamera.js
+++ b/src/components/Camera/AICamera/AICamera.js
@@ -38,6 +38,20 @@ import LocationStatus from "./LocationStatus";
 
 const isTablet = DeviceInfo.isTablet();
 
+const getResultContainerClassName = insetsTop => {
+  const widthClassName = isTablet
+    ? "w-[493px]"
+    : "w-[346px]";
+  const phoneTopClassName = insetsTop > 0
+    ? "top-14"
+    : "top-8";
+  const topClassName = isTablet
+    ? ""
+    : phoneTopClassName;
+
+  return classnames( "self-center", widthClassName, topClassName );
+};
+
 // const exampleTaxonResult = {
 //   id: 12704,
 //   name: "Muscicapidae",
@@ -241,11 +255,7 @@ const AICamera = ( {
         className="w-full h-[219px]"
       >
         <View
-          className={classnames( "self-center", {
-            "w-[493px]": isTablet,
-            "w-[346px] top-8": !isTablet,
-            "top-14": insets.top > 0,
-          } )}
+          className={getResultContainerClassName( insets.top )}
         >
           {showPrediction && result
             ? (

--- a/src/components/Camera/AICamera/AICamera.tsx
+++ b/src/components/Camera/AICamera/AICamera.tsx
@@ -1,5 +1,3 @@
-// @flow
-
 import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
 import FadeInOutView from "components/Camera/FadeInOutView";
@@ -7,11 +5,12 @@ import useRotation from "components/Camera/hooks/useRotation";
 import useZoom from "components/Camera/hooks/useZoom";
 import { Body1, INatIcon, TaxonResult } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import type { Node } from "react";
+import type { NoBottomTabStackScreenProps } from "navigation/types";
 import React, { useCallback, useEffect, useState } from "react";
 import DeviceInfo from "react-native-device-info";
 import LinearGradient from "react-native-linear-gradient";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { CameraDevice } from "react-native-vision-camera";
 import { VolumeManager } from "react-native-volume-manager";
 import convertScoreToConfidence from "sharedHelpers/convertScores";
 import { completeSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
@@ -21,6 +20,7 @@ import {
   useLayoutPrefs,
   useTranslation,
 } from "sharedHooks";
+import type { UserLocation } from "sharedHooks/useWatchPosition";
 import useStore from "stores/useStore";
 import colors from "styles/tailwindColors";
 
@@ -38,7 +38,7 @@ import LocationStatus from "./LocationStatus";
 
 const isTablet = DeviceInfo.isTablet();
 
-const getResultContainerClassName = insetsTop => {
+const getResultContainerClassName = ( insetsTop: number ) => {
   const widthClassName = isTablet
     ? "w-[493px]"
     : "w-[346px]";
@@ -60,19 +60,20 @@ const getResultContainerClassName = insetsTop => {
 //   preferred_common_name: "Old World Flycatchers and Chats"
 // };
 
-type Props = {
-  camera: Object,
-  device: Object,
-  flipCamera: Function,
-  isLandscapeMode: boolean,
-  toggleFlash: Function,
-  takingPhoto: boolean,
-  takePhotoAndStoreUri: Function,
-  takePhotoOptions: Object,
-  userLocation?: Object, // UserLocation | null
-  hasLocationPermissions: boolean,
-  requestLocationPermissions: () => void,
-};
+interface Props {
+  camera: object;
+  device: CameraDevice;
+  flipCamera: ( ) => void;
+  isLandscapeMode: boolean;
+  toggleFlash: ( ) => void;
+  takingPhoto: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  takePhotoAndStoreUri: Function;
+  takePhotoOptions: object;
+  userLocation: UserLocation | null;
+  hasLocationPermissions: boolean;
+  requestLocationPermissions: () => void;
+}
 
 const AICamera = ( {
   camera,
@@ -86,8 +87,8 @@ const AICamera = ( {
   userLocation,
   hasLocationPermissions,
   requestLocationPermissions,
-}: Props ): Node => {
-  const navigation = useNavigation( );
+}: Props ) => {
+  const navigation = useNavigation<NoBottomTabStackScreenProps<"Camera">["navigation"]>( );
   const sentinelFileName = useStore( state => state.sentinelFileName );
   const setAICameraSuggestion = useStore( state => state.setAICameraSuggestion );
 
@@ -112,8 +113,8 @@ const AICamera = ( {
     result,
     setResult,
   } = usePredictions( );
-  const [inactive, setInactive] = React.useState( false );
-  const [initialVolume, setInitialVolume] = useState( null );
+  const [inactive, setInactive] = useState( false );
+  const [initialVolume, setInitialVolume] = useState<number | null>( null );
   const [hasTakenPhoto, setHasTakenPhoto] = useState( false );
 
   const [userDisabledLocation, setUserDisabledLocation] = useState( false );
@@ -264,7 +265,7 @@ const AICamera = ( {
                 clearBackground
                 confidence={
                   isDefaultMode
-                    ? null
+                    ? undefined
                     : convertScoreToConfidence( result?.combined_score )
                 }
                 unpressable

--- a/src/components/Camera/AICamera/AICamera.tsx
+++ b/src/components/Camera/AICamera/AICamera.tsx
@@ -1,16 +1,18 @@
 import { useNavigation } from "@react-navigation/native";
 import classnames from "classnames";
 import FadeInOutView from "components/Camera/FadeInOutView";
+import type { Camera } from "components/Camera/helpers/visionCameraWrapper";
 import useRotation from "components/Camera/hooks/useRotation";
 import useZoom from "components/Camera/hooks/useZoom";
 import { Body1, INatIcon, TaxonResult } from "components/SharedComponents";
 import { View } from "components/styledComponents";
 import type { NoBottomTabStackScreenProps } from "navigation/types";
+import type { RefObject } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 import DeviceInfo from "react-native-device-info";
 import LinearGradient from "react-native-linear-gradient";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import type { CameraDevice } from "react-native-vision-camera";
+import type { CameraDevice, TakePhotoOptions } from "react-native-vision-camera";
 import { VolumeManager } from "react-native-volume-manager";
 import convertScoreToConfidence from "sharedHelpers/convertScores";
 import { completeSentinelFile, logStage } from "sharedHelpers/sentinelFiles";
@@ -61,7 +63,7 @@ const getResultContainerClassName = ( insetsTop: number ) => {
 // };
 
 interface Props {
-  camera: object;
+  camera: RefObject<Camera | null>;
   device: CameraDevice;
   flipCamera: ( ) => void;
   isLandscapeMode: boolean;
@@ -69,7 +71,7 @@ interface Props {
   takingPhoto: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   takePhotoAndStoreUri: Function;
-  takePhotoOptions: object;
+  takePhotoOptions: TakePhotoOptions;
   userLocation: UserLocation | null;
   hasLocationPermissions: boolean;
   requestLocationPermissions: () => void;

--- a/src/components/Camera/CameraWithDevice.tsx
+++ b/src/components/Camera/CameraWithDevice.tsx
@@ -1,7 +1,9 @@
+import type { Camera } from "components/Camera/helpers/visionCameraWrapper";
 import { View } from "components/styledComponents";
+import type { RefObject } from "react";
 import React from "react";
 import DeviceInfo from "react-native-device-info";
-import type { CameraDevice } from "react-native-vision-camera";
+import type { CameraDevice, TakePhotoOptions } from "react-native-vision-camera";
 import useDeviceOrientation from "sharedHooks/useDeviceOrientation";
 import type { UserLocation } from "sharedHooks/useWatchPosition";
 
@@ -13,7 +15,7 @@ const isTablet = DeviceInfo.isTablet( );
 interface Props {
   cameraType: "AI" | "Standard";
   device: CameraDevice;
-  camera: object;
+  camera: RefObject<Camera | null>;
   flipCamera: ( ) => void;
   handleCheckmarkPress: ( ) => void;
   confirmPhotosInProgress: boolean;
@@ -24,7 +26,7 @@ interface Props {
   newPhotoUris: object[];
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   setNewPhotoUris: Function;
-  takePhotoOptions: object;
+  takePhotoOptions: TakePhotoOptions;
   userLocation: UserLocation | null;
   hasLocationPermissions: boolean;
   requestLocationPermissions: () => void;

--- a/src/components/Camera/CameraWithDevice.tsx
+++ b/src/components/Camera/CameraWithDevice.tsx
@@ -17,8 +17,7 @@ interface Props {
   flipCamera: ( ) => void;
   handleCheckmarkPress: ( ) => void;
   confirmPhotosInProgress: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  toggleFlash: Function;
+  toggleFlash: ( ) => void;
   takingPhoto: boolean;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   takePhotoAndStoreUri: Function;

--- a/src/components/Camera/hooks/useZoom.ts
+++ b/src/components/Camera/hooks/useZoom.ts
@@ -29,7 +29,7 @@ const SCALE_FULL_ZOOM = 3;
 const PAN_ZOOM_MIN_DISTANCE = -100;
 const PAN_ZOOM_MAX_DISTANCE = 100;
 
-const useZoom = ( device: CameraDevice ): object => {
+const useZoom = ( device: CameraDevice ) => {
   const initialZoomTextValue = "1";
   const zoomButtonOptions = useMemo( () => {
     const options = [initialZoomTextValue];

--- a/src/components/SharedComponents/TaxonResult.tsx
+++ b/src/components/SharedComponents/TaxonResult.tsx
@@ -38,6 +38,7 @@ interface TaxonResultBaseProps {
   hideNavButtons?: boolean;
   lastScreen?: "Suggestions";
   onPressInfo?: ( taxon: RealmTaxon | ApiTaxon ) => void;
+  retryQuery?: boolean;
   showEditButton?: boolean;
   showRemoveButton?: boolean;
   taxon: RealmTaxon | ApiTaxon;


### PR DESCRIPTION
closes MOB-1762

corrects a nativewind4 regression around style overrides

Photos vs screenshots bc screenshots don't capture notch interaction
|Before|After|
|---|---|
|<img width="3072" height="4080" alt="image" src="https://github.com/user-attachments/assets/7007a1f3-b4a8-4e64-bb08-357bf0c294de" />|<img width="3072" height="4080" alt="image" src="https://github.com/user-attachments/assets/c303bcf5-3b81-46ff-adf9-e0bc1991ff58" />|