### PR TITLE
bump concurrent-ruby@1.3.8 manually to make dependabot go away

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby ">= 2.6.10"
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem "activesupport", ">= 6.1.7.5", "!= 7.1.0"
 gem "cocoapods", ">= 1.13", "!= 1.15.0", "!= 1.15.1"
-gem "concurrent-ruby", "< 1.3.4"
+gem "concurrent-ruby", "< 1.3.8"
 gem "xcodeproj", "< 1.26.0"
 
 # Ruby 3.4.0 has removed some libraries from the standard library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ DEPENDENCIES
   benchmark
   bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
+  concurrent-ruby (< 1.3.8)
   fastlane
   logger
   nokogiri


### PR DESCRIPTION
I don't know how https://github.com/inaturalist/iNaturalistReactNative/pull/3757 ended up with a mix of 1.3.7 & 1.3.8, but I pushed to .8 for safety: https://github.com/ruby-concurrency/concurrent-ruby/releases/tag/v1.3.8 changes seem inconsequential between the two

validated on fresh `cd ios && bundle install && bundle exec pod install` then rebuilds. Everything seems fine.