### PR TITLE
fix multiple selection from GPhotos by removing intent condition

### DIFF
--- a/patches/react-native-image-picker+8.2.1.patch
+++ b/patches/react-native-image-picker+8.2.1.patch
@@ -20,10 +20,10 @@ index 708c7d1..ed5b33c 100644
  | height       | OK  | OK      | OK  | BOTH        | NO                   | Asset dimensions                                                                                                                                                                                                                                                               |
  | fileSize     | OK  | OK      | NO  | BOTH        | NO                   | The file size                                                                                                                                                                                                                                                                  |
 diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
-index 56149f1..48ea38c 100644
+index 56149f1..631ea9e 100644
 --- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
 +++ b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
-@@ -162,7 +162,37 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
+@@ -162,7 +162,38 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
          }
  
          try {
@@ -34,9 +34,10 @@ index 56149f1..48ea38c 100644
 +                // of that selector - so we need a hybrid approach which shows
 +                Intent pickIntent = new Intent(Intent.ACTION_PICK);
 +                if (!isSingleSelect) {
-+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-+                        pickIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-+                    } else {
++                    // EXTRA_ALLOW_MULTIPLE is what ACTION_PICK handlers like Google Photos honor;
++                    // EXTRA_PICK_IMAGES_MAX below is additionally needed for the system Photo Picker on 13+.
++                    pickIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
++                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 +                        if ((selectionLimit != 1) && (!libraryIntent.getAction().equals(Intent.ACTION_GET_CONTENT)))  {
 +                            int maxNum = selectionLimit;
 +                            if (selectionLimit == 0) maxNum = MediaStore.getPickImagesMaxLimit();


### PR DESCRIPTION
closes MOB-1645

Diff is unhelpful (SemanticDiff is also wonky) but the key change is removing the `Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU` guard before setting `Intent.EXTRA_ALLOW_MULTIPLE`, the one that GPhotos (and ostensibly other modern pickers?) handles. I confirmed it's harmless to have the multiple intents: this works on pre-and-post Android 13 devices (flexing my trusty LG G6).

We definitely _do_ need to keep the `TIRAMISU` guard on the later logic so I've left that untouched.

Before: System Browser works w/ multiple photos, but GPhotos only allows 1 photo and "shares" as soon as I tap the first one

https://github.com/user-attachments/assets/160f6657-bddd-49e0-8ac8-7711923f11f4

After: both allow selecting multiple

https://github.com/user-attachments/assets/7a27af2a-7df0-48b1-b865-4197f75c08e3

