### PR TITLE
expose local-only / logged out language switching

### DIFF
--- a/src/components/Settings/LanguageSetting.tsx
+++ b/src/components/Settings/LanguageSetting.tsx
@@ -1,5 +1,4 @@
 import fetchAvailableLocales from "api/translations";
-import { getJWT } from "components/LoginSignUp/AuthenticationService";
 import {
   Button,
   Heading4,
@@ -7,11 +6,9 @@ import {
   UnderlinedLink,
 } from "components/SharedComponents";
 import { View } from "components/styledComponents";
-import React, { useEffect, useState } from "react";
-import changeLanguage from "sharedHelpers/changeLanguage";
+import React, { useState } from "react";
 import { openExternalWebBrowser } from "sharedHelpers/util";
-import { useTranslation } from "sharedHooks";
-import { zustandStorage } from "stores/useStore";
+import { useQuery, useTranslation } from "sharedHooks";
 
 type LocalesResponse = {
   locale: string;
@@ -24,8 +21,10 @@ interface Props {
   onChange: ( newLocale: string ) => void;
 }
 
-const localesToOptions = ( localesResponse: LocalesResponse ) => Object.fromEntries(
-  localesResponse?.map( locale => [
+const localesToOptions = (
+  localesResponse?: LocalesResponse,
+): LocalesOptions => Object.fromEntries(
+  ( localesResponse ?? [] ).map( locale => [
     locale.locale,
     {
       label: locale.language_in_locale,
@@ -36,25 +35,16 @@ const localesToOptions = ( localesResponse: LocalesResponse ) => Object.fromEntr
 
 const LanguageSetting = ( { onChange }: Props ) => {
   const { t, i18n } = useTranslation();
-  const [localeOptions, setLocaleOptions] = useState<LocalesOptions | null>( () => {
-    const currentLocales = zustandStorage.getItem( "availableLocales" );
-    return currentLocales
-      ? localesToOptions( JSON.parse( currentLocales as string ) )
-      : null;
-  } );
   const [localeSheetOpen, setLocaleSheetOpen] = useState( false );
 
-  useEffect( () => {
-    async function fetchLocales() {
-      const apiToken = await getJWT( );
-      const locales = await fetchAvailableLocales( {}, { api_token: apiToken } );
-      zustandStorage.setItem( "availableLocales", JSON.stringify( locales ) );
-      setLocaleOptions( localesToOptions( locales as LocalesResponse ) );
-    }
-    fetchLocales();
-  }, [] );
+  const { data: locales } = useQuery(
+    ["fetchAvailableLocales"],
+    ( ) => fetchAvailableLocales( {} ),
+  );
 
-  if ( !localeOptions ) {
+  const localeOptions = localesToOptions( locales as LocalesResponse | undefined );
+
+  if ( Object.keys( localeOptions ).length === 0 ) {
     return null;
   }
 
@@ -81,8 +71,6 @@ const LanguageSetting = ( { onChange }: Props ) => {
           headerText={t( "APP-LANGUAGE" )}
           confirm={( newLocale: string ) => {
             setLocaleSheetOpen( false );
-            // Remember the new locale locally
-            changeLanguage( newLocale );
             onChange( newLocale );
           }}
           onPressClose={() => setLocaleSheetOpen( false )}

--- a/src/components/Settings/LoggedInDefaultSettings.tsx
+++ b/src/components/Settings/LoggedInDefaultSettings.tsx
@@ -21,7 +21,11 @@ import TaxonNamesSetting from "./TaxonNamesSetting";
 
 const { useRealm } = RealmContext;
 
-const LoggedInDefaultSettings = ( ) => {
+interface Props {
+  onLocaleChange: ( newLocale: string ) => void;
+}
+
+const LoggedInDefaultSettings = ( { onLocaleChange }: Props ) => {
   const realm = useRealm( );
   const { t } = useTranslation( );
   const {
@@ -72,6 +76,7 @@ const LoggedInDefaultSettings = ( ) => {
       />
       <LanguageSetting
         onChange={newLocale => {
+          onLocaleChange( newLocale );
           QueueItem.enqueue(
             realm,
             JSON.stringify( {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -7,6 +7,7 @@ import React, { useCallback } from "react";
 import {
   View,
 } from "react-native";
+import changeLanguage from "sharedHelpers/changeLanguage";
 import {
   useCurrentUser,
   useLayoutPrefs,
@@ -14,6 +15,7 @@ import {
 } from "sharedHooks";
 
 import AdvancedSettings from "./AdvancedSettings";
+import LanguageSetting from "./LanguageSetting";
 import LoggedInDefaultSettings from "./LoggedInDefaultSettings";
 
 const Settings = ( ) => {
@@ -45,7 +47,13 @@ const Settings = ( ) => {
           label={t( "Advanced-Mode" )}
         />
         {isAdvancedMode && <AdvancedSettings />}
-        {currentUser && <LoggedInDefaultSettings />}
+        {currentUser
+          ? <LoggedInDefaultSettings onLocaleChange={changeLanguage} />
+          : (
+            <View className="mt-[30px]">
+              <LanguageSetting onChange={changeLanguage} />
+            </View>
+          )}
       </View>
     </ScrollViewWrapper>
   );

--- a/tests/unit/components/Settings/LanguageSetting.test.js
+++ b/tests/unit/components/Settings/LanguageSetting.test.js
@@ -30,7 +30,8 @@ describe( "LanguageSetting", ( ) => {
       locale: "es-CO",
     }] ) );
 
-    renderComponent( <LanguageSetting onChange={jest.fn( )} /> );
+    const onChange = jest.fn( );
+    renderComponent( <LanguageSetting onChange={onChange} /> );
 
     expect( i18n.language ).toEqual( "en" );
     const changeLanguageButton = await screen.findByText( /CHANGE APP LANGUAGE/ );
@@ -47,6 +48,6 @@ describe( "LanguageSetting", ( ) => {
     const confirmText = await screen.findByText( "CONFIRM" );
     expect( confirmText ).toBeVisible( );
     fireEvent.press( confirmText );
-    expect( i18n.language ).toEqual( "es-CO" );
+    expect( onChange ).toHaveBeenCalledWith( "es-CO" );
   } );
 } );


### PR DESCRIPTION
Closes MOB-1711 (and incidentally MOB-1378)

The language switcher will now display for logged out users.

Confirmed in the ticket w/ Product: we _do_ want account settings to override logged-out locale on login.

This endpoint is available unauth'd so I switched it to unconditionally use the unauth'd useQuery.

For some reason I can't tell, we were also doing a manual disk cache of locales. I went ahead and removed that because it doesn't seem justified. This was tracked as a "don't do that w/ the zustand store" in [MOB-1378](https://linear.app/inaturalist/issue/MOB-1378) and looking into this, I further confirmed that it was unnecessary.