### PR TITLE
use an obs uuid/pk when we're doing a single item Realm query for isUnsync'd

### DIFF
--- a/src/components/ObservationsFlashList/ObservationsFlashList.tsx
+++ b/src/components/ObservationsFlashList/ObservationsFlashList.tsx
@@ -131,8 +131,7 @@ const ObservationsFlashList = ( {
     // TODO: may want push this into one connected wrapper that serves list, grid, and small-grid
     // layouts (probably folded into ObsPressable) that subscribes to the upload store with
     // narrow selectors, the way MyObservations/SmallGridObsItemContainer now does. Computing it
-    // here means every visible cell re-renders on every upload progress tick, and each one runs
-    // isUnsyncedObservation, which filters the whole Observation table.
+    // here means every visible cell re-renders on every upload progress tick.
     const obsNeedsSync = RealmObservation.isUnsyncedObservation( realm, item );
     const obsUploadState = totalUploadProgress.find( o => o.uuid === uuid );
     const uploadProgress = obsNeedsSync

--- a/src/realmModels/Observation.js
+++ b/src/realmModels/Observation.js
@@ -480,8 +480,8 @@ class Observation extends Realm.Object {
   };
 
   static isUnsyncedObservation = ( realm, obs ) => {
-    const obsList = Observation.filterUnsyncedObservations( realm );
-    const unsyncedObs = obsList.filtered( `uuid == "${obs.uuid}"` );
+    const unsyncedObs = realm.objects( "Observation" )
+      .filtered( `uuid == "${obs.uuid}" && ( ${UNSYNCED_FILTER} )` );
     return unsyncedObs.length > 0;
   };
 

--- a/tests/unit/models/Observation.test.js
+++ b/tests/unit/models/Observation.test.js
@@ -174,6 +174,39 @@ describe( "Observation", ( ) => {
     } );
   } );
 
+  describe( "isUnsyncedObservation", ( ) => {
+    it( "should return true for an unsynced observation", ( ) => {
+      const obsUuid = uuid.v4( );
+      safeRealmWrite( global.realm, ( ) => {
+        global.realm.create( "Observation", {
+          uuid: obsUuid,
+          _synced_at: null,
+        } );
+      }, "create unsynced obs" );
+
+      expect(
+        Observation.isUnsyncedObservation( global.realm, { uuid: obsUuid } ),
+      ).toBe( true );
+    } );
+
+    it( "should return false for a synced observation", ( ) => {
+      const obsUuid = uuid.v4( );
+      const updatedDate = new Date( "2020-01-01" );
+      const syncDate = new Date( "2020-01-02" );
+      safeRealmWrite( global.realm, ( ) => {
+        global.realm.create( "Observation", {
+          uuid: obsUuid,
+          _synced_at: syncDate,
+          _updated_at: updatedDate,
+        } );
+      }, "create synced obs" );
+
+      expect(
+        Observation.isUnsyncedObservation( global.realm, { uuid: obsUuid } ),
+      ).toBe( false );
+    } );
+  } );
+
   describe( "saveLocalObservationForUpload", ( ) => {
     it( "creates Realm tombstones from pending-removal POs", async ( ) => {
       const obsUuid = uuid.v4( );


### PR DESCRIPTION
closes MOB-1654

I swear I had done this before but maybe I just did the `UNSYNCED_FILTER` and missed following up on `isUnsyncedObservation`. Sorry about that, and good catch @.abbey!