### PR TITLE
add rn-nitro-image (dep only)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -179,6 +179,36 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - NitroImage (0.15.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - NitroModules
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - NitroModules (0.36.5):
     - boost
     - DoubleConversion
@@ -4004,6 +4034,7 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - NitroImage (from `../node_modules/react-native-nitro-image`)
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -4176,6 +4207,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-v0.14.1
+  NitroImage:
+    :path: "../node_modules/react-native-nitro-image"
   NitroModules:
     :path: "../node_modules/react-native-nitro-modules"
   RCT-Folly:
@@ -4446,6 +4479,7 @@ SPEC CHECKSUMS:
   LicensePlist: 91465ee0724beab897ed5482775c5d3932a3f379
   Mute: 20135a96076f140cc82bfc8b810e2d6150d8ec7e
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  NitroImage: aaf23abdf2f5446f392b43867c27860508b52965
   NitroModules: d52aaa5db99af2be4c2b171460e3a7541d78fe4d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "react-native-mmkv": "^3.3.3",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-modal-datetime-picker": "^18.0.0",
-        "react-native-nitro-image": "^0.15.1",
+        "react-native-nitro-image": "0.15.1",
         "react-native-nitro-modules": "0.36.5",
         "react-native-open-maps": "^0.4.3",
         "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "react-native-mmkv": "^3.3.3",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-modal-datetime-picker": "^18.0.0",
+        "react-native-nitro-image": "^0.15.1",
         "react-native-nitro-modules": "0.36.5",
         "react-native-open-maps": "^0.4.3",
         "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",
@@ -19381,6 +19382,20 @@
       "peerDependencies": {
         "@react-native-community/datetimepicker": ">=6.7.0",
         "react-native": ">=0.65.0"
+      }
+    },
+    "node_modules/react-native-nitro-image": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/react-native-nitro-image/-/react-native-nitro-image-0.15.1.tgz",
+      "integrity": "sha512-slrImfUgasAdzylTiNWuTkawE0R4t7LGh+7N2VFa/D9+SxlQbkKYp1J6hA3XkkEnTnUCKaea39ZVg+1xx665MQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-nitro-modules": "*"
       }
     },
     "node_modules/react-native-nitro-modules": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "react-native-mmkv": "^3.3.3",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",
+    "react-native-nitro-image": "^0.15.1",
     "react-native-nitro-modules": "0.36.5",
     "react-native-open-maps": "^0.4.3",
     "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-native-mmkv": "^3.3.3",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-modal-datetime-picker": "^18.0.0",
-    "react-native-nitro-image": "^0.15.1",
+    "react-native-nitro-image": "0.15.1",
     "react-native-nitro-modules": "0.36.5",
     "react-native-open-maps": "^0.4.3",
     "react-native-orientation-locker": "github:wonday/react-native-orientation-locker",


### PR DESCRIPTION
closes MOB-1754

Per ticket, we're not actually cutting over to this for image components as of now. We're just pulling it for react-native-vision-camera@5 support. See also https://github.com/inaturalist/SeekReactNative/pull/1017

Package only doesn't seem to have impact on build. I ran into some stuff while spiking the component cutover, but will document those separately since we're not doing that right now.