### PR TITLE
MOB-1660: zoom changes + test

### DIFF
--- a/src/components/Camera/hooks/useZoom.ts
+++ b/src/components/Camera/hooks/useZoom.ts
@@ -1,3 +1,4 @@
+import clamp from "lodash/clamp";
 import indexOf from "lodash/indexOf";
 import last from "lodash/last";
 import {
@@ -45,11 +46,6 @@ const useZoom = ( device: CameraDevice ): object => {
   }, [device?.physicalDevices] );
   const minZoom = device?.minZoom ?? 1;
   const neutralZoom = device?.neutralZoom ?? 2;
-  // this maxZoom zooms to 3x magnification on an iPhone 15 Pro
-  // currently the camera viewport is different than the photo taken
-  // so the photo taken with this zoom looks accurate compared with the native camera
-  // photo taken, but the camera preview looks a little too small
-  const maxZoomWithButton = neutralZoom ** 2.5;
   const maxZoomWithPinch = Math.min( device.maxZoom ?? 1, MAX_ZOOM_FACTOR );
   const initialZoom = !device?.isMultiCam
     ? minZoom
@@ -58,7 +54,28 @@ const useZoom = ( device: CameraDevice ): object => {
   const startZoom = useSharedValue( initialZoom );
   const [zoomTextValue, setZoomTextValue] = useState( initialZoomTextValue );
 
-  const zoomButtonValues = [minZoom, neutralZoom, maxZoomWithButton];
+  // goal here is to turn the display labels (some subset of .5, 1, 3) into the zoom factor for
+  // zoom.set so the result matches what the native camera shows for that label
+  //
+  // The labels are magnifications relative to the main wide lens. neutralZoom is the zoom
+  // factor at which that main lens is active, so factor = neutralZoom * label.
+  // ios/android anchor their zoom scales differently, which is why neutralZoom differs:
+  //   - Android puts the wide lens at 1.0 and the ultra-wide below it (minZoom ~0.5-0.67),
+  //     so neutralZoom is always 1 and the labels already are the zoom factors.
+  //   - iOS puts the widest lens at 1.0, so on any iPhone with an ultra-wide the default lens
+  //     sits at 2.0 and neutralZoom is 2. Without an ultra-wide it is 1.
+  // The clamp keeps requests inside the device's real range
+  //
+  // notably 3x is that threshold for handing off to the telephoto lens on the 15 Pro
+  // but for more recent Pros, that threshold is 5x so maybe we want to account for that someday
+  const zoomButtonValues = useMemo(
+    ( ) => zoomButtonOptions.map( option => clamp(
+      neutralZoom * Number( option ),
+      minZoom,
+      maxZoomWithPinch,
+    ) ),
+    [maxZoomWithPinch, minZoom, neutralZoom, zoomButtonOptions],
+  );
 
   useEffect( ( ) => {
     const newInitialZoom = !device?.isMultiCam
@@ -90,19 +107,17 @@ const useZoom = ( device: CameraDevice ): object => {
   }, [initialZoom, initialZoomTextValue, zoom] );
 
   const updateZoomTextValue = useCallback( ( newZoom: number ) => {
-    const closestZoomTextValue = zoomButtonOptions.reduce(
-      ( prev, curr ) => {
-        if ( newZoom === minZoom ) {
-          return zoomButtonOptions[0];
-        }
-        return (
-          Math.abs( curr - newZoom ) < Math.abs( prev - newZoom )
-            ? curr
-            : prev );
-      },
+    // Compare against the zoom factors the buttons map to, not the labels themselves: a
+    // label like "3" is a magnification, while newZoom is a device zoom factor.
+    const closestIndex = zoomButtonValues.reduce(
+      ( closest, value, index ) => (
+        Math.abs( value - newZoom ) < Math.abs( zoomButtonValues[closest] - newZoom )
+          ? index
+          : closest ),
+      0,
     );
-    setZoomTextValue( closestZoomTextValue );
-  }, [zoomButtonOptions, minZoom] );
+    setZoomTextValue( zoomButtonOptions[closestIndex] );
+  }, [zoomButtonOptions, zoomButtonValues] );
 
   const onZoomChange = useCallback( ( newValue: number ) => {
     "worklet";

--- a/tests/unit/components/Camera/hooks/useZoom.test.js
+++ b/tests/unit/components/Camera/hooks/useZoom.test.js
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react-native";
+import useZoom from "components/Camera/hooks/useZoom";
+import { withSpring } from "react-native-reanimated";
+
+jest.mock( "react-native-reanimated", ( ) => {
+  const actual = jest.requireActual( "react-native-reanimated" );
+  return {
+    __esModule: true,
+    ...actual,
+    withSpring: jest.fn( value => value ),
+  };
+} );
+
+// A triple-camera iPhone: the wide-angle camera sits at zoom factor 2 within the virtual
+// multi-camera device, so 1x is 2 and 3x is 6.
+const iPhoneDevice = {
+  physicalDevices: ["ultra-wide-angle-camera", "wide-angle-camera", "telephoto-camera"],
+  isMultiCam: true,
+  minZoom: 1,
+  neutralZoom: 2,
+  maxZoom: 63,
+};
+
+// An Android device with the same lenses. Android always reports neutralZoom as 1, so 3x
+// is 3 — the case that used to resolve to 1 and leave the camera unzoomed (MOB-1660).
+const androidDevice = {
+  physicalDevices: ["ultra-wide-angle-camera", "wide-angle-camera", "telephoto-camera"],
+  isMultiCam: true,
+  minZoom: 0.5,
+  neutralZoom: 1,
+  maxZoom: 10,
+};
+
+const pinch = async ( result, scale ) => {
+  await act( async ( ) => {
+    result.current.pinchToZoom.handlers.onStart( {} );
+    result.current.pinchToZoom.handlers.onChange( { scale } );
+  } );
+};
+
+beforeEach( ( ) => {
+  withSpring.mockClear( );
+} );
+
+describe( "useZoom", ( ) => {
+  it( "zooms in when the button steps up to 3x on Android", ( ) => {
+    const { result } = renderHook( ( ) => useZoom( androidDevice ) );
+
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+
+    expect( result.current.zoomTextValue ).toEqual( "3" );
+    expect( withSpring ).toHaveBeenLastCalledWith( 3 );
+  } );
+
+  it( "zooms in when the button steps up to 3x on iOS", ( ) => {
+    const { result } = renderHook( ( ) => useZoom( iPhoneDevice ) );
+
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+
+    expect( result.current.zoomTextValue ).toEqual( "3" );
+    expect( withSpring ).toHaveBeenLastCalledWith( 6 );
+  } );
+
+  it( "cycles back to the ultra-wide option after the last one", ( ) => {
+    const { result } = renderHook( ( ) => useZoom( androidDevice ) );
+
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+
+    expect( result.current.zoomTextValue ).toEqual( ".5" );
+    expect( withSpring ).toHaveBeenLastCalledWith( 0.5 );
+  } );
+
+  it( "wraps out to ultra-wide, then back to 1x, without a telephoto camera", ( ) => {
+    const device = {
+      ...androidDevice,
+      physicalDevices: ["ultra-wide-angle-camera", "wide-angle-camera"],
+    };
+    const { result } = renderHook( ( ) => useZoom( device ) );
+
+    // 1x is the last option on this device, so the first press wraps rather than steps up
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+
+    expect( result.current.zoomTextValue ).toEqual( ".5" );
+    expect( withSpring ).toHaveBeenLastCalledWith( 0.5 );
+
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+
+    expect( result.current.zoomTextValue ).toEqual( "1" );
+    expect( withSpring ).toHaveBeenLastCalledWith( 1 );
+  } );
+
+  it( "zooms in on a device with a telephoto but no ultra-wide camera", ( ) => {
+    const device = {
+      ...androidDevice,
+      physicalDevices: ["wide-angle-camera", "telephoto-camera"],
+      minZoom: 1,
+    };
+    const { result } = renderHook( ( ) => useZoom( device ) );
+
+    act( ( ) => result.current.handleZoomButtonPress( ) );
+
+    expect( result.current.zoomTextValue ).toEqual( "3" );
+    expect( withSpring ).toHaveBeenLastCalledWith( 3 );
+  } );
+
+  it( "labels a pinch out to the ultra-wide camera as .5 on iOS", async ( ) => {
+    const { result } = renderHook( ( ) => useZoom( iPhoneDevice ) );
+
+    await pinch( result, 0.5 );
+
+    expect( result.current.zoomTextValue ).toEqual( ".5" );
+  } );
+
+  it( "hides the zoom button after flipping to a single-camera (front-facing)", ( ) => {
+    const frontDevice = {
+      physicalDevices: ["wide-angle-camera"],
+      isMultiCam: false,
+      minZoom: 1,
+      neutralZoom: 1,
+      maxZoom: 10,
+    };
+    const { result, rerender } = renderHook( device => useZoom( device ), {
+      initialProps: iPhoneDevice,
+    } );
+    expect( result.current.showZoomButton ).toBe( true );
+
+    rerender( frontDevice );
+
+    expect( result.current.showZoomButton ).toBe( false );
+  } );
+} );


### PR DESCRIPTION
fixes https://linear.app/inaturalist/issue/MOB-1660/mobile-bug-tapping-zoom-button-doesnt-zoom-in

update the zoom label -> zoom value mapping to account for more types of device

Please, if folks have an android device with multiple cameras or a recent iPhone pro, this is an important one to test