### PR TITLE
MOB-1764: parity between UniversalSearch and AdvancedSearch user defaults

### DIFF
--- a/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
+++ b/src/components/Explore/ExploreV2/components/ExploreV2Header.tsx
@@ -113,7 +113,7 @@ const ExploreV2Header = ( { showBackButton }: Props ) => {
         scientificNameFirst={currentUser?.prefers_scientific_name_first}
       />
     );
-  } else if ( subject?.type === "unobserved" ) {
+  } else if ( subject?.type === "unobserved" || state.filters.unobservedByUser ) {
     headerContent = (
       <TitleHeader
         title={t( "Unobserved" )}

--- a/src/components/Explore/ExploreV2/helpers/advancedSearchReducer.ts
+++ b/src/components/Explore/ExploreV2/helpers/advancedSearchReducer.ts
@@ -37,17 +37,25 @@ export interface AdvancedSearchDraft {
   filters: ExploreV2Filters;
 }
 
-// Only taxon goes in the subject. user/project live in the filter blob
+// Only taxon goes in the subject. user/project/unobserved live in the filter blob
 export const draftFromV2State = ( v2: ExploreV2State ): AdvancedSearchDraft => {
   const { subject } = v2;
   const base = { location: v2.location, sortBy: v2.sortBy };
   switch ( subject?.type ) {
     case "user":
-      return { ...base, subject: null, filters: { ...v2.filters, user: subject.user } };
+      return {
+        ...base,
+        subject: null,
+        filters: { ...v2.filters, user: subject.user, unobservedByUser: null },
+      };
     case "project":
       return { ...base, subject: null, filters: { ...v2.filters, project: subject.project } };
     case "unobserved":
-      return { ...base, subject: null, filters: v2.filters };
+      return {
+        ...base,
+        subject: null,
+        filters: { ...v2.filters, unobservedByUser: subject.user, user: null },
+      };
     default:
       return { ...base, subject: subject ?? null, filters: v2.filters };
   }
@@ -70,7 +78,7 @@ export type AdvancedSearchAction =
   | { type: "SET_LOCATION_WORLDWIDE" }
   | { type: "SET_SORT"; sortBy: OBSERVATIONS_SORT }
   | { type: "SET_USER"; user: ApiUser | null }
-  | { type: "SET_EXCLUDE_USER"; user: ApiUser | null }
+  | { type: "SET_UNOBSERVED_BY_USER"; user: ApiUser | null }
   | { type: "SET_PROJECT"; project: ApiProjectSummary | null }
   | { type: "TOGGLE_RESEARCH_GRADE" }
   | { type: "TOGGLE_NEEDS_ID" }
@@ -132,9 +140,9 @@ export const advancedSearchReducer = (
     case "SET_SORT":
       return { ...draft, sortBy: action.sortBy };
     case "SET_USER":
-      return withFilters( draft, { user: action.user, excludeUser: null } );
-    case "SET_EXCLUDE_USER":
-      return withFilters( draft, { excludeUser: action.user, user: null } );
+      return withFilters( draft, { user: action.user, unobservedByUser: null } );
+    case "SET_UNOBSERVED_BY_USER":
+      return withFilters( draft, { unobservedByUser: action.user, user: null } );
     case "SET_PROJECT":
       return withFilters( draft, { project: action.project } );
     case "TOGGLE_RESEARCH_GRADE":

--- a/src/components/Explore/ExploreV2/helpers/buildQueryParams.ts
+++ b/src/components/Explore/ExploreV2/helpers/buildQueryParams.ts
@@ -16,7 +16,6 @@ export interface ExploreV2QueryParams extends FilterApiParams {
   order: SortDirection;
   taxon_id?: number;
   iconic_taxa?: string[];
-  unobserved_by_user_id?: number;
   lat?: number;
   lng?: number;
   radius?: number;

--- a/src/components/Explore/ExploreV2/helpers/countFilters.ts
+++ b/src/components/Explore/ExploreV2/helpers/countFilters.ts
@@ -4,7 +4,7 @@ import { defaultExploreV2Filters } from "providers/ExploreV2Context";
 const countedDefaults = {
   ...defaultExploreV2Filters,
   user: null,
-  excludeUser: null,
+  unobservedByUser: null,
   project: null,
 };
 

--- a/src/components/Explore/ExploreV2/helpers/filtersToApiParams.ts
+++ b/src/components/Explore/ExploreV2/helpers/filtersToApiParams.ts
@@ -29,7 +29,7 @@ export interface FilterApiParams {
   viewer_id?: number;
   photo_license?: string;
   user_id?: number;
-  not_user_id?: number;
+  unobserved_by_user_id?: number;
   project_id?: number;
 }
 
@@ -105,8 +105,8 @@ const filtersToApiParams = (
 
   if ( filters.user?.id ) { params.user_id = filters.user.id; }
 
-  if ( filters.excludeUser?.id ) {
-    params.not_user_id = filters.excludeUser.id;
+  if ( filters.unobservedByUser?.id ) {
+    params.unobserved_by_user_id = filters.unobservedByUser.id;
   }
 
   if ( filters.project?.id ) { params.project_id = filters.project.id; }

--- a/src/components/Explore/ExploreV2/helpers/savedSearchKey.ts
+++ b/src/components/Explore/ExploreV2/helpers/savedSearchKey.ts
@@ -55,7 +55,7 @@ const filtersKey = ( filters: ExploreV2Filters ): string => {
     reviewedFilter: filters.reviewedFilter,
     photoLicense: filters.photoLicense,
     user: String( filters.user?.id ?? "" ),
-    excludeUser: String( filters.excludeUser?.id ?? "" ),
+    unobservedByUser: String( filters.unobservedByUser?.id ?? "" ),
     project: String( filters.project?.id ?? "" ),
   };
 

--- a/src/components/Explore/ExploreV2/screens/AdvancedSearch.tsx
+++ b/src/components/Explore/ExploreV2/screens/AdvancedSearch.tsx
@@ -52,6 +52,7 @@ import {
 import SearchHeader from "components/SharedComponents/SearchHeader";
 import BottomSheetV2 from "components/SharedComponents/Sheets/BottomSheetV2";
 import WarningSheet from "components/SharedComponents/Sheets/WarningSheet";
+import Body1 from "components/SharedComponents/Typography/Body1";
 import { SharedStackViewWrapper } from "components/SharedComponents/ViewWrapper";
 import { ScrollView, View } from "components/styledComponents";
 import UserListItem from "components/UserList/UserListItem";
@@ -138,11 +139,21 @@ const AdvancedSearch = ( ) => {
     type: "FILTER_BY_ICONIC_UNKNOWN",
   } );
 
-  const updateUser = ( selectedUser: ExploreSearchUser | null, exclude?: boolean ) => dispatch(
-    exclude
-      ? { type: "SET_EXCLUDE_USER", user: selectedUser }
-      : { type: "SET_USER", user: selectedUser },
-  );
+  const updateUser = ( selectedUser: ExploreSearchUser | null ) => dispatch( {
+    type: "SET_USER",
+    user: selectedUser,
+  } );
+
+  const updateUnobservedByUser = ( selectedUser: ExploreSearchUser ) => dispatch( {
+    type: "SET_UNOBSERVED_BY_USER",
+    user: {
+      id: selectedUser.id,
+      login: selectedUser.login,
+      icon_url: selectedUser.icon_url,
+    },
+  } );
+
+  const clearUserFilters = ( ) => dispatch( { type: "SET_USER", user: null } );
 
   const updateProject = ( selectedProject: ApiProjectSummary | null ) => dispatch( {
     type: "SET_PROJECT",
@@ -185,7 +196,6 @@ const AdvancedSearch = ( ) => {
     dateObserved,
     dateUploaded,
     establishmentMean,
-    excludeUser,
     hrank,
     lrank,
     media,
@@ -196,6 +206,7 @@ const AdvancedSearch = ( ) => {
     project,
     researchGrade,
     reviewedFilter,
+    unobservedByUser,
     user,
     wildStatus,
   } = filters;
@@ -210,7 +221,6 @@ const AdvancedSearch = ( ) => {
     return [];
   };
 
-  const displayUser = user || excludeUser;
   const displayProject = project;
 
   const sortByValues = getSortByValues( t );
@@ -425,37 +435,42 @@ const AdvancedSearch = ( ) => {
 
           {/* User Section */}
           <View className="mb-7">
-            <Heading4 className="mb-5">
-              {excludeUser
-                ? t( "ALL-USERS-EXCEPT" )
-                : t( "USER" )}
-            </Heading4>
+            <Heading4 className="mb-5">{t( "USER" )}</Heading4>
             <View className="mb-5">
-              {displayUser
-                ? (
-                  <SelectedFilterRow
-                    accessibilityLabel={t( "Change-user" )}
-                    justify="justify-around"
-                    onEdit={() => setOpenPicker( "user" )}
-                    onRemove={() => updateUser( null )}
-                    removeAccessibilityLabel={t( "Remove-user-filter" )}
-                  >
-                    <UserListItem
-                      item={{ user: displayUser }}
-                      countText={t( "X-Observations", { count: displayUser.observations_count } )}
-                      pressable={false}
-                    />
-                  </SelectedFilterRow>
-                )
-                : (
-                  <Button
-                    text={t( "FILTER-BY-A-USER" )}
-                    onPress={() => {
-                      setOpenPicker( "user" );
-                    }}
-                    accessibilityLabel={t( "Filter" )}
+              {unobservedByUser && (
+                <SelectedFilterRow
+                  accessibilityLabel={t( "Change-user" )}
+                  onEdit={() => setOpenPicker( "user" )}
+                  onRemove={clearUserFilters}
+                  removeAccessibilityLabel={t( "Remove-user-filter" )}
+                >
+                  <Body1>{t( "Species-I-havent-observed" )}</Body1>
+                </SelectedFilterRow>
+              )}
+              {user && (
+                <SelectedFilterRow
+                  accessibilityLabel={t( "Change-user" )}
+                  justify="justify-around"
+                  onEdit={() => setOpenPicker( "user" )}
+                  onRemove={clearUserFilters}
+                  removeAccessibilityLabel={t( "Remove-user-filter" )}
+                >
+                  <UserListItem
+                    item={{ user }}
+                    countText={t( "X-Observations", { count: user.observations_count } )}
+                    pressable={false}
                   />
-                )}
+                </SelectedFilterRow>
+              )}
+              {!user && !unobservedByUser && (
+                <Button
+                  text={t( "FILTER-BY-A-USER" )}
+                  onPress={() => {
+                    setOpenPicker( "user" );
+                  }}
+                  accessibilityLabel={t( "Filter" )}
+                />
+              )}
             </View>
           </View>
 
@@ -749,6 +764,7 @@ const AdvancedSearch = ( ) => {
           showModal
           closeModal={closePicker}
           updateUser={updateUser}
+          onSelectUnobserved={updateUnobservedByUser}
         />
       )}
       {openPicker === "project" && (

--- a/src/components/Explore/Modals/ExploreUserSearchModal.tsx
+++ b/src/components/Explore/Modals/ExploreUserSearchModal.tsx
@@ -7,12 +7,14 @@ interface Props {
   showModal: boolean;
   closeModal: () => void;
   updateUser: ( user: ExploreSearchUser | null, exclude?: boolean ) => void;
+  onSelectUnobserved?: ( user: ExploreSearchUser ) => void;
 }
 
 const ExploreUserSearchModal = ( {
   showModal,
   closeModal,
   updateUser,
+  onSelectUnobserved,
 }: Props ) => (
   <Modal
     showModal={showModal}
@@ -23,6 +25,7 @@ const ExploreUserSearchModal = ( {
       <ExploreUserSearch
         closeModal={closeModal}
         updateUser={updateUser}
+        onSelectUnobserved={onSelectUnobserved}
       />
     )}
   />

--- a/src/components/Explore/SearchScreens/ExploreUserSearch.tsx
+++ b/src/components/Explore/SearchScreens/ExploreUserSearch.tsx
@@ -3,8 +3,9 @@ import type { ButtonConfiguration } from "components/SharedComponents/ButtonBar"
 import ButtonBar from "components/SharedComponents/ButtonBar";
 import SearchBar from "components/SharedComponents/SearchBar";
 import SearchHeader from "components/SharedComponents/SearchHeader";
+import Body1 from "components/SharedComponents/Typography/Body1";
 import ViewWrapper from "components/SharedComponents/ViewWrapper";
-import { View } from "components/styledComponents";
+import { Pressable, View } from "components/styledComponents";
 import UserList from "components/UserList/UserList";
 import React, {
   useCallback,
@@ -30,15 +31,22 @@ export type ExploreSearchUser = ApiUser | UserPojo;
 interface Props {
   closeModal: ( ) => void;
   updateUser: ( user: ExploreSearchUser | null, exclude?: boolean ) => void;
+  onSelectUnobserved?: ( user: ExploreSearchUser ) => void;
 }
 
-const ExploreUserSearch = ( { closeModal, updateUser }: Props ) => {
+const DEFAULT_ROW_CLASSES = "px-[15px] py-[11px] border-b border-lightGray";
+
+const ExploreUserSearch = ( { closeModal, updateUser, onSelectUnobserved }: Props ) => {
   const [userQuery, setUserQuery] = useState( "" );
   const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets( );
   const currentUser = useCurrentUser();
   const { keyboardHeight, keyboardShown } = useKeyboardInfo();
   const { users: userList = [], isLoading, refetch } = useUserSearch( userQuery );
+
+  // The picker shows default results instead of an empty list before the user
+  // has typed anything
+  const showDefaultResults = !!onSelectUnobserved && userQuery.trim( ).length === 0;
 
   const onUserSelected = useCallback( async ( user: ExploreSearchUser, exclude?: boolean ) => {
     if ( !user.id && !user.login ) {
@@ -58,6 +66,12 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ) => {
     [updateUser, closeModal],
   );
 
+  const onUnobservedSelected = useCallback( ( ) => {
+    if ( !currentUser || !onSelectUnobserved ) { return; }
+    onSelectUnobserved( currentUser );
+    closeModal();
+  }, [closeModal, currentUser, onSelectUnobserved] );
+
   // TODO: pagination like in ExploreFlashList ?
 
   const emptyListComponent = useMemo(
@@ -71,10 +85,25 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ) => {
     [isLoading, refetch, userQuery],
   );
 
+  const keyboardPadding = keyboardShown
+    ? bottom + keyboardHeight
+    : bottom;
+
   const footerComponent = ( ) => (
-    keyboardShown
-      ? <View style={{ paddingBottom: bottom + keyboardHeight }} />
-      : <View style={{ paddingBottom: bottom }} />
+    <>
+      {showDefaultResults && currentUser && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t( "Species-I-havent-observed" )}
+          className={DEFAULT_ROW_CLASSES}
+          onPress={onUnobservedSelected}
+          testID="ExploreUserSearch.unobserved"
+        >
+          <Body1>{t( "Species-I-havent-observed" )}</Body1>
+        </Pressable>
+      )}
+      <View style={{ paddingBottom: keyboardPadding }} />
+    </>
   );
 
   const buttons: ButtonConfiguration[] = [
@@ -100,6 +129,13 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ) => {
     },
   ];
 
+  const defaultResults = currentUser
+    ? [currentUser]
+    : [];
+  const users = showDefaultResults
+    ? defaultResults
+    : userList;
+
   return (
     <ViewWrapper>
       <SearchHeader
@@ -117,7 +153,7 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ) => {
           value={userQuery}
           testID="SearchUser"
         />
-        {currentUser && (
+        {currentUser && !onSelectUnobserved && (
           <ButtonBar
             buttonConfiguration={buttons}
             containerClass="justify-center pt-[15px]"
@@ -127,7 +163,7 @@ const ExploreUserSearch = ( { closeModal, updateUser }: Props ) => {
       <UserList
         ListEmptyComponent={emptyListComponent}
         ListFooterComponent={footerComponent}
-        users={userList}
+        users={users}
         keyboardShouldPersistTaps="handled"
         accessibilityLabel={t( "Select-user" )}
         onPress={onUserSelected}

--- a/src/providers/ExploreV2Context.tsx
+++ b/src/providers/ExploreV2Context.tsx
@@ -100,7 +100,7 @@ export interface ExploreV2Filters {
   photoLicense: PHOTO_LICENSE;
   // User / project, in ExploreV2 parlance we always consider taxon to be the "subject"
   user?: ApiUser | null;
-  excludeUser?: ApiUser | null;
+  unobservedByUser?: ApiUser | null;
   project?: ApiProjectSummary | null;
 }
 

--- a/tests/unit/components/Explore/ExploreV2/helpers/advancedSearchReducer.test.js
+++ b/tests/unit/components/Explore/ExploreV2/helpers/advancedSearchReducer.test.js
@@ -135,24 +135,24 @@ describe( "advancedSearchReducer", ( ) => {
   } );
 
   describe( "user filter", ( ) => {
-    it( "sets a user and clears any excluded user", ( ) => {
-      const draft = makeDraft( { filters: { excludeUser: OTHER_USER } } );
+    it( "sets a user and clears an unobserved-by user", ( ) => {
+      const draft = makeDraft( { filters: { unobservedByUser: OTHER_USER } } );
 
       const newDraft = advancedSearchReducer( draft, { type: "SET_USER", user: USER } );
 
       expect( newDraft.filters.user ).toEqual( USER );
-      expect( newDraft.filters.excludeUser ).toBeNull( );
+      expect( newDraft.filters.unobservedByUser ).toBeNull( );
     } );
 
-    it( "sets an excluded user and clears any user", ( ) => {
+    it( "sets an unobserved-by user and clears any user", ( ) => {
       const draft = makeDraft( { filters: { user: USER } } );
 
       const newDraft = advancedSearchReducer( draft, {
-        type: "SET_EXCLUDE_USER",
+        type: "SET_UNOBSERVED_BY_USER",
         user: OTHER_USER,
       } );
 
-      expect( newDraft.filters.excludeUser ).toEqual( OTHER_USER );
+      expect( newDraft.filters.unobservedByUser ).toEqual( OTHER_USER );
       expect( newDraft.filters.user ).toBeNull( );
     } );
 

--- a/tests/unit/components/Explore/ExploreV2/helpers/countFilters.test.js
+++ b/tests/unit/components/Explore/ExploreV2/helpers/countFilters.test.js
@@ -34,7 +34,7 @@ describe( "countFilters", ( ) => {
 
   it.each( [
     ["a user", "user"],
-    ["an excluded user", "excludeUser"],
+    ["a user whose observed taxa are excluded", "unobservedByUser"],
   ] )( "counts %s", ( _name, key ) => {
     const user = factory( "RemoteUser" );
     expect( countFilters( withFilters( { [key]: user } ) ) ).toEqual( 1 );

--- a/tests/unit/components/Explore/ExploreV2/helpers/filtersToApiParams.test.js
+++ b/tests/unit/components/Explore/ExploreV2/helpers/filtersToApiParams.test.js
@@ -196,5 +196,14 @@ describe( "filtersToApiParams", ( ) => {
       expect( params.user_id ).toBe( 7 );
       expect( params.project_id ).toBe( 9 );
     } );
+
+    it( "maps an unobserved-by user alongside a project", ( ) => {
+      const params = filtersToApiParams( makeFilters( {
+        unobservedByUser: { id: 7 },
+        project: { id: 9 },
+      } ) );
+      expect( params.unobserved_by_user_id ).toBe( 7 );
+      expect( params.project_id ).toBe( 9 );
+    } );
   } );
 } );

--- a/tests/unit/components/Explore/ExploreV2/screens/AdvancedSearch.test.js
+++ b/tests/unit/components/Explore/ExploreV2/screens/AdvancedSearch.test.js
@@ -222,13 +222,13 @@ describe( "AdvancedSearch screen", ( ) => {
       expect( screen.queryByText( t( "FILTER-BY-A-PROJECT" ) ) ).toBeNull( );
     } );
 
-    it( "shows an excluded user under an all-users-except heading", ( ) => {
-      setExploreState( { filters: { excludeUser: USER } } );
+    it( "shows a carried unobserved subject in the user section", ( ) => {
+      setExploreState( { subject: { type: "unobserved", user: CURRENT_USER } } );
       renderComponent( <AdvancedSearch /> );
 
-      expect( screen.getByText( t( "ALL-USERS-EXCEPT" ) ) ).toBeVisible( );
-      expect( screen.queryByText( t( "USER" ) ) ).toBeNull( );
-      expect( screen.getByText( USER.login ) ).toBeVisible( );
+      expect( screen.getByText( t( "USER" ) ) ).toBeVisible( );
+      expect( screen.getByText( t( "Species-I-havent-observed" ) ) ).toBeVisible( );
+      expect( screen.queryByText( t( "FILTER-BY-A-USER" ) ) ).toBeNull( );
     } );
 
     it( "shows the unknown subject as an unknown taxon", ( ) => {
@@ -414,18 +414,25 @@ describe( "AdvancedSearch screen", ( ) => {
       } );
     } );
 
-    it( "clears a carried subject that the user replaced with a user filter", async ( ) => {
-      setExploreState( {
-        subject: { type: "unobserved", user: CURRENT_USER },
-        filters: { user: USER },
-      } );
+    it( "commits a carried unobserved subject as a filter that survives the search", async ( ) => {
+      setExploreState( { subject: { type: "unobserved", user: CURRENT_USER } } );
       renderComponent( <AdvancedSearch /> );
 
-      // Editing the user section supersedes the unobserved subject.
+      await pressSearch( );
+
+      expect( committedSearch( ).subject ).toBeNull( );
+      expect( committedFilters( ).unobservedByUser.id ).toEqual( CURRENT_USER.id );
+    } );
+
+    it( "removes a carried unobserved subject the user cleared", async ( ) => {
+      setExploreState( { subject: { type: "unobserved", user: CURRENT_USER } } );
+      renderComponent( <AdvancedSearch /> );
+
       await actor.press( screen.getByLabelText( t( "Remove-user-filter" ) ) );
       await pressSearch( );
 
       expect( committedSearch( ).subject ).toBeNull( );
+      expect( committedFilters( ).unobservedByUser ).toBeNull( );
     } );
   } );
 


### PR DESCRIPTION
Makes it so a user on AdvancedSearch has the same defaults a user on UniversalSearch would wrt users

<details>
<summary>
screens
</summary>
<img width="330" height="717" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-09-10 at 17 26 51" src="https://github.com/user-attachments/assets/0519d043-8dd2-44a6-ae09-da4a615cd393" />
<img width="330" height="717" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-09-10 at 17 26 44" src="https://github.com/user-attachments/assets/4b8b834c-2753-4d4f-85f3-c50710a9d019" />

</details>