### PR TITLE
 remove extra list bottom padding

### DIFF
--- a/src/components/SharedComponents/FlashList/InfiniteScrollLoadingWheel.tsx
+++ b/src/components/SharedComponents/FlashList/InfiniteScrollLoadingWheel.tsx
@@ -23,7 +23,7 @@ const InfiniteScrollLoadingWheel = ( {
     ? "h-[128px] py-16"
     : "h-64 py-16";
   if ( hideLoadingWheel ) {
-    return <View className={loadingWheelClass} testID="InfiniteScrollLoadingWheel.footerView" />;
+    return <View testID="InfiniteScrollLoadingWheel.footerView" />;
   }
   return (
     <View className={classnames( loadingWheelClass, {

--- a/src/sharedHooks/useGridLayout.ts
+++ b/src/sharedHooks/useGridLayout.ts
@@ -4,13 +4,12 @@ import { useDeviceOrientation } from "sharedHooks";
 
 const GUTTER = 15;
 const HALF_GUTTER = GUTTER / 2;
-const TAB_BAR_HEIGHT = 80;
 
 const flashListStyle = {
   paddingTop: HALF_GUTTER,
   paddingLeft: HALF_GUTTER,
   paddingRight: HALF_GUTTER,
-  paddingBottom: TAB_BAR_HEIGHT + HALF_GUTTER,
+  paddingBottom: HALF_GUTTER,
 };
 
 const useGridLayout = ( layout?: "list" ) => {


### PR DESCRIPTION
closes MOB-1719

two separate fixes:
- `InfiniteScrollLoadingWheel` renders a `View` with a `testId` even when `hideLoadingWheel`. This change removes the styling from that `View` so it doesn't unconditionally add padding.
- We still had extra padding in GridView with that change due to a `TAB_BAR_HEIGHT = 80` added to to paddingBottom. _as far as I can tell_, this is vestigial from when we actually needed to account for an absolutely positioned bottom tab bar.

~I have an open question on the ticket about whether we want to retain _some_ padding because our floating controls / overlays obscure the bottom of the list. But this implements ticket as written so ready for review.~ To account for controls on list view only, we're maintaining some artificial space. 


https://github.com/user-attachments/assets/d96a4a68-e68c-408a-a30b-7f3c96859489

