### PR TITLE
MOB-1720: less exploreV2 header spacing

### DIFF
--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -131,7 +131,7 @@ const ExploreV2Header = ( { showBackButton }: Props ) => {
       select back button, header content, or search button */}
       <Pressable
         accessible={false}
-        className="p-4 flex-row items-center"
+        className="px-4 pt-1 pb-[5px] flex-row items-center"
         onPress={() => navigation.navigate( searchScreen )}
         testID="ExploreV2Header.pressable"
       >

--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -131,7 +131,7 @@ const ExploreV2Header = ( { showBackButton }: Props ) => {
       select back button, header content, or search button */}
       <Pressable
         accessible={false}
-        className="px-4 pt-1 pb-[5px] flex-row items-center"
+        className="px-4 pt-1 pb-[8px] flex-row items-center"
         onPress={() => navigation.navigate( searchScreen )}
         testID="ExploreV2Header.pressable"
       >


### PR DESCRIPTION
Before
<details>
<img width="603" height="380" alt="before" src="https://github.com/user-attachments/assets/6a3af509-a72b-482a-8098-36271ba0d4b8" />
<img width="603" height="382" alt="Simulator Screenshot - iPhone 16 Pro - 2026-09-09 at 17 41 37" src="https://github.com/user-attachments/assets/99c75f90-33a5-4f87-883d-2373db23953a" />

</details>
After
<details>
<img width="603" height="370" alt="after_after" src="https://github.com/user-attachments/assets/c91d2c35-0424-4f72-90e6-d29747920cbb" />
<img width="603" height="372" alt="Simulator Screenshot - iPhone 16 Pro - 2026-09-09 at 17 39 21" src="https://github.com/user-attachments/assets/6e7f9138-9854-4233-92e2-070446ba08eb" />

</details>